### PR TITLE
fix(vec): avoid pathological join order in sqlite-vec search

### DIFF
--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -1984,7 +1984,7 @@ async function vectorSearch(query: string, opts: OutputOptions, model: string = 
 
   for (const q of queries) {
     // searchVec accepts collection name as number parameter for legacy reasons (will be fixed in store.ts)
-    const vecResults = await searchVec(db, q, model, perQueryLimit, collectionName as any);
+    const vecResults = await searchVec(db, q, model, perQueryLimit, collectionName);
     for (const r of vecResults) {
       const existing = allResults.get(r.filepath);
       if (!existing || r.score > existing.score) {
@@ -2112,7 +2112,7 @@ async function querySearch(query: string, opts: OutputOptions, embedModel: strin
     // Vector search - get ranked results
     if (hasVectors) {
       // searchVec accepts collection name as number parameter for legacy reasons (will be fixed in store.ts)
-      const vecResults = await searchVec(db, q, embedModel, 20, collectionName as any);
+      const vecResults = await searchVec(db, q, embedModel, 20, collectionName);
       if (vecResults.length > 0) {
         rankedLists.push(vecResults.map(r => ({ file: r.filepath, displayPath: r.displayPath, title: r.title, body: r.body || "", score: r.score })));
       }


### PR DESCRIPTION
Vector search (and the hybrid query pipeline) can become extremely slow on larger indexes because SQLite may choose a join order that scans the documents table before evaluating the vec0 KNN constraint. This makes qmd vsearch/query look like it is hanging even though the embedding call is fast.

This change forces the KNN step to run first by materializing the vec0 lookup in a CTE (WITH knn AS MATERIALIZED ...), then joining the small KNN result set to content_vectors/documents/content. It also removes the placeholder-replacement hack for collection filtering and binds the collection name as a normal parameter.