### PR TITLE
fix(docs): mcp-setup.md params out of sync with mcp.ts schemas

### DIFF
--- a/skills/qmd/references/mcp-setup.md
+++ b/skills/qmd/references/mcp-setup.md
@@ -49,7 +49,7 @@ qmd mcp stop                # Stop daemon
 
 ## Tools
 
-### structured_search
+### query
 
 Search with pre-expanded queries.
 
@@ -61,7 +61,7 @@ Search with pre-expanded queries.
     { "type": "hyde", "query": "hypothetical answer passage..." }
   ],
   "limit": 10,
-  "collection": "optional",
+  "collections": ["optional-collection-name"],
   "minScore": 0.0
 }
 ```
@@ -78,9 +78,10 @@ Retrieve document by path or `#docid`.
 
 | Param | Type | Description |
 |-------|------|-------------|
-| `path` | string | File path or `#docid` |
-| `full` | bool? | Return full content |
-| `lineNumbers` | bool? | Add line numbers |
+| `file` | string | File path or `#docid` (e.g., `pages/meeting.md`, `#abc123`, or `pages/meeting.md:100`) |
+| `fromLine` | number? | Start from this line number (1-indexed) |
+| `maxLines` | number? | Maximum number of lines to return |
+| `lineNumbers` | bool? | Add line numbers to output |
 
 ### multi_get
 
@@ -89,7 +90,9 @@ Retrieve multiple documents.
 | Param | Type | Description |
 |-------|------|-------------|
 | `pattern` | string | Glob or comma-separated list |
+| `maxLines` | number? | Maximum lines per file |
 | `maxBytes` | number? | Skip large files (default 10KB) |
+| `lineNumbers` | bool? | Add line numbers to output |
 
 ### status
 


### PR DESCRIPTION
v1.1.0 rewrote the MCP layer but `mcp-setup.md` wasn't updated. Wrong tool name, wrong param names, ghost params that don't exist.

## What was wrong

Verified line-by-line against `inputSchema` in `src/mcp.ts`:

| Location | Was | Now | Source |
|----------|-----|-----|--------|
| Tool name | `structured_search` | `query` | `mcp.ts:243` |
| `query` example | `"collection": "optional"` | `"collections": ["optional-collection-name"]` | `mcp.ts:310`, `z.array(z.string())` |
| `get` param | `path` | `file` | `mcp.ts:364` |
| `get` param | `full` (doesn't exist) | removed | |
| `get` params | missing | `fromLine`, `maxLines` | `mcp.ts:365-366` |
| `multi_get` params | missing | `maxLines`, `lineNumbers` | `mcp.ts:430,432` |

The `collection` -> `collections` one is the worst. Sending `{ "collection": "docs" }` gets silently ignored by the schema validator. Filter never applies.

## Changes

`skills/qmd/references/mcp-setup.md` only (+8/-5).

## Test plan

- [x] `query` matches `server.registerTool("query", ...)` at `mcp.ts:243`
- [x] `collections` is `z.array(z.string()).optional()` at `mcp.ts:310`
- [x] `get` params match `mcp.ts:364-367` (`file`, `fromLine`, `maxLines`, `lineNumbers`)
- [x] `multi_get` params match `mcp.ts:429-432` (`pattern`, `maxLines`, `maxBytes`, `lineNumbers`)
- [x] `status` has no params (`mcp.ts:501: inputSchema: {}`)