### PR TITLE
fix: correct Qwen3-1.7B model filename casing

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -150,7 +150,7 @@ export type RerankDocument = {
 const DEFAULT_EMBED_MODEL = "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";
 const DEFAULT_RERANK_MODEL = "hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf";
 // const DEFAULT_GENERATE_MODEL = "hf:ggml-org/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf";
-const DEFAULT_GENERATE_MODEL = "hf:ggml-org/Qwen3-1.7B-GGUF/Qwen3-1.7b-q8_0.gguf";
+const DEFAULT_GENERATE_MODEL = "hf:ggml-org/Qwen3-1.7B-GGUF/Qwen3-1.7B-Q8_0.gguf";
 
 // Local model cache directory
 const MODEL_CACHE_DIR = join(homedir(), ".cache", "qmd", "models");


### PR DESCRIPTION
## Summary

Fix incorrect model filename casing that caused 404 errors when downloading the Qwen3-1.7B model for query expansion.

**Was:** `Qwen3-1.7b-q8_0.gguf`
**Now:** `Qwen3-1.7B-Q8_0.gguf`

## Background

The HuggingFace repository uses uppercase: `Qwen3-1.7B-Q8_0.gguf`. The typo was introduced when upgrading from Qwen3-0.6B to Qwen3-1.7B.

## Test plan

- [x] Model downloads successfully from HuggingFace
- [x] Query expansion works with the corrected model path

🤖 Generated with [Claude Code](https://claude.com/claude-code)