### PR TITLE
fix: prevent MCP server from exiting immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,13 @@ Although the tool works perfectly fine when you just tell your agent to use it o
 - `qmd_multi_get` - Retrieve multiple documents by glob pattern, list, or docids
 - `qmd_status` - Index health and collection info
 
-**Claude Desktop configuration** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+**Claude Code CLI:**
+
+```sh
+claude mcp add qmd -- qmd mcp
+```
+
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
 
 ```json
 {
@@ -84,7 +90,7 @@ Although the tool works perfectly fine when you just tell your agent to use it o
 }
 ```
 
-**Claude Code configuration** (`~/.claude/settings.json`):
+**Claude Code manual configuration** (`~/.claude.json`):
 
 ```json
 {

--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -2588,7 +2588,8 @@ if (import.meta.main) {
     case "mcp": {
       const { startMcpServer } = await import("./mcp.js");
       await startMcpServer();
-      break;
+      // MCP server runs until stdin closes - wait indefinitely
+      await new Promise(() => {});
     }
 
     case "cleanup": {


### PR DESCRIPTION
## Summary

- Fixed MCP server exiting immediately after starting due to `process.exit(0)` being called after `startMcpServer()` returns
- Added Claude Code CLI installation command to README

## Problem

The MCP server was unusable because after `startMcpServer()` completed its async setup, the code fell through to cleanup and `process.exit(0)`, killing the server before it could process any requests.

```
$ claude mcp list
qmd: qmd mcp - ✗ Failed to connect
```

## Solution

Added `await new Promise(() => {})` after starting the server to keep the process alive indefinitely. The stdin listener from the MCP SDK keeps the event loop active until the client disconnects.

## Test plan

- [x] Verified `qmd mcp` responds to MCP initialize message
- [x] Verified `claude mcp list` shows `qmd` as connected
- [x] Tested MCP tools work in Claude Code session

🤖 Generated with [Claude Code](https://claude.ai/code)