### PR TITLE
chore(cli): remove unused --no-lex parser option

### DIFF
--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -2102,9 +2102,6 @@ function parseCLI() {
       context: {
         type: "string",
       },
-      "no-lex": {
-        type: "boolean",
-      },
       help: { type: "boolean", short: "h" },
       version: { type: "boolean", short: "v" },
       // Search options


### PR DESCRIPTION
## Summary
- remove `--no-lex` from CLI parser options because it is not used in any execution path
- reduces dead CLI surface and avoids implying behavior that does not exist

## Validation
- `npx vitest run --reporter=verbose test/cli.test.ts`
