### PR TITLE
fix: BM25 scoring, deterministic RRF, dead code cleanup, and CLI enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "vector": "bun src/qmd.ts vector",
     "search": "bun src/qmd.ts search",
     "vsearch": "bun src/qmd.ts vsearch",
-    "rerank": "bun src/qmd.ts rerank",
     "link": "bun link",
     "inspector": "npx @modelcontextprotocol/inspector bun src/qmd.ts mcp"
   },
@@ -46,8 +45,7 @@
     "vector",
     "sqlite",
     "bm25",
-    "embeddings",
-    "ollama"
+    "embeddings"
   ],
   "license": "MIT"
 }

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -40,7 +40,7 @@ import {
   type SearchResult,
   type RankedResult,
 } from "./store.js";
-import type { CollectionConfig } from "./collections.js";
+import { clearConfigCache, type CollectionConfig } from "./collections.js";
 
 // =============================================================================
 // LlamaCpp Setup
@@ -66,6 +66,9 @@ async function createTestStore(): Promise<Store> {
 
   // Set environment variable to use test config
   process.env.QMD_CONFIG_DIR = testConfigDir;
+
+  // Clear config cache from previous test
+  clearConfigCache();
 
   // Create empty YAML config
   const emptyConfig: CollectionConfig = { collections: {} };
@@ -172,8 +175,9 @@ async function createTestCollection(
     pattern: glob,
   };
 
-  // Write back
+  // Write back and clear cache
   await writeFile(configPath, YAML.stringify(config));
+  clearConfigCache();
   return name;
 }
 
@@ -196,8 +200,9 @@ async function addPathContext(collectionName: string, pathPrefix: string, contex
 
   config.collections[collectionName].context![pathPrefix] = contextText;
 
-  // Write back
+  // Write back and clear cache
   await writeFile(configPath, YAML.stringify(config));
+  clearConfigCache();
 }
 
 // Helper to add global context in YAML config
@@ -210,6 +215,7 @@ async function addGlobalContext(contextText: string): Promise<void> {
   config.global_context = contextText;
 
   await writeFile(configPath, YAML.stringify(config));
+  clearConfigCache();
 }
 
 // =============================================================================
