### PR TITLE
feat(query): add --explain score traces for hybrid retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Changes
+
+- Query: add `--explain` for `qmd query` to expose retrieval score traces
+  in JSON and CLI output. Includes backend scores (FTS/vector), per-list
+  RRF contributions, top-rank bonus, reranker score, and final blended score.
+
 ## [1.0.8] - 2026-02-19
 
 QMD now speaks in **query documents** — structured multi-line queries where each line is typed (`lex:`, `vec:`, `hyde:`, `expand:`), combining keyword precision with semantic recall. A single plain query still works exactly as before. AI agents using the MCP tool get significantly richer search capability: lex now supports quoted phrases and negation (`"C++ performance" -sports -athlete`), making intent-aware disambiguation practical.
@@ -358,4 +364,3 @@ notes, journals, and meeting transcripts.
 [Unreleased]: https://github.com/tobi/qmd/compare/v1.0.0...HEAD
 [1.0.0]: https://github.com/tobi/qmd/releases/tag/v1.0.0
 [0.9.0]: https://github.com/tobi/qmd/compare/v0.8.0...v0.9.0
-

--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ qmd query "user authentication"
 --min-score <num>  # Minimum score threshold (default: 0)
 --full             # Show full document content
 --line-numbers     # Add line numbers to output
+--explain          # Include retrieval score traces (query, JSON/CLI output)
 --index <name>     # Use named index
 
 # Output formats (for search and multi-get)
@@ -427,6 +428,9 @@ qmd search --md --full "error handling"
 
 # JSON output for scripting
 qmd query --json "quarterly reports"
+
+# Inspect how each result was scored (RRF + rerank blend)
+qmd query --json --explain "quarterly reports"
 
 # Use separate index for different knowledge base
 qmd --index work search "quarterly reports"

--- a/test/rrf-trace.test.ts
+++ b/test/rrf-trace.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest";
+import { buildRrfTrace, reciprocalRankFusion, type RankedResult } from "../src/store";
+
+describe("buildRrfTrace", () => {
+  test("matches reciprocalRankFusion totals and records per-list contributions", () => {
+    const list1: RankedResult[] = [
+      { file: "qmd://docs/a.md", displayPath: "docs/a.md", title: "A", body: "", score: 0.92 },
+      { file: "qmd://docs/b.md", displayPath: "docs/b.md", title: "B", body: "", score: 0.81 },
+    ];
+    const list2: RankedResult[] = [
+      { file: "qmd://docs/b.md", displayPath: "docs/b.md", title: "B", body: "", score: 0.77 },
+      { file: "qmd://docs/a.md", displayPath: "docs/a.md", title: "A", body: "", score: 0.65 },
+    ];
+
+    const weights = [2.0, 1.0];
+    const traces = buildRrfTrace(
+      [list1, list2],
+      weights,
+      [
+        { source: "fts", queryType: "lex", query: "lex query" },
+        { source: "vec", queryType: "vec", query: "vec query" },
+      ]
+    );
+    const fused = reciprocalRankFusion([list1, list2], weights);
+
+    for (const result of fused) {
+      const trace = traces.get(result.file);
+      expect(trace).toBeDefined();
+      expect(trace!.totalScore).toBeCloseTo(result.score, 10);
+    }
+
+    const aTrace = traces.get("qmd://docs/a.md")!;
+    expect(aTrace.contributions).toHaveLength(2);
+    expect(aTrace.contributions[0]?.source).toBe("fts");
+    expect(aTrace.contributions[1]?.source).toBe("vec");
+    expect(aTrace.topRank).toBe(1);
+    expect(aTrace.topRankBonus).toBeCloseTo(0.05, 10);
+  });
+
+  test("applies top-rank bonus thresholds correctly", () => {
+    const list: RankedResult[] = [
+      { file: "qmd://docs/r1.md", displayPath: "docs/r1.md", title: "R1", body: "", score: 0.9 },
+      { file: "qmd://docs/r2.md", displayPath: "docs/r2.md", title: "R2", body: "", score: 0.8 },
+      { file: "qmd://docs/r3.md", displayPath: "docs/r3.md", title: "R3", body: "", score: 0.7 },
+      { file: "qmd://docs/r4.md", displayPath: "docs/r4.md", title: "R4", body: "", score: 0.6 },
+    ];
+
+    const traces = buildRrfTrace([list], [1.0], [{ source: "fts", queryType: "lex", query: "rank" }]);
+
+    expect(traces.get("qmd://docs/r1.md")?.topRankBonus).toBeCloseTo(0.05, 10);
+    expect(traces.get("qmd://docs/r2.md")?.topRankBonus).toBeCloseTo(0.02, 10);
+    expect(traces.get("qmd://docs/r3.md")?.topRankBonus).toBeCloseTo(0.02, 10);
+    expect(traces.get("qmd://docs/r4.md")?.topRankBonus).toBeCloseTo(0.0, 10);
+  });
+});


### PR DESCRIPTION
## Summary
- add `--explain` option to `qmd query` for retrieval score attribution
- expose backend scores (FTS/vector), per-list RRF contributions, top-rank bonus, reranker score, and final blended score
- include explain payload in JSON output and concise explain section in CLI output
- add unit tests for RRF trace correctness and bonus thresholds
- document the flag in README and add changelog entry

## Validation
- `npm run build`
- `npx vitest run --reporter=verbose test/rrf-trace.test.ts test/store.helpers.unit.test.ts`