### PR TITLE
fix(cli): suppress progress bars when not TTY

### DIFF
--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -165,19 +165,20 @@ const cursor = {
 process.on('SIGINT', () => { cursor.show(); process.exit(130); });
 process.on('SIGTERM', () => { cursor.show(); process.exit(143); });
 
-// Terminal progress bar using OSC 9;4 escape sequence
+// Terminal progress bar using OSC 9;4 escape sequence (TTY only)
+const isTTY = process.stderr.isTTY;
 const progress = {
   set(percent: number) {
-    process.stderr.write(`\x1b]9;4;1;${Math.round(percent)}\x07`);
+    if (isTTY) process.stderr.write(`\x1b]9;4;1;${Math.round(percent)}\x07`);
   },
   clear() {
-    process.stderr.write(`\x1b]9;4;0\x07`);
+    if (isTTY) process.stderr.write(`\x1b]9;4;0\x07`);
   },
   indeterminate() {
-    process.stderr.write(`\x1b]9;4;3\x07`);
+    if (isTTY) process.stderr.write(`\x1b]9;4;3\x07`);
   },
   error() {
-    process.stderr.write(`\x1b]9;4;2\x07`);
+    if (isTTY) process.stderr.write(`\x1b]9;4;2\x07`);
   },
 };
 
@@ -1491,7 +1492,7 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
     const rate = processed / elapsed;
     const remaining = (total - processed) / rate;
     const eta = processed > 2 ? ` ETA: ${formatETA(remaining)}` : "";
-    process.stderr.write(`\rIndexing: ${processed}/${total}${eta}        `);
+    if (isTTY) process.stderr.write(`\rIndexing: ${processed}/${total}${eta}        `);
   }
 
   // Deactivate documents in this collection that no longer exist
@@ -1682,7 +1683,7 @@ async function vectorIndex(model: string = DEFAULT_EMBED_MODEL, force: boolean =
       const eta = elapsed > 2 ? formatETA(etaSec) : "...";
       const errStr = errors > 0 ? ` ${c.yellow}${errors} err${c.reset}` : "";
 
-      process.stderr.write(`\r${c.cyan}${bar}${c.reset} ${c.bold}${percentStr}%${c.reset} ${c.dim}${chunksEmbedded}/${totalChunks}${c.reset}${errStr} ${c.dim}${throughput} ETA ${eta}${c.reset}   `);
+      if (isTTY) process.stderr.write(`\r${c.cyan}${bar}${c.reset} ${c.bold}${percentStr}%${c.reset} ${c.dim}${chunksEmbedded}/${totalChunks}${c.reset}${errStr} ${c.dim}${throughput} ETA ${eta}${c.reset}   `);
     }
 
     progress.clear();


### PR DESCRIPTION
## Problem

When `qmd update` or `qmd embed` runs inside a parent process (CI, cron, daemon, MCP server, editor plugin), the captured output is ~247K chars for a typical index with ~1600 documents. This is because:

1. **OSC 9;4 progress sequences** (`\x1b]9;4;1;N\x07`) are written unconditionally to stderr
2. **Carriage-return status lines** (`\rIndexing: X/Y ETA: Zs`) accumulate instead of overwriting (no terminal to interpret `\r`)
3. **Embed progress bars** with ANSI color codes similarly accumulate

This causes issues for any integration that captures output — in our case, OpenClaw's `qmd update` was failing with "too much output" errors, retrying ~24 times per 10 minutes.

## Fix

Gate all progress/status output on `process.stderr.isTTY`. Summary lines (`Indexed: N new, M updated...`) still print normally — only the ephemeral progress indicators are suppressed.

**Before (non-TTY):** 247,296 chars
**After (non-TTY):** 6,639 chars

## Changes

- Add `const isTTY = process.stderr.isTTY` 
- Wrap OSC 9;4 progress calls in `if (isTTY)`
- Wrap `\rIndexing: X/Y` line in `if (isTTY)`
- Wrap embed progress bar in `if (isTTY)`

Minimal, no behavior change when running interactively.