### PR TITLE
fix(package.json): correct Windows sqlite-vec package name + add linux-arm64

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,9 @@
   "optionalDependencies": {
     "sqlite-vec-darwin-arm64": "^0.1.7-alpha.2",
     "sqlite-vec-darwin-x64": "^0.1.7-alpha.2",
+    "sqlite-vec-linux-arm64": "^0.1.7-alpha.2",
     "sqlite-vec-linux-x64": "^0.1.7-alpha.2",
-    "sqlite-vec-win32-x64": "^0.1.7-alpha.2"
+    "sqlite-vec-windows-x64": "^0.1.7-alpha.2"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",


### PR DESCRIPTION
## Summary

- Renames `sqlite-vec-win32-x64` → `sqlite-vec-windows-x64` in `optionalDependencies` (the old name doesn't exist on npm — 404)
- Adds missing `sqlite-vec-linux-arm64` entry to match all 5 platforms declared in `sqlite-vec`'s own `optionalDependencies`

Fixes #224

## Root Cause

The `sqlite-vec` npm package maps `process.platform` value `win32` → `windows` in its [`platformPackageName()`](https://github.com/asg017/sqlite-vec) function. The published npm package is `sqlite-vec-windows-x64`, not `sqlite-vec-win32-x64`.

## Verification

Tested on Windows 11 x64, Node.js v25.6.1:

**1. Package name confirmation:**
```
$ npm view sqlite-vec-win32-x64
npm error code E404 — does not exist

$ npm view sqlite-vec-windows-x64 version
0.1.7-alpha.2 ✓
```

**2. Extension loading works:**
```
$ node -e "const sv = require('sqlite-vec'); console.log(sv.getLoadablePath())"
C:\...\node_modules\sqlite-vec-windows-x64\vec0.dll ✓
```

**3. Full round-trip (load → create table → insert → KNN query):**
```js
const Database = require('better-sqlite3');
const sqliteVec = require('sqlite-vec');
const db = new Database(':memory:');
sqliteVec.load(db);

db.exec(`CREATE VIRTUAL TABLE vectors_vec USING vec0(
  hash_seq TEXT PRIMARY KEY,
  embedding float[4] distance_metric=cosine
)`);

const ins = db.prepare('INSERT OR REPLACE INTO vectors_vec (hash_seq, embedding) VALUES (?, ?)');
ins.run('abc_0', new Float32Array([1, 0, 0, 0]));
ins.run('def_0', new Float32Array([0.9, 0.1, 0, 0]));

const results = db.prepare(
  'SELECT hash_seq, distance FROM vectors_vec WHERE embedding MATCH ? AND k = 2'
).all(new Float32Array([1, 0, 0, 0]));

// → [{ hash_seq: 'abc_0', distance: 0 }, { hash_seq: 'def_0', distance: 0.00611... }] ✓
```

**4. qmd status confirms sqlite-vec operational:**
```
$ qmd status
Documents
  Total:    1055 files indexed
  Vectors:  1145 embedded  ✓
```

**5. sqlite-vec's own optionalDependencies (all 5 platforms):**
```json
{
  "sqlite-vec-darwin-x64": "0.1.7-alpha.2",
  "sqlite-vec-darwin-arm64": "0.1.7-alpha.2",
  "sqlite-vec-linux-arm64": "0.1.7-alpha.2",
  "sqlite-vec-linux-x64": "0.1.7-alpha.2",
  "sqlite-vec-windows-x64": "0.1.7-alpha.2"
}
```

qmd previously listed only 4, missing `linux-arm64` and using wrong Windows name.

## Test plan

- [ ] `npm install` on Windows x64 — no 404 warning for sqlite-vec
- [ ] `npm install` on Linux arm64 — sqlite-vec binary installs
- [ ] `qmd embed` + `qmd vsearch` on Windows — vector search works
- [ ] Existing CI/tests pass (change is package.json only, no code changes)