### PR TITLE
fix: respect XDG_CONFIG_HOME for collection config path

### DIFF
--- a/src/collections.ts
+++ b/src/collections.ts
@@ -66,6 +66,11 @@ function getConfigDir(): string {
   if (process.env.QMD_CONFIG_DIR) {
     return process.env.QMD_CONFIG_DIR;
   }
+  // Respect XDG_CONFIG_HOME per XDG Base Directory spec
+  const xdgConfig = process.env.XDG_CONFIG_HOME;
+  if (xdgConfig) {
+    return join(xdgConfig, "qmd");
+  }
   return join(homedir(), ".config", "qmd");
 }
 


### PR DESCRIPTION
## Problem

`getConfigDir()` in `collections.ts` is hardcoded to `~/.config/qmd`, ignoring the `XDG_CONFIG_HOME` environment variable. This makes it impossible to run isolated QMD instances with separate collection configs on the same machine.

The store already respects `XDG_CACHE_HOME` for the SQLite database location, but the collection YAML config doesn't follow the same convention. When a host application (e.g. OpenClaw) sets both `XDG_CACHE_HOME` and `XDG_CONFIG_HOME` to isolate its QMD instance, the config still reads/writes from the shared `~/.config/qmd/index.yml`, causing cross-environment collection pollution.

## Fix

Check `XDG_CONFIG_HOME` in `getConfigDir()` before falling back to `~/.config/qmd`, consistent with the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/). `QMD_CONFIG_DIR` still takes precedence when set.

## Changes

- `src/collections.ts`: `getConfigDir()` now checks `XDG_CONFIG_HOME` → `$XDG_CONFIG_HOME/qmd`

Priority: `QMD_CONFIG_DIR` > `XDG_CONFIG_HOME/qmd` > `~/.config/qmd`