### PR TITLE
Fix: qmd get command now supports docid lookup

### DIFF
--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -18,6 +18,7 @@ import {
   removeCollection,
   renameCollection,
   findSimilarFiles,
+  findDocumentByDocid,
   matchFilesByGlob,
   getHashesNeedingEmbedding,
   getHashesForEmbedding,
@@ -686,6 +687,18 @@ function getDocument(filename: string, fromLine?: number, maxLines?: number, lin
     if (matched) {
       fromLine = parseInt(matched, 10);
       inputPath = inputPath.slice(0, -colonMatch[0].length);
+    }
+  }
+
+  // Handle docid lookup (#hash or 6-char hex)
+  if (inputPath.startsWith('#') || /^[a-f0-9]{6}$/i.test(inputPath)) {
+    const docidMatch = findDocumentByDocid(db, inputPath);
+    if (docidMatch) {
+      inputPath = docidMatch.filepath;
+    } else {
+      console.error(`Document not found: ${filename}`);
+      closeDb();
+      process.exit(1);
     }
   }
 


### PR DESCRIPTION
## Summary

`qmd get` is documented to support docid lookups (e.g., `qmd get "#abc123"`), but this functionality was not implemented.

## How to Reproduce

1. Index a collection: `qmd collection add . --name test`
2. Run a search to get a docid: `qmd search "some query" --json`
3. Note the docid in results (e.g., `"docid": "#c8d050"`)
4. Try to retrieve by docid: `qmd get "#c8d050"`

**Expected:** Document content is displayed  
**Actual (before fix):** `Document not found: #c8d050`

## Root Cause

The `getDocument()` function in `qmd.ts` reimplements document lookup logic but never calls `findDocumentByDocid()` from `store.ts`. It handles:
- Virtual paths (`qmd://...`)
- Collection/path format (`collection/path.md`)
- Filesystem paths

But it never checks for docid patterns (`#abc123` or bare 6-char hex).

## The Fix

Added docid detection at the start of `getDocument()` that:
1. Checks if input matches docid pattern (`#...` or 6-char hex)
2. Calls the existing `findDocumentByDocid()` to resolve to a virtual path
3. Continues with normal path handling

## Documentation References

The following docs claim docid support for `qmd get`:
- CLAUDE.md line 19: `qmd get <file>  # Get document by path or docid (#abc123)`
- CLAUDE.md lines 89-90: `qmd get "#abc123"`
- README.md line 35: `qmd get "#abc123"`
- README.md line 399: `# Get document by docid (from search results)`

## Test plan

- [x] `qmd get "#c8d050"` now returns document content
- [x] `qmd get c8d050` (without `#`) also works
- [x] Existing path-based lookups still work
- [x] Invalid docids show appropriate error message

---

🤖 Generated with [Claude Code](https://claude.ai/code)