### PR TITLE
fix: proper MCP server lifecycle management

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,13 @@ Although the tool works perfectly fine when you just tell your agent to use it o
 - `qmd_multi_get` - Retrieve multiple documents by glob pattern, list, or docids
 - `qmd_status` - Index health and collection info
 
-**Claude Desktop configuration** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+**Claude Code CLI:**
+
+```sh
+claude mcp add qmd -- qmd mcp
+```
+
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
 
 ```json
 {
@@ -84,7 +90,7 @@ Although the tool works perfectly fine when you just tell your agent to use it o
 }
 ```
 
-**Claude Code configuration** (`~/.claude/settings.json`):
+**Claude Code manual configuration** (`~/.claude.json`):
 
 ```json
 {


### PR DESCRIPTION
## Summary

- Add `transport.onclose` handler to wait for server shutdown
- Add SIGINT/SIGTERM handlers for graceful shutdown
- Close database connection on shutdown
- Restore break statement in CLI switch (remove Promise hack)

The MCP server now properly waits for stdin close via `transport.onclose` rather than using `await new Promise(() => {})`.

## Background

The MCP server was exiting immediately after starting because the code fell through to `process.exit(0)` after `startMcpServer()` returned. The original fix used a hacky `await new Promise(() => {})` to prevent this. This PR implements proper lifecycle management as documented by the MCP SDK.

## Test plan

- [x] MCP server starts and responds to initialize
- [x] MCP server stays alive while stdin is open
- [x] MCP server exits cleanly when stdin closes
- [x] SIGINT/SIGTERM trigger graceful shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)