### PR TITLE
Fix multi-collection filtering in search/query/vsearch

### DIFF
--- a/test/query-collection-routing.test.ts
+++ b/test/query-collection-routing.test.ts
@@ -1,0 +1,69 @@
+import { describe, test, expect, vi } from "vitest";
+import {
+  hybridQuery,
+  vectorSearchQuery,
+  type Store,
+  type SearchResult,
+} from "../src/store.js";
+
+describe("multi-collection routing in query pipelines", () => {
+  test("hybridQuery passes array collection filters into FTS", async () => {
+    const searchFTS = vi.fn().mockReturnValue([] as SearchResult[]);
+
+    const store = {
+      db: {
+        prepare: () => ({ get: () => undefined }), // no vectors table
+      },
+      searchFTS,
+      expandQuery: vi.fn().mockResolvedValue([]),
+    } as unknown as Store;
+
+    await hybridQuery(store, "dominator", {
+      collection: ["target-a", "target-b"],
+      limit: 10,
+    });
+
+    expect(searchFTS).toHaveBeenCalledWith("dominator", 20, ["target-a", "target-b"]);
+  });
+
+  test("vectorSearchQuery passes array collection filters into vector search", async () => {
+    const vectorResult: SearchResult = {
+      filepath: "qmd://target-a/hit-a.md",
+      displayPath: "target-a/hit-a.md",
+      title: "Hit A",
+      hash: "abcdef123456",
+      docid: "abcdef",
+      collectionName: "target-a",
+      modifiedAt: "",
+      bodyLength: 10,
+      body: "dominator",
+      context: null,
+      score: 0.9,
+      source: "vec",
+    };
+
+    const searchVec = vi.fn().mockResolvedValue([vectorResult]);
+
+    const store = {
+      db: {
+        prepare: () => ({ get: () => ({ name: "vectors_vec" }) }),
+      },
+      expandQuery: vi.fn().mockResolvedValue([]),
+      searchVec,
+      getContextForFile: vi.fn().mockReturnValue(null),
+    } as unknown as Store;
+
+    await vectorSearchQuery(store, "dominator", {
+      collection: ["target-a", "target-b"],
+      limit: 7,
+      minScore: 0,
+    });
+
+    expect(searchVec).toHaveBeenCalledWith(
+      "dominator",
+      expect.any(String),
+      7,
+      ["target-a", "target-b"],
+    );
+  });
+});

