### PR TITLE
fix: rename plugin to qmd-plugin to avoid executable conflict

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-	"name": "qmd",
+	"name": "qmd-plugin",
 	"owner": {
 		"name": "tobi",
 		"email": "tobi@lutke.com"


### PR DESCRIPTION
This PR is fixes error described in the #139 