### PR TITLE
qmd: agentic ask + bridgeCandidates + LLM dispose fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ qmd search "project timeline"           # Fast keyword search
 qmd vsearch "how to deploy"             # Semantic search
 qmd query "quarterly planning process"  # Hybrid + reranking (best quality)
 
+# Ask (agentic RAG) - answer with citations
+qmd ask "What is the quarterly planning process?" --json
+qmd ask "How do we deploy?" --json --dry-run --explain
+qmd ask "How do we deploy?" --json --bridge-candidates 30
+
 # Get a specific document
 qmd get "meetings/2024-01-15.md"
 
@@ -64,12 +69,24 @@ qmd get "docs/api-reference.md" --full
 Although the tool works perfectly fine when you just tell your agent to use it on the command line, it also exposes an MCP (Model Context Protocol) server for tighter integration.
 
 **Tools exposed:**
-- `qmd_search` - Fast BM25 keyword search (supports collection filter)
-- `qmd_vsearch` - Semantic vector search (supports collection filter)
-- `qmd_query` - Hybrid search with reranking (supports collection filter)
-- `qmd_get` - Retrieve document by path or docid (with fuzzy matching suggestions)
-- `qmd_multi_get` - Retrieve multiple documents by glob pattern, list, or docids
-- `qmd_status` - Index health and collection info
+- `search` - Fast BM25 keyword search (supports collection filter)
+- `vsearch` - Semantic vector search (supports collection filter)
+- `query` - Hybrid search with reranking (supports collection filter)
+- `get` - Retrieve document by path or docid (with fuzzy matching suggestions)
+- `multi_get` - Retrieve multiple documents by glob pattern, list, or docids
+- `status` - Index health and collection info
+- `ask` - Agentic RAG: returns `{ status, answer?, citations, trace? }`
+
+**ask tool parameters (high-level):**
+- `query` (string)
+- `collection` (optional string)
+- `limit` (optional number)
+- `maxSteps` (optional number)
+- `context` (optional string)
+- `dryRun` (optional boolean)
+- `explain` (optional boolean)
+- `minScore` (optional number)
+- `bridgeCandidates` (optional number)
 
 **Claude Desktop configuration** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -462,6 +462,15 @@ describe("CLI Output Formats", () => {
     expect(stdout).toContain(".md");
   });
 
+  test("ask with --json flag outputs JSON", async () => {
+    // Use dry-run to avoid requiring generation model for this test.
+    const { stdout, exitCode } = await runQmd(["ask", "--json", "--dry-run", "test"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(typeof parsed.status).toBe("string");
+    expect(Array.isArray(parsed.citations)).toBe(true);
+  });
+
   test("search output includes snippets by default", async () => {
     const { stdout, exitCode } = await runQmd(["search", "API"]);
     expect(exitCode).toBe(0);

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -187,6 +187,7 @@ import {
   getDocumentBody,
   findDocuments,
   getStatus,
+  ask,
   DEFAULT_EMBED_MODEL,
   DEFAULT_QUERY_MODEL,
   DEFAULT_RERANK_MODEL,
@@ -884,6 +885,16 @@ QMD is your on-device search engine for markdown knowledge bases.`;
         expect(typeof col.pattern).toBe("string");
         expect(typeof col.documents).toBe("number");
       }
+    });
+
+    test("ask returns structured result shape", async () => {
+      const store = createStore(testDbPath);
+      const result = await store.ask("readme", { dryRun: true, explain: true, limit: 3 });
+      expect(["answered", "needs_more_context", "abstain"]).toContain(result.status);
+      expect(Array.isArray(result.citations)).toBe(true);
+      // In explain mode, trace should exist
+      expect(result.trace && Array.isArray(result.trace.steps)).toBe(true);
+      store.close();
     });
   });
 });

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1905,6 +1905,19 @@ describe("LlamaCpp Integration", () => {
     await cleanupTestDb(store);
   }, 30000);
 
+  test("expandQueryTyped returns typed queryables", async () => {
+    const store = await createTestStore();
+
+    const qs = await store.expandQueryTyped("test query", { includeLexical: true, context: "", scope: "local" });
+    expect(Array.isArray(qs)).toBe(true);
+    if (qs.length > 0) {
+      expect(["lex", "vec", "hyde"]).toContain(qs[0]!.type);
+      expect(typeof qs[0]!.text).toBe("string");
+    }
+
+    await cleanupTestDb(store);
+  }, 30000);
+
   test("expandQuery caches results", async () => {
     const store = await createTestStore();
 


### PR DESCRIPTION
## Summary
- Add agentic `ask` (CLI + MCP) that answers with citations, with bounded stepwise retrieval escalation.
- Improve bridge-stage recall by selecting bridge collections dynamically and supporting `--bridge-candidates` / `bridgeCandidates`.
- Fix Bun/NAPI finalizer crash risk by ensuring deterministic LLM disposal and keeping strong references to disposed instances.

## Test plan
- [x] bun test