### PR TITLE
fix(cli): use collection add in empty-collection guidance

### DIFF
--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -1154,7 +1154,7 @@ function listFiles(pathArg?: string): void {
     const yamlCollections = yamlListCollections();
 
     if (yamlCollections.length === 0) {
-      console.log("No collections found. Run 'qmd add .' to index files.");
+      console.log("No collections found. Run 'qmd collection add .' to index files.");
       closeDb();
       return;
     }
@@ -1293,7 +1293,7 @@ function collectionList(): void {
   const collections = listCollections(db);
 
   if (collections.length === 0) {
-    console.log("No collections found. Run 'qmd add .' to create one.");
+    console.log("No collections found. Run 'qmd collection add .' to create one.");
     closeDb();
     return;
   }


### PR DESCRIPTION
## Summary
- replace stale `qmd add .` guidance with `qmd collection add .` in CLI output paths
- aligns runtime hints with current command structure and README usage

## Validation
- `npx vitest run --reporter=verbose test/cli.test.ts`
