### PR TITLE
Make docid lookup more lenient with quotes support

### DIFF
--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -19,6 +19,7 @@ import {
   renameCollection,
   findSimilarFiles,
   findDocumentByDocid,
+  isDocid,
   matchFilesByGlob,
   getHashesNeedingEmbedding,
   getHashesForEmbedding,
@@ -698,8 +699,8 @@ function getDocument(filename: string, fromLine?: number, maxLines?: number, lin
     }
   }
 
-  // Handle docid lookup (#hash or 6-char hex)
-  if (inputPath.startsWith('#') || /^[a-f0-9]{6}$/i.test(inputPath)) {
+  // Handle docid lookup (#abc123, abc123, "#abc123", "abc123", etc.)
+  if (isDocid(inputPath)) {
     const docidMatch = findDocumentByDocid(db, inputPath);
     if (docidMatch) {
       inputPath = docidMatch.filepath;


### PR DESCRIPTION
## Summary
- Add `normalizeDocid()` to strip quotes and # prefix
- Add `isDocid()` to detect docid patterns including quoted forms
- Update `findDocumentByDocid`, `findDocument`, `getDocument` to use new helpers

All formats now work: `#abc123`, `abc123`, `"#abc123"`, `"abc123"`, `'#abc123'`, `'abc123'`

## Test plan
- [x] Added 18 unit tests for `normalizeDocid` and `isDocid`
- [x] All 164 store tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)