### PR TITLE
fix: allow $ route filenames in handelize

### DIFF
--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -378,6 +378,11 @@ describe("handelize", () => {
     expect(handelize("(DRAFT) Proposal v1.md")).toBe("draft-proposal-v1.md");
   });
 
+  test("handles symbol-only route filenames", () => {
+    expect(handelize("routes/api/auth/$.ts")).toBe("routes/api/auth/$.ts");
+    expect(handelize("app/routes/$id.tsx")).toBe("app/routes/$id.tsx");
+  });
+
   test("filters out empty segments", () => {
     expect(handelize("a//b/c.md")).toBe("a/b/c.md");
     expect(handelize("/a/b/")).toBe("a/b");

--- a/src/store.ts
+++ b/src/store.ts
@@ -798,12 +798,11 @@ export function handelize(path: string): string {
     throw new Error('handelize: path cannot be empty');
   }
 
-  // Check for paths that are just extensions or only dots/special chars
-  // A valid path must have at least one letter or digit (including Unicode)
+  // Allow route-style "$" filenames while still rejecting paths with no usable content.
   const segments = path.split('/').filter(Boolean);
   const lastSegment = segments[segments.length - 1] || '';
   const filenameWithoutExt = lastSegment.replace(/\.[^.]+$/, '');
-  const hasValidContent = /[\p{L}\p{N}]/u.test(filenameWithoutExt);
+  const hasValidContent = /[\p{L}\p{N}$]/u.test(filenameWithoutExt);
   if (!hasValidContent) {
     throw new Error(`handelize: path "${path}" has no valid filename content`);
   }
@@ -822,14 +821,14 @@ export function handelize(path: string): string {
         const nameWithoutExt = ext ? segment.slice(0, -ext.length) : segment;
 
         const cleanedName = nameWithoutExt
-          .replace(/[^\p{L}\p{N}]+/gu, '-')  // Replace non-letter/digit chars with dash
+          .replace(/[^\p{L}\p{N}$]+/gu, '-')  // Keep route marker "$", dash-separate other chars
           .replace(/^-+|-+$/g, ''); // Remove leading/trailing dashes
 
         return cleanedName + ext;
       } else {
         // For directories, just clean normally
         return segment
-          .replace(/[^\p{L}\p{N}]+/gu, '-')
+          .replace(/[^\p{L}\p{N}$]+/gu, '-')
           .replace(/^-+|-+$/g, '');
       }
     })


### PR DESCRIPTION
qmd currently crashes on valid route filenames like [$.ts](app://-/index.html#) and [$id.tsx](app://-/index.html#), which are standard in TanStack Router/Start-style file routing. This means indexing fails on common project structures, not edge cases, so many users will hit this immediately when trying to use qmd on modern TypeScript web apps. The fix treats $ as valid filename content during path normalization, preserving route paths while keeping existing validation for truly invalid names.