### PR TITLE
fix: prevent disposal crashes and reduce memory usage

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -149,8 +149,8 @@ export type RerankDocument = {
 // Format: hf:<user>/<repo>/<file>
 const DEFAULT_EMBED_MODEL = "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";
 const DEFAULT_RERANK_MODEL = "hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf";
-// const DEFAULT_GENERATE_MODEL = "hf:ggml-org/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf";
-const DEFAULT_GENERATE_MODEL = "hf:ggml-org/Qwen3-1.7B-GGUF/Qwen3-1.7B-Q8_0.gguf";
+const DEFAULT_GENERATE_MODEL = "hf:ggml-org/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf";
+// const DEFAULT_GENERATE_MODEL = "hf:ggml-org/Qwen3-1.7B-GGUF/Qwen3-1.7B-Q8_0.gguf";
 
 // Local model cache directory
 const MODEL_CACHE_DIR = join(homedir(), ".cache", "qmd", "models");
@@ -225,8 +225,8 @@ export type LlamaCppConfig = {
 /**
  * LLM implementation using node-llama-cpp
  */
-// Default inactivity timeout: 2 minutes
-const DEFAULT_INACTIVITY_TIMEOUT_MS = 2 * 60 * 1000;
+// Default inactivity timeout: 10 minutes (increased to avoid disposal during long reranking)
+const DEFAULT_INACTIVITY_TIMEOUT_MS = 10 * 60 * 1000;
 
 export class LlamaCpp implements LLM {
   private llama: Llama | null = null;
@@ -549,6 +549,7 @@ export class LlamaCpp implements LLM {
         texts.map(async (text) => {
           try {
             const embedding = await context.getEmbeddingFor(text);
+            this.touchActivity();  // Keep-alive during slow batches (fix for issue #40)
             return {
               embedding: Array.from(embedding.vector),
               model: this.embedModelUri,
@@ -734,6 +735,7 @@ Final Output:`;
 
     // Use the proper ranking API - returns [{document: string, score: number}] sorted by score
     const ranked = await context.rankAndSort(query, texts);
+    this.touchActivity();  // Keep-alive after reranking completes
 
     // Map back to our result format using the text-to-doc map
     const results: RerankDocumentResult[] = ranked.map((item) => {
@@ -796,10 +798,13 @@ let defaultLlamaCpp: LlamaCpp | null = null;
 
 /**
  * Get the default LlamaCpp instance (creates one if needed)
+ * Disables inactivity timeout to prevent GC crashes during disposal (Bun/node-llama-cpp issue)
  */
 export function getDefaultLlamaCpp(): LlamaCpp {
   if (!defaultLlamaCpp) {
-    defaultLlamaCpp = new LlamaCpp();
+    defaultLlamaCpp = new LlamaCpp({
+      inactivityTimeoutMs: 0,  // Disable auto-disposal to avoid GC crash
+    });
   }
   return defaultLlamaCpp;
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -1928,6 +1928,10 @@ export async function expandQuery(query: string, model: string = DEFAULT_QUERY_M
 // Reranking
 // =============================================================================
 
+// Max characters per document for reranking (~500 tokens)
+// Prevents context overflow with large documents
+const RERANK_MAX_CHARS = 1500;
+
 export async function rerank(query: string, documents: { file: string; text: string }[], model: string = DEFAULT_RERANK_MODEL, db: Database): Promise<{ file: string; score: number }[]> {
   const cachedResults: Map<string, number> = new Map();
   const uncachedDocs: RerankDocument[] = [];
@@ -1939,7 +1943,11 @@ export async function rerank(query: string, documents: { file: string; text: str
     if (cached !== null) {
       cachedResults.set(doc.file, parseFloat(cached));
     } else {
-      uncachedDocs.push({ file: doc.file, text: doc.text });
+      // Truncate document text to prevent context overflow
+      const truncatedText = doc.text.length > RERANK_MAX_CHARS
+        ? doc.text.slice(0, RERANK_MAX_CHARS) + "..."
+        : doc.text;
+      uncachedDocs.push({ file: doc.file, text: truncatedText });
     }
   }
 


### PR DESCRIPTION
## Summary

This PR addresses several stability issues affecting systems with limited GPU memory (tested on Apple M1 16GB):

- **Fix DisposedError during slow operations** (Issue #40) - Add keep-alive calls during long-running embed/rerank operations
- **Prevent GC crash during disposal** - Disable auto-disposal to avoid Bun/node-llama-cpp NAPI finalizer bug
- **Reduce memory for query expansion** - Use Qwen3-0.6B (~800MB) instead of 1.7B (~2.2GB)
- **Prevent context overflow in reranking** - Truncate large documents to 1500 chars

## Changes

| File | Change |
|------|--------|
| `src/llm.ts` | Add `touchActivity()` after embeddings and reranking |
| `src/llm.ts` | Disable inactivity timeout for default instance |
| `src/llm.ts` | Switch to smaller Qwen3-0.6B model |
| `src/store.ts` | Truncate documents before reranking (1500 char limit) |

## Test plan

- [x] `qmd query "test" -c collection` completes without crash on M1 16GB
- [x] `qmd embed` should no longer fail with DisposedError on slow systems
- [x] Reranking large documents no longer causes context overflow

## Related Issues

- Fixes #40 (DisposedError on slow systems)

---

🤖 Generated with [Claude Code](https://claude.ai/code)