### PR TITLE
feat: support QMD_EMBED_MODEL and QMD_EMBED_CTX_SIZE env vars

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -386,7 +386,7 @@ export class LlamaCpp implements LLM {
 
 
   constructor(config: LlamaCppConfig = {}) {
-    this.embedModelUri = config.embedModel || DEFAULT_EMBED_MODEL;
+    this.embedModelUri = config.embedModel || process.env.QMD_EMBED_MODEL || DEFAULT_EMBED_MODEL;
     this.generateModelUri = config.generateModel || DEFAULT_GENERATE_MODEL;
     this.rerankModelUri = config.rerankModel || DEFAULT_RERANK_MODEL;
     this.modelCacheDir = config.modelCacheDir || MODEL_CACHE_DIR;
@@ -627,10 +627,12 @@ export class LlamaCpp implements LLM {
       // Embed contexts are ~143 MB each (nomic-embed 2048 ctx)
       const n = await this.computeParallelism(150);
       const threads = await this.threadsPerContext(n);
+      const envCtxSize = process.env.QMD_EMBED_CTX_SIZE ? parseInt(process.env.QMD_EMBED_CTX_SIZE) : undefined;
       for (let i = 0; i < n; i++) {
         try {
           this.embedContexts.push(await model.createEmbeddingContext({
             ...(threads > 0 ? { threads } : {}),
+            ...(envCtxSize ? { contextSize: envCtxSize } : {}),
           }));
         } catch {
           if (this.embedContexts.length === 0) throw new Error("Failed to create any embedding context");


### PR DESCRIPTION
## Summary

Allow overriding the default embedding model and context size via environment variables, enabling use of alternative GGUF embedding models without code changes.

### New Environment Variables

| Variable | Purpose | Default |
|---|---|---|
| `QMD_EMBED_MODEL` | Override the embedding model URI (any `hf:` URI or local path) | `embeddinggemma-300M` |
| `QMD_EMBED_CTX_SIZE` | Override embedding context size (tokens) | Model's GGUF default |

### Usage

```bash
export QMD_EMBED_MODEL="hf:nomic-ai/nomic-embed-text-v2-moe-GGUF/nomic-embed-text-v2-moe.Q8_0.gguf"
export QMD_EMBED_CTX_SIZE=2048
qmd embed -f
qmd query "my search"
```

Without the env vars, behavior is unchanged (falls back to embeddinggemma-300M).

### Motivation

Some GGUF embedding models (e.g., Nomic Embed v2 MoE) offer significant improvements in speed and multilingual support. Currently there's no way to swap the embedding model without editing the compiled JS.

This is a minimal, non-breaking change — 3 lines added to `src/llm.ts`.

### Testing

Tested with `nomic-embed-text-v2-moe` (Q8_0, 768d) on Apple M4 (Metal):

- **3x faster** embedding throughput (26.3 KB/s vs 8.1 KB/s)
- **2.4x faster** query embedding (378ms vs 923ms)
- Improved retrieval quality on security/vulnerability queries
- Same 768-dim vectors — no storage schema changes

### Why QMD_EMBED_CTX_SIZE?

Some models' GGUF metadata reports a default context size smaller than qmd's 900-token chunks. Without an override, embedding fails with `Input is longer than the context size`. The env var lets users set an appropriate context size (e.g., 2048) without touching code.

### Changes

`src/llm.ts`: 3 lines added, 1 line modified (constructor + `ensureEmbedContexts`)
