### PR TITLE
fix(release): build dist/ into release commit for git installs

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -100,6 +100,11 @@ awk '
 
 jq --arg v "$NEW" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
 
+# Build dist/ so git-based installs work (npm install github:tobi/qmd#vX.Y.Z)
+echo "Building dist/..."
+npm run build
+git add -f dist/
+
 git add package.json CHANGELOG.md
 git commit -m "release: v$NEW"
 git tag -a "v$NEW" -m "v$NEW"


### PR DESCRIPTION
`npm install github:tobi/qmd#vX.Y.Z` fails on first use because `dist/` is gitignored and never committed. npm checks out the tag, finds no `dist/qmd.js`, and crashes with "Cannot find module".

`release.sh` now runs `npm run build` and `git add -f dist/` before the release commit. The tag includes the compiled output.

```bash
npm install github:tobi/qmd#v1.1.0
node_modules/.bin/qmd --version
# qmd 1.1.0
```

The `prepare` hook was the obvious path but it compiles on every consumer install, pulls TypeScript (~50MB) as a devDependency, and `|| true` can swallow build failures mid-pipeline leaving a broken install. Building at release time avoids all of that.

CI rebuilds from source before `npm publish`, so the committed `dist/` is irrelevant to registry installs. Unversioned git installs (`npm install github:tobi/qmd`) work when HEAD is a release commit but not between releases.
