### PR TITLE
Use native realpathSync instead of spawning subprocess per file

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -13,6 +13,7 @@
 
 import { Database } from "bun:sqlite";
 import { Glob } from "bun";
+import { realpathSync } from "node:fs";
 import * as sqliteVec from "sqlite-vec";
 import {
   LlamaCpp,
@@ -116,12 +117,10 @@ export function getPwd(): string {
 
 export function getRealPath(path: string): string {
   try {
-    const result = Bun.spawnSync(["realpath", path]);
-    if (result.success) {
-      return result.stdout.toString().trim();
-    }
-  } catch {}
-  return resolve(path);
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
 }
 
 // =============================================================================


### PR DESCRIPTION
The previous implementation spawned a subprocess for every file during indexing (e.g., thousands of subprocess spawns for a large collection). Using Node's native realpathSync is orders of magnitude faster.

before: 15.6s
after: 1.0s