@@ -884,7 +890,7 @@ describe("FTS Search", () => {
     expect(allResults).toHaveLength(2);
 
     // Filter by collection name (collectionId is now treated as collection name string)
-    const filtered = store.searchFTS("searchable", 10, collection1 as unknown as number);
+    const filtered = store.searchFTS("searchable", 10, collection1);
     expect(filtered).toHaveLength(1);
     expect(filtered[0]!.displayPath).toBe(`${collection1}/doc1.md`);
 


### PR DESCRIPTION
## Summary

Comprehensive fix pass across the search pipeline: 5 critical bug fixes, 3 structural fixes, dead code cleanup (~130 net lines removed), and 8 quality-of-life enhancements. All changes preserve the existing test suite (359/360 pass — 1 pre-existing flaky LLM test).

### P0: Critical Bug Fixes

- **BM25 score normalization** — `Math.max(0, row.bm25_score)` clamped all negative FTS5 scores to 0, making every result score 1.0. Fixed with `abs(score) / (1 + abs(score))` which preserves discriminating range
- **BM25 column weights** — Only 2 weights for 3 FTS columns (filepath, title, body). Title was unweighted. Fixed to `bm25(documents_fts, 2.0, 10.0, 1.0)` giving title the heaviest weight
- **Non-deterministic RRF** — `Promise.all` randomized search result list ordering, breaking the weight assignment that assumed the first lists were from the original query. Fixed with tagged `originalLists[]` / `expansionLists[]` + sequential vector searches (avoids concurrent embedding hangs)
- **`--context` flag** — Parsed by `parseArgs` but never assigned to the opts object

### P1: Structural Fixes

- **Rerank text collision** — `Map<string, {file, index}>` keyed by document text silently dropped duplicates. Changed to array-based lookup with `shift()` for correct 1:1 mapping
- **`searchFTS` type signature** — Parameter was `collectionId?: number` but callers passed strings via `as any`. Changed to `collectionName?: string`, removed all 5 `as any` casts
- **MCP test FTS schema** — Test created FTS with `(name, body)` but production uses `(filepath, title, body)`. Aligned test schema and triggers

### P2: Dead Code Cleanup

- Deleted 6 dead functions from `qmd.ts` (0 call sites each): `computeDisplayPath`, `normalizeBM25`, `normalizeScores`, `shortPath`, `sanitizeFTS5Term`, `buildFTS5Query`
- Deleted 5 dead exports from `store.ts`: `insertContext`, `deleteContext`, `deleteGlobalContexts`, `listPathContexts`, `getAllCollections`
- Consolidated duplicates: `reciprocalRankFusion` (imported from store.ts), `addLineNumbers` (imported from formatter.ts)
- Upgraded `buildFTS5Query` in store.ts with OR/NEAR/phrase strategy and Unicode-aware regex (`\p{L}\p{N}` for CJK support)
- Cleaned `package.json`: removed dead `"rerank"` script and `"ollama"` keyword

### P3: Enhancements

- **MCP tool annotations** — Added `readOnlyHint`, `idempotentHint`, `openWorldHint` to all 6 tools
- **Empty index detection** — MCP search/vsearch/query handlers return helpful setup message when no documents are indexed
- **Config caching** — `loadConfig()` cached at module level, invalidated by `saveConfig()`. Eliminates redundant YAML reads per invocation
- **`--version` flag** — Reads from package.json
- **Improved `--help`** — Grouped sections (Search, Retrieval, Management, Options) with `Usage:` line and `qmd` prefix on all commands
- **`strict: true` in parseArgs** — Rejects unknown flags with friendly error message
- **SIGINT handler cleanup** — Calls `closeDb()` and `disposeDefaultLlamaCpp()` on signal
- **`mkdirSync` for cache dir** — Replaces `Bun.spawnSync(["mkdir", "-p", ...])` with native `mkdirSync(..., { recursive: true })`

## Before / After: BM25 Scoring

**Before** (all results score 1.0 — no ranking signal):
```
Score: 1.0  mcp-setup.md
Score: 1.0  readme.md  
Score: 1.0  skill.md
Score: 1.0  claude.md
```

**After** (differentiated scores — proper ranking):
```
Score: 0.26  mcp-setup.md
Score: 0.25  readme.md
Score: 0.17  skill.md
Score: 0.15  claude.md
Score: 0.11  finetune/claude.md
```

## Test Evidence

```
359 pass, 1 fail (pre-existing flaky LLM query expansion test), 2 errors (pre-existing Metal cleanup)
Ran 360 tests across 6 files [41.32s]
```

E2E CLI verification:
- `qmd --version` → `qmd 1.0.0` ✓
- `qmd --help` → Grouped help with Usage line ✓
- `qmd search "BM25"` → Differentiated scores (0.26 → 0.08) ✓
- `qmd search "test" --context "search engine"` → Context flag works ✓
- `qmd search "test" --bogus` → Friendly error, not stack trace ✓
- `qmd status` → Shows 15 indexed files ✓
- `qmd ls` → Lists collections ✓

## Files Changed (8 files, +230 -363)

| File | Changes |
|------|---------|
| `package.json` | Remove dead "rerank" script, "ollama" keyword |
| `src/collections.ts` | Config cache + `clearConfigCache()` export |
| `src/llm.ts` | Fix rerank text collision (array-based lookup) |
| `src/mcp.test.ts` | Align FTS schema to production |
| `src/mcp.ts` | MCP annotations, empty index detection |
| `src/qmd.ts` | BM25/RRF fixes, dead code removal, CLI enhancements |
| `src/store.test.ts` | Config cache clearing in test helpers |
| `src/store.ts` | BM25 normalization/weights, type fix, dead exports removed |

## Test plan

- [x] `bun test` — 359/360 pass (1 pre-existing flaky)
- [x] E2E: `qmd search` returns differentiated BM25 scores
- [x] E2E: `--version`, `--help`, `status`, `ls` all work
- [x] E2E: `--context` flag is wired through
- [x] E2E: Unknown flags produce friendly error
- [x] E2E: MCP tool annotations present on all tools
- [ ] Reviewer: Verify BM25 weight tuning (2.0, 10.0, 1.0) matches expected ranking behavior for your data

🤖 Generated with [Claude Code](https://claude.com/claude-code)