### PR TITLE
fix: skip unreadable files during indexing instead of crashing

### DIFF
--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -1455,7 +1455,15 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
     const path = handelize(relativeFile); // Normalize path for token-friendliness
     seenPaths.add(path);
 
-    const content = readFileSync(filepath, "utf-8");
+    let content: string;
+    try {
+      content = readFileSync(filepath, "utf-8");
+    } catch (err: any) {
+      // Skip files that can't be read (e.g. iCloud evicted files returning EAGAIN)
+      processed++;
+      progress.set((processed / total) * 100);
+      continue;
+    }
 
     // Skip empty files - nothing useful to index
     if (!content.trim()) {


### PR DESCRIPTION
Fixes #252

## Problem

`qmd update` crashes when it encounters files that can't be read — specifically iCloud Drive files with the `SF_DATALESS` flag (evicted content). Node's `readFileSync` throws `EAGAIN` (error -11), and since there's no error handling around the read, the entire indexing run dies on the first bad file.

## Fix

Wrap the `readFileSync` call in a try/catch. On failure, skip the file and continue indexing. This is consistent with how qmd already handles empty files (skip and continue).

## Impact

Before: a single unreadable file out of 1,540 would crash the entire update.
After: 1,530+ files index successfully, 10 unreadable files are silently skipped.

## Testing

Tested against a 1,540-file iCloud Drive shared folder on macOS with 10 evicted files. Before the fix, `qmd update` crashed at file ~133. After the fix, all 1,540 files are processed (1,530 indexed, 10 skipped).