### PR TITLE
feat: add --version/-v flag

### DIFF
--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -2303,6 +2303,7 @@ function parseCLI() {
         type: "boolean",
       },
       help: { type: "boolean", short: "h" },
+      version: { type: "boolean", short: "v" },
       // Search options
       n: { type: "string" },
       "min-score": { type: "string" },
@@ -2421,9 +2422,31 @@ function showHelp(): void {
   console.log(`Index: ${getDbPath()}`);
 }
 
+async function showVersion(): Promise<void> {
+  const scriptDir = import.meta.dir;
+  const pkgPath = resolve(scriptDir, "..", "package.json");
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+
+  let commit = "";
+  try {
+    const result = await $`git -C ${scriptDir} rev-parse --short HEAD`.quiet();
+    commit = result.text().trim();
+  } catch {
+    // Not a git repo or git not available
+  }
+
+  const versionStr = commit ? `${pkg.version} (${commit})` : pkg.version;
+  console.log(`qmd ${versionStr}`);
+}
+
 // Main CLI - only run if this is the main module
 if (import.meta.main) {
   const cli = parseCLI();
+
+  if (cli.values.version) {
+    await showVersion();
+    process.exit(0);
+  }
 
   if (!cli.command || cli.values.help) {
     showHelp();


### PR DESCRIPTION
## Summary
- Adds `--version` / `-v` flag to display version and git commit hash
- Output format: `qmd 1.0.0 (47b7054)`
- Gracefully handles non-git environments by showing version only

## Test plan
- [x] `qmd --version` outputs version with commit hash
- [x] `qmd -v` works as short form
- [x] Version flag takes precedence over help flag
- [x] Works when run from any directory (uses script location for git)

🤖 Generated with [Claude Code](https://claude.com/claude-code)