### PR TITLE
Add Docker and Docker Compose setup with persistent volume configurat…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Docker path configuration
+
+# Absolute local path to your Obsidian vault (or the notes folder you want to index)
+# The container will mount it at /vault (read-only)
+OBSIDIAN_VAULT_PATH=/absolute/path/to/your/obsidian/vault
+
+# Absolute local path where QMD will store its persistent data (index, models, cache)
+# The container will mount it at /data (read/write)
+QMD_DATA_PATH=/absolute/path/to/your/qmd-data/folder
+
+# Optional: User and Group ID to avoid permission issues
+# By default they use 1000:1000. Uncomment and change if you use another ID (e.g., id -u)
+# UID=1000
+# GID=1000

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ texts/
 !finetune/*.md
 finetune/outputs/
 finetune/data/train/
+qmd-data/
+.env

--- a/README.md
+++ b/README.md
@@ -170,11 +170,11 @@ Or configure MCP manually in `~/.claude/settings.json`:
 
 ### Search Backends
 
-| Backend | Raw Score | Conversion | Range |
-|---------|-----------|------------|-------|
-| **FTS (BM25)** | SQLite FTS5 BM25 | `Math.abs(score)` | 0 to ~25+ |
-| **Vector** | Cosine distance | `1 / (1 + distance)` | 0.0 to 1.0 |
-| **Reranker** | LLM 0-10 rating | `score / 10` | 0.0 to 1.0 |
+| Backend        | Raw Score        | Conversion           | Range      |
+| -------------- | ---------------- | -------------------- | ---------- |
+| **FTS (BM25)** | SQLite FTS5 BM25 | `Math.abs(score)`    | 0 to ~25+  |
+| **Vector**     | Cosine distance  | `1 / (1 + distance)` | 0.0 to 1.0 |
+| **Reranker**   | LLM 0-10 rating  | `score / 10`         | 0.0 to 1.0 |
 
 ### Fusion Strategy
 
@@ -195,12 +195,12 @@ The `query` command uses **Reciprocal Rank Fusion (RRF)** with position-aware bl
 
 ### Score Interpretation
 
-| Score | Meaning |
-|-------|---------|
-| 0.8 - 1.0 | Highly relevant |
+| Score     | Meaning             |
+| --------- | ------------------- |
+| 0.8 - 1.0 | Highly relevant     |
 | 0.5 - 0.8 | Moderately relevant |
-| 0.2 - 0.5 | Somewhat relevant |
-| 0.0 - 0.2 | Low relevance |
+| 0.2 - 0.5 | Somewhat relevant   |
+| 0.0 - 0.2 | Low relevance       |
 
 ## Requirements
 
@@ -216,10 +216,10 @@ The `query` command uses **Reciprocal Rank Fusion (RRF)** with position-aware bl
 
 QMD uses three local GGUF models (auto-downloaded on first use):
 
-| Model | Purpose | Size |
-|-------|---------|------|
-| `embeddinggemma-300M-Q8_0` | Vector embeddings | ~300MB |
-| `qwen3-reranker-0.6b-q8_0` | Re-ranking | ~640MB |
+| Model                             | Purpose                      | Size   |
+| --------------------------------- | ---------------------------- | ------ |
+| `embeddinggemma-300M-Q8_0`        | Vector embeddings            | ~300MB |
+| `qwen3-reranker-0.6b-q8_0`        | Re-ranking                   | ~640MB |
 | `qmd-query-expansion-1.7B-q4_k_m` | Query expansion (fine-tuned) | ~1.1GB |
 
 Models are downloaded from HuggingFace and cached in `~/.cache/qmd/models/`.
@@ -239,6 +239,62 @@ git clone https://github.com/tobi/qmd
 cd qmd
 bun install
 bun link
+```
+
+## Docker Deployment
+
+Run QMD in a containerized environment to keep your system clean.
+
+### Configuration
+
+Create a `.env` file from the example:
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` to configure your directories and user ID:
+
+```ini
+# Path to your Obsidian vault or markdown notes (mounted to /vault)
+OBSIDIAN_VAULT_PATH=/path/to/your/notes
+
+# Path where QMD will store index and models (mounted to /data)
+QMD_DATA_PATH=./qmd-data
+
+# Your user ID (run `id -u`)
+UID=1000
+GID=1000
+```
+
+### Build and Run
+
+Build the image and start the container:
+
+```bash
+docker compose build
+docker compose up -d
+```
+
+### Executing Commands
+
+Running commands inside the container:
+
+```bash
+# Add your mounted collection
+docker compose run --rm qmd collection add /vault --name notes
+
+# Generate embeddings
+docker compose run --rm qmd embed
+
+# Search
+docker compose run --rm qmd search "project timeline"
+```
+
+Alternatively, use `docker exec` on the running container:
+
+```bash
+docker exec -it qmd-engine qmd search "API"
 ```
 
 ## Usage
@@ -453,8 +509,8 @@ llm_cache       -- Cached LLM responses (query expansion, rerank scores)
 
 ## Environment Variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
+| Variable         | Default    | Description              |
+| ---------------- | ---------- | ------------------------ |
 | `XDG_CACHE_HOME` | `~/.cache` | Cache directory location |
 
 ## How It Works

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  qmd:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    image: qmd:latest
+    container_name: qmd-engine
+    env_file:
+      - .env
+    volumes:
+      # Mount Obsidian vault as read-only
+      - ${OBSIDIAN_VAULT_PATH}:/vault:ro
+      # Mount persistent data directory (index, models, cache)
+      - ${QMD_DATA_PATH}:/data:rw
+    # Run as your local user to avoid permission issues
+    # Define UID and GID in .env if they are not 1000
+    user: "${UID:-1000}:${GID:-1000}"
+    # Optional: limit resources if desired
+    # deploy:
+    #   resources:
+    #     limits:
+    #       memory: 4G
+    environment:
+      # Override index PATH if necessary, although QMD uses XDG_CACHE_HOME defined in Dockerfile
+      # Force index into the data volume
+      - INDEX_PATH=/data/index.sqlite
+    restart: unless-stopped

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,60 @@
+# Stage 1: Builder
+FROM oven/bun:1 AS builder
+
+WORKDIR /app
+
+# Install system dependencies required to compile native modules (node-llama-cpp)
+RUN apt-get update && apt-get install -y \
+    python3 \
+    make \
+    g++ \
+    cmake \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy dependency files
+COPY package.json bun.lock tsconfig.json ./
+
+# Install dependencies (including compiling native modules)
+RUN bun install --frozen-lockfile
+
+# Copy source code
+COPY src ./src
+COPY qmd ./qmd
+
+# Stage 2: Runtime
+FROM debian:bookworm-slim AS runtime
+
+WORKDIR /app
+
+# Install dependencies required for runtime
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    curl \
+    libstdc++6 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Bun in the runtime image
+COPY --from=builder /usr/local/bin/bun /usr/local/bin/bun
+
+# Copy node_modules and compiled code from builder
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/src ./src
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/tsconfig.json ./tsconfig.json
+COPY --from=builder /app/qmd ./qmd
+
+# Create directories for volumes
+RUN mkdir -p /vault /data
+
+# Environment variables for QMD
+# Set HOME to /data so that models are saved in the volume
+ENV XDG_CACHE_HOME=/data/.cache
+ENV HOME=/data
+ENV PATH="/app:${PATH}"
+
+# Expose data and vault volumes
+VOLUME ["/vault", "/data"]
+
+# Keep the container alive waiting for commands
+# The user is defined in docker-compose.yml
+CMD ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
# Docker Support: Containerization & Persistent Storage

## Description
This PR introduces Docker support to the project, enabling users to run QMD in a containerized environment with persistent storage for both the application data and the Obsidian vault/notes.

## Changes
- **Dockerfile**: Added [docker/Dockerfile](cci:7://file:///home/enrique/git/qmd/docker/Dockerfile:0:0-0:0) to build the application image.
- **Docker Compose**: Added `docker-compose.yml` to orchestrate the container setup, including volume mounts for data persistence.
- **Environment Configuration**: Added `.env.example` to provide a template for necessary environment variables (`OBSIDIAN_VAULT_PATH`, `QMD_DATA_PATH`, `UID`, `GID`).
- **Documentation**: Updated [README.md](cci:7://file:///home/enrique/git/qmd/README.md:0:0-0:0) with a comprehensive "Docker Deployment" section explaining how to configure, build, and run the application using Docker.
- **Gitignore**: Updated `.gitignore` to exclude local `.env` files.

## How to Test
1. Create a `.env` file from the example:
```bash
   cp .env.example .env
```

2. Configure the .env file with your local paths and user ID.
3. Build and execute the container:
```bash
docker compose up -d --build
```
4. Run a test command inside the container:
```bash
docker compose run --rm qmd collection list
```