### PR TITLE
fix(llama): respect NODE_LLAMA_CPP_GPU override

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -500,8 +500,15 @@ export class LlamaCpp implements LLM {
       // Detect available GPU types and use the best one.
       // We can't rely on gpu:"auto" — it returns false even when CUDA is available
       // (likely a binary/build config issue in node-llama-cpp).
-      // @ts-expect-error node-llama-cpp API compat
-      const gpuTypes = await getLlamaGpuTypes();
+      // Allow explicit override via NODE_LLAMA_CPP_GPU env var for AMD GPUs
+      const envGpu = process.env.NODE_LLAMA_CPP_GPU as "cuda" | "metal" | "vulkan" | undefined;
+      let gpuTypes: string[] = [];
+      if (envGpu && ["cuda", "metal", "vulkan"].includes(envGpu)) {
+        gpuTypes = [envGpu];
+      } else {
+        // @ts-expect-error node-llama-cpp API compat
+        gpuTypes = await getLlamaGpuTypes();
+      }
       // Prefer CUDA > Metal > Vulkan > CPU
       const preferred = (["cuda", "metal", "vulkan"] as const).find(g => gpuTypes.includes(g));
 


### PR DESCRIPTION
### Problem

On some systems with AMD GPUs (and potentially others), `getLlamaGpuTypes()` returns an empty array even when Vulkan is available. This causes QMD to fall back to CPU-only mode, which is significantly slower for embedding operations.

### Root Cause

While the detection logic looks correct (see [src/bindings/utils/getLlamaGpuTypes.ts](https://github.com/withcatai/node-llama-cpp/blob/master/src/bindings/utils/getLlamaGpuTypes.ts)), it appears to fail on some Linux/Vulkan configurations (tested on AMD 7900 XTX). The exact root cause is unclear - could be path resolution issues or async handling.

### Solution

Check for `NODE_LLAMA_CPP_GPU` environment variable before calling the potentially broken auto-detection. This allows users to explicitly specify their preferred GPU backend (cuda, metal, or vulkan).

Why this variable? Because it is what `node-llama-cpp` already uses: [src/config.ts#L56](https://github.com/withcatai/node-llama-cpp/blob/master/src/config.ts#L56)


### Why this approach:
- Non-breaking change: If the env var is not set, behavior remains identical to before
- Follows conventions: Uses the same naming pattern as other NODE_LLAMA_CPP_* variables used by the library
- User control: Allows overriding broken auto-detection without waiting for upstream fixes
- Clean workaround: Doesn't require modifying node-llama-cpp internals

### Usage:
#### Force Vulkan on AMD GPUs
```bash
export NODE_LLAMA_CPP_GPU=vulkan
qmd status  # Now shows GPU: vulkan with offloading
```

### Testing:
- Tested on AMD Radeon RX 7900 XTX (24GB VRAM) with CachyOS (Arch-based)
- Before: GPU: none (running on CPU)
- After: GPU: vulkan (offloading: yes) with 37GB VRAM detected

### References:
- node-llama-cpp/src/config.ts:56 - env var definition
- node-llama-cpp/src/bindings/utils/getLlamaGpuTypes.ts - detection issue