### PR TITLE
feat: add graph layer for entity relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,64 @@ qmd multi-get "docs/*.md" --json
 qmd cleanup
 ```
 
+## Graph Layer
+
+QMD includes a lightweight graph layer for storing relationships between entities (people, companies, topics, etc.) alongside your documents.
+
+### Entity Management
+
+```bash
+# Create entities
+qmd graph entity add person "Joe Bloggs"
+qmd graph entity add company "Acme Corp"
+qmd graph entity add topic "Software Dev"
+
+# List and search entities
+qmd graph entity list                    # All entities
+qmd graph entity list --type person      # Filter by type
+qmd graph entity search "Joe"          # FTS search
+
+# Delete an entity (also removes its edges)
+qmd graph entity rm person:joe-bloggs
+```
+
+### Relationships (Edges)
+
+```bash
+# Create relationships
+qmd graph edge add person:joe-bloggs works_at company:acme-corp
+qmd graph edge add person:john-smith owns company:acme-corp
+qmd graph edge add company:acme-corp related_to topic:software-dev
+
+# List edges
+qmd graph edge list person:joe-bloggs           # All edges
+qmd graph edge list company:acme-corp --dir in    # Incoming only
+qmd graph edge list person:john-smith --rel owns    # Filter by relation
+
+# Delete edges
+qmd graph edge rm person:joe-bloggs company:acme-corp
+```
+
+### Graph Traversal
+
+```bash
+# Find connected nodes (default: 2 hops)
+qmd graph traverse person:john-smith
+qmd graph traverse company:acme-corp --depth 3
+
+# Find shortest path between nodes
+qmd graph path person:joe-bloggs person:john-smith
+
+# Graph statistics
+qmd graph stats
+```
+
+### Use Cases
+
+- **Memory systems**: Track relationships between people, companies, and projects
+- **Knowledge graphs**: Connect documents to entities they mention
+- **Agent context**: Build rich context by traversing relationships
+
 ## Data Storage
 
 Index stored in: `~/.cache/qmd/index.sqlite`

--- a/src/graph.test.ts
+++ b/src/graph.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for the graph layer (entities, edges, traversal)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import {
+  initGraphSchema,
+  createEntity,
+  getEntity,
+  listEntities,
+  searchEntities,
+  deleteEntity,
+  createEdge,
+  getEdges,
+  deleteEdge,
+  traverse,
+  findPath,
+  getGraphStats,
+  entityId,
+} from "./graph";
+
+describe("Graph Layer", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    initGraphSchema(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  describe("entityId", () => {
+    it("creates slugified entity IDs", () => {
+      expect(entityId("person", "John Smith")).toBe("person:john-smith");
+      expect(entityId("company", "Acme Corp")).toBe("company:acme-corp");
+      expect(entityId("topic", "AI & ML")).toBe("topic:ai-ml");
+    });
+  });
+
+  describe("Entity CRUD", () => {
+    it("creates and retrieves entities", () => {
+      const entity = createEntity(db, "person", "John Smith");
+      expect(entity.id).toBe("person:john-smith");
+      expect(entity.type).toBe("person");
+      expect(entity.name).toBe("John Smith");
+
+      const retrieved = getEntity(db, "person:john-smith");
+      expect(retrieved).not.toBeNull();
+      expect(retrieved!.name).toBe("John Smith");
+    });
+
+    it("creates entities with custom IDs", () => {
+      const entity = createEntity(db, "person", "John", "custom-id");
+      expect(entity.id).toBe("custom-id");
+    });
+
+    it("creates entities with metadata", () => {
+      const entity = createEntity(db, "person", "John", undefined, { role: "founder" });
+      expect(entity.metadata).toEqual({ role: "founder" });
+
+      const retrieved = getEntity(db, "person:john");
+      expect(retrieved!.metadata).toEqual({ role: "founder" });
+    });
+
+    it("upserts on conflict", () => {
+      createEntity(db, "person", "John", undefined, { v: 1 });
+      createEntity(db, "person", "John Updated", "person:john", { v: 2 });
+
+      const entity = getEntity(db, "person:john");
+      expect(entity!.name).toBe("John Updated");
+      expect(entity!.metadata).toEqual({ v: 2 });
+    });
+
+    it("lists entities by type", () => {
+      createEntity(db, "person", "John");
+      createEntity(db, "person", "Joe");
+      createEntity(db, "company", "Acme Corp");
+
+      const people = listEntities(db, "person");
+      expect(people.length).toBe(2);
+
+      const companies = listEntities(db, "company");
+      expect(companies.length).toBe(1);
+
+      const all = listEntities(db);
+      expect(all.length).toBe(3);
+    });
+
+    it("searches entities by name", () => {
+      createEntity(db, "person", "John Smith");
+      createEntity(db, "person", "Joe Bloggs");
+      createEntity(db, "company", "Smith Industries");
+
+      const results = searchEntities(db, "Smith");
+      expect(results.length).toBe(2);
+      expect(results.map(r => r.id)).toContain("person:john-smith");
+    });
+
+    it("deletes entities and their edges", () => {
+      createEntity(db, "person", "John");
+      createEntity(db, "company", "Acme Corp");
+      createEdge(db, "person:john", "company:acme-corp", "owns");
+
+      expect(getEdges(db, "person:john").length).toBe(1);
+
+      deleteEntity(db, "person:john");
+
+      expect(getEntity(db, "person:john")).toBeNull();
+      expect(getEdges(db, "company:acme-corp").length).toBe(0);
+    });
+  });
+
+  describe("Edge CRUD", () => {
+    beforeEach(() => {
+      createEntity(db, "person", "John");
+      createEntity(db, "person", "Joe");
+      createEntity(db, "company", "Acme Corp");
+    });
+
+    it("creates edges between entities", () => {
+      const edge = createEdge(db, "person:john", "company:acme-corp", "owns");
+      expect(edge.source_id).toBe("person:john");
+      expect(edge.target_id).toBe("company:acme-corp");
+      expect(edge.relation).toBe("owns");
+      expect(edge.weight).toBe(1.0);
+    });
+
+    it("creates edges with weights", () => {
+      const edge = createEdge(db, "person:john", "person:joe", "knows", 0.8);
+      expect(edge.weight).toBe(0.8);
+    });
+
+    it("gets outgoing edges", () => {
+      createEdge(db, "person:john", "company:acme-corp", "owns");
+      createEdge(db, "person:joe", "company:acme-corp", "works_at");
+
+      const outgoing = getEdges(db, "person:john", "outgoing");
+      expect(outgoing.length).toBe(1);
+      expect(outgoing[0]!.relation).toBe("owns");
+    });
+
+    it("gets incoming edges", () => {
+      createEdge(db, "person:john", "company:acme-corp", "owns");
+      createEdge(db, "person:joe", "company:acme-corp", "works_at");
+
+      const incoming = getEdges(db, "company:acme-corp", "incoming");
+      expect(incoming.length).toBe(2);
+    });
+
+    it("gets edges by relation", () => {
+      createEdge(db, "person:john", "company:acme-corp", "owns");
+      createEdge(db, "person:john", "person:joe", "knows");
+
+      const owns = getEdges(db, "person:john", "both", "owns");
+      expect(owns.length).toBe(1);
+    });
+
+    it("deletes specific edges", () => {
+      createEdge(db, "person:john", "company:acme-corp", "owns");
+      createEdge(db, "person:john", "company:acme-corp", "founded");
+
+      deleteEdge(db, "person:john", "company:acme-corp", "owns");
+
+      const remaining = getEdges(db, "person:john");
+      expect(remaining.length).toBe(1);
+      expect(remaining[0]!.relation).toBe("founded");
+    });
+
+    it("upserts edges on conflict", () => {
+      createEdge(db, "person:john", "company:acme-corp", "owns", 0.5);
+      createEdge(db, "person:john", "company:acme-corp", "owns", 1.0);
+
+      const edges = getEdges(db, "person:john", "outgoing", "owns");
+      expect(edges.length).toBe(1);
+      expect(edges[0]!.weight).toBe(1.0);
+    });
+  });
+
+  describe("Graph Traversal", () => {
+    beforeEach(() => {
+      // Create a small graph:
+      // John --owns--> Acme Corp <--works_at-- Joe
+      //   |                                      |
+      //   +--knows--> Joe <--mentor-- Bob
+      createEntity(db, "person", "John");
+      createEntity(db, "person", "Joe");
+      createEntity(db, "person", "Bob");
+      createEntity(db, "company", "Acme Corp");
+
+      createEdge(db, "person:john", "company:acme-corp", "owns");
+      createEdge(db, "person:joe", "company:acme-corp", "works_at");
+      createEdge(db, "person:john", "person:joe", "knows");
+      createEdge(db, "person:bob", "person:joe", "mentors");
+    });
+
+    it("traverses from a node", () => {
+      const results = traverse(db, "person:john", 1);
+      expect(results.length).toBe(2); // Acme Corp and Joe
+      expect(results.map(r => r.node_id)).toContain("company:acme-corp");
+      expect(results.map(r => r.node_id)).toContain("person:joe");
+    });
+
+    it("traverses multiple hops", () => {
+      const results = traverse(db, "person:john", 2);
+      // Should find: Acme Corp (1 hop), Joe (1 hop), Bob (2 hops via Joe)
+      expect(results.map(r => r.node_id)).toContain("person:bob");
+    });
+
+    it("respects direction constraints", () => {
+      const outgoing = traverse(db, "person:john", 2, undefined, "outgoing");
+      // Only follows outgoing edges from john: owns -> Acme Corp, knows -> Joe
+      expect(outgoing.map(r => r.node_id)).toContain("company:acme-corp");
+      expect(outgoing.map(r => r.node_id)).toContain("person:joe");
+      // Bob's edge points TO Joe, so shouldn't be found in outgoing traversal from John
+    });
+
+    it("filters by relation types", () => {
+      const results = traverse(db, "person:john", 2, ["owns"]);
+      expect(results.length).toBe(1);
+      expect(results[0]!.node_id).toBe("company:acme-corp");
+    });
+
+    it("tracks path and relations", () => {
+      const results = traverse(db, "person:john", 2);
+      const joe = results.find(r => r.node_id === "person:joe" && r.depth === 1);
+      expect(joe).toBeDefined();
+      expect(joe!.path).toEqual(["person:john", "person:joe"]);
+      expect(joe!.relations).toEqual(["knows"]);
+    });
+  });
+
+  describe("Path Finding", () => {
+    beforeEach(() => {
+      createEntity(db, "person", "A");
+      createEntity(db, "person", "B");
+      createEntity(db, "person", "C");
+      createEntity(db, "person", "D");
+
+      // A -> B -> C -> D
+      createEdge(db, "person:a", "person:b", "next");
+      createEdge(db, "person:b", "person:c", "next");
+      createEdge(db, "person:c", "person:d", "next");
+    });
+
+    it("finds path between nodes", () => {
+      const path = findPath(db, "person:a", "person:d");
+      expect(path).not.toBeNull();
+      expect(path!.depth).toBe(3);
+      expect(path!.path).toEqual(["person:a", "person:b", "person:c", "person:d"]);
+    });
+
+    it("returns null when no path exists", () => {
+      createEntity(db, "person", "Isolated");
+      const path = findPath(db, "person:a", "person:isolated");
+      expect(path).toBeNull();
+    });
+
+    it("respects max depth", () => {
+      const path = findPath(db, "person:a", "person:d", 2);
+      expect(path).toBeNull(); // Path requires 3 hops
+    });
+  });
+
+  describe("Graph Statistics", () => {
+    it("returns correct stats", () => {
+      createEntity(db, "person", "John");
+      createEntity(db, "person", "Joe");
+      createEntity(db, "company", "Acme Corp");
+      createEdge(db, "person:john", "company:acme-corp", "owns");
+      createEdge(db, "person:joe", "company:acme-corp", "works_at");
+
+      const stats = getGraphStats(db);
+      expect(stats.entity_count).toBe(3);
+      expect(stats.edge_count).toBe(2);
+      expect(stats.entity_types).toEqual({ person: 2, company: 1 });
+      expect(stats.relation_types).toEqual({ owns: 1, works_at: 1 });
+    });
+
+    it("handles empty graph", () => {
+      const stats = getGraphStats(db);
+      expect(stats.entity_count).toBe(0);
+      expect(stats.edge_count).toBe(0);
+      expect(stats.entity_types).toEqual({});
+      expect(stats.relation_types).toEqual({});
+    });
+  });
+});

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -1,0 +1,259 @@
+/**
+ * QMD Graph - Lightweight graph layer for qmd
+ *
+ * Adds entity and edge storage to qmd's SQLite database,
+ * enabling relationship traversal alongside vector/BM25 search.
+ */
+
+import { Database } from "bun:sqlite";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface Entity {
+  id: string;
+  type: string;
+  name: string;
+  metadata?: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Edge {
+  id: number;
+  source_id: string;
+  target_id: string;
+  relation: string;
+  weight: number;
+  metadata?: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface TraversalResult {
+  node_id: string;
+  node_type: 'entity' | 'document';
+  depth: number;
+  path: string[];
+  relations: string[];
+}
+
+export interface GraphStats {
+  entity_count: number;
+  edge_count: number;
+  entity_types: Record<string, number>;
+  relation_types: Record<string, number>;
+}
+
+// =============================================================================
+// Schema Initialization
+// =============================================================================
+
+export function initGraphSchema(db: Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS entities (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      name TEXT NOT NULL,
+      metadata TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_entities_type ON entities(type)`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_entities_name ON entities(name)`);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS edges (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      source_id TEXT NOT NULL,
+      target_id TEXT NOT NULL,
+      relation TEXT NOT NULL,
+      weight REAL NOT NULL DEFAULT 1.0,
+      metadata TEXT,
+      created_at TEXT NOT NULL,
+      UNIQUE(source_id, target_id, relation)
+    )
+  `);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source_id)`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target_id)`);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_edges_relation ON edges(relation)`);
+
+  db.exec(`
+    CREATE VIRTUAL TABLE IF NOT EXISTS entities_fts USING fts5(
+      id, name, type,
+      tokenize='porter unicode61'
+    )
+  `);
+
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS entities_ai AFTER INSERT ON entities
+    BEGIN
+      INSERT INTO entities_fts(rowid, id, name, type)
+      VALUES (new.rowid, new.id, new.name, new.type);
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS entities_ad AFTER DELETE ON entities
+    BEGIN
+      DELETE FROM entities_fts WHERE rowid = old.rowid;
+    END
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS entities_au AFTER UPDATE ON entities
+    BEGIN
+      DELETE FROM entities_fts WHERE rowid = old.rowid;
+      INSERT INTO entities_fts(rowid, id, name, type)
+      VALUES (new.rowid, new.id, new.name, new.type);
+    END
+  `);
+}
+
+// =============================================================================
+// Entity CRUD
+// =============================================================================
+
+function slugify(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+export function entityId(type: string, name: string): string {
+  return `${type}:${slugify(name)}`;
+}
+
+export function createEntity(
+  db: Database, type: string, name: string, id?: string, metadata?: Record<string, unknown>
+): Entity {
+  const eid = id || entityId(type, name);
+  const now = new Date().toISOString();
+  const metadataJson = metadata ? JSON.stringify(metadata) : null;
+  db.prepare(`
+    INSERT INTO entities (id, type, name, metadata, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET name = excluded.name, metadata = excluded.metadata, updated_at = excluded.updated_at
+  `).run(eid, type, name, metadataJson, now, now);
+  return { id: eid, type, name, metadata, created_at: now, updated_at: now };
+}
+
+export function getEntity(db: Database, id: string): Entity | null {
+  const row = db.prepare(`SELECT * FROM entities WHERE id = ?`).get(id) as {
+    id: string; type: string; name: string; metadata: string | null;
+    created_at: string; updated_at: string;
+  } | null;
+  if (!row) return null;
+  return { ...row, metadata: row.metadata ? JSON.parse(row.metadata) : undefined };
+}
+
+export function listEntities(db: Database, type?: string, limit = 100): Entity[] {
+  const query = type
+    ? db.prepare(`SELECT * FROM entities WHERE type = ? ORDER BY name LIMIT ?`)
+    : db.prepare(`SELECT * FROM entities ORDER BY type, name LIMIT ?`);
+  const rows = (type ? query.all(type, limit) : query.all(limit)) as Array<{
+    id: string; type: string; name: string; metadata: string | null;
+    created_at: string; updated_at: string;
+  }>;
+  return rows.map(r => ({ ...r, metadata: r.metadata ? JSON.parse(r.metadata) : undefined }));
+}
+
+export function searchEntities(db: Database, query: string, limit = 20): Entity[] {
+  const rows = db.prepare(`
+    SELECT e.* FROM entities e
+    JOIN entities_fts fts ON e.rowid = fts.rowid
+    WHERE entities_fts MATCH ?
+    ORDER BY rank LIMIT ?
+  `).all(query, limit) as Array<{
+    id: string; type: string; name: string; metadata: string | null;
+    created_at: string; updated_at: string;
+  }>;
+  return rows.map(r => ({ ...r, metadata: r.metadata ? JSON.parse(r.metadata) : undefined }));
+}
+
+export function deleteEntity(db: Database, id: string): boolean {
+  db.prepare(`DELETE FROM edges WHERE source_id = ? OR target_id = ?`).run(id, id);
+  return db.prepare(`DELETE FROM entities WHERE id = ?`).run(id).changes > 0;
+}
+
+// =============================================================================
+// Edge CRUD
+// =============================================================================
+
+export function createEdge(
+  db: Database, sourceId: string, targetId: string, relation: string, weight = 1.0, metadata?: Record<string, unknown>
+): Edge {
+  const now = new Date().toISOString();
+  const metadataJson = metadata ? JSON.stringify(metadata) : null;
+  const result = db.prepare(`
+    INSERT INTO edges (source_id, target_id, relation, weight, metadata, created_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+    ON CONFLICT(source_id, target_id, relation) DO UPDATE SET weight = excluded.weight, metadata = excluded.metadata
+  `).run(sourceId, targetId, relation, weight, metadataJson, now);
+  return { id: Number(result.lastInsertRowid), source_id: sourceId, target_id: targetId, relation, weight, metadata, created_at: now };
+}
+
+export function getEdges(db: Database, nodeId: string, direction: 'outgoing' | 'incoming' | 'both' = 'both', relation?: string): Edge[] {
+  let query: string;
+  const params: unknown[] = [];
+  if (direction === 'outgoing') { query = `SELECT * FROM edges WHERE source_id = ?`; params.push(nodeId); }
+  else if (direction === 'incoming') { query = `SELECT * FROM edges WHERE target_id = ?`; params.push(nodeId); }
+  else { query = `SELECT * FROM edges WHERE (source_id = ? OR target_id = ?)`; params.push(nodeId, nodeId); }
+  if (relation) { query += ` AND relation = ?`; params.push(relation); }
+  const rows = db.prepare(query).all(...params) as Array<{
+    id: number; source_id: string; target_id: string; relation: string;
+    weight: number; metadata: string | null; created_at: string;
+  }>;
+  return rows.map(r => ({ ...r, metadata: r.metadata ? JSON.parse(r.metadata) : undefined }));
+}
+
+export function deleteEdge(db: Database, sourceId: string, targetId: string, relation?: string): number {
+  if (relation) return db.prepare(`DELETE FROM edges WHERE source_id = ? AND target_id = ? AND relation = ?`).run(sourceId, targetId, relation).changes;
+  return db.prepare(`DELETE FROM edges WHERE source_id = ? AND target_id = ?`).run(sourceId, targetId).changes;
+}
+
+// =============================================================================
+// Graph Traversal
+// =============================================================================
+
+export function traverse(
+  db: Database, startId: string, maxDepth = 2, relations?: string[], direction: 'outgoing' | 'incoming' | 'both' = 'both'
+): TraversalResult[] {
+  const relationFilter = relations?.length ? `AND e.relation IN (${relations.map(() => '?').join(',')})` : '';
+  let edgeCondition: string, nextNode: string;
+  if (direction === 'outgoing') { edgeCondition = 'e.source_id = t.node_id'; nextNode = 'e.target_id'; }
+  else if (direction === 'incoming') { edgeCondition = 'e.target_id = t.node_id'; nextNode = 'e.source_id'; }
+  else { edgeCondition = '(e.source_id = t.node_id OR e.target_id = t.node_id)'; nextNode = "CASE WHEN e.source_id = t.node_id THEN e.target_id ELSE e.source_id END"; }
+
+  const query = `
+    WITH RECURSIVE traversal(node_id, depth, path, relations) AS (
+      SELECT ? as node_id, 0 as depth, json_array(?) as path, json_array() as relations
+      UNION ALL
+      SELECT ${nextNode}, t.depth + 1, json_insert(t.path, '$[#]', ${nextNode}), json_insert(t.relations, '$[#]', e.relation)
+      FROM traversal t JOIN edges e ON ${edgeCondition}
+      WHERE t.depth < ? AND ${nextNode} NOT IN (SELECT value FROM json_each(t.path)) ${relationFilter}
+    )
+    SELECT DISTINCT t.node_id, CASE WHEN EXISTS (SELECT 1 FROM entities WHERE id = t.node_id) THEN 'entity' ELSE 'document' END as node_type, t.depth, t.path, t.relations
+    FROM traversal t WHERE t.depth > 0 ORDER BY t.depth, t.node_id
+  `;
+  const params: unknown[] = [startId, startId, maxDepth];
+  if (relations?.length) params.push(...relations);
+  const rows = db.prepare(query).all(...params) as Array<{
+    node_id: string; node_type: 'entity' | 'document'; depth: number; path: string; relations: string;
+  }>;
+  return rows.map(r => ({ node_id: r.node_id, node_type: r.node_type, depth: r.depth, path: JSON.parse(r.path), relations: JSON.parse(r.relations) }));
+}
+
+export function findPath(db: Database, fromId: string, toId: string, maxDepth = 5): TraversalResult | null {
+  const results = traverse(db, fromId, maxDepth, undefined, 'both');
+  return results.find(r => r.node_id === toId) || null;
+}
+
+export function getGraphStats(db: Database): GraphStats {
+  const entityCount = (db.prepare(`SELECT COUNT(*) as cnt FROM entities`).get() as { cnt: number }).cnt;
+  const edgeCount = (db.prepare(`SELECT COUNT(*) as cnt FROM edges`).get() as { cnt: number }).cnt;
+  const entityTypes = db.prepare(`SELECT type, COUNT(*) as cnt FROM entities GROUP BY type`).all() as Array<{ type: string; cnt: number }>;
+  const relationTypes = db.prepare(`SELECT relation, COUNT(*) as cnt FROM edges GROUP BY relation`).all() as Array<{ relation: string; cnt: number }>;
+  return {
+    entity_count: entityCount, edge_count: edgeCount,
+    entity_types: Object.fromEntries(entityTypes.map(r => [r.type, r.cnt])),
+    relation_types: Object.fromEntries(relationTypes.map(r => [r.relation, r.cnt])),
+  };
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -23,6 +23,25 @@ import {
   type RerankDocument,
 } from "./llm";
 import {
+  initGraphSchema,
+  createEntity,
+  getEntity,
+  listEntities,
+  searchEntities,
+  deleteEntity,
+  createEdge,
+  getEdges,
+  deleteEdge,
+  traverse,
+  findPath,
+  getGraphStats,
+  entityId,
+  type Entity,
+  type Edge,
+  type TraversalResult,
+  type GraphStats,
+} from "./graph";
+import {
   findContextForPath as collectionsFindContextForPath,
   addContext as collectionsAddContext,
   removeContext as collectionsRemoveContext,
@@ -558,6 +577,9 @@ function initializeDatabase(db: Database): void {
       WHERE new.active = 1;
     END
   `);
+
+  // Initialize graph schema (entities + edges)
+  initGraphSchema(db);
 }
 
 
@@ -2566,3 +2588,26 @@ export function extractSnippet(body: string, query: string, maxLen = 500, chunkP
     snippetLines: snippetLineCount,
   };
 }
+
+// =============================================================================
+// Graph Re-exports
+// =============================================================================
+
+export {
+  createEntity,
+  getEntity,
+  listEntities,
+  searchEntities,
+  deleteEntity,
+  createEdge,
+  getEdges,
+  deleteEdge,
+  traverse,
+  findPath,
+  getGraphStats,
+  entityId,
+  type Entity,
+  type Edge,
+  type TraversalResult,
+  type GraphStats,
+};


### PR DESCRIPTION
## Summary

Add a lightweight graph layer for storing and querying relationships between entities (people, companies, topics, etc.) alongside documents. This enables building knowledge graphs and memory systems for AI agents.

## Features

- **Entity management**: Create, list, search, and delete named nodes
- **Edge management**: Create relationships with optional weights  
- **Graph traversal**: Multi-hop queries via recursive CTEs
- **Path finding**: Find shortest path between any two nodes
- **FTS search**: Full-text search on entity names
- **Statistics**: Entity/edge counts by type

## CLI Commands

```bash
# Entities
qmd graph entity add person "Joe Bloggs"
qmd graph entity add company "Acme Corp"
qmd graph entity list --type person
qmd graph entity search "Joe"

# Relationships
qmd graph edge add person:joe-bloggs works_at company:acme-corp
qmd graph edge list person:joe-bloggs

# Traversal
qmd graph traverse person:joe-bloggs --depth 3
qmd graph path person:joe person:jane

# Stats
qmd graph stats
```

## Use Cases

- **Memory systems**: Track relationships between people, companies, projects
- **Knowledge graphs**: Connect documents to entities they mention
- **Agent context**: Build rich context by traversing relationships

## Testing

All 25 tests pass:
```
bun test src/graph.test.ts
25 pass, 0 fail
```
