### PR TITLE
feat: add QMD_GPU env var to override GPU backend detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,6 +601,23 @@ const DEFAULT_RERANK_MODEL = "hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-re
 const DEFAULT_GENERATE_MODEL = "hf:tobil/qmd-query-expansion-1.7B-gguf/qmd-query-expansion-1.7B-q4_k_m.gguf";
 ```
 
+### GPU Backend Override
+
+QMD auto-detects GPU acceleration (CUDA > Metal > Vulkan > CPU). On some systems, auto-detection picks the wrong backend — for example, AMD ROCm systems where CUDA appears available but no CUDA Toolkit is installed.
+
+Set the `QMD_GPU` environment variable to force a specific backend:
+
+```bash
+# Force Vulkan (recommended for AMD GPUs)
+export QMD_GPU=vulkan
+
+# Force CUDA
+export QMD_GPU=cuda
+
+# Disable GPU (CPU only)
+export QMD_GPU=false
+```
+
 ### EmbeddingGemma Prompt Format
 
 ```


### PR DESCRIPTION
## Problem

On AMD systems with ROCm installed, `node-llama-cpp`'s `getLlamaGpuTypes()` reports CUDA as available (via ROCm's CUDA compatibility layer). QMD then tries to build with CUDA, fails because there's no actual CUDA Toolkit, and falls back to CPU mode — which causes a Bun segfault when loading embedding/reranking models into RAM.

This affects AMD GPU systems (tested: Radeon 780M / gfx1103) that have ROCm + Vulkan but no NVIDIA hardware.

## Fix

Add a `QMD_GPU` environment variable that overrides the auto-detection:

```bash
export QMD_GPU=vulkan  # Force Vulkan (works great on AMD)
export QMD_GPU=cuda    # Force CUDA
export QMD_GPU=false   # Disable GPU entirely
```

When unset, behaviour is unchanged (auto-detect: CUDA > Metal > Vulkan > CPU).

## Changes

- `src/llm.ts`: Read `QMD_GPU` env var before falling through to auto-detection
- `README.md`: Document the new env var under Model Configuration

## Testing

Tested on:
- AMD Ryzen 7 255 + Radeon 780M (gfx1103)
- ROCm 1.14 + Vulkan (mesa-vulkan-drivers)
- Bun 1.3.10, Ubuntu 25.10
- `QMD_GPU=vulkan qmd query "test"` → works, GPU-accelerated, no crash
