### PR TITLE
fix: respect XDG_CONFIG_HOME in collection config path

### DIFF
--- a/src/collections.ts
+++ b/src/collections.ts
@@ -66,6 +66,10 @@ function getConfigDir(): string {
   if (process.env.QMD_CONFIG_DIR) {
     return process.env.QMD_CONFIG_DIR;
   }
+  // Respect XDG Base Directory specification (consistent with store.ts)
+  if (process.env.XDG_CONFIG_HOME) {
+    return join(process.env.XDG_CONFIG_HOME, "qmd");
+  }
   return join(homedir(), ".config", "qmd");
 }
 


### PR DESCRIPTION
## Problem

`store.ts` already respects `XDG_CACHE_HOME` for the database path:

```ts
const cacheDir = process.env.XDG_CACHE_HOME || resolve(homedir(), ".cache");
```

But `collections.ts` ignores `XDG_CONFIG_HOME` and hardcodes `~/.config/qmd/`:

```ts
return join(homedir(), ".config", "qmd");
```

This makes it impossible to run multiple isolated qmd instances on the same machine — they all share the same collection config even when `XDG_CONFIG_HOME` is set to different directories.

**Real-world impact:** AI agent frameworks (like [OpenClaw](https://github.com/openclaw/openclaw)) run multiple agents per machine, each with their own `XDG_CONFIG_HOME` and `XDG_CACHE_HOME`. The cache (database) is correctly isolated per agent, but collections are shared — causing all agents to index the same directories instead of their own workspace files.

## Fix

Add `XDG_CONFIG_HOME` as a fallback between `QMD_CONFIG_DIR` and the hardcoded default, matching the existing pattern in `store.ts`:

```ts
function getConfigDir(): string {
  if (process.env.QMD_CONFIG_DIR) {
    return process.env.QMD_CONFIG_DIR;
  }
  if (process.env.XDG_CONFIG_HOME) {
    return join(process.env.XDG_CONFIG_HOME, "qmd");
  }
  return join(homedir(), ".config", "qmd");
}
```

This follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/) and is consistent with how `store.ts` already handles `XDG_CACHE_HOME`.

No breaking changes — `QMD_CONFIG_DIR` still takes priority, and the default (`~/.config/qmd/`) is unchanged when neither env var is set.