### PR TITLE
Refactor store usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,11 @@ bun install
 bun link
 ```
 
+For testing:
+```sh
+bun test --timeout 300000
+```
+
 ## Usage
 
 ### Collection Management

--- a/src/eval.test.ts
+++ b/src/eval.test.ts
@@ -94,11 +94,9 @@ function calcHitRate(
 
 describe("BM25 Search (FTS)", () => {
   let store: ReturnType<typeof createStore>;
-  let db: Database;
 
   beforeAll(() => {
     store = createStore();
-    db = store.db;
 
     // Load and index eval documents
     const evalDocsDir = join(import.meta.dir, "../test/eval-docs");
@@ -197,7 +195,7 @@ describe("Vector Search", () => {
       }
     }
     hasEmbeddings = true;
-  }, 120000); // 2 minute timeout for embedding generation
+  }, 300_000); // 5 minute timeout for embedding generation
 
   afterAll(() => {
     store.close();

--- a/src/llm.test.ts
+++ b/src/llm.test.ts
@@ -374,7 +374,7 @@ describe("LlamaCpp Integration", () => {
         expect(["lex", "vec", "hyde"]).toContain(q.type);
         expect(q.text.length).toBeGreaterThan(0);
       }
-    }, 30000); // 30s timeout for model loading
+    }, 300_000); // 300s timeout for model loading
 
     test("can exclude lexical queries", async () => {
       const result = await llm.expandQuery("authentication setup", { includeLexical: false });

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -21,6 +21,7 @@ import type { CollectionConfig } from "./collections";
 // Test Database Setup
 // =============================================================================
 
+let testStore: Store;
 let testDb: Database;
 let testDbPath: string;
 let testConfigDir: string;
@@ -176,22 +177,14 @@ function seedTestData(db: Database): void {
 // Since McpServer uses internal routing, we'll test the handler functions directly
 
 import {
-  searchFTS,
-  searchVec,
-  expandQuery,
-  rerank,
   reciprocalRankFusion,
   extractSnippet,
-  getContextForFile,
-  findDocument,
-  getDocumentBody,
-  findDocuments,
-  getStatus,
   DEFAULT_EMBED_MODEL,
   DEFAULT_QUERY_MODEL,
   DEFAULT_RERANK_MODEL,
   DEFAULT_MULTI_GET_MAX_BYTES,
   createStore,
+  type Store,
 } from "./store";
 import type { RankedResult } from "./store";
 // Note: searchResultsToMcpCsv no longer used in MCP - using structuredContent instead
@@ -226,13 +219,13 @@ describe("MCP Server", () => {
     await writeFile(join(testConfigDir, "index.yml"), YAML.stringify(testConfig));
 
     testDbPath = `/tmp/qmd-mcp-test-${Date.now()}.sqlite`;
-    testDb = new Database(testDbPath);
-    initTestDatabase(testDb);
+    testStore = createStore(testDbPath);
+    testDb = testStore.db;
     seedTestData(testDb);
   });
 
   afterAll(async () => {
-    testDb.close();
+    testStore.close();
     try {
       require("fs").unlinkSync(testDbPath);
     } catch {}
@@ -255,30 +248,30 @@ describe("MCP Server", () => {
 
   describe("qmd_search tool", () => {
     test("returns results for matching query", () => {
-      const results = searchFTS(testDb, "readme", 10);
+      const results = testStore.searchFTS( "readme", 10);
       expect(results.length).toBeGreaterThan(0);
       expect(results[0]!.displayPath).toBe("docs/readme.md");
     });
 
     test("returns empty for non-matching query", () => {
-      const results = searchFTS(testDb, "xyznonexistent", 10);
+      const results = testStore.searchFTS( "xyznonexistent", 10);
       expect(results.length).toBe(0);
     });
 
     test("respects limit parameter", () => {
-      const results = searchFTS(testDb, "meeting", 1);
+      const results = testStore.searchFTS( "meeting", 1);
       expect(results.length).toBe(1);
     });
 
     // Note: Collection filtering tests removed - collections are now managed in YAML, not DB
 
     test("formats results as structured content", () => {
-      const results = searchFTS(testDb, "api", 10);
+      const results = testStore.searchFTS( "api", 10);
       const filtered = results.map(r => ({
         file: r.displayPath,
         title: r.title,
         score: Math.round(r.score * 100) / 100,
-        context: getContextForFile(testDb, r.filepath),
+        context: testStore.getContextForFile( r.filepath),
         snippet: extractSnippet(r.body || "", "api", 300, r.chunkPos).snippet,
       }));
       // MCP now returns structuredContent with results array
@@ -296,23 +289,22 @@ describe("MCP Server", () => {
 
   describe("qmd_vsearch tool", () => {
     test("returns results for semantic query", async () => {
-      const results = await searchVec(testDb, "project documentation", DEFAULT_EMBED_MODEL, 10);
+      const results = await testStore.searchVec( "project documentation", DEFAULT_EMBED_MODEL, 10);
       expect(results.length).toBeGreaterThan(0);
     });
 
     test("respects limit parameter", async () => {
-      const results = await searchVec(testDb, "documentation", DEFAULT_EMBED_MODEL, 2);
+      const results = await testStore.searchVec( "documentation", DEFAULT_EMBED_MODEL, 2);
       expect(results.length).toBeLessThanOrEqual(2);
     });
 
     test("returns empty when no vector table exists", async () => {
-      const emptyDb = new Database(":memory:");
-      initTestDatabase(emptyDb);
-      emptyDb.exec("DROP TABLE IF EXISTS vectors_vec");
+      const emptyStore = createStore(":memory:");
+      emptyStore.db.exec("DROP TABLE IF EXISTS vectors_vec");
 
-      const results = await searchVec(emptyDb, "test", DEFAULT_EMBED_MODEL, 10);
+      const results = await emptyStore.searchVec("test", DEFAULT_EMBED_MODEL, 10);
       expect(results.length).toBe(0);
-      emptyDb.close();
+      emptyStore.close();
     });
   });
 
@@ -322,7 +314,7 @@ describe("MCP Server", () => {
 
   describe("qmd_query tool", () => {
     test("expands query with variations", async () => {
-      const queries = await expandQuery("api documentation", DEFAULT_QUERY_MODEL, testDb);
+      const queries = await testStore.expandQuery("api documentation", DEFAULT_QUERY_MODEL);
       // Always returns at least the original query, may have more if generation succeeds
       expect(queries.length).toBeGreaterThanOrEqual(1);
       expect(queries[0]).toBe("api documentation");
@@ -350,7 +342,7 @@ describe("MCP Server", () => {
         { file: "/test/docs/readme.md", text: "Project readme" },
         { file: "/test/docs/api.md", text: "API documentation" },
       ];
-      const reranked = await rerank("readme", docs, DEFAULT_RERANK_MODEL, testDb);
+      const reranked = await testStore.rerank("readme", docs, DEFAULT_RERANK_MODEL);
       expect(reranked.length).toBe(2);
       expect(reranked[0]!.score).toBeGreaterThan(0);
     });
@@ -358,11 +350,11 @@ describe("MCP Server", () => {
     test("full hybrid search pipeline", async () => {
       // Simulate full qmd_query flow
       const query = "meeting notes";
-      const queries = await expandQuery(query, DEFAULT_QUERY_MODEL, testDb);
+      const queries = await testStore.expandQuery(query, DEFAULT_QUERY_MODEL);
 
       const rankedLists: RankedResult[][] = [];
       for (const q of queries) {
-        const ftsResults = searchFTS(testDb, q, 20);
+        const ftsResults = testStore.searchFTS( q, 20);
         if (ftsResults.length > 0) {
           rankedLists.push(ftsResults.map(r => ({
             file: r.filepath,
@@ -380,11 +372,10 @@ describe("MCP Server", () => {
       expect(fused.length).toBeGreaterThan(0);
 
       const candidates = fused.slice(0, 10);
-      const reranked = await rerank(
+      const reranked = await testStore.rerank(
         query,
         candidates.map(c => ({ file: c.file, text: c.body })),
-        DEFAULT_RERANK_MODEL,
-        testDb
+        DEFAULT_RERANK_MODEL
       );
 
       expect(reranked.length).toBeGreaterThan(0);
@@ -397,29 +388,29 @@ describe("MCP Server", () => {
 
   describe("qmd_get tool", () => {
     test("retrieves document by display_path", () => {
-      const meta = findDocument(testDb, "readme.md", { includeBody: false });
+      const meta = testStore.findDocument( "readme.md", { includeBody: false });
       expect("error" in meta).toBe(false);
       if ("error" in meta) return;
-      const body = getDocumentBody(testDb, meta) ?? "";
+      const body = testStore.getDocumentBody( meta) ?? "";
 
       expect(meta.displayPath).toBe("docs/readme.md");
       expect(body).toContain("Project README");
     });
 
     test("retrieves document by filepath", () => {
-      const meta = findDocument(testDb, "/test/docs/api.md", { includeBody: false });
+      const meta = testStore.findDocument( "/test/docs/api.md", { includeBody: false });
       expect("error" in meta).toBe(false);
       if ("error" in meta) return;
       expect(meta.title).toBe("API Documentation");
     });
 
     test("retrieves document by partial path", () => {
-      const result = findDocument(testDb, "api.md", { includeBody: false });
+      const result = testStore.findDocument( "api.md", { includeBody: false });
       expect("error" in result).toBe(false);
     });
 
     test("returns not found for missing document", () => {
-      const result = findDocument(testDb, "nonexistent.md", { includeBody: false });
+      const result = testStore.findDocument( "nonexistent.md", { includeBody: false });
       expect("error" in result).toBe(true);
       if ("error" in result) {
         expect(result.error).toBe("not_found");
@@ -427,7 +418,7 @@ describe("MCP Server", () => {
     });
 
     test("suggests similar files when not found", () => {
-      const result = findDocument(testDb, "readm.md", { includeBody: false }); // typo
+      const result = testStore.findDocument( "readm.md", { includeBody: false }); // typo
       expect("error" in result).toBe(true);
       if ("error" in result) {
         expect(result.similarFiles.length).toBeGreaterThanOrEqual(0);
@@ -435,33 +426,33 @@ describe("MCP Server", () => {
     });
 
     test("supports line range with :line suffix", () => {
-      const meta = findDocument(testDb, "readme.md:2", { includeBody: false });
+      const meta = testStore.findDocument( "readme.md:2", { includeBody: false });
       expect("error" in meta).toBe(false);
       if ("error" in meta) return;
-      const body = getDocumentBody(testDb, meta, 2, 2) ?? "";
+      const body = testStore.getDocumentBody( meta, 2, 2) ?? "";
       const lines = body.split("\n");
       expect(lines.length).toBeLessThanOrEqual(2);
     });
 
     test("supports fromLine parameter", () => {
-      const meta = findDocument(testDb, "readme.md", { includeBody: false });
+      const meta = testStore.findDocument( "readme.md", { includeBody: false });
       expect("error" in meta).toBe(false);
       if ("error" in meta) return;
-      const body = getDocumentBody(testDb, meta, 3) ?? "";
+      const body = testStore.getDocumentBody( meta, 3) ?? "";
       expect(body).not.toContain("# Project README");
     });
 
     test("supports maxLines parameter", () => {
-      const meta = findDocument(testDb, "api.md", { includeBody: false });
+      const meta = testStore.findDocument( "api.md", { includeBody: false });
       expect("error" in meta).toBe(false);
       if ("error" in meta) return;
-      const body = getDocumentBody(testDb, meta, 1, 3) ?? "";
+      const body = testStore.getDocumentBody( meta, 1, 3) ?? "";
       const lines = body.split("\n");
       expect(lines.length).toBeLessThanOrEqual(3);
     });
 
     test("includes context for documents in context path", () => {
-      const result = findDocument(testDb, "meetings/meeting-2024-01.md", { includeBody: false });
+      const result = testStore.findDocument( "meetings/meeting-2024-01.md", { includeBody: false });
       expect("error" in result).toBe(false);
       if ("error" in result) return;
       expect(result.context).toBe("Meeting notes and transcripts");
@@ -474,7 +465,7 @@ describe("MCP Server", () => {
 
   describe("qmd_multi_get tool", () => {
     test("retrieves multiple documents by glob pattern", () => {
-      const { docs, errors } = findDocuments(testDb, "meetings/*.md", { includeBody: true });
+      const { docs, errors } = testStore.findDocuments( "meetings/*.md", { includeBody: true });
       expect(errors.length).toBe(0);
       expect(docs.length).toBe(2);
       const paths = docs.map(d => d.doc.displayPath);
@@ -483,20 +474,20 @@ describe("MCP Server", () => {
     });
 
     test("retrieves documents by comma-separated list", () => {
-      const { docs, errors } = findDocuments(testDb, "readme.md, api.md", { includeBody: true });
+      const { docs, errors } = testStore.findDocuments( "readme.md, api.md", { includeBody: true });
       expect(errors.length).toBe(0);
       expect(docs.length).toBe(2);
     });
 
     test("returns errors for missing files in comma list", () => {
-      const { docs, errors } = findDocuments(testDb, "readme.md, nonexistent.md", { includeBody: true });
+      const { docs, errors } = testStore.findDocuments( "readme.md, nonexistent.md", { includeBody: true });
       expect(docs.length).toBe(1);
       expect(errors.length).toBe(1);
       expect(errors[0]).toContain("not found");
     });
 
     test("skips files larger than maxBytes", () => {
-      const { docs } = findDocuments(testDb, "*.md", { includeBody: true, maxBytes: 1000 }); // 1KB limit
+      const { docs } = testStore.findDocuments( "*.md", { includeBody: true, maxBytes: 1000 }); // 1KB limit
       const large = docs.find(d => d.doc.displayPath === "docs/large-file.md");
       expect(large).toBeDefined();
       expect(large?.skipped).toBe(true);
@@ -504,7 +495,7 @@ describe("MCP Server", () => {
     });
 
     test("respects maxLines parameter", () => {
-      const { docs } = findDocuments(testDb, "readme.md", { includeBody: true, maxBytes: DEFAULT_MULTI_GET_MAX_BYTES });
+      const { docs } = testStore.findDocuments( "readme.md", { includeBody: true, maxBytes: DEFAULT_MULTI_GET_MAX_BYTES });
       expect(docs.length).toBe(1);
       const d = docs[0]!;
       expect(d.skipped).toBe(false);
@@ -517,14 +508,14 @@ describe("MCP Server", () => {
     });
 
     test("returns error for non-matching glob", () => {
-      const { docs, errors } = findDocuments(testDb, "nonexistent/*.md", { includeBody: true });
+      const { docs, errors } = testStore.findDocuments( "nonexistent/*.md", { includeBody: true });
       expect(docs.length).toBe(0);
       expect(errors.length).toBe(1);
       expect(errors[0]).toContain("No files matched");
     });
 
     test("includes context in results", () => {
-      const { docs } = findDocuments(testDb, "meetings/meeting-2024-01.md", { includeBody: true });
+      const { docs } = testStore.findDocuments( "meetings/meeting-2024-01.md", { includeBody: true });
       expect(docs.length).toBe(1);
       const d = docs[0]!;
       expect(d.skipped).toBe(false);
@@ -542,7 +533,7 @@ describe("MCP Server", () => {
 
   describe("qmd_status tool", () => {
     test("returns index status", () => {
-      const status = getStatus(testDb);
+      const status = testStore.getStatus();
       expect(status.totalDocuments).toBe(5);
       expect(status.hasVectorIndex).toBe(true);
       expect(status.collections.length).toBe(1);
@@ -550,7 +541,7 @@ describe("MCP Server", () => {
     });
 
     test("shows documents needing embedding", () => {
-      const status = getStatus(testDb);
+      const status = testStore.getStatus();
       // large-file.md doesn't have embeddings
       expect(status.needsEmbedding).toBe(1);
     });
@@ -648,7 +639,7 @@ describe("MCP Server", () => {
       `).get(path) as { filepath: string; display_path: string; body: string } | null;
 
       expect(doc).not.toBeNull();
