### PR TITLE
docs(readme): update storage schema to match YAML-backed config

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,12 +473,13 @@ qmd cleanup
 
 Index stored in: `~/.cache/qmd/index.sqlite`
 
+Collections and path contexts are stored in YAML config (default): `~/.config/qmd/index.yml`
+
 ### Schema
 
 ```sql
-collections     -- Indexed directories with name and glob patterns
-path_contexts   -- Context descriptions by virtual path (qmd://...)
 documents       -- Markdown content with metadata and docid (6-char hash)
+content         -- Content-addressed markdown bodies (hash -> full document)
 documents_fts   -- FTS5 full-text index
 content_vectors -- Embedding chunks (hash, seq, pos, 900 tokens each)
 vectors_vec     -- sqlite-vec vector index (hash_seq key)


### PR DESCRIPTION
## Summary
- update README data storage section to reflect that collections/contexts are stored in YAML config
- remove legacy `collections` and `path_contexts` table references from schema snippet
- add `content` table entry to match current DB schema

## Validation
- `npx vitest run --reporter=verbose test/cli.test.ts -t 'CLI Help'`
