### PR TITLE
feat(llm): qmd query speedup - add environment variable overrides for faster model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,26 @@ llm_cache       -- Cached LLM responses (query expansion, rerank scores)
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `XDG_CACHE_HOME` | `~/.cache` | Cache directory location |
+| `QMD_EMBED_MODEL` | `hf:ggml-org/embeddinggemma-300M-GGUF/...` | Override embedding model URI |
+| `QMD_GENERATE_MODEL` | `hf:tobil/qmd-query-expansion-1.7B-gguf/...` | Override query expansion model URI |
+| `QMD_RERANK_MODEL` | `hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/...` | Override reranker model URI |
+| `QMD_MODEL_CACHE_DIR` | `~/.cache/qmd/models` | Override model cache directory |
+
+### Model Override Example
+
+For latency-critical applications (e.g., API timeouts), use a faster reranker:
+
+```sh
+# Use Jina's tiny reranker (185x faster cold start, 6-10x faster warm)
+export QMD_RERANK_MODEL="hf:gpustack/jina-reranker-v1-tiny-en-GGUF/jina-reranker-v1-tiny-en-FP16.gguf"
+qmd query "your search"
+```
+
+**Priority order:** config object > environment variable > default
+
+**Trade-offs:**
+- `jina-reranker-v1-tiny-en` (33M params, 67MB): ~80ms cold, ~50ms warm, 78% ranking agreement
+- `qwen3-reranker-0.6b` (600M params, 639MB): ~15s cold, ~400ms warm, best quality
 
 ## How It Works
 

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -386,10 +386,11 @@ export class LlamaCpp implements LLM {
 
 
   constructor(config: LlamaCppConfig = {}) {
-    this.embedModelUri = config.embedModel || DEFAULT_EMBED_MODEL;
-    this.generateModelUri = config.generateModel || DEFAULT_GENERATE_MODEL;
-    this.rerankModelUri = config.rerankModel || DEFAULT_RERANK_MODEL;
-    this.modelCacheDir = config.modelCacheDir || MODEL_CACHE_DIR;
+    // Priority: config > env var > default
+    this.embedModelUri = config.embedModel || process.env.QMD_EMBED_MODEL || DEFAULT_EMBED_MODEL;
+    this.generateModelUri = config.generateModel || process.env.QMD_GENERATE_MODEL || DEFAULT_GENERATE_MODEL;
+    this.rerankModelUri = config.rerankModel || process.env.QMD_RERANK_MODEL || DEFAULT_RERANK_MODEL;
+    this.modelCacheDir = config.modelCacheDir || process.env.QMD_MODEL_CACHE_DIR || MODEL_CACHE_DIR;
     this.inactivityTimeoutMs = config.inactivityTimeoutMs ?? DEFAULT_INACTIVITY_TIMEOUT_MS;
     this.disposeModelsOnInactivity = config.disposeModelsOnInactivity ?? false;
   }


### PR DESCRIPTION
## Problem 

When using `qmd query` for latency-sensitive applications (like AI agent memory search with 5-second timeouts), the default reranker becomes a bottleneck. For instance, on my Mac Mini M4 16GB, `qmd query`'s full process takes ~15s

## Solution 

This PR allows to select faster models by adding environment variables for runtime model configuration without code changes:

- QMD_EMBED_MODEL - override embedding model
- QMD_GENERATE_MODEL - override query expansion model
- QMD_RERANK_MODEL - override reranker model
- QMD_MODEL_CACHE_DIR - override model cache directory

Priority: config object > environment variable > default

I managed to get great results with [Jina Reranker v1-tiny](https://huggingface.co/jinaai/jina-reranker-v1-tiny-en) - a 33M parameter distilled model optimized for speed, without changing defaults or rebuilding.

Example:
  export QMD_RERANK_MODEL='hf:gpustack/jina-reranker-v1-tiny-en-GGUF/jina-reranker-v1-tiny-en-FP16.gguf'
  qmd query "your search"

Benchmarks on Mac Mini M4 16GB:

| Scenario            | qwen3 (default) | jina-tiny | Speedup |
|---------------------|-----------------|-----------|---------|
| Cold start (8 docs) | ~15,000ms       | ~80ms     | 185x    |
| Warm cache (8 docs) | 400-440ms       | 40-65ms   | 6-10x   |
| Full pipeline cold  | ~20s            | ~7s       | 3x      |
| Full pipeline warm  | ~15s            | ~5.7s     | 2.6x    |

Quality: ~78% top-3 ranking agreement (same relevant docs, order differs slightly).

Includes:
- Unit tests for env var configuration
- README documentation with model override examples

No breaking changes. Default remains qwen3-reranker-0.6b.