### PR TITLE
fix: move tsx to runtime dependencies and resolve from script dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "node-llama-cpp": "^3.14.5",
     "picomatch": "^4.0.0",
     "sqlite-vec": "^0.1.7-alpha.2",
+    "tsx": "^4.0.0",
     "yaml": "^2.8.2",
     "zod": "^4.2.1"
   },
@@ -54,7 +55,6 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",
-    "tsx": "^4.0.0",
     "vitest": "^3.0.0"
   },
   "peerDependencies": {

--- a/qmd
+++ b/qmd
@@ -43,4 +43,13 @@ while [[ -L "$SOURCE" ]]; do
 done
 SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 
-exec "$NODE" --import tsx "$SCRIPT_DIR/src/qmd.ts" "$@"
+# Resolve tsx from qmd's own node_modules to avoid ESM bare-specifier
+# resolution issues (Node resolves from CWD, not from the script location)
+TSX_LOADER="$SCRIPT_DIR/node_modules/tsx/dist/esm/index.mjs"
+if [[ ! -f "$TSX_LOADER" ]]; then
+  echo "Error: tsx not found at $TSX_LOADER" >&2
+  echo "Run: cd $SCRIPT_DIR && npm install" >&2
+  exit 1
+fi
+
+exec "$NODE" --import "$TSX_LOADER" "$SCRIPT_DIR/src/qmd.ts" "$@"


### PR DESCRIPTION
## Summary

Fixes #182 — `tsx` was in `devDependencies` but is required at runtime by the `qmd` wrapper script. Global installs via `npm install -g` or `bun install -g` skip devDependencies, causing `ERR_MODULE_NOT_FOUND` immediately on any `qmd` command.

**Changes:**
- **package.json**: Move `tsx` from `devDependencies` to `dependencies` so it's always installed alongside qmd
- **qmd wrapper**: Use explicit path to `tsx` ESM loader (`$SCRIPT_DIR/node_modules/tsx/dist/esm/index.mjs`) instead of bare `--import tsx` specifier, since Node's ESM resolver walks up from CWD — not from the script location — when resolving bare specifiers

Both changes are needed: moving to `dependencies` ensures `tsx` is present in qmd's `node_modules`, and the explicit path ensures Node finds it regardless of the user's current working directory.