### PR TITLE
Added filename support for +-=[], for example as might be used in +=.…

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -967,7 +967,7 @@ export function handelize(path: string): string {
   const segments = path.split('/').filter(Boolean);
   const lastSegment = segments[segments.length - 1] || '';
   const filenameWithoutExt = lastSegment.replace(/\.[^.]+$/, '');
-  const hasValidContent = /[\p{L}\p{N}$]/u.test(filenameWithoutExt);
+  const hasValidContent = /[\p{L}\p{N}$+\-=\[\]]/u.test(filenameWithoutExt);
   if (!hasValidContent) {
     throw new Error(`handelize: path "${path}" has no valid filename content`);
   }
@@ -986,14 +986,14 @@ export function handelize(path: string): string {
         const nameWithoutExt = ext ? segment.slice(0, -ext.length) : segment;
 
         const cleanedName = nameWithoutExt
-          .replace(/[^\p{L}\p{N}$]+/gu, '-')  // Keep route marker "$", dash-separate other chars
+          .replace(/[^\p{L}\p{N}$+\-=\[\]]+/gu, '-')  // Keep route marker "$" and operators, dash-separate other chars
           .replace(/^-+|-+$/g, ''); // Remove leading/trailing dashes
 
         return cleanedName + ext;
       } else {
         // For directories, just clean normally
         return segment
-          .replace(/[^\p{L}\p{N}$]+/gu, '-')
+          .replace(/[^\p{L}\p{N}$+\-=\[\]]+/gu, '-')
           .replace(/^-+|-+$/g, '');
       }
     })


### PR DESCRIPTION
I have filenames that are named after their operator functions that I would like to be able to index without having to rename. This seemed like a straightforward solution. 