### PR TITLE
fix: add missing nix build dependencies for node-gyp

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,13 @@
 
           src = ./.;
 
-          nativeBuildInputs = [ pkgs.bun pkgs.makeWrapper ];
+          nativeBuildInputs = [
+            pkgs.bun
+            pkgs.makeWrapper
+            pkgs.python3  # needed by node-gyp to compile better-sqlite3
+          ] ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+            pkgs.darwin.cctools  # provides libtool needed by node-gyp on macOS
+          ];
 
           buildInputs = [ pkgs.sqlite ];
 


### PR DESCRIPTION
## Summary

`nix build` fails because `node-gyp` can't compile `better-sqlite3` inside the Nix sandbox.

### Root cause

The flake tracks `nixpkgs-unstable`, which now ships bun 1.3.x (previously 1.1.x). This changes how `better-sqlite3`'s install script behaves.

The install script runs `prebuild-install || node-gyp rebuild`. The `prebuild-install` step looks for prebuilt binaries matching the Node version that bun reports via `process.version`:

- **Bun 1.1.x** reported `process.version` as Node 18 — prebuilt binaries exist for Node 18, so `prebuild-install` downloads them and `node-gyp` is never invoked.
- **Bun 1.3.x** reports `process.version` as `v24.3.0` — no prebuilt binaries exist for Node 24, so `prebuild-install` fails and falls through to `node-gyp rebuild`, which needs `python3` and `libtool` (macOS) to compile from source.

The build log confirms this:
```
prebuild-install warn install No prebuilt binaries found (target=24.3.0 runtime=node arch=arm64 libc= platform=darwin)
```

### Fix

Add the missing native build dependencies so `node-gyp` can compile `better-sqlite3`:

- **python3**: required by `node-gyp` to run its build scripts
- **darwin.cctools** (macOS only): provides `libtool` for creating static libraries

## Test plan

- Verified `nix build` succeeds on macOS (aarch64-darwin) with nixpkgs containing bun 1.3.x