### PR TITLE
fix: normalize Unicode paths to NFC for macOS compatibility

### DIFF
--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -2,6 +2,7 @@
 import { Database } from "bun:sqlite";
 import { Glob, $ } from "bun";
 import { parseArgs } from "util";
+import { readFileSync, statSync } from "fs";
 import * as sqliteVec from "sqlite-vec";
 import {
   getPwd,
@@ -281,7 +282,7 @@ function showStatus(): void {
   // Index size
   let indexSize = 0;
   try {
-    const stat = Bun.file(dbPath).size;
+    const stat = statSync(dbPath).size;
     indexSize = stat;
   } catch { }
 
@@ -1401,7 +1402,7 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
     const path = handelize(relativeFile); // Normalize path for token-friendliness
     seenPaths.add(path);
 
-    const content = await Bun.file(filepath).text();
+    const content = readFileSync(filepath, "utf-8");
 
     // Skip empty files - nothing useful to index
     if (!content.trim()) {
@@ -1427,7 +1428,7 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
       } else {
         // Content changed - insert new content hash and update document
         insertContent(db, hash, content, now);
-        const stat = await Bun.file(filepath).stat();
+        const stat = statSync(filepath);
         updateDocument(db, existing.id, title, hash,
           stat ? new Date(stat.mtime).toISOString() : now);
         updated++;
@@ -1436,7 +1437,7 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
       // New document - insert content and document
       indexed++;
       insertContent(db, hash, content, now);
-      const stat = await Bun.file(filepath).stat();
+      const stat = statSync(filepath);
       insertDocument(db, collectionName, path, title, hash,
         stat ? new Date(stat.birthtime).toISOString() : now,
         stat ? new Date(stat.mtime).toISOString() : now);

--- a/src/store.ts
+++ b/src/store.ts
@@ -13,7 +13,7 @@
 
 import { Database } from "bun:sqlite";
 import { Glob } from "bun";
-import { realpathSync } from "node:fs";
+import { realpathSync, statSync } from "node:fs";
 import * as sqliteVec from "sqlite-vec";
 import {
   LlamaCpp,
@@ -427,7 +427,7 @@ function setSQLiteFromBrewPrefixEnv(): void {
 
   for (const candidate of candidates) {
     try {
-      if (Bun.file(candidate).size > 0) {
+      if (statSync(candidate).size > 0) {
         Database.setCustomSQLite(candidate);
         return;
       }


### PR DESCRIPTION
## Summary

Workaround for Bun UTF-8 path corruption bug in `Bun.file().stat()` that causes ENOENT errors when indexing files with non-ASCII characters.

## Bug Discovery

**Only `Bun.file().stat()` is affected.** Investigation revealed:

- ✗ `Bun.file(path).stat()` - **BROKEN** - corrupts UTF-8 paths internally
- ✓ `Bun.file(path).text()` - **WORKS** - uses different code path, not affected

The bug causes mojibake when Bun converts the JavaScript string to a system call path, resulting in ENOENT errors for files with non-ASCII characters (e.g., German umlauts like ö, ü, ä).

## Changes

While only `.stat()` was buggy, we standardized on Node.js `fs` module for consistency:

- **src/qmd.ts**: Use `statSync()` instead of `Bun.file().stat()` (fixes the bug)
- **src/qmd.ts**: Use `readFileSync()` instead of `Bun.file().text()` (for API consistency)
- **src/store.ts**: Use `statSync()` for SQLite custom path detection

## Impact

- Fixes indexing for files with international characters (German, French, etc.)
- Consistent sync API usage throughout the indexing pipeline
- No breaking changes - standard Node.js API

## Future Work

These workarounds can be reverted once Bun fixes the UTF-8 path handling in `Bun.file().stat()`.

## Test Plan

- Verified with paths containing non-ASCII characters
- No regressions in ASCII-only filename handling

Fixes #81
