### PR TITLE
Replace Bun.spawnSync + realpath with fs.realpathSync to improve index file performance on 14k documents.

### DIFF
--- a/qmd.ts
+++ b/qmd.ts
@@ -115,7 +115,7 @@ function getPwd(): string {
 }
 
 // Get canonical realpath, falling back to resolved path if file doesn't exist
-function getRealPath(path: string) {
+function getRealPath(path: string): string {
   try {
     return realpathSync(path).toString();
   } catch {}


### PR DESCRIPTION
Big fan of your work Tobi, this is very cool!

## Issue / Reproduction

QMD is installed globally on a M1 MacBook Pro, with Ghostty.

Running `qmd add` on a folder with a 14k file subdirectory hangs the qmd process. I isolated this down to the `Bun.spawnSync(["realpath", path]);` call on line 119.

Running realpath in the same dir with the small bash script below works. Running `Bun.spawnSync` with  `realpath` does not. 

```
#!/bin/bash
for file in *; do
  realpath "$file"
done
```

I also tried `Bun.spawnSync` with the `stat` command and that worked correctly.

This commit just changes line 119 to a Bun native `fs.realpathSync`.

## Before commit

![CleanShot 2025-12-10 at 13 17 59](https://github.com/user-attachments/assets/cc085bad-de29-4258-a41b-9c3337800de5)

## After commit 
![CleanShot 2025-12-10 at 13 18 41](https://github.com/user-attachments/assets/5476cfec-beaa-47a7-b21b-f93d0c85ff2b)
