### PR TITLE
Display a message when the MCP server starts

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -534,6 +534,8 @@ export async function startMcpServer(): Promise<void> {
   const server = createMcpServer(store);
   const transport = new StdioServerTransport();
   await server.connect(transport);
+  // Log to stderr (not stdout, which is used for MCP messages)
+  console.error("QMD MCP server ready on stdio (PID %d)", process.pid);
 }
 
 // =============================================================================

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -534,8 +534,8 @@ export async function startMcpServer(): Promise<void> {
   const server = createMcpServer(store);
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  // Log to stderr (not stdout, which is used for MCP messages)
-  console.error("QMD MCP server ready on stdio (PID %d)", process.pid);
+  // Informational log to stderr (not stdout, which is used for MCP messages)
+  console.info("QMD MCP server ready on stdio (PID %d)", process.pid);
 }
 
 // =============================================================================


### PR DESCRIPTION
The MCP server starts fine, but because we don't display info it may seem that its hung, this PR simply consoles, out that the MCP server is running