### PR TITLE
WIP: Interactive REPL for RLM-style reasoning over qmd collections

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "2025-12-07-bm25-q",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.1",
+        "just-bash": "^2.5.2",
         "node-llama-cpp": "^3.14.5",
         "sqlite-vec": "^0.1.7-alpha.2",
         "yaml": "^2.8.2",
@@ -26,15 +27,25 @@
     },
   },
   "packages": {
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
+
     "@hono/node-server": ["@hono/node-server@1.19.7", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw=="],
 
     "@huggingface/jinja": ["@huggingface/jinja@0.5.3", "", {}, "sha512-asqfZ4GQS0hD876Uw4qiUb7Tr/V5Q+JZuo2L+BtdrD4U40QU58nIRq3ZSgAzJgT874VLjhGVacaYfrdpXtEvtA=="],
+
+    "@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
+
+    "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.0", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA=="],
 
     "@kwsites/file-exists": ["@kwsites/file-exists@1.1.1", "", { "dependencies": { "debug": "^4.1.1" } }, "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw=="],
 
     "@kwsites/promise-deferred": ["@kwsites/promise-deferred@1.1.1", "", {}, "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="],
 
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
+
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
+
+    "@mongodb-js/zstd": ["@mongodb-js/zstd@7.0.0", "", { "dependencies": { "node-addon-api": "^8.5.0", "prebuild-install": "^7.1.3" } }, "sha512-mQ2s0pYYiav+tzCDR05Zptem8Ey2v8s11lri5RKGhTtL4COVCvVCk5vtyRYNT+9L8qSfyOqqefF9UtnW8mC5jA=="],
 
     "@node-llama-cpp/linux-arm64": ["@node-llama-cpp/linux-arm64@3.14.5", "", { "os": "linux", "cpu": [ "x64", "arm64", ] }, "sha512-58IcWW7EOqc/66mYWXRsoMCy1MR3pTX/YaC0HYF9Rg5XeAPKhUP7NHrglbqgjO62CkcuFZaSEiX2AtG972GQYQ=="],
 
@@ -132,6 +143,10 @@
 
     "@tinyhttp/content-disposition": ["@tinyhttp/content-disposition@2.2.2", "", {}, "sha512-crXw1txzrS36huQOyQGYFvhTeLeG0Si1xu+/l6kXUVYpE0TjFjEZRqTbuadQLfKGZ0jaI+jJoRyqaWwxOSHW2g=="],
 
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
     "@types/aws-lambda": ["@types/aws-lambda@8.10.159", "", {}, "sha512-SAP22WSGNN12OQ8PlCzGzRCZ7QDCwI85dQZbmpz7+mAk+L7j+wI7qnvmdKh+o7A5LaOp6QnOZ2NJphAZQTTHQg=="],
 
     "@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
@@ -143,6 +158,8 @@
     "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "amdefine": ["amdefine@1.0.1", "", {}, "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg=="],
 
     "ansi-escapes": ["ansi-escapes@6.2.1", "", {}, "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig=="],
 
@@ -160,11 +177,17 @@
 
     "axios": ["axios@1.13.2", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.4", "proxy-from-env": "^1.1.0" } }, "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA=="],
 
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
+
+    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
     "body-parser": ["body-parser@2.2.1", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw=="],
 
     "bottleneck": ["bottleneck@2.19.5", "", {}, "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="],
+
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
 
@@ -198,7 +221,9 @@
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
-    "commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
+    "commander": ["commander@2.8.1", "", { "dependencies": { "graceful-readlink": ">= 1.0.0" } }, "sha512-+pJLBFVk+9ZZdlAOB5WuIElVPPth47hILFkmGym57aq8kwxsowvByvB0DHs1vQAhyMZzdcpTtF0VDKGkSDR4ZQ=="],
+
+    "compressjs": ["compressjs@1.0.3", "", { "dependencies": { "amdefine": "~1.0.0", "commander": "~2.8.1" }, "bin": { "compressjs": "./bin/compressjs" } }, "sha512-jpKJjBTretQACTGLNuvnozP1JdP2ZLrjdGdBgk/tz1VfXlUcBhhSZW6vEsuThmeot/yjvSrPQKEgfF3X2Lpi8Q=="],
 
     "console-control-strings": ["console-control-strings@1.1.0", "", {}, "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="],
 
@@ -216,6 +241,8 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
     "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
@@ -224,6 +251,10 @@
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
+
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
@@ -231,6 +262,8 @@
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "env-var": ["env-var@7.5.0", "", {}, "sha512-mKZOzLRN0ETzau2W2QXefbFjo5EF4yWq28OyKb9ICdeNhHJlOE/pHHnz4hdYJ9cNZXcJHo5xN4OT4pzuSHSNvA=="],
 
@@ -254,6 +287,8 @@
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
+    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
     "express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
@@ -263,6 +298,10 @@
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.3.3", "", { "dependencies": { "strnum": "^2.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-2O3dkPAAC6JavuMm8+4+pgTk+5hoAs+CjZ+sWcQLkX9+/tHRuTkQh/Oaifr8qDmZ8iEHb771Ea6G8CdwkrgvYA=="],
+
+    "file-type": ["file-type@21.3.0", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA=="],
 
     "filename-reserved-regex": ["filename-reserved-regex@3.0.0", "", {}, "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw=="],
 
@@ -277,6 +316,8 @@
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
     "fs-extra": ["fs-extra@11.3.3", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg=="],
 
@@ -294,9 +335,13 @@
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
+    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
+
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "graceful-readlink": ["graceful-readlink@1.0.1", "", {}, "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
@@ -312,11 +357,13 @@
 
     "iconv-lite": ["iconv-lite@0.7.0", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ=="],
 
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
-    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+    "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
@@ -340,6 +387,8 @@
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
+    "just-bash": ["just-bash@2.5.2", "", { "dependencies": { "@mongodb-js/zstd": "^7.0.0", "compressjs": "^1.0.3", "diff": "^8.0.2", "fast-xml-parser": "^5.3.3", "file-type": "^21.2.0", "ini": "^6.0.0", "minimatch": "^10.1.1", "modern-tar": "^0.7.3", "papaparse": "^5.5.3", "smol-toml": "^1.6.0", "sprintf-js": "^1.1.3", "sql.js": "^1.13.0", "turndown": "^7.2.2", "yaml": "^2.8.2" }, "optionalDependencies": { "node-liblzma": "^2.0.3" }, "bin": { "just-bash": "dist/bin/just-bash.js", "just-bash-shell": "dist/bin/shell/shell.js" } }, "sha512-Huv+JXBvl3F0pJ5mLnUUlNUmfwlvjQpbvwpCHsB4mDAyWEpmnTG9nNlwMJ/t7a17tkZ9l8CPihRmuNhEFMqDWQ=="],
+
     "lifecycle-utils": ["lifecycle-utils@3.0.1", "", {}, "sha512-Qt/Jl5dsNIsyCAZsHB6x3mbwHFn0HJbdmvF49sVX/bHgX2cW7+G+U+I67Zw+TPM1Sr21Gb2nfJMd2g6iUcI1EQ=="],
 
     "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
@@ -362,6 +411,10 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
+    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
+
+    "minimatch": ["minimatch@10.1.1", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ=="],
+
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
@@ -370,15 +423,27 @@
 
     "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
 
+    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
+
+    "modern-tar": ["modern-tar@0.7.3", "", {}, "sha512-4W79zekKGyYU4JXVmB78DOscMFaJth2gGhgfTl2alWE4rNe3nf4N2pqenQ0rEtIewrnD79M687Ouba3YGTLOvg=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@5.1.6", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
 
+    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
+
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "node-abi": ["node-abi@3.86.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-sn9Et4N3ynsetj3spsZR729DVlGH6iBG4RiDMV7HEp3guyOW6W3S0unGpLDxT50mXortGUMax/ykUNQXdqc/Xg=="],
 
     "node-addon-api": ["node-addon-api@8.5.0", "", {}, "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A=="],
 
     "node-api-headers": ["node-api-headers@1.7.0", "", {}, "sha512-uJMGdkhVwu9+I3UsVvI3KW6ICAy/yDfsu5Br9rSnTtY3WpoaComXvKloiV5wtx0Md2rn0B9n29Ys2WMNwWxj9A=="],
+
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
+
+    "node-liblzma": ["node-liblzma@2.0.3", "", { "dependencies": { "node-addon-api": "^8.5.0", "node-gyp-build": "^4.8.4" } }, "sha512-BZTOQtHTFiq9FNAXeRJI25P7ZFzudXK1K72HJ/XXuVNwZsLIK6zHLCjIFZWEIfdPKrnLtEUhZ0+TelXvVCDnvQ=="],
 
     "node-llama-cpp": ["node-llama-cpp@3.14.5", "", { "dependencies": { "@huggingface/jinja": "^0.5.3", "async-retry": "^1.3.3", "bytes": "^3.1.2", "chalk": "^5.4.1", "chmodrp": "^1.0.2", "cmake-js": "^7.4.0", "cross-spawn": "^7.0.6", "env-var": "^7.5.0", "filenamify": "^6.0.0", "fs-extra": "^11.3.0", "ignore": "^7.0.4", "ipull": "^3.9.2", "is-unicode-supported": "^2.1.0", "lifecycle-utils": "^3.0.1", "log-symbols": "^7.0.0", "nanoid": "^5.1.5", "node-addon-api": "^8.3.1", "octokit": "^5.0.3", "ora": "^8.2.0", "pretty-ms": "^9.2.0", "proper-lockfile": "^4.1.2", "semver": "^7.7.1", "simple-git": "^3.27.0", "slice-ansi": "^7.1.0", "stdout-update": "^4.0.1", "strip-ansi": "^7.1.0", "validate-npm-package-name": "^6.0.0", "which": "^5.0.0", "yargs": "^17.7.2" }, "optionalDependencies": { "@node-llama-cpp/linux-arm64": "3.14.5", "@node-llama-cpp/linux-armv7l": "3.14.5", "@node-llama-cpp/linux-x64": "3.14.5", "@node-llama-cpp/linux-x64-cuda": "3.14.5", "@node-llama-cpp/linux-x64-cuda-ext": "3.14.5", "@node-llama-cpp/linux-x64-vulkan": "3.14.5", "@node-llama-cpp/mac-arm64-metal": "3.14.5", "@node-llama-cpp/mac-x64": "3.14.5", "@node-llama-cpp/win-arm64": "3.14.5", "@node-llama-cpp/win-x64": "3.14.5", "@node-llama-cpp/win-x64-cuda": "3.14.5", "@node-llama-cpp/win-x64-cuda-ext": "3.14.5", "@node-llama-cpp/win-x64-vulkan": "3.14.5" }, "peerDependencies": { "typescript": ">=5.0.0" }, "optionalPeers": ["typescript"], "bin": { "node-llama-cpp": "dist/cli/cli.js", "nlc": "dist/cli/cli.js" } }, "sha512-Db+RFqFMJOOVWprUINq77LVe44FaiJ6JvNiq14r2+DZRgkgyxckSZa6DcZ5Xe5MC+hGA5aqOdnNxsrudUcs74Q=="],
 
@@ -398,6 +463,8 @@
 
     "ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
 
+    "papaparse": ["papaparse@5.5.3", "", {}, "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A=="],
+
     "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
@@ -408,6 +475,8 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+
     "pretty-bytes": ["pretty-bytes@6.1.1", "", {}, "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ=="],
 
     "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
@@ -417,6 +486,8 @@
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
 
     "qs": ["qs@6.14.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w=="],
 
@@ -466,11 +537,21 @@
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
+    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
+
+    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
+
     "simple-git": ["simple-git@3.30.0", "", { "dependencies": { "@kwsites/file-exists": "^1.1.1", "@kwsites/promise-deferred": "^1.1.1", "debug": "^4.4.0" } }, "sha512-q6lxyDsCmEal/MEGhP1aVyQ3oxnagGlBDOVSIB4XUVLl1iZh0Pah6ebC9V4xBap/RfgP2WlI8EKs0WS0rMEJHg=="],
 
     "sleep-promise": ["sleep-promise@9.1.0", "", {}, "sha512-UHYzVpz9Xn8b+jikYSD6bqvf754xL2uBUzDFwiU6NcdZeifPr6UfgU43xpkPu67VMS88+TI2PSI7Eohgqf2fKA=="],
 
     "slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
+
+    "smol-toml": ["smol-toml@1.6.0", "", {}, "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw=="],
+
+    "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
+
+    "sql.js": ["sql.js@1.13.0", "", {}, "sha512-RJbVP1HRDlUUXahJ7VMTcu9Rm1Nzw+EBpoPr94vnbD4LwR715F3CcxE2G2k45PewcaZ57pjetYa+LoSJLAASgA=="],
 
     "sqlite-vec": ["sqlite-vec@0.1.7-alpha.2", "", { "optionalDependencies": { "sqlite-vec-darwin-arm64": "0.1.7-alpha.2", "sqlite-vec-darwin-x64": "0.1.7-alpha.2", "sqlite-vec-linux-arm64": "0.1.7-alpha.2", "sqlite-vec-linux-x64": "0.1.7-alpha.2", "sqlite-vec-windows-x64": "0.1.7-alpha.2" } }, "sha512-rNgRCv+4V4Ed3yc33Qr+nNmjhtrMnnHzXfLVPeGb28Dx5mmDL3Ngw/Wk8vhCGjj76+oC6gnkmMG8y73BZWGBwQ=="],
 
@@ -500,15 +581,31 @@
 
     "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
+    "strnum": ["strnum@2.1.2", "", {}, "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ=="],
+
+    "strtok3": ["strtok3@10.3.4", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg=="],
+
     "tar": ["tar@6.2.1", "", { "dependencies": { "chownr": "^2.0.0", "fs-minipass": "^2.0.0", "minipass": "^5.0.0", "minizlib": "^2.1.1", "mkdirp": "^1.0.3", "yallist": "^4.0.0" } }, "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A=="],
+
+    "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
+
+    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
     "toad-cache": ["toad-cache@3.7.0", "", {}, "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
+    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
+
+    "turndown": ["turndown@7.2.2", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-1F7db8BiExOKxjSMU2b7if62D/XOyQyZbPKq/nUwopfgnHlqXHqQ0lvfUTeUIr1lZJzOPFn43dODyMSIfvWRKQ=="],
+
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -568,6 +665,8 @@
 
     "gauge/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "ipull/commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
+
     "ipull/lifecycle-utils": ["lifecycle-utils@2.1.0", "", {}, "sha512-AnrXnE2/OF9PHCyFg0RSqsnQTzV991XaZA/buhFDoc58xU7rhSCDgCz/09Lqpsn4MpoPHt7TRAXV1kWZypFVsA=="],
 
     "ipull/pretty-ms": ["pretty-ms@8.0.0", "", { "dependencies": { "parse-ms": "^3.0.0" } }, "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q=="],
@@ -578,7 +677,11 @@
 
     "proper-lockfile/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
+    "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
     "restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "tar-fs/chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "wide-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.1",
+    "just-bash": "^2.5.2",
     "node-llama-cpp": "^3.14.5",
     "sqlite-vec": "^0.1.7-alpha.2",
     "yaml": "^2.8.2",

--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -2631,13 +2631,19 @@ if (import.meta.main) {
       break;
     }
 
+    case "repl": {
+      const { startRepl } = await import("./repl.js");
+      await startRepl();
+      break;
+    }
+
     default:
       console.error(`Unknown command: ${cli.command}`);
       console.error("Run 'qmd --help' for usage.");
       process.exit(1);
   }
 
-  if (cli.command !== "mcp") {
+  if (cli.command !== "mcp" && cli.command !== "repl") {
     await disposeDefaultLlamaCpp();
     process.exit(0);
   }

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -1,0 +1,705 @@
+#!/usr/bin/env bun
+/**
+ * QMD REPL - Interactive shell with qmd collections mounted read-only
+ *
+ * Features:
+ * - All qmd collections mounted under /qmd/<collection-name>/
+ * - Home directory writable at /home
+ * - Built-in search and query commands
+ * - Tab completion for files and commands
+ * - --prompt argument to initialize prompt.txt
+ */
+
+import * as readline from "node:readline";
+import { parseArgs } from "util";
+import {
+  Bash,
+  InMemoryFs,
+  MountableFs,
+  defineCommand,
+  type IFileSystem,
+  type FsStat,
+  type MkdirOptions,
+  type RmOptions,
+  type CpOptions,
+  type DirentEntry,
+} from "just-bash";
+import {
+  createStore,
+  enableProductionMode,
+  searchFTS,
+  searchVec,
+  type Store,
+  type SearchResult,
+} from "./store.js";
+import { listCollections as yamlListCollections, getCollection } from "./collections.js";
+
+// Enable production mode for database access
+enableProductionMode();
+
+// Terminal colors
+const useColor = !process.env.NO_COLOR && process.stdout.isTTY;
+const c = {
+  reset: useColor ? "\x1b[0m" : "",
+  dim: useColor ? "\x1b[2m" : "",
+  bold: useColor ? "\x1b[1m" : "",
+  cyan: useColor ? "\x1b[36m" : "",
+  yellow: useColor ? "\x1b[33m" : "",
+  green: useColor ? "\x1b[32m" : "",
+  magenta: useColor ? "\x1b[35m" : "",
+  blue: useColor ? "\x1b[34m" : "",
+  red: useColor ? "\x1b[31m" : "",
+};
+
+/**
+ * Read-only filesystem that exposes qmd collections.
+ * Files are loaded on-demand from the SQLite database.
+ */
+class QmdReadOnlyFs implements IFileSystem {
+  private store: Store;
+  private fileCache = new Map<string, { content: string; mtime: Date }>();
+  private dirCache = new Map<string, string[]>();
+
+  constructor(store: Store) {
+    this.store = store;
+    this.buildDirectoryCache();
+  }
+
+  private buildDirectoryCache(): void {
+    const db = this.store.db;
+    const collections = yamlListCollections();
+
+    // Root directory contains collection names
+    this.dirCache.set("/", collections.map(c => c.name));
+
+    // For each collection, get all document paths and build directory structure
+    for (const coll of collections) {
+      const docs = db.prepare(`
+        SELECT path FROM documents WHERE collection = ? AND active = 1
+      `).all(coll.name) as { path: string }[];
+
+      const collPath = `/${coll.name}`;
+      const dirs = new Map<string, Set<string>>();
+      dirs.set(collPath, new Set());
+
+      for (const doc of docs) {
+        const parts = doc.path.split("/");
+        let currentPath = collPath;
+
+        // Build directory hierarchy
+        for (let i = 0; i < parts.length - 1; i++) {
+          const part = parts[i]!;
+          const parentPath = currentPath;
+          currentPath = `${currentPath}/${part}`;
+
+          if (!dirs.has(currentPath)) {
+            dirs.set(currentPath, new Set());
+          }
+          dirs.get(parentPath)!.add(part);
+        }
+
+        // Add file to its parent directory
+        const filename = parts[parts.length - 1]!;
+        dirs.get(currentPath)!.add(filename);
+      }
+
+      // Convert Sets to arrays
+      for (const [path, entries] of dirs) {
+        this.dirCache.set(path, Array.from(entries).sort());
+      }
+    }
+  }
+
+  private normalizePath(path: string): string {
+    const parts = path.split("/").filter(Boolean);
+    const normalized: string[] = [];
+    for (const part of parts) {
+      if (part === "..") normalized.pop();
+      else if (part !== ".") normalized.push(part);
+    }
+    return "/" + normalized.join("/");
+  }
+
+  private parseQmdPath(path: string): { collection: string; relativePath: string } | null {
+    const normalized = this.normalizePath(path);
+    const parts = normalized.split("/").filter(Boolean);
+    if (parts.length < 1) return null;
+    return {
+      collection: parts[0]!,
+      relativePath: parts.slice(1).join("/"),
+    };
+  }
+
+  private throwReadOnly(): never {
+    throw new Error("Read-only filesystem");
+  }
+
+  async readFile(path: string): Promise<string> {
+    const normalized = this.normalizePath(path);
+
+    // Check cache
+    const cached = this.fileCache.get(normalized);
+    if (cached) return cached.content;
+
+    const parsed = this.parseQmdPath(normalized);
+    if (!parsed || !parsed.relativePath) {
+      throw new Error(`ENOENT: no such file: ${path}`);
+    }
+
+    const db = this.store.db;
+    const row = db.prepare(`
+      SELECT c.doc, d.modified_at
+      FROM documents d
+      JOIN content c ON d.hash = c.hash
+      WHERE d.collection = ? AND d.path = ? AND d.active = 1
+    `).get(parsed.collection, parsed.relativePath) as { doc: string; modified_at: string } | null;
+
+    if (!row) {
+      throw new Error(`ENOENT: no such file: ${path}`);
+    }
+
+    this.fileCache.set(normalized, {
+      content: row.doc,
+      mtime: new Date(row.modified_at),
+    });
+
+    return row.doc;
+  }
+
+  async readFileBuffer(path: string): Promise<Uint8Array> {
+    const content = await this.readFile(path);
+    return new TextEncoder().encode(content);
+  }
+
+  async writeFile(): Promise<void> {
+    this.throwReadOnly();
+  }
+
+  async appendFile(): Promise<void> {
+    this.throwReadOnly();
+  }
+
+  async exists(path: string): Promise<boolean> {
+    const normalized = this.normalizePath(path);
+
+    // Check if it's a directory
+    if (this.dirCache.has(normalized)) return true;
+
+    // Check if it's a file
+    const parsed = this.parseQmdPath(normalized);
+    if (!parsed || !parsed.relativePath) return false;
+
+    const db = this.store.db;
+    const row = db.prepare(`
+      SELECT 1 FROM documents
+      WHERE collection = ? AND path = ? AND active = 1
+      LIMIT 1
+    `).get(parsed.collection, parsed.relativePath);
+
+    return !!row;
+  }
+
+  async stat(path: string): Promise<FsStat> {
+    const normalized = this.normalizePath(path);
+
+    // Check if it's a directory
+    if (this.dirCache.has(normalized)) {
+      return {
+        isFile: false,
+        isDirectory: true,
+        isSymbolicLink: false,
+        mode: 0o755,
+        size: 0,
+        mtime: new Date(),
+      };
+    }
+
+    // Check if it's a file
+    const parsed = this.parseQmdPath(normalized);
+    if (!parsed || !parsed.relativePath) {
+      throw new Error(`ENOENT: no such file or directory: ${path}`);
+    }
+
+    const db = this.store.db;
+    const row = db.prepare(`
+      SELECT LENGTH(c.doc) as size, d.modified_at
+      FROM documents d
+      JOIN content c ON d.hash = c.hash
+      WHERE d.collection = ? AND d.path = ? AND d.active = 1
+    `).get(parsed.collection, parsed.relativePath) as { size: number; modified_at: string } | null;
+
+    if (!row) {
+      throw new Error(`ENOENT: no such file or directory: ${path}`);
+    }
+
+    return {
+      isFile: true,
+      isDirectory: false,
+      isSymbolicLink: false,
+      mode: 0o644,
+      size: row.size,
+      mtime: new Date(row.modified_at),
+    };
+  }
+
+  async lstat(path: string): Promise<FsStat> {
+    return this.stat(path);
+  }
+
+  async mkdir(): Promise<void> {
+    this.throwReadOnly();
+  }
+
+  async readdir(path: string): Promise<string[]> {
+    const normalized = this.normalizePath(path);
+    const entries = this.dirCache.get(normalized);
+    if (!entries) {
+      throw new Error(`ENOENT: no such directory: ${path}`);
+    }
+    return [...entries];
+  }
+
+  async readdirWithFileTypes(path: string): Promise<DirentEntry[]> {
+    const normalized = this.normalizePath(path);
+    const entries = await this.readdir(path);
+
+    return Promise.all(entries.map(async (name) => {
+      const fullPath = `${normalized}/${name}`;
+      const isDir = this.dirCache.has(fullPath);
+      return {
+        name,
+        isFile: !isDir,
+        isDirectory: isDir,
+        isSymbolicLink: false,
+      };
+    }));
+  }
+
+  async rm(): Promise<void> {
+    this.throwReadOnly();
+  }
+
+  async cp(): Promise<void> {
+    this.throwReadOnly();
+  }
+
+  async mv(): Promise<void> {
+    this.throwReadOnly();
+  }
+
+  resolvePath(base: string, path: string): string {
+    if (path.startsWith("/")) return this.normalizePath(path);
+    return this.normalizePath(`${base}/${path}`);
+  }
+
+  getAllPaths(): string[] {
+    const paths: string[] = [];
+    for (const dir of this.dirCache.keys()) {
+      paths.push(dir);
+    }
+    // Add all files
+    for (const [dir, entries] of this.dirCache) {
+      for (const entry of entries) {
+        const fullPath = `${dir}/${entry}`;
+        if (!this.dirCache.has(fullPath)) {
+          paths.push(fullPath);
+        }
+      }
+    }
+    return paths;
+  }
+
+  async chmod(): Promise<void> {
+    this.throwReadOnly();
+  }
+
+  async symlink(): Promise<void> {
+    this.throwReadOnly();
+  }
+
+  async link(): Promise<void> {
+    this.throwReadOnly();
+  }
+
+  async readlink(): Promise<string> {
+    throw new Error("EINVAL: not a symlink");
+  }
+}
+
+/**
+ * Format search results for terminal output
+ */
+function formatSearchResults(results: SearchResult[], query: string): string {
+  if (results.length === 0) {
+    return "No results found.\n";
+  }
+
+  const lines: string[] = [];
+  for (const result of results) {
+    const score = result.score.toFixed(2);
+    lines.push(`${c.cyan}${result.displayPath}${c.reset} ${c.dim}(${score})${c.reset}`);
+    lines.push(`  ${c.bold}${result.title}${c.reset}`);
+    if (result.context) {
+      lines.push(`  ${c.dim}Context: ${result.context.substring(0, 60)}...${c.reset}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Create custom commands for qmd
+ */
+function createQmdCommands(store: Store) {
+  const searchCmd = defineCommand("search", async (args, ctx) => {
+    const query = args.join(" ");
+    if (!query) {
+      return { stdout: "", stderr: "Usage: search <query>\n", exitCode: 1 };
+    }
+
+    const results = searchFTS(store.db, query, 10);
+    const output = formatSearchResults(results, query);
+    return { stdout: output, stderr: "", exitCode: 0 };
+  });
+
+  const queryCmd = defineCommand("query", async (args, ctx) => {
+    const query = args.join(" ");
+    if (!query) {
+      return { stdout: "", stderr: "Usage: query <query>\n", exitCode: 1 };
+    }
+
+    // Check if vector index exists
+    const tableExists = store.db.prepare(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'`
+    ).get();
+
+    if (!tableExists) {
+      // Fall back to FTS-only search
+      const results = searchFTS(store.db, query, 10);
+      const output = formatSearchResults(results, query);
+      return {
+        stdout: output,
+        stderr: `${c.yellow}Note: Vector index not found. Using BM25 search only.${c.reset}\n`,
+        exitCode: 0,
+      };
+    }
+
+    // Perform both FTS and vector search
+    const ftsResults = searchFTS(store.db, query, 20);
+    const vecResults = await searchVec(store.db, query, "embeddinggemma", 20);
+
+    // Simple RRF fusion
+    const scores = new Map<string, { result: SearchResult; score: number }>();
+    const k = 60;
+
+    for (let i = 0; i < ftsResults.length; i++) {
+      const r = ftsResults[i]!;
+      const rrfScore = 1 / (k + i + 1);
+      scores.set(r.filepath, { result: r, score: rrfScore });
+    }
+
+    for (let i = 0; i < vecResults.length; i++) {
+      const r = vecResults[i]!;
+      const rrfScore = 1 / (k + i + 1);
+      const existing = scores.get(r.filepath);
+      if (existing) {
+        existing.score += rrfScore;
+      } else {
+        scores.set(r.filepath, { result: r, score: rrfScore });
+      }
+    }
+
+    const merged = Array.from(scores.values())
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 10)
+      .map(({ result, score }) => ({ ...result, score }));
+
+    const output = formatSearchResults(merged, query);
+    return { stdout: output, stderr: "", exitCode: 0 };
+  });
+
+  const helpCmd = defineCommand("qmd-help", async () => {
+    const help = `${c.bold}QMD REPL Commands${c.reset}
+
+${c.cyan}search${c.reset} <query>   - BM25 full-text search
+${c.cyan}query${c.reset} <query>    - Hybrid search (BM25 + vectors)
+
+${c.bold}Filesystem${c.reset}
+  /qmd/<collection>/  - Read-only qmd documents
+  /home/              - Writable home directory
+
+${c.bold}Standard Commands${c.reset}
+  ls, cat, head, tail, grep, find, etc.
+
+`;
+    return { stdout: help, stderr: "", exitCode: 0 };
+  });
+
+  return [searchCmd, queryCmd, helpCmd];
+}
+
+/**
+ * Get the shell prompt
+ */
+function getPrompt(cwd: string): string {
+  // Simplify path for display
+  let displayPath = cwd;
+  if (cwd.startsWith("/home")) {
+    displayPath = "~" + cwd.slice("/home".length);
+  }
+
+  const user = process.env.USER || "user";
+  const hostname = process.env.HOSTNAME || "qmd";
+
+  return `${c.green}${user}@${hostname}${c.reset}:${c.blue}${displayPath}${c.reset}$ `;
+}
+
+/**
+ * Main REPL function
+ */
+async function startRepl(options: { prompt?: string }) {
+  const store = createStore();
+
+  // Create the QMD read-only filesystem
+  const qmdFs = new QmdReadOnlyFs(store);
+
+  // Create in-memory filesystem as base (for paths not under /qmd or /home)
+  const baseFs = new InMemoryFs();
+
+  // Create in-memory filesystem for /home with some initial structure
+  const homeFs = new InMemoryFs({
+    "/.bashrc": "# QMD REPL\nexport PS1='\\u@qmd:\\w$ '\n",
+  });
+
+  // Create mountable filesystem
+  const fs = new MountableFs({ base: baseFs });
+  fs.mount("/qmd", qmdFs);
+  fs.mount("/home", homeFs);
+
+  // Handle --prompt argument
+  if (options.prompt) {
+    await homeFs.writeFile("/prompt.txt", options.prompt);
+    console.log(`${c.dim}Wrote prompt to /home/prompt.txt${c.reset}`);
+  }
+
+  // Create custom commands
+  const customCommands = createQmdCommands(store);
+
+  // Create bash environment
+  const bash = new Bash({
+    fs,
+    cwd: "/home",
+    env: {
+      HOME: "/home",
+      USER: process.env.USER || "user",
+      PATH: "/usr/bin:/bin",
+      TERM: process.env.TERM || "xterm-256color",
+    },
+    customCommands,
+  });
+
+  // Print welcome message
+  console.log(`${c.bold}QMD REPL${c.reset} ${c.dim}(type 'qmd-help' for commands, 'exit' to quit)${c.reset}`);
+
+  const collections = yamlListCollections();
+  if (collections.length > 0) {
+    console.log(`${c.dim}Collections mounted at /qmd/:${c.reset}`);
+    for (const coll of collections) {
+      const count = store.db.prepare(
+        `SELECT COUNT(*) as c FROM documents WHERE collection = ? AND active = 1`
+      ).get(coll.name) as { c: number };
+      console.log(`  ${c.cyan}/qmd/${coll.name}/${c.reset} ${c.dim}(${count.c} files)${c.reset}`);
+    }
+  }
+  console.log("");
+
+  // Create readline interface
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: true,
+    completer: (line: string) => {
+      // Basic tab completion
+      const completions: string[] = [];
+      const parts = line.split(/\s+/);
+      const lastPart = parts[parts.length - 1] || "";
+
+      // Command completion
+      if (parts.length === 1) {
+        const commands = [
+          "search", "query", "qmd-help", "ls", "cat", "head", "tail",
+          "grep", "find", "pwd", "cd", "echo", "exit", "help"
+        ];
+        completions.push(...commands.filter(cmd => cmd.startsWith(lastPart)));
+      }
+
+      // Path completion
+      if (lastPart.includes("/") || parts.length > 1) {
+        try {
+          const cwd = bash.getCwd();
+          let searchPath = lastPart;
+          let prefix = "";
+
+          if (!searchPath.startsWith("/")) {
+            searchPath = `${cwd}/${searchPath}`;
+          }
+
+          // Find the directory to search
+          const lastSlash = searchPath.lastIndexOf("/");
+          const dir = lastSlash === 0 ? "/" : searchPath.substring(0, lastSlash);
+          const partial = searchPath.substring(lastSlash + 1);
+          prefix = lastPart.substring(0, lastPart.lastIndexOf("/") + 1);
+
+          // Get directory contents (sync-ish via cache)
+          const allPaths = fs.getAllPaths();
+          const matching = allPaths
+            .filter(p => p.startsWith(dir === "/" ? "/" : dir + "/"))
+            .map(p => {
+              const rel = p.substring(dir === "/" ? 1 : dir.length + 1);
+              const firstPart = rel.split("/")[0];
+              return firstPart;
+            })
+            .filter((v, i, a) => a.indexOf(v) === i) // unique
+            .filter(name => name && name.startsWith(partial))
+            .map(name => prefix + name);
+
+          completions.push(...matching);
+        } catch {
+          // Ignore completion errors
+        }
+      }
+
+      return [completions, lastPart];
+    },
+  });
+
+  // Track cwd ourselves since just-bash doesn't persist cd across exec calls
+  let cwd = "/home";
+
+  // Resolve a path relative to cwd
+  const resolvePath = (path: string): string => {
+    if (path.startsWith("/")) return path;
+    if (path === "~" || path.startsWith("~/")) {
+      return "/home" + path.slice(1);
+    }
+    const parts = (cwd + "/" + path).split("/").filter(Boolean);
+    const resolved: string[] = [];
+    for (const part of parts) {
+      if (part === "..") resolved.pop();
+      else if (part !== ".") resolved.push(part);
+    }
+    return "/" + resolved.join("/");
+  };
+
+  const promptUser = () => {
+    rl.question(getPrompt(cwd), async (line) => {
+      const trimmed = line.trim();
+
+      if (!trimmed) {
+        promptUser();
+        return;
+      }
+
+      if (trimmed === "exit" || trimmed === "quit") {
+        console.log("Goodbye!");
+        rl.close();
+        store.close();
+        process.exit(0);
+      }
+
+      try {
+        // Handle cd specially to track cwd ourselves
+        const cdMatch = trimmed.match(/^cd\s*(.*)$/);
+        if (cdMatch) {
+          const target = cdMatch[1]?.trim() || "/home";
+          const newCwd = resolvePath(target);
+
+          // Verify the directory exists
+          const exists = await fs.exists(newCwd);
+          if (!exists) {
+            console.error(`${c.red}cd: ${target}: No such file or directory${c.reset}`);
+          } else {
+            const stat = await fs.stat(newCwd);
+            if (!stat.isDirectory) {
+              console.error(`${c.red}cd: ${target}: Not a directory${c.reset}`);
+            } else {
+              cwd = newCwd;
+            }
+          }
+          promptUser();
+          return;
+        }
+
+        // Execute other commands with our tracked cwd
+        const result = await bash.exec(trimmed, { cwd });
+
+        if (result.stdout) {
+          process.stdout.write(result.stdout);
+        }
+        if (result.stderr) {
+          process.stderr.write(`${c.red}${result.stderr}${c.reset}`);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`${c.red}Error: ${msg}${c.reset}`);
+      }
+
+      promptUser();
+    });
+  };
+
+  promptUser();
+}
+
+/**
+ * Parse CLI arguments and start REPL
+ */
+async function main() {
+  const { values, positionals } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      prompt: { type: "string", short: "p" },
+      file: { type: "string", short: "f" },
+      help: { type: "boolean", short: "h" },
+    },
+    allowPositionals: true,
+  });
+
+  if (values.help) {
+    console.log(`Usage: qmd repl [options]
+
+Options:
+  -p, --prompt <text>   Initialize /home/prompt.txt with text
+  -f, --file <path>     Initialize /home/prompt.txt with file contents
+  -h, --help            Show this help message
+`);
+    process.exit(0);
+  }
+
+  let promptContent: string | undefined;
+
+  if (values.file) {
+    try {
+      promptContent = await Bun.file(values.file).text();
+    } catch (err) {
+      console.error(`Error reading file: ${values.file}`);
+      process.exit(1);
+    }
+  } else if (values.prompt) {
+    promptContent = values.prompt;
+  }
+  // Note: positionals are not used for prompt - use --prompt or --file explicitly
+
+  await startRepl({ prompt: promptContent });
+}
+
+// Export for CLI integration
+export { main as startRepl };
+
+// Run if called directly
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

This PR adds an interactive REPL (`qmd repl`) that mounts qmd collections as a read-only virtual filesystem, enabling LLMs to interact with large knowledge bases **symbolically through shell commands** rather than loading everything into context.

## Motivation: Recursive Language Models (RLMs)

This is groundwork for implementing [RLM (Recursive Language Models)](https://arxiv.org/html/2512.24601v1) - an inference-time strategy that allows LLMs to process inputs **far beyond their context windows**.

### The Key Insight

Instead of tokenizing massive documents directly into the model's context, RLMs treat the knowledge base as **part of the environment that the LLM can symbolically interact with**. The model writes commands to:

- **Filter** context using grep/search based on learned patterns
- **Chunk** information and query recursively
- **Verify** answers through additional searches
- **Build** outputs by composing results in files

This enables handling inputs **two orders of magnitude beyond model context windows**.

### Why Bash Instead of Python

We use [just-bash](https://github.com/anthropics/just-bash) - a sandboxed bash environment - because:

1. **LLMs are excellent at shell commands** - grep, cat, head, tail, find are intuitive
2. **Composability** - Unix pipes naturally chain operations
3. **Safety** - just-bash provides a sandboxed virtual filesystem
4. **Simplicity** - No Python runtime overhead, just text processing

## What This PR Adds

- **Virtual filesystem**: All qmd collections mounted read-only at `/qmd/<collection>/`
- **Writable workspace**: Home directory at `/home/` for intermediate results
- **Search primitives**: `search` (BM25) and `query` (hybrid) commands built-in
- **Standard tools**: `ls`, `cat`, `head`, `tail`, `grep`, `find`, `awk`, etc.
- **Prompt injection**: `--prompt` or `--file` flags to seed `/home/prompt.txt`

## Usage

```bash
qmd repl                          # Start interactive REPL
qmd repl --prompt "Find all mentions of product strategy"
qmd repl --file ./task.md         # Load task description
```

Inside the REPL:
```bash
cd /qmd/journals
ls | wc -l                        # Count files
search "company strategy"         # Semantic search
grep -l "revenue" *.md            # Find files mentioning revenue
cat 2025-01-15.md | head -50      # Read snippet
echo "Found: $result" >> /home/notes.txt  # Save findings
```

## Example RLM-style Workflow

```bash
# 1. Discover relevant documents
search "quarterly goals" > /home/candidates.txt

# 2. Filter and examine
for f in $(cat /home/candidates.txt | head -5); do
  echo "=== $f ===" >> /home/summary.txt
  cat "/qmd/$f" | head -30 >> /home/summary.txt
done

# 3. Output is in /home/summary.txt for the LLM to read back
```

---

🤖 Generated with [Claude Code](https://claude.ai/code)