### PR TITLE
Fix plugin install EEXIST error

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
 	},
 	"plugins": [
 		{
-			"name": "qmd",
+			"name": "qmd-search",
 			"source": "./",
 			"description": "Search and retrieve documents from local markdown files.",
 			"version": "0.1.0",


### PR DESCRIPTION
## Summary

- Rename plugin from `qmd` to `qmd-search` in `marketplace.json` to fix `EEXIST` error during installation

The plugin name `"qmd"` conflicts with the `qmd` executable file at the repo root. When Claude Code installs the plugin, it creates the path `cache/<marketplace>/<plugin-name>/` and copies repo contents into it. Since both the directory and the file are named `qmd`, `mkdir` fails with `EEXIST`.

Renaming the plugin to `qmd-search` avoids the conflict.

```
Error: Failed to install: EEXIST: file already exists, mkdir '/Users/houss/.claude/plugins/cache/qmd/qmd'
```

Fixes the issue reported in #99 by @klaascuvelier.

## Test plan

- [x] Clean plugin cache (`rm -rf ~/.claude/plugins/cache/qmd`)
- [x] Apply the rename in local marketplace
- [x] `/plugin install qmd-search@qmd` → installs successfully
- [x] `qmd status` via MCP → works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)