### PR TITLE
fix: use getLlamaGpuTypes("supported") to detect actual GPU availability

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -498,10 +498,10 @@ export class LlamaCpp implements LLM {
   private async ensureLlama(): Promise<Llama> {
     if (!this.llama) {
       // Detect available GPU types and use the best one.
-      // We can't rely on gpu:"auto" — it returns false even when CUDA is available
-      // (likely a binary/build config issue in node-llama-cpp).
-      // @ts-expect-error node-llama-cpp API compat
-      const gpuTypes = await getLlamaGpuTypes();
+      // Use "supported" to only return GPU types with actual drivers/libraries
+      // installed, rather than the default which returns all valid types for the
+      // platform (e.g. "cuda" on any Linux box even without NVIDIA hardware).
+      const gpuTypes = await getLlamaGpuTypes("supported");
       // Prefer CUDA > Metal > Vulkan > CPU
       const preferred = (["cuda", "metal", "vulkan"] as const).find(g => gpuTypes.includes(g));
 


### PR DESCRIPTION
## Problem

On Linux machines without NVIDIA GPUs, QMD attempts to compile llama.cpp with CUDA support on every invocation. This adds ~30 seconds of noisy CMake failures to every `qmd` command before falling back to CPU.

## Root cause

`getLlamaGpuTypes()` called without an argument returns all GPU types *valid for the platform* — on Linux that's always `["cuda", "vulkan", false]` regardless of installed hardware. QMD then tries `getLlama({gpu: "cuda"})`, which triggers a source build of llama.cpp with `GGML_CUDA=1`, fails because there's no CUDA toolkit, and falls back to CPU.

## Fix

Pass `"supported"` to `getLlamaGpuTypes()`, which checks for actual driver/library presence before including a GPU type. This is the intended API per node-llama-cpp docs.

Also removes the now-unnecessary @ts-expect-error directive — "supported" is a properly typed argument, so the type suppression was masking the issue.

## Testing

Verified on Intel NUC (i7-1165G7, no discrete GPU) running Arch Linux

**Before:** every QMD command triggers ~30s of CUDA CMake build spam

**After:** instant startup, correctly detects CPU-only and skips GPU entirely

tsc passes clean with zero errors