### PR TITLE
Fix MCP server exiting immediately after startup

### DIFF
--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -2626,8 +2626,9 @@ if (import.meta.main) {
       process.exit(1);
   }
 
-  // Cleanup LlamaCpp instance to prevent NAPI crash on exit
-  await disposeDefaultLlamaCpp();
-  process.exit(0);
+  if (cli.command !== "mcp") {
+    await disposeDefaultLlamaCpp();
+    process.exit(0);
+  }
 
 } // end if (import.meta.main)


### PR DESCRIPTION
## Summary

Fixes #28

The MCP server was exiting immediately after startup because `process.exit(0)` was called at the end of every command handler in `qmd.ts`. When `startMcpServer()` returned (after connecting to the stdio transport), the process was terminated before any MCP requests could be handled.

## Fix

Skip `process.exit(0)` when the command is `mcp`, allowing the server to stay alive and handle requests via stdio until the client closes the connection.

## Test plan

- [x] Verified MCP server stays running and responds to requests
- [x] All prior 50 tests pass