### PR TITLE
fix: verify sqlite-vec readiness after extension load

### DIFF
--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach, mock, spyOn } from "bun:test";
 import { Database } from "bun:sqlite";
+import * as sqliteVec from "sqlite-vec";
 import { unlink, mkdtemp, rmdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -15,6 +16,7 @@ import YAML from "yaml";
 import { disposeDefaultLlamaCpp } from "./llm.js";
 import {
   createStore,
+  verifySqliteVecLoaded,
   getDefaultDbPath,
   homedir,
   resolve,
@@ -445,6 +447,25 @@ describe("Store Creation", () => {
     const result = store.db.prepare("PRAGMA journal_mode").get() as { journal_mode: string };
     expect(result.journal_mode).toBe("wal");
     await cleanupTestDb(store);
+  });
+
+  test("verifySqliteVecLoaded throws when sqlite-vec is not loaded", () => {
+    const db = new Database(":memory:");
+    try {
+      expect(() => verifySqliteVecLoaded(db)).toThrow("sqlite-vec extension is unavailable");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("verifySqliteVecLoaded succeeds when sqlite-vec is loaded", () => {
+    const db = new Database(":memory:");
+    try {
+      sqliteVec.load(db);
+      expect(() => verifySqliteVecLoaded(db)).not.toThrow();
+    } finally {
+      db.close();
+    }
   });
 
   test("store.close closes the database connection", async () => {


### PR DESCRIPTION
## Summary
- add `verifySqliteVecLoaded()` to probe `vec_version()` immediately after `sqliteVec.load(db)`
- treat probe failures as a clear initialization error instead of proceeding with a half-initialized vector setup
- keep existing dynamic-extension detection but normalize user-facing guidance through a shared error constructor
- add unit tests for both failure (no sqlite-vec loaded) and success paths

## Why
In some Bun/SQLite environments, `sqliteVec.load(db)` can fail to initialize vector functionality without throwing a hard error. QMD then continues and later fails/hangs during vector operations.

By verifying `vec_version()` during DB initialization, QMD fails fast with an actionable error message.

## Validation
- `bun test src/store.test.ts -t "verifySqliteVecLoaded|Store Creation|Content-Addressable Storage"`

Fixes #161
