### PR TITLE
feat: expose candidateLimit as MCP tool parameter and CLI flag

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -307,10 +307,13 @@ Intent-aware lex (C++ performance, not sports):
         ),
         limit: z.number().optional().default(10).describe("Max results (default: 10)"),
         minScore: z.number().optional().default(0).describe("Min relevance 0-1 (default: 0)"),
+        candidateLimit: z.number().optional().describe(
+          "Maximum candidates to rerank (default: 40, lower = faster but may miss results)"
+        ),
         collections: z.array(z.string()).optional().describe("Filter to collections (OR match)"),
       },
     },
-    async ({ searches, limit, minScore, collections }) => {
+    async ({ searches, limit, minScore, candidateLimit, collections }) => {
       // Map to internal format
       const subSearches: StructuredSubSearch[] = searches.map(s => ({
         type: s.type,
@@ -324,6 +327,7 @@ Intent-aware lex (C++ performance, not sports):
         collections: effectiveCollections.length > 0 ? effectiveCollections : undefined,
         limit,
         minScore,
+        candidateLimit,
       });
 
       // Use first lex or vec query for snippet extraction
@@ -635,6 +639,7 @@ export async function startMcpHttpServer(port: number, options?: { quiet?: boole
           collections: effectiveCollections.length > 0 ? effectiveCollections : undefined,
           limit: params.limit ?? 10,
           minScore: params.minScore ?? 0,
+          candidateLimit: params.candidateLimit,
         });
 
         // Use first lex or vec query for snippet extraction


### PR DESCRIPTION
## Summary

- Add optional `candidateLimit` param to MCP `query` tool, REST `/query` endpoint, and CLI (`--candidate-limit` / `-C`)
- Default stays 40 (no behavior change) — users can lower for speed tradeoff on CPU-only machines
- Reranking is the bottleneck (~2 min for 40 chunks on 8 vCPU); lowering candidate count cuts it proportionally

Closes #254. Complements #231.

## Changes (2 files, +13/-1)

**`src/mcp.ts`**
- Add `candidateLimit` to `query` tool inputSchema (zod `z.number().optional()`)
- Pass through to `structuredSearch()` in both MCP handler and REST `/query` endpoint

**`src/qmd.ts`**
- Add `--candidate-limit` / `-C` to `parseCLI()` options
- Add `candidateLimit` to `OutputOptions` type
- Pass through to both `structuredSearch()` and `hybridQuery()` in `querySearch()`
- Add to `--help` output

## Test plan

- [x] `npm run build` compiles without errors
- [x] `npm test` — 539/545 pass (6 failures are pre-existing LLM-dependent timeouts)
- [ ] Manual: `qmd query --candidate-limit 10 "test query"` on indexed data
- [ ] Manual: MCP tool call with `candidateLimit: 10` via adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)