--- a/test/searchvec-multi-collection.test.ts
+++ b/test/searchvec-multi-collection.test.ts
@@ -1,0 +1,107 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import YAML from "yaml";
+import { createStore, hashContent, isSqliteVecAvailable, type Store } from "../src/store.js";
+
+let testDir: string;
+let configDir: string;
+let store: Store;
+let hasSqliteVec = false;
+
+async function insertVectorDoc(
+  store: Store,
+  collection: string,
+  path: string,
+  body: string,
+  embedding: number[],
+): Promise<void> {
+  const now = new Date().toISOString();
+  const hash = await hashContent(`${collection}:${path}:${body}`);
+
+  store.db.prepare(`
+    INSERT INTO content (hash, doc, created_at)
+    VALUES (?, ?, ?)
+  `).run(hash, body, now);
+
+  store.db.prepare(`
+    INSERT INTO documents (collection, path, title, hash, created_at, modified_at, active)
+    VALUES (?, ?, ?, ?, ?, ?, 1)
+  `).run(collection, path, path.replace(/\.md$/, ""), hash, now, now);
+
+  store.db.prepare(`
+    INSERT INTO content_vectors (hash, seq, pos, model, embedded_at)
+    VALUES (?, 0, 0, 'test', ?)
+  `).run(hash, now);
+
+  store.db.prepare(`
+    INSERT INTO vectors_vec (hash_seq, embedding)
+    VALUES (?, ?)
+  `).run(`${hash}_0`, new Float32Array(embedding));
+}
+
+describe("searchVec multi-collection filtering", () => {
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), "qmd-searchvec-multi-"));
+    configDir = join(testDir, "config");
+    await mkdir(configDir, { recursive: true });
+
+    await writeFile(
+      join(configDir, "index.yml"),
+      YAML.stringify({
+        collections: {
+          "target-a": { path: "/tmp/target-a", pattern: "**/*.md" },
+          "target-b": { path: "/tmp/target-b", pattern: "**/*.md" },
+          noisy: { path: "/tmp/noisy", pattern: "**/*.md" },
+        },
+      })
+    );
+
+    process.env.QMD_CONFIG_DIR = configDir;
+    store = createStore(join(testDir, "index.sqlite"));
+    hasSqliteVec = isSqliteVecAvailable();
+    if (hasSqliteVec) {
+      store.ensureVecTable(3);
+    }
+  });
+
+  afterEach(async () => {
+    if (store) {
+      store.close();
+    }
+    delete process.env.QMD_CONFIG_DIR;
+    if (testDir) {
+      await rm(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test("supports collection IN filters for repeated -c semantics", async () => {
+    if (!hasSqliteVec) {
+      return;
+    }
+
+    await insertVectorDoc(store, "target-a", "a.md", "dominator target a", [0.99, 0.01, 0]);
+    await insertVectorDoc(store, "target-b", "b.md", "dominator target b", [0.98, 0.02, 0]);
+
+    // Create many highly similar vectors in an unrequested collection to mimic top-k domination.
+    for (let i = 0; i < 60; i++) {
+      await insertVectorDoc(store, "noisy", `noise-${i}.md`, `dominator noisy ${i}`, [1, 0, 0]);
+    }
+
+    const results = await store.searchVec(
+      "dominator",
+      "embeddinggemma",
+      10,
+      ["target-a", "target-b"],
+      undefined,
+      [1, 0, 0],
+    );
+
+    const collections = new Set(results.map(r => r.collectionName));
+
+    expect(collections.has("target-a")).toBe(true);
+    expect(collections.has("target-b")).toBe(true);
+    expect(collections.has("noisy")).toBe(false);
+  });
+});

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1228,6 +1228,39 @@ describe("FTS Search", () => {
     await cleanupTestDb(store);
   });
 
+  test("searchFTS filters by multiple collection names", async () => {
+    const store = await createTestStore();
+    const collection1 = await createTestCollection({ pwd: "/path/one", glob: "**/*.md", name: "one" });
+    const collection2 = await createTestCollection({ pwd: "/path/two", glob: "**/*.md", name: "two" });
+    const collection3 = await createTestCollection({ pwd: "/path/three", glob: "**/*.md", name: "three" });
+
+    await insertTestDocument(store.db, collection1, {
+      name: "doc1",
+      body: "searchable content",
+      displayPath: "doc1.md",
+    });
+
+    await insertTestDocument(store.db, collection2, {
+      name: "doc2",
+      body: "searchable content",
+      displayPath: "doc2.md",
+    });
+
+    await insertTestDocument(store.db, collection3, {
+      name: "doc3",
+      body: "searchable content",
+      displayPath: "doc3.md",
+    });
+
+    const filtered = store.searchFTS("searchable", 10, [collection1, collection2]);
+    expect(filtered).toHaveLength(2);
+    expect(filtered.every(r => r.collectionName === collection1 || r.collectionName === collection2)).toBe(true);
+    expect(filtered.some(r => r.collectionName === collection1)).toBe(true);
+    expect(filtered.some(r => r.collectionName === collection2)).toBe(true);
+
+    await cleanupTestDb(store);
+  });
+
   test("searchFTS handles special characters in query", async () => {
     const store = await createTestStore();
     const collectionName = await createTestCollection();


### PR DESCRIPTION
## Problem

When multiple `-c/--collection` flags are passed to `qmd search`, `query`, or `vsearch`, results are often empty or incomplete.

**Root cause:** With a single `-c`, the collection filter is pushed into the SQL query (`AND d.collection = ?`). With multiple `-c` flags, qmd performs a global unfiltered top-K search then post-filters by `qmd://{collection}/` prefix. Large collections dominate the global top-K, so post-filtering removes everything from smaller requested collections.

## Fix

Push the collection filter into the underlying retrieval for all three search paths instead of post-filtering a limited result set:

- **FTS search:** `WHERE ... AND d.collection IN (?, ...)` via a shared SQL helper
- **Vector search:** Precompute eligible `hash_seq` values for requested collections and apply `AND hash_seq IN (...)` directly in the sqlite-vec KNN query
- **Hybrid query:** Same filter pushed through to both FTS and vector sub-queries

Added `normalizeCollectionFilter()` and `appendCollectionFilterSql()` helpers in `store.ts` to handle single vs. multi-collection SQL generation consistently.

## Type changes

- `searchFTS` and `searchVec` (both the `Store` methods and the exported functions) now accept `string | string[]` for the collection parameter
- `HybridQueryOptions.collection` and `VectorSearchOptions.collection` updated to `string | string[]`

## Tests

Added 4 test files/scenarios (TDD, written before the fix, confirmed failing, then passing):

- `test/cli.test.ts` — end-to-end CLI regression with 80-doc noisy collection vs 2 small target collections
- `test/store.test.ts` — `searchFTS` with multi-collection array filter
- `test/query-collection-routing.test.ts` — verifies `hybridQuery`/`vectorSearchQuery` pass array filters through
- `test/searchvec-multi-collection.test.ts` — vector search under top-K domination with collection IN filter

Full test suite passes (5 pre-existing LLM timeout failures unrelated to this change).