### PR TITLE
Fix DisposedError during slow batch embedding

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -549,6 +549,7 @@ export class LlamaCpp implements LLM {
         texts.map(async (text) => {
           try {
             const embedding = await context.getEmbeddingFor(text);
+            this.touchActivity();  // Keep-alive during slow batches
             return {
               embedding: Array.from(embedding.vector),
               model: this.embedModelUri,


### PR DESCRIPTION
Call touchActivity() after each successful embedding to prevent the inactivity timeout from disposing the context mid-batch.

On slow systems (CPU-only), batch embedding can take much longer than the 2-minute inactivity timeout, causing the context to be disposed while embeddings are still in progress.

Fixes #40