### PR TITLE
feat(embed): skip oversized files with configurable size limit (#1)

### DIFF
--- a/src/embed-config.test.ts
+++ b/src/embed-config.test.ts
@@ -1,0 +1,76 @@
+/**
+ * embed-config.test.ts - Tests for embed configuration helpers
+ *
+ * Run with: bun test embed-config.test.ts
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { getMaxEmbedFileBytes } from "./qmd.js";
+import { DEFAULT_MAX_EMBED_FILE_BYTES } from "./store.js";
+
+describe("getMaxEmbedFileBytes", () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.QMD_MAX_EMBED_FILE_BYTES;
+    delete process.env.QMD_MAX_EMBED_FILE_BYTES;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.QMD_MAX_EMBED_FILE_BYTES = originalEnv;
+    } else {
+      delete process.env.QMD_MAX_EMBED_FILE_BYTES;
+    }
+  });
+
+  test("returns default when env var is unset", () => {
+    expect(getMaxEmbedFileBytes()).toBe(DEFAULT_MAX_EMBED_FILE_BYTES);
+    expect(getMaxEmbedFileBytes()).toBe(5 * 1024 * 1024);
+  });
+
+  test("respects valid numeric env var", () => {
+    process.env.QMD_MAX_EMBED_FILE_BYTES = "1048576"; // 1MB
+    expect(getMaxEmbedFileBytes()).toBe(1048576);
+  });
+
+  test("respects large values", () => {
+    process.env.QMD_MAX_EMBED_FILE_BYTES = "10485760"; // 10MB
+    expect(getMaxEmbedFileBytes()).toBe(10485760);
+  });
+
+  test("floors fractional values to integer", () => {
+    process.env.QMD_MAX_EMBED_FILE_BYTES = "1500.7";
+    expect(getMaxEmbedFileBytes()).toBe(1500);
+  });
+
+  test("falls back to default for non-numeric string", () => {
+    process.env.QMD_MAX_EMBED_FILE_BYTES = "abc";
+    expect(getMaxEmbedFileBytes()).toBe(DEFAULT_MAX_EMBED_FILE_BYTES);
+  });
+
+  test("falls back to default for empty string", () => {
+    process.env.QMD_MAX_EMBED_FILE_BYTES = "";
+    expect(getMaxEmbedFileBytes()).toBe(DEFAULT_MAX_EMBED_FILE_BYTES);
+  });
+
+  test("falls back to default for zero", () => {
+    process.env.QMD_MAX_EMBED_FILE_BYTES = "0";
+    expect(getMaxEmbedFileBytes()).toBe(DEFAULT_MAX_EMBED_FILE_BYTES);
+  });
+
+  test("falls back to default for negative value", () => {
+    process.env.QMD_MAX_EMBED_FILE_BYTES = "-100";
+    expect(getMaxEmbedFileBytes()).toBe(DEFAULT_MAX_EMBED_FILE_BYTES);
+  });
+
+  test("falls back to default for Infinity", () => {
+    process.env.QMD_MAX_EMBED_FILE_BYTES = "Infinity";
+    expect(getMaxEmbedFileBytes()).toBe(DEFAULT_MAX_EMBED_FILE_BYTES);
+  });
+
+  test("falls back to default for NaN", () => {
+    process.env.QMD_MAX_EMBED_FILE_BYTES = "NaN";
+    expect(getMaxEmbedFileBytes()).toBe(DEFAULT_MAX_EMBED_FILE_BYTES);
+  });
+});

--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -21,6 +21,7 @@ import {
   isDocid,
   matchFilesByGlob,
   getHashesNeedingEmbedding,
+  getEmbedBreakdown,
   getHashesForEmbedding,
   clearAllEmbeddings,
   insertEmbedding,
@@ -62,6 +63,7 @@ import {
   DEFAULT_RERANK_MODEL,
   DEFAULT_GLOB,
   DEFAULT_MULTI_GET_MAX_BYTES,
+  DEFAULT_MAX_EMBED_FILE_BYTES,
   createStore,
   getDefaultDbPath,
 } from "./store.js";
@@ -269,7 +271,8 @@ function showStatus(): void {
   // Overall stats
   const totalDocs = db.prepare(`SELECT COUNT(*) as count FROM documents WHERE active = 1`).get() as { count: number };
   const vectorCount = db.prepare(`SELECT COUNT(*) as count FROM content_vectors`).get() as { count: number };
-  const needsEmbedding = getHashesNeedingEmbedding(db);
+  const maxEmbedSize = getMaxEmbedFileBytes();
+  const { needsEmbedding, tooLarge } = getEmbedBreakdown(db, maxEmbedSize);
 
   // Most recent update across all collections
   const mostRecent = db.prepare(`SELECT MAX(modified_at) as latest FROM documents WHERE active = 1`).get() as { latest: string | null };
@@ -300,6 +303,9 @@ function showStatus(): void {
   console.log(`  Vectors:  ${vectorCount.count} embedded`);
   if (needsEmbedding > 0) {
     console.log(`  ${c.yellow}Pending:  ${needsEmbedding} need embedding${c.reset} (run 'qmd embed')`);
+  }
+  if (tooLarge > 0) {
+    console.log(`  ${c.dim}Skipped:  ${tooLarge} exceed ${formatBytes(maxEmbedSize)} size limit${c.reset}`);
   }
   if (mostRecent.latest) {
     const lastUpdate = new Date(mostRecent.latest);
@@ -1482,7 +1488,20 @@ function renderProgressBar(percent: number, width: number = 30): string {
   return bar;
 }
 
-async function vectorIndex(model: string = DEFAULT_EMBED_MODEL, force: boolean = false): Promise<void> {
+export function getMaxEmbedFileBytes(): number {
+  const env = process.env.QMD_MAX_EMBED_FILE_BYTES;
+  if (!env) return DEFAULT_MAX_EMBED_FILE_BYTES;
+  const parsed = Number(env);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    process.stderr.write(
+      `${c.yellow}Warning: Invalid QMD_MAX_EMBED_FILE_BYTES="${env}", using default ${formatBytes(DEFAULT_MAX_EMBED_FILE_BYTES)}${c.reset}\n`
+    );
+    return DEFAULT_MAX_EMBED_FILE_BYTES;
+  }
+  return Math.floor(parsed);
+}
+
+async function vectorIndex({ model = DEFAULT_EMBED_MODEL, force = false, noSizeLimit = false }: { model?: string; force?: boolean; noSizeLimit?: boolean } = {}): Promise<void> {
   const db = getDb();
   const now = new Date().toISOString();
 
@@ -1507,11 +1526,22 @@ async function vectorIndex(model: string = DEFAULT_EMBED_MODEL, force: boolean =
   let multiChunkDocs = 0;
 
   // Chunk all documents using actual token counts
+  const maxEmbedSize = noSizeLimit ? Infinity : getMaxEmbedFileBytes();
+  let skippedFiles = 0;
+
   process.stderr.write(`Chunking ${hashesToEmbed.length} documents by token count...\n`);
   for (const item of hashesToEmbed) {
-    const encoder = new TextEncoder();
-    const bodyBytes = encoder.encode(item.body).length;
+    const bodyBytes = Buffer.byteLength(item.body, 'utf8');
     if (bodyBytes === 0) continue; // Skip empty
+
+    // Content size limit check
+    if (bodyBytes > maxEmbedSize) {
+      process.stderr.write(
+        `${c.yellow}Skipping ${item.path} (${formatBytes(bodyBytes)} exceeds ${formatBytes(maxEmbedSize)} limit)${c.reset}\n`
+      );
+      skippedFiles++;
+      continue;
+    }
 
     const title = extractTitle(item.body, item.path);
     const displayName = item.path;
@@ -1527,10 +1557,14 @@ async function vectorIndex(model: string = DEFAULT_EMBED_MODEL, force: boolean =
         seq,
         pos: chunks[seq]!.pos,
         tokens: chunks[seq]!.tokens,
-        bytes: encoder.encode(chunks[seq]!.text).length,
+        bytes: Buffer.byteLength(chunks[seq]!.text, 'utf8'),
         displayName,
       });
     }
+  }
+
+  if (skippedFiles > 0) {
+    console.log(`${c.yellow}${skippedFiles} file(s) skipped (exceeded ${formatBytes(maxEmbedSize)} file size limit). Use --no-size-limit to include all files.${c.reset}`);
   }
 
   if (allChunks.length === 0) {
@@ -1541,7 +1575,7 @@ async function vectorIndex(model: string = DEFAULT_EMBED_MODEL, force: boolean =
 
   const totalBytes = allChunks.reduce((sum, chk) => sum + chk.bytes, 0);
   const totalChunks = allChunks.length;
-  const totalDocs = hashesToEmbed.length;
+  const totalDocs = hashesToEmbed.length - skippedFiles;
 
   console.log(`${c.bold}Embedding ${totalDocs} documents${c.reset} ${c.dim}(${totalChunks} chunks, ${formatBytes(totalBytes)})${c.reset}`);
   if (multiChunkDocs > 0) {
@@ -2046,6 +2080,7 @@ function parseCLI() {
       mask: { type: "string" },  // glob pattern
       // Embed options
       force: { type: "boolean", short: "f" },
+      "no-size-limit": { type: "boolean" },
       // Update options
       pull: { type: "boolean" },  // git pull before update
       refresh: { type: "boolean" },
@@ -2116,7 +2151,7 @@ function showHelp(): void {
   console.log("  qmd multi-get <pattern> [-l N] [--max-bytes N]  - Get multiple docs by glob or comma-separated list");
   console.log("  qmd status                    - Show index status and collections");
   console.log("  qmd update [--pull]           - Re-index all collections (--pull: git pull first)");
-  console.log("  qmd embed [-f]                - Create vector embeddings (800 tokens/chunk, 15% overlap)");
+  console.log("  qmd embed [-f] [--no-size-limit]  - Create vector embeddings (800 tokens/chunk, 15% overlap)");
   console.log("  qmd cleanup                   - Remove cache and orphaned data, vacuum DB");
   console.log("  qmd search <query>            - Full-text search (BM25)");
   console.log("  qmd vsearch <query>           - Vector similarity search");
@@ -2146,6 +2181,10 @@ function showHelp(): void {
   console.log("  -l <num>                   - Maximum lines per file");
   console.log("  --max-bytes <num>          - Skip files larger than N bytes (default: 10240)");
   console.log("  --json/--csv/--md/--xml/--files - Output format (same as search)");
+  console.log("");
+  console.log("Embed options:");
+  console.log("  -f, --force                - Force re-index all embeddings");
+  console.log("  --no-size-limit            - Embed all files regardless of size (default limit: 5MB)");
   console.log("");
   console.log("Models (auto-downloaded from HuggingFace):");
   console.log("  Embedding: embeddinggemma-300M-Q8_0");
@@ -2333,7 +2372,7 @@ if (import.meta.main) {
       break;
 
     case "embed":
-      await vectorIndex(DEFAULT_EMBED_MODEL, !!cli.values.force);
+      await vectorIndex({ force: !!cli.values.force, noSizeLimit: !!cli.values["no-size-limit"] });
       break;
 
     case "pull": {


### PR DESCRIPTION
> Replaces #153 (branch was recreated during a rebase to resolve merge conflicts with #149).

## Summary

Add a configurable content size limit to `qmd embed` that skips oversized files before tokenization. Prevents OOM on constrained systems and improves embedding quality by avoiding excessively large documents that produce too many diluted chunks.

## Changes

- Add `getEmbedBreakdown()` SQL query in `store.ts` to split pending docs into embeddable vs too-large
- Add `DEFAULT_MAX_EMBED_FILE_BYTES` constant (5MB) in `store.ts`
- Add `getMaxEmbedFileBytes()` helper with `QMD_MAX_EMBED_FILE_BYTES` env var override
- Add `--no-size-limit` CLI flag to bypass size checks for one-off full embeds
- Show "Skipped: N exceed X size limit" in `qmd status` output
- Replace `new TextEncoder().encode(str).length` with `Buffer.byteLength(str, 'utf8')` (avoids unnecessary memory allocation in the chunking loop)
- Add 20 automated tests (10 env var parsing, 5 SQL query unit, 5 CLI integration)

## Type of Change

- [x] `feat`: New feature (non-breaking change which adds functionality)
- [x] `test`: Adding or updating tests

## Related Issues/Stories

- Issue: #156
- Note: this does NOT fix #91 -- that issue is about reranker context overflow in `src/mcp.ts`, not embedding OOM
- Replaces: #153

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing completed
- [x] All tests passing

**Test Summary:**

- Unit tests: 15 passing (10 `getMaxEmbedFileBytes` env var parsing + 5 `getEmbedBreakdown` SQL query)
- Integration tests: 5 passing (status display with/without skipped files, embed skip behavior, `--no-size-limit` flag, help text)

## Files Modified

**Modified:**
- `src/store.ts` -- add `getEmbedBreakdown()` function and `DEFAULT_MAX_EMBED_FILE_BYTES` constant
- `src/qmd.ts` -- add `getMaxEmbedFileBytes()`, `--no-size-limit` flag, skip logic in `vectorIndex()`, breakdown display in `status`
- `src/store.test.ts` -- add `describe("getEmbedBreakdown")` with 5 unit tests
- `src/cli.test.ts` -- add `describe("CLI Embed File Size Limit")` with 5 integration tests

**Created:**
- `src/embed-config.test.ts` -- 10 unit tests for `getMaxEmbedFileBytes()` env var parsing

## Key Features

- Files exceeding the size limit are skipped **before model loading and tokenization**, so `qmd embed` stays fast even when all files are too large
- `qmd status` shows a breakdown: pending count vs skipped count
- `--no-size-limit` flag overrides the limit for a single run without changing config
- `QMD_MAX_EMBED_FILE_BYTES` env var allows per-environment tuning
- Invalid env var values produce a stderr warning and fall back to the 5MB default (prevents silent NaN bypass)

## Configuration

```bash
# Default: 5MB limit
qmd embed

# Override via env var (e.g., 10MB)
QMD_MAX_EMBED_FILE_BYTES=10485760 qmd embed

# Bypass all limits
qmd embed --no-size-limit
```

## Motivation

Large files cause two problems during embedding:
1. **OOM on constrained systems** -- tokenizing a 10MB+ file creates millions of tokens in memory
2. **Poor embedding quality** -- a 5MB file produces ~625 chunks at 800 tokens each; semantic meaning gets diluted and one file dominates search results

Skipping with a clear warning is better than crashing or producing bad embeddings.

## Breaking Changes

- [x] No breaking changes

## Checklist

- [x] Code follows project conventions and style guidelines
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Self-review of code completed
- [x] Tests added/updated and passing
- [x] No new warnings or errors introduced
- [x] Changes are backward compatible (or breaking changes documented)