-      const context = getContextForFile(testDb, doc!.filepath);
+      const context = testStore.getContextForFile( doc!.filepath);
       expect(context).toBe("Meeting notes and transcripts");
 
       // Verify context would be prepended
@@ -767,29 +758,29 @@ QMD is your on-device search engine for markdown knowledge bases.`;
 
   describe("edge cases", () => {
     test("handles empty query", () => {
-      const results = searchFTS(testDb, "", 10);
+      const results = testStore.searchFTS( "", 10);
       expect(results.length).toBe(0);
     });
 
     test("handles special characters in query", () => {
-      const results = searchFTS(testDb, "project's", 10);
+      const results = testStore.searchFTS( "project's", 10);
       // Should not throw
       expect(Array.isArray(results)).toBe(true);
     });
 
     test("handles unicode in query", () => {
-      const results = searchFTS(testDb, "文档", 10);
+      const results = testStore.searchFTS( "文档", 10);
       expect(Array.isArray(results)).toBe(true);
     });
 
     test("handles very long query", () => {
       const longQuery = "documentation ".repeat(100);
-      const results = searchFTS(testDb, longQuery, 10);
+      const results = testStore.searchFTS( longQuery, 10);
       expect(Array.isArray(results)).toBe(true);
     });
 
     test("handles query with only stopwords", () => {
-      const results = searchFTS(testDb, "the and or", 10);
+      const results = testStore.searchFTS( "the and or", 10);
       expect(Array.isArray(results)).toBe(true);
     });
 
@@ -823,12 +814,12 @@ QMD is your on-device search engine for markdown knowledge bases.`;
     });
 
     test("search results have correct structure for structuredContent", () => {
-      const results = searchFTS(testDb, "readme", 5);
+      const results = testStore.searchFTS( "readme", 5);
       const structured = results.map(r => ({
         file: r.displayPath,
         title: r.title,
         score: Math.round(r.score * 100) / 100,
-        context: getContextForFile(testDb, r.filepath),
+        context: testStore.getContextForFile( r.filepath),
         snippet: extractSnippet(r.body || "", "readme", 300, r.chunkPos).snippet,
       }));
 
@@ -854,10 +845,10 @@ QMD is your on-device search engine for markdown knowledge bases.`;
 
     test("embedded resources include name and title", () => {
       // Simulate what qmd_get returns
-      const meta = findDocument(testDb, "readme.md", { includeBody: false });
+      const meta = testStore.findDocument( "readme.md", { includeBody: false });
       expect("error" in meta).toBe(false);
       if ("error" in meta) return;
-      const body = getDocumentBody(testDb, meta) ?? "";
+      const body = testStore.getDocumentBody( meta) ?? "";
       const resource = {
         uri: `qmd://${meta.displayPath}`,
         name: meta.displayPath,
@@ -871,7 +862,7 @@ QMD is your on-device search engine for markdown knowledge bases.`;
     });
 
     test("status response includes structuredContent", () => {
-      const status = getStatus(testDb);
+      const status = testStore.getStatus();
       // Verify structure matches StatusResult type
       expect(typeof status.totalDocuments).toBe("number");
       expect(typeof status.needsEmbedding).toBe("number");

--- a/src/mcp.test.ts
+++ b/src/mcp.test.ts
@@ -221,6 +221,7 @@ describe("MCP Server", () => {
     testDbPath = `/tmp/qmd-mcp-test-${Date.now()}.sqlite`;
     testStore = createStore(testDbPath);
     testDb = testStore.db;
+    initTestDatabase(testDb);
     seedTestData(testDb);
   });
 
@@ -300,6 +301,7 @@ describe("MCP Server", () => {
 
     test("returns empty when no vector table exists", async () => {
       const emptyStore = createStore(":memory:");
+      initTestDatabase(emptyStore.db);
       emptyStore.db.exec("DROP TABLE IF EXISTS vectors_vec");
 
       const results = await emptyStore.searchVec("test", DEFAULT_EMBED_MODEL, 10);

--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -11,7 +11,6 @@ import {
   homedir,
   resolve,
   enableProductionMode,
-  getDefaultDbPath,
   // Virtual path utilities (pure - no db dependency)
   parseVirtualPath,
   buildVirtualPath,
@@ -60,6 +59,17 @@ import {
 // Tests must set INDEX_PATH or use createStore() with explicit path
 enableProductionMode();
 
+// Compute default db path (needed before store exists for --index option)
+function computeDefaultDbPath(indexName: string = "index"): string {
+  if (Bun.env.INDEX_PATH) {
+    return Bun.env.INDEX_PATH;
+  }
+  const cacheDir = Bun.env.XDG_CACHE_HOME || resolve(homedir(), ".cache");
+  const qmdCacheDir = resolve(cacheDir, "qmd");
+  try { Bun.spawnSync(["mkdir", "-p", qmdCacheDir]); } catch { }
+  return resolve(qmdCacheDir, `${indexName}.sqlite`);
+}
+
 // =============================================================================
 // Store/DB lifecycle (no legacy singletons in store.ts)
 // =============================================================================
@@ -86,11 +96,11 @@ function closeDb(): void {
 }
 
 function getDbPath(): string {
-  return store?.dbPath ?? storeDbPathOverride ?? getDefaultDbPath();
+  return store?.dbPath ?? storeDbPathOverride ?? computeDefaultDbPath();
 }
 
 function setIndexName(name: string | null): void {
-  storeDbPathOverride = name ? getDefaultDbPath(name) : undefined;
+  storeDbPathOverride = name ? computeDefaultDbPath(name) : undefined;
   // Reset open handle so next use opens the new index
   closeDb();
 }

--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -10,6 +10,7 @@ import {
   homedir,
   resolve,
   enableProductionMode,
+  getDefaultDbPath,
   // Virtual path utilities (pure - no db dependency)
   parseVirtualPath,
   buildVirtualPath,
@@ -58,17 +59,6 @@ import {
 // Tests must set INDEX_PATH or use createStore() with explicit path
 enableProductionMode();
 
-// Compute default db path (needed before store exists for --index option)
-function computeDefaultDbPath(indexName: string = "index"): string {
-  if (Bun.env.INDEX_PATH) {
-    return Bun.env.INDEX_PATH;
-  }
-  const cacheDir = Bun.env.XDG_CACHE_HOME || resolve(homedir(), ".cache");
-  const qmdCacheDir = resolve(cacheDir, "qmd");
-  try { Bun.spawnSync(["mkdir", "-p", qmdCacheDir]); } catch { }
-  return resolve(qmdCacheDir, `${indexName}.sqlite`);
-}
-
 // =============================================================================
 // Store/DB lifecycle (no legacy singletons in store.ts)
 // =============================================================================
@@ -91,11 +81,11 @@ function closeDb(): void {
 }
 
 function getDbPath(): string {
-  return store?.dbPath ?? storeDbPathOverride ?? computeDefaultDbPath();
+  return store?.dbPath ?? storeDbPathOverride ?? getDefaultDbPath();
 }
 
 function setIndexName(name: string | null): void {
-  storeDbPathOverride = name ? computeDefaultDbPath(name) : undefined;
+  storeDbPathOverride = name ? getDefaultDbPath(name) : undefined;
   // Reset open handle so next use opens the new index
   closeDb();
 }

--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -5,66 +5,37 @@ import { parseArgs } from "util";
 import { readFileSync, statSync } from "fs";
 import * as sqliteVec from "sqlite-vec";
 import {
+  // Path utilities (pure - no db dependency)
   getPwd,
   getRealPath,
   homedir,
   resolve,
   enableProductionMode,
-  searchFTS,
-  searchVec,
-  extractSnippet,
-  getContextForFile,
-  getContextForPath,
-  listCollections,
-  removeCollection,
-  renameCollection,
-  findSimilarFiles,
-  findDocumentByDocid,
-  isDocid,
-  matchFilesByGlob,
-  getHashesNeedingEmbedding,
-  getHashesForEmbedding,
-  clearAllEmbeddings,
-  insertEmbedding,
-  getStatus,
-  hashContent,
-  extractTitle,
-  formatDocForEmbedding,
-  formatQueryForEmbedding,
-  chunkDocument,
-  chunkDocumentByTokens,
-  clearCache,
-  getCacheKey,
-  getCachedResult,
-  setCachedResult,
-  getIndexHealth,
+  getDefaultDbPath,
+  // Virtual path utilities (pure - no db dependency)
   parseVirtualPath,
   buildVirtualPath,
   isVirtualPath,
-  resolveVirtualPath,
-  toVirtualPath,
-  insertContent,
-  insertDocument,
-  findActiveDocument,
-  updateDocumentTitle,
-  updateDocument,
-  deactivateDocument,
-  getActiveDocumentPaths,
-  cleanupOrphanedContent,
-  deleteLLMCache,
-  deleteInactiveDocuments,
-  cleanupOrphanedVectors,
-  vacuumDatabase,
-  getCollectionsWithoutContext,
-  getTopLevelPathsWithoutContext,
+  // Document utilities (pure - no db dependency)
+  isDocid,
+  hashContent,
+  extractTitle,
+  extractSnippet,
+  chunkDocument,
+  chunkDocumentByTokens,
   handelize,
+  // LLM utilities (re-exports - no db dependency)
+  formatDocForEmbedding,
+  formatQueryForEmbedding,
+  // Constants
   DEFAULT_EMBED_MODEL,
   DEFAULT_QUERY_MODEL,
   DEFAULT_RERANK_MODEL,
   DEFAULT_GLOB,
   DEFAULT_MULTI_GET_MAX_BYTES,
+  // Store factory and type
   createStore,
-  getDefaultDbPath,
+  type Store,
 } from "./store.js";
 import { getDefaultLlamaCpp, disposeDefaultLlamaCpp, withLLMSession, pullModels, DEFAULT_EMBED_MODEL_URI, DEFAULT_GENERATE_MODEL_URI, DEFAULT_RERANK_MODEL_URI, DEFAULT_MODEL_CACHE_DIR, type ILLMSession, type RerankDocument, type Queryable, type QueryType } from "./llm.js";
 import type { SearchResult, RankedResult } from "./store.js";
@@ -177,8 +148,8 @@ function formatETA(seconds: number): string {
 
 
 // Check index health and print warnings/tips
-function checkIndexHealth(db: Database): void {
-  const { needsEmbedding, totalDocs, daysStale } = getIndexHealth(db);
+function checkIndexHealth(store: Store): void {
+  const { needsEmbedding, totalDocs, daysStale } = store.getIndexHealth();
 
   // Warn if many docs need embedding
   if (needsEmbedding > 0) {
@@ -275,7 +246,7 @@ function formatBytes(bytes: number): string {
 
 function showStatus(): void {
   const dbPath = getDbPath();
-  const db = getDb();
+  const store = getStore();
 
   // Collections are defined in YAML; no duplicate cleanup needed.
   // Collections are defined in YAML; no duplicate cleanup needed.
@@ -288,15 +259,15 @@ function showStatus(): void {
   } catch { }
 
   // Collections info (from YAML + database stats)
-  const collections = listCollections(db);
+  const collections = store.listCollections();
 
   // Overall stats
-  const totalDocs = db.prepare(`SELECT COUNT(*) as count FROM documents WHERE active = 1`).get() as { count: number };
-  const vectorCount = db.prepare(`SELECT COUNT(*) as count FROM content_vectors`).get() as { count: number };
-  const needsEmbedding = getHashesNeedingEmbedding(db);
+  const totalDocs = store.db.prepare(`SELECT COUNT(*) as count FROM documents WHERE active = 1`).get() as { count: number };
+  const vectorCount = store.db.prepare(`SELECT COUNT(*) as count FROM content_vectors`).get() as { count: number };
+  const needsEmbedding = store.getHashesNeedingEmbedding();
 
   // Most recent update across all collections
-  const mostRecent = db.prepare(`SELECT MAX(modified_at) as latest FROM documents WHERE active = 1`).get() as { latest: string | null };
+  const mostRecent = store.db.prepare(`SELECT MAX(modified_at) as latest FROM documents WHERE active = 1`).get() as { latest: string | null };
 
   console.log(`${c.bold}QMD Status${c.reset}\n`);
   console.log(`Index: ${dbPath}`);
@@ -373,13 +344,13 @@ function showStatus(): void {
 }
 
 async function updateCollections(): Promise<void> {
-  const db = getDb();
+  const store = getStore();
   // Collections are defined in YAML; no duplicate cleanup needed.
 
   // Clear Ollama cache on update
-  clearCache(db);
+  store.clearCache();
 
-  const collections = listCollections(db);
+  const collections = store.listCollections();
 
   if (collections.length === 0) {
     console.log(`${c.dim}No collections found. Run 'qmd collection add .' to index markdown files.${c.reset}`);
@@ -432,8 +403,8 @@ async function updateCollections(): Promise<void> {
   }
 
   // Check if any documents need embedding (show once at end)
-  const finalDb = getDb();
-  const needsEmbedding = getHashesNeedingEmbedding(finalDb);
+  const finalStore = getStore();
+  const needsEmbedding = finalStore.getHashesNeedingEmbedding();
   closeDb();
 
   console.log(`${c.green}✓ All collections updated.${c.reset}`);
@@ -444,9 +415,9 @@ async function updateCollections(): Promise<void> {
 
 /**
  * Detect which collection (if any) contains the given filesystem path.
- * Returns { collectionId, collectionName, relativePath } or null if not in any collection.
+ * Returns { collectionName, relativePath } or null if not in any collection.
  */
-function detectCollectionFromPath(db: Database, fsPath: string): { collectionName: string; relativePath: string } | null {
+function detectCollectionFromPath(fsPath: string): { collectionName: string; relativePath: string } | null {
   const realPath = getRealPath(fsPath);
 
   // Find collections that this path is under from YAML
@@ -479,14 +450,11 @@ function detectCollectionFromPath(db: Database, fsPath: string): { collectionNam
 }
 
 async function contextAdd(pathArg: string | undefined, contextText: string): Promise<void> {
-  const db = getDb();
-
   // Handle "/" as global context (applies to all collections)
   if (pathArg === '/') {
     setGlobalContext(contextText);
     console.log(`${c.green}✓${c.reset} Set global context`);
     console.log(`${c.dim}Context: ${contextText}${c.reset}`);
-    closeDb();
     return;
   }
 
@@ -521,12 +489,11 @@ async function contextAdd(pathArg: string | undefined, contextText: string): Pro
       : `qmd://${parsed.collectionName}/ (collection root)`;
     console.log(`${c.green}✓${c.reset} Added context for: ${displayPath}`);
     console.log(`${c.dim}Context: ${contextText}${c.reset}`);
-    closeDb();
     return;
   }
 
   // Detect collection from filesystem path
-  const detected = detectCollectionFromPath(db, fsPath);
+  const detected = detectCollectionFromPath(fsPath);
   if (!detected) {
     console.error(`${c.yellow}Path is not in any indexed collection: ${fsPath}${c.reset}`);
     console.error(`${c.dim}Run 'qmd status' to see indexed collections${c.reset}`);
@@ -538,17 +505,13 @@ async function contextAdd(pathArg: string | undefined, contextText: string): Pro
   const displayPath = detected.relativePath ? `qmd://${detected.collectionName}/${detected.relativePath}` : `qmd://${detected.collectionName}/`;
   console.log(`${c.green}✓${c.reset} Added context for: ${displayPath}`);
   console.log(`${c.dim}Context: ${contextText}${c.reset}`);
-  closeDb();
 }
 
 function contextList(): void {
-  const db = getDb();
-
   const allContexts = listAllContexts();
 
   if (allContexts.length === 0) {
     console.log(`${c.dim}No contexts configured. Use 'qmd context add' to add one.${c.reset}`);
-    closeDb();
     return;
   }
 
@@ -565,8 +528,6 @@ function contextList(): void {
     console.log(`${displayPath}`);
     console.log(`    ${c.dim}${ctx.context}${c.reset}`);
   }
-
-  closeDb();
 }
 
 function contextRemove(pathArg: string): void {
@@ -612,9 +573,7 @@ function contextRemove(pathArg: string): void {
     fsPath = resolve(getPwd(), fsPath);
   }
 
-  const db = getDb();
-  const detected = detectCollectionFromPath(db, fsPath);
-  closeDb();
+  const detected = detectCollectionFromPath(fsPath);
 
   if (!detected) {
     console.error(`${c.yellow}Path is not in any indexed collection: ${fsPath}${c.reset}`);
@@ -632,13 +591,13 @@ function contextRemove(pathArg: string): void {
 }
 
 function contextCheck(): void {
-  const db = getDb();
+  const store = getStore();
 
   // Get collections without any context
-  const collectionsWithoutContext = getCollectionsWithoutContext(db);
+  const collectionsWithoutContext = store.getCollectionsWithoutContext();
 
   // Get all collections to check for missing path contexts
-  const allCollections = listCollections(db);
+  const allCollections = store.listCollections();
 
   if (collectionsWithoutContext.length === 0 && allCollections.length > 0) {
     // Check if all collections have contexts
@@ -655,15 +614,15 @@ function contextCheck(): void {
   }
 
   // Check for top-level paths without context within collections that DO have context
-  const collectionsWithContext = allCollections.filter(c =>
-    c && !collectionsWithoutContext.some(cwc => cwc.name === c.name)
+  const collectionsWithContext = allCollections.filter(col =>
+    col && !collectionsWithoutContext.some(cwc => cwc.name === col.name)
   );
 
   let hasPathSuggestions = false;
 
   for (const coll of collectionsWithContext) {
     if (!coll) continue;
-    const missingPaths = getTopLevelPathsWithoutContext(db, coll.name);
+    const missingPaths = store.getTopLevelPathsWithoutContext(coll.name);
 
     if (missingPaths.length > 0) {
       if (!hasPathSuggestions) {
@@ -689,7 +648,7 @@ function contextCheck(): void {
 }
 
 function getDocument(filename: string, fromLine?: number, maxLines?: number, lineNumbers?: boolean): void {
-  const db = getDb();
+  const store = getStore();
 
   // Parse :linenum suffix from filename (e.g., "file.md:100")
   let inputPath = filename;
@@ -704,7 +663,7 @@ function getDocument(filename: string, fromLine?: number, maxLines?: number, lin
 
   // Handle docid lookup (#abc123, abc123, "#abc123", "abc123", etc.)
   if (isDocid(inputPath)) {
-    const docidMatch = findDocumentByDocid(db, inputPath);
+    const docidMatch = store.findDocumentByDocid(inputPath);
     if (docidMatch) {
       inputPath = docidMatch.filepath;
     } else {
@@ -727,7 +686,7 @@ function getDocument(filename: string, fromLine?: number, maxLines?: number, lin
     }
 
     // Try exact match on collection + path
-    doc = db.prepare(`
+    doc = store.db.prepare(`
       SELECT d.collection as collectionName, d.path, content.doc as body
       FROM documents d
       JOIN content ON content.hash = d.hash
@@ -736,7 +695,7 @@ function getDocument(filename: string, fromLine?: number, maxLines?: number, lin
 
     if (!doc) {
       // Try fuzzy match by path ending
-      doc = db.prepare(`
+      doc = store.db.prepare(`
         SELECT d.collection as collectionName, d.path, content.doc as body
         FROM documents d
         JOIN content ON content.hash = d.hash
@@ -756,13 +715,13 @@ function getDocument(filename: string, fromLine?: number, maxLines?: number, lin
         const possiblePath = parts.slice(1).join('/');
 
         // Check if this collection exists
-        const collExists = possibleCollection ? db.prepare(`
+        const collExists = possibleCollection ? store.db.prepare(`
           SELECT 1 FROM documents WHERE collection = ? AND active = 1 LIMIT 1
         `).get(possibleCollection) : null;
 
         if (collExists) {
           // Try exact match on collection + path
-          doc = db.prepare(`
+          doc = store.db.prepare(`
             SELECT d.collection as collectionName, d.path, content.doc as body
             FROM documents d
             JOIN content ON content.hash = d.hash
@@ -771,7 +730,7 @@ function getDocument(filename: string, fromLine?: number, maxLines?: number, lin
 
           if (!doc) {
             // Try fuzzy match by path ending
-            doc = db.prepare(`
+            doc = store.db.prepare(`
               SELECT d.collection as collectionName, d.path, content.doc as body
               FROM documents d
               JOIN content ON content.hash = d.hash
@@ -802,11 +761,11 @@ function getDocument(filename: string, fromLine?: number, maxLines?: number, lin
       fsPath = getRealPath(fsPath);
 
       // Try to detect which collection contains this path
-      const detected = detectCollectionFromPath(db, fsPath);
+      const detected = detectCollectionFromPath(fsPath);
 
       if (detected) {
         // Found collection - query by collection name + relative path
-        doc = db.prepare(`
+        doc = store.db.prepare(`
           SELECT d.collection as collectionName, d.path, content.doc as body
           FROM documents d
           JOIN content ON content.hash = d.hash
@@ -816,14 +775,14 @@ function getDocument(filename: string, fromLine?: number, maxLines?: number, lin
 
       // Fuzzy match by filename (last component of path)
       if (!doc) {
-        const filename = inputPath.split('/').pop() || inputPath;
-        doc = db.prepare(`
+        const fname = inputPath.split('/').pop() || inputPath;
+        doc = store.db.prepare(`
           SELECT d.collection as collectionName, d.path, content.doc as body
           FROM documents d
           JOIN content ON content.hash = d.hash
           WHERE d.path LIKE ? AND d.active = 1
           LIMIT 1
-        `).get(`%${filename}`) as { collectionName: string; path: string; body: string } | null;
+        `).get(`%${fname}`) as { collectionName: string; path: string; body: string } | null;
       }
 
       if (doc) {
@@ -842,7 +801,7 @@ function getDocument(filename: string, fromLine?: number, maxLines?: number, lin
   }
 
   // Get context for this file
-  const context = getContextForPath(db, doc.collectionName, doc.path);
+  const context = store.getContextForPath(doc.collectionName, doc.path);
 
   let output = doc.body;
   const startLine = fromLine || 1;
@@ -870,7 +829,7 @@ function getDocument(filename: string, fromLine?: number, maxLines?: number, lin
 
 // Multi-get: fetch multiple documents by glob pattern or comma-separated list
 function multiGet(pattern: string, maxLines?: number, maxBytes: number = DEFAULT_MULTI_GET_MAX_BYTES, format: OutputFormat = "cli"): void {
-  const db = getDb();
+  const store = getStore();
 
   // Check if it's a comma-separated list or a glob pattern
   const isCommaSeparated = pattern.includes(',') && !pattern.includes('*') && !pattern.includes('?');
@@ -889,7 +848,7 @@ function multiGet(pattern: string, maxLines?: number, maxBytes: number = DEFAULT
         const parsed = parseVirtualPath(name);
         if (parsed) {
           // Try exact match on collection + path
-          doc = db.prepare(`
+          doc = store.db.prepare(`
             SELECT
               'qmd://' || d.collection || '/' || d.path as virtual_path,
               LENGTH(content.doc) as body_length,
@@ -902,7 +861,7 @@ function multiGet(pattern: string, maxLines?: number, maxBytes: number = DEFAULT
         }
       } else {
         // Try exact match on path
-        doc = db.prepare(`
+        doc = store.db.prepare(`
           SELECT
             'qmd://' || d.collection || '/' || d.path as virtual_path,
             LENGTH(content.doc) as body_length,
@@ -916,7 +875,7 @@ function multiGet(pattern: string, maxLines?: number, maxBytes: number = DEFAULT
 
         // Try suffix match
         if (!doc) {
-          doc = db.prepare(`
+          doc = store.db.prepare(`
             SELECT
               'qmd://' || d.collection || '/' || d.path as virtual_path,
               LENGTH(content.doc) as body_length,
@@ -944,7 +903,7 @@ function multiGet(pattern: string, maxLines?: number, maxBytes: number = DEFAULT
     }
   } else {
     // Glob pattern - matchFilesByGlob now returns virtual paths
-    files = matchFilesByGlob(db, pattern).map(f => ({
+    files = store.matchFilesByGlob(pattern).map(f => ({
       ...f,
       collection: undefined,  // Will be fetched later if needed
       path: undefined
@@ -973,7 +932,7 @@ function multiGet(pattern: string, maxLines?: number, maxBytes: number = DEFAULT
     }
 
     // Get context using collection-scoped function
-    const context = collection && path ? getContextForPath(db, collection, path) : null;
+    const context = collection && path ? store.getContextForPath(collection, path) : null;
 
     // Check size limit
     if (file.bodyLength > maxBytes) {
@@ -992,7 +951,7 @@ function multiGet(pattern: string, maxLines?: number, maxBytes: number = DEFAULT
     // Fetch document content using collection and path
     if (!collection || !path) continue;
 
-    const doc = db.prepare(`
+    const doc = store.db.prepare(`
       SELECT content.doc as body, d.title
       FROM documents d
       JOIN content ON content.hash = d.hash
@@ -1104,7 +1063,7 @@ function multiGet(pattern: string, maxLines?: number, maxBytes: number = DEFAULT
 
 // List files in virtual file tree
 function listFiles(pathArg?: string): void {
-  const db = getDb();
+  const store = getStore();
 
   if (!pathArg) {
     // No argument - list all collections
@@ -1118,7 +1077,7 @@ function listFiles(pathArg?: string): void {
 
     // Get file counts from database for each collection
     const collections = yamlCollections.map(coll => {
-      const stats = db.prepare(`
+      const stats = store.db.prepare(`
         SELECT COUNT(*) as file_count
         FROM documents d
         WHERE d.collection = ? AND d.active = 1
@@ -1196,7 +1155,7 @@ function listFiles(pathArg?: string): void {
     params = [coll.name];
   }
 
-  const files = db.prepare(query).all(...params) as { path: string; title: string; modified_at: string; size: number }[];
+  const files = store.db.prepare(query).all(...params) as { path: string; title: string; modified_at: string; size: number }[];
 
   if (files.length === 0) {
     if (pathPrefix) {
@@ -1246,8 +1205,8 @@ function formatLsTime(date: Date): string {
 
 // Collection management commands
 function collectionList(): void {
-  const db = getDb();
-  const collections = listCollections(db);
+  const store = getStore();
+  const collections = store.listCollections();
 
   if (collections.length === 0) {
     console.log("No collections found. Run 'qmd add .' to create one.");
@@ -1318,8 +1277,8 @@ function collectionRemove(name: string): void {
     process.exit(1);
   }
 
-  const db = getDb();
-  const result = removeCollection(db, name);
+  const store = getStore();
+  const result = store.removeCollection(name);
   closeDb();
 
   console.log(`${c.green}✓${c.reset} Removed collection '${name}'`);
@@ -1346,8 +1305,8 @@ function collectionRename(oldName: string, newName: string): void {
     process.exit(1);
   }
 
-  const db = getDb();
-  renameCollection(db, oldName, newName);
+  const store = getStore();
+  store.renameCollection(oldName, newName);
   closeDb();
 
   console.log(`${c.green}✓${c.reset} Renamed collection '${oldName}' to '${newName}'`);
@@ -1355,13 +1314,13 @@ function collectionRename(oldName: string, newName: string): void {
 }
 
 async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, collectionName?: string, suppressEmbedNotice: boolean = false): Promise<void> {
-  const db = getDb();
+  const store = getStore();
   const resolvedPwd = pwd || getPwd();
   const now = new Date().toISOString();
   const excludeDirs = ["node_modules", ".git", ".cache", "vendor", "dist", "build"];
 
   // Clear Ollama cache on index
-  clearCache(db);
+  store.clearCache();
 
   // Collection name must be provided (from YAML)
   if (!collectionName) {
@@ -1415,31 +1374,31 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
     const title = extractTitle(content, relativeFile);
 
     // Check if document exists in this collection with this path
-    const existing = findActiveDocument(db, collectionName, path);
+    const existing = store.findActiveDocument(collectionName, path);
 
     if (existing) {
       if (existing.hash === hash) {
         // Hash unchanged, but check if title needs updating
         if (existing.title !== title) {
-          updateDocumentTitle(db, existing.id, title, now);
+          store.updateDocumentTitle(existing.id, title, now);
           updated++;
         } else {
           unchanged++;
         }
       } else {
         // Content changed - insert new content hash and update document
-        insertContent(db, hash, content, now);
+        store.insertContent(hash, content, now);
         const stat = statSync(filepath);
-        updateDocument(db, existing.id, title, hash,
+        store.updateDocument(existing.id, title, hash,
           stat ? new Date(stat.mtime).toISOString() : now);
         updated++;
       }
     } else {
       // New document - insert content and document
       indexed++;
-      insertContent(db, hash, content, now);
+      store.insertContent(hash, content, now);
       const stat = statSync(filepath);
-      insertDocument(db, collectionName, path, title, hash,
+      store.insertDocument(collectionName, path, title, hash,
         stat ? new Date(stat.birthtime).toISOString() : now,
         stat ? new Date(stat.mtime).toISOString() : now);
     }
@@ -1454,20 +1413,20 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
   }
 
   // Deactivate documents in this collection that no longer exist
-  const allActive = getActiveDocumentPaths(db, collectionName);
+  const allActive = store.getActiveDocumentPaths(collectionName);
   let removed = 0;
-  for (const path of allActive) {
-    if (!seenPaths.has(path)) {
-      deactivateDocument(db, collectionName, path);
+  for (const docPath of allActive) {
+    if (!seenPaths.has(docPath)) {
+      store.deactivateDocument(collectionName, docPath);
       removed++;
     }
   }
 
   // Clean up orphaned content hashes (content not referenced by any document)
-  const orphanedContent = cleanupOrphanedContent(db);
+  const orphanedContent = store.cleanupOrphanedContent();
 
   // Check if vector index needs updating
-  const needsEmbedding = getHashesNeedingEmbedding(db);
+  const needsEmbedding = store.getHashesNeedingEmbedding();
 
   progress.clear();
   console.log(`\nIndexed: ${indexed} new, ${updated} updated, ${unchanged} unchanged, ${removed} removed`);
@@ -1490,17 +1449,17 @@ function renderProgressBar(percent: number, width: number = 30): string {
 }
 
 async function vectorIndex(model: string = DEFAULT_EMBED_MODEL, force: boolean = false): Promise<void> {
-  const db = getDb();
+  const store = getStore();
   const now = new Date().toISOString();
 
   // If force, clear all vectors
   if (force) {
     console.log(`${c.yellow}Force re-indexing: clearing all vectors...${c.reset}`);
-    clearAllEmbeddings(db);
+    store.clearAllEmbeddings();
   }
 
   // Find unique hashes that need embedding (from active documents)
-  const hashesToEmbed = getHashesForEmbedding(db);
+  const hashesToEmbed = store.getHashesForEmbedding();
 
   if (hashesToEmbed.length === 0) {
     console.log(`${c.green}✓ All content hashes already have embeddings.${c.reset}`);
@@ -1599,7 +1558,7 @@ async function vectorIndex(model: string = DEFAULT_EMBED_MODEL, force: boolean =
           const embedding = embeddings[i];
 
           if (embedding) {
-            insertEmbedding(db, chunk.hash, chunk.seq, chunk.pos, new Float32Array(embedding.embedding), model, now);
+            store.insertEmbedding(chunk.hash, chunk.seq, chunk.pos, new Float32Array(embedding.embedding), model, now);
             chunksEmbedded++;
           } else {
             errors++;
@@ -1614,7 +1573,7 @@ async function vectorIndex(model: string = DEFAULT_EMBED_MODEL, force: boolean =
             const text = formatDocForEmbedding(chunk.text, chunk.title);
             const result = await session.embed(text);
             if (result) {
-              insertEmbedding(db, chunk.hash, chunk.seq, chunk.pos, new Float32Array(result.embedding), model, now);
+              store.insertEmbedding(chunk.hash, chunk.seq, chunk.pos, new Float32Array(result.embedding), model, now);
               chunksEmbedded++;
             } else {
               errors++;
@@ -1917,7 +1876,7 @@ function outputResults(results: { file: string; displayPath: string; title: stri
 }
 
 function search(query: string, opts: OutputOptions): void {
-  const db = getDb();
+  const store = getStore();
 
   // Validate collection filter if specified
   let collectionName: string | undefined;
@@ -1934,7 +1893,7 @@ function search(query: string, opts: OutputOptions): void {
   // Use large limit for --all, otherwise fetch more than needed and let outputResults filter
   const fetchLimit = opts.all ? 100000 : Math.max(50, opts.limit * 2);
   // searchFTS accepts collection name as number parameter for legacy reasons (will be fixed in store.ts)
-  const results = searchFTS(db, query, fetchLimit, collectionName as any);
+  const results = store.searchFTS(query, fetchLimit, collectionName as any);
 
   // Add context to results
   const resultsWithContext = results.map(r => ({
@@ -1943,7 +1902,7 @@ function search(query: string, opts: OutputOptions): void {
     title: r.title,
     body: r.body || "",
     score: r.score,
-    context: getContextForFile(db, r.filepath),
+    context: store.getContextForFile(r.filepath),
     hash: r.hash,
     docid: r.docid,
   }));
@@ -1958,7 +1917,7 @@ function search(query: string, opts: OutputOptions): void {
 }
 
 async function vectorSearch(query: string, opts: OutputOptions, model: string = DEFAULT_EMBED_MODEL): Promise<void> {
-  const db = getDb();
+  const store = getStore();
 
   // Validate collection filter if specified
   let collectionName: string | undefined;
@@ -1972,7 +1931,7 @@ async function vectorSearch(query: string, opts: OutputOptions, model: string = 
     collectionName = opts.collection;
   }
 
-  const tableExists = db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'`).get();
+  const tableExists = store.db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'`).get();
   if (!tableExists) {
     console.error("Vector index not found. Run 'qmd embed' first to create embeddings.");
     closeDb();
@@ -1980,7 +1939,7 @@ async function vectorSearch(query: string, opts: OutputOptions, model: string = 
   }
 
   // Check index health and warn about issues
-  checkIndexHealth(db);
+  checkIndexHealth(store);
 
   // Wrap LLM operations in a session for lifecycle management
   await withLLMSession(async (session) => {
@@ -2008,7 +1967,7 @@ async function vectorSearch(query: string, opts: OutputOptions, model: string = 
     // are made. This is a known limitation of the LlamaEmbeddingContext.
     // See: https://github.com/tobi/qmd/pull/23
     for (const q of vectorQueries) {
-      const vecResults = await searchVec(db, q, model, perQueryLimit, collectionName as any, session);
+      const vecResults = await store.searchVec(q, model, perQueryLimit, collectionName as any, session);
       for (const r of vecResults) {
         const existing = allResults.get(r.filepath);
         if (!existing || r.score > existing.score) {
@@ -2021,7 +1980,7 @@ async function vectorSearch(query: string, opts: OutputOptions, model: string = 
     const results = Array.from(allResults.values())
       .sort((a, b) => b.score - a.score)
       .slice(0, opts.limit)
-      .map(r => ({ ...r, context: getContextForFile(db, r.file) }));
+      .map(r => ({ ...r, context: store.getContextForFile(r.file) }));
 
     closeDb();
 
@@ -2081,7 +2040,7 @@ async function expandQuery(query: string, _model: string = DEFAULT_QUERY_MODEL, 
 }
 
 async function querySearch(query: string, opts: OutputOptions, embedModel: string = DEFAULT_EMBED_MODEL, rerankModel: string = DEFAULT_RERANK_MODEL): Promise<void> {
-  const db = getDb();
+  const store = getStore();
 
   // Validate collection filter if specified
   let collectionName: string | undefined;
@@ -2096,11 +2055,11 @@ async function querySearch(query: string, opts: OutputOptions, embedModel: strin
   }
 
   // Check index health and warn about issues
-  checkIndexHealth(db);
+  checkIndexHealth(store);
 
   // Run initial BM25 search (will be reused for retrieval)
-  const initialFts = searchFTS(db, query, 20, collectionName as any);
-  let hasVectors = !!db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'`).get();
+  const initialFts = store.searchFTS(query, 20, collectionName as any);
+  let hasVectors = !!store.db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'`).get();
 
   // Check if initial results have strong signals (skip expansion if so)
   // Strong signal = top result is strong AND clearly separated from runner-up.
@@ -2152,7 +2111,7 @@ async function querySearch(query: string, opts: OutputOptions, embedModel: strin
     for (const q of ftsQueries) {
       if (!q) continue;
       searchPromises.push((async () => {
-        const ftsResults = searchFTS(db, q, 20, (collectionName || "") as any);
+        const ftsResults = store.searchFTS(q, 20, (collectionName || "") as any);
         if (ftsResults.length > 0) {
           for (const r of ftsResults) {
             // Mutex for hashMap is not strictly needed as it's just adding values
@@ -2168,7 +2127,7 @@ async function querySearch(query: string, opts: OutputOptions, embedModel: strin
       for (const q of vectorQueries) {
         if (!q) continue;
         searchPromises.push((async () => {
-          const vecResults = await searchVec(db, q, embedModel, 20, (collectionName || "") as any, session);
+          const vecResults = await store.searchVec(q, embedModel, 20, (collectionName || "") as any, session);
           if (vecResults.length > 0) {
             for (const r of vecResults) hashMap.set(r.filepath, r.hash);
             rankedLists.push(vecResults.map(r => ({ file: r.filepath, displayPath: r.displayPath, title: r.title, body: r.body || "", score: r.score })));
@@ -2226,7 +2185,7 @@ async function querySearch(query: string, opts: OutputOptions, embedModel: strin
       query,
       chunksToRerank.map(ch => ({ file: ch.file, text: ch.text })),
       rerankModel,
-      db,
+      undefined,
       session
     );
 
@@ -2269,7 +2228,7 @@ async function querySearch(query: string, opts: OutputOptions, embedModel: strin
         body: chunkBody,
         chunkPos,
         score: blendedScore,
-        context: getContextForFile(db, file),
+        context: store.getContextForFile(file),
         hash: hashMap.get(file) || "",
       };
     }).sort((a, b) => b.score - a.score);
@@ -2657,14 +2616,14 @@ if (import.meta.main) {
     }
 
     case "cleanup": {
-      const db = getDb();
+      const store = getStore();
 
       // 1. Clear llm_cache
-      const cacheCount = deleteLLMCache(db);
+      const cacheCount = store.deleteLLMCache();
       console.log(`${c.green}✓${c.reset} Cleared ${cacheCount} cached API responses`);
 
       // 2. Remove orphaned vectors
-      const orphanedVecs = cleanupOrphanedVectors(db);
+      const orphanedVecs = store.cleanupOrphanedVectors();
       if (orphanedVecs > 0) {
         console.log(`${c.green}✓${c.reset} Removed ${orphanedVecs} orphaned embedding chunks`);
       } else {
@@ -2672,13 +2631,13 @@ if (import.meta.main) {
       }
 
       // 3. Remove inactive documents
-      const inactiveDocs = deleteInactiveDocuments(db);
+      const inactiveDocs = store.deleteInactiveDocuments();
       if (inactiveDocs > 0) {
         console.log(`${c.green}✓${c.reset} Removed ${inactiveDocs} inactive document records`);
       }
 
       // 4. Vacuum to reclaim space
-      vacuumDatabase(db);
+      store.vacuumDatabase();
       console.log(`${c.green}✓${c.reset} Database vacuumed`);
 
       closeDb();

--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -84,10 +84,6 @@ function getStore(): ReturnType<typeof createStore> {
   return store;
 }
 
-function getDb(): Database {
-  return getStore().db;
-}
-
 function closeDb(): void {
   if (store) {
     store.close();

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -453,7 +453,7 @@ describe("Store Creation", () => {
     expect(() => store.db.prepare("SELECT 1").get()).toThrow();
     try {
       await unlink(testDbPath);
-    } catch {}
+    } catch { }
   });
 });
 

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -15,6 +15,7 @@ import YAML from "yaml";
 import { disposeDefaultLlamaCpp } from "./llm.js";
 import {
   createStore,
+  getDefaultDbPath,
   homedir,
   resolve,
   getPwd,
@@ -275,14 +276,12 @@ describe("Path Utilities", () => {
     if (originalIndexPath) process.env.INDEX_PATH = originalIndexPath;
   });
 
-  test("store.getDefaultDbPath uses INDEX_PATH when set", () => {
+  test("getDefaultDbPath uses INDEX_PATH when set", () => {
     const originalIndexPath = process.env.INDEX_PATH;
     process.env.INDEX_PATH = "/tmp/test-index.sqlite";
 
-    const store = createStore();
-    expect(store.getDefaultDbPath()).toBe("/tmp/test-index.sqlite");
-    expect(store.getDefaultDbPath("custom")).toBe("/tmp/test-index.sqlite"); // INDEX_PATH overrides name
-    store.close();
+    expect(getDefaultDbPath()).toBe("/tmp/test-index.sqlite");
+    expect(getDefaultDbPath("custom")).toBe("/tmp/test-index.sqlite"); // INDEX_PATH overrides name
 
     // Restore
     if (originalIndexPath) {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1904,7 +1904,7 @@ describe("LlamaCpp Integration", () => {
     expect(queries.length).toBeGreaterThanOrEqual(1);
 
     await cleanupTestDb(store);
-  }, 120000);
+  }, 300_000);
 
   test("expandQuery caches results", async () => {
     const store = await createTestStore();
@@ -1917,7 +1917,7 @@ describe("LlamaCpp Integration", () => {
     expect(queries1[0]).toBe(queries2[0]);
 
     await cleanupTestDb(store);
-  }, 30000);
+  }, 300_000);
 
   test("rerank scores documents", async () => {
     const store = await createTestStore();

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -15,7 +15,6 @@ import YAML from "yaml";
 import { disposeDefaultLlamaCpp } from "./llm.js";
 import {
   createStore,
-  getDefaultDbPath,
   homedir,
   resolve,
   getPwd,
@@ -264,24 +263,26 @@ describe("Path Utilities", () => {
     expect(resolve("/foo/bar/../../baz")).toBe("/baz");
   });
 
-  test("getDefaultDbPath throws in test mode without INDEX_PATH", () => {
-    // In test mode, getDefaultDbPath should throw to prevent accidental writes to global index
+  test("createStore throws in test mode without INDEX_PATH or explicit path", () => {
+    // In test mode, createStore should throw to prevent accidental writes to global index
     // This is intentional safety behavior
     const originalIndexPath = process.env.INDEX_PATH;
     delete process.env.INDEX_PATH;
 
-    expect(() => getDefaultDbPath()).toThrow("Database path not set");
+    expect(() => createStore()).toThrow("Database path not set");
 
     // Restore
     if (originalIndexPath) process.env.INDEX_PATH = originalIndexPath;
   });
 
-  test("getDefaultDbPath uses INDEX_PATH when set", () => {
+  test("store.getDefaultDbPath uses INDEX_PATH when set", () => {
     const originalIndexPath = process.env.INDEX_PATH;
     process.env.INDEX_PATH = "/tmp/test-index.sqlite";
 
-    expect(getDefaultDbPath()).toBe("/tmp/test-index.sqlite");
-    expect(getDefaultDbPath("custom")).toBe("/tmp/test-index.sqlite"); // INDEX_PATH overrides name
+    const store = createStore();
+    expect(store.getDefaultDbPath()).toBe("/tmp/test-index.sqlite");
+    expect(store.getDefaultDbPath("custom")).toBe("/tmp/test-index.sqlite"); // INDEX_PATH overrides name
+    store.close();
 
     // Restore
     if (originalIndexPath) {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1904,7 +1904,7 @@ describe("LlamaCpp Integration", () => {
     expect(queries.length).toBeGreaterThanOrEqual(1);
 
     await cleanupTestDb(store);
-  }, 30000);
+  }, 120000);
 
   test("expandQuery caches results", async () => {
     const store = await createTestStore();

--- a/src/store.ts
+++ b/src/store.ts
@@ -238,7 +238,7 @@ export function enableProductionMode(): void {
   _productionMode = true;
 }
 
-function getDefaultDbPath(indexName: string = "index"): string {
+export function getDefaultDbPath(indexName: string = "index"): string {
   // Always allow override via INDEX_PATH (for testing)
   if (Bun.env.INDEX_PATH) {
     return Bun.env.INDEX_PATH;
@@ -583,7 +583,6 @@ function ensureVecTableInternal(db: Database, dimensions: number): void {
 export type Store = {
   db: Database;
   dbPath: string;
-  getDefaultDbPath: (indexName?: string) => string;
   close: () => void;
   ensureVecTable: (dimensions: number) => void;
 
@@ -679,7 +678,6 @@ export function createStore(dbPath?: string): Store {
   return {
     db,
     dbPath: resolvedPath,
-    getDefaultDbPath,
     close: () => db.close(),
     ensureVecTable: (dimensions: number) => ensureVecTableInternal(db, dimensions),
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -238,7 +238,7 @@ export function enableProductionMode(): void {
   _productionMode = true;
 }
 
-export function getDefaultDbPath(indexName: string = "index"): string {
+function getDefaultDbPath(indexName: string = "index"): string {
   // Always allow override via INDEX_PATH (for testing)
   if (Bun.env.INDEX_PATH) {
     return Bun.env.INDEX_PATH;
@@ -583,6 +583,7 @@ function ensureVecTableInternal(db: Database, dimensions: number): void {
 export type Store = {
   db: Database;
   dbPath: string;
+  getDefaultDbPath: (indexName?: string) => string;
   close: () => void;
   ensureVecTable: (dimensions: number) => void;
 
@@ -678,6 +679,7 @@ export function createStore(dbPath?: string): Store {
   return {
     db,
     dbPath: resolvedPath,
+    getDefaultDbPath,
     close: () => db.close(),
     ensureVecTable: (dimensions: number) => ensureVecTableInternal(db, dimensions),
 


### PR DESCRIPTION
Hi, thanks for the great project!

I want to experiment with storage layer in the `qmd` - so I made first simple refactoring to make store usages more uniform across codebase (before code used free functions with explicit Db parameter for some cases - now it always uses `store: Store`)

For local run of the tests I increased few timeouts to 300s (should this be set up in the CI for the `qmd` PRs?)

Locally, tests are passing for me if I exclude `expandQuery` related query (since they are very slow for me locally on WSL)