### PR TITLE
feat: add QMD_EMBED_MODEL env var for multilingual embedding support

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,11 +252,33 @@ QMD uses three local GGUF models (auto-downloaded on first use):
 
 | Model | Purpose | Size |
 |-------|---------|------|
-| `embeddinggemma-300M-Q8_0` | Vector embeddings | ~300MB |
+| `embeddinggemma-300M-Q8_0` | Vector embeddings (default) | ~300MB |
 | `qwen3-reranker-0.6b-q8_0` | Re-ranking | ~640MB |
 | `qmd-query-expansion-1.7B-q4_k_m` | Query expansion (fine-tuned) | ~1.1GB |
 
 Models are downloaded from HuggingFace and cached in `~/.cache/qmd/models/`.
+
+### Custom Embedding Model
+
+Override the default embedding model via the `QMD_EMBED_MODEL` environment variable.
+This is useful for multilingual corpora (e.g. Chinese, Japanese, Korean) where
+`embeddinggemma-300M` has limited coverage.
+
+```sh
+# Use Qwen3-Embedding-0.6B for better multilingual (CJK) support
+export QMD_EMBED_MODEL="hf:Qwen/Qwen3-Embedding-0.6B-GGUF/qwen3-embedding-0.6b-q8_0.gguf"
+
+# After changing the model, re-embed all collections:
+qmd embed -f
+```
+
+Supported model families:
+- **embeddinggemma** (default) — English-optimized, small footprint
+- **Qwen3-Embedding** — Multilingual (119 languages including CJK), MTEB top-ranked
+
+> **Note:** When switching embedding models, you must re-index with `qmd embed -f`
+> since vectors are not cross-compatible between models. The prompt format is
+> automatically adjusted for each model family.
 
 ## Installation
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -2242,7 +2242,7 @@ export async function searchVec(db: Database, query: string, model: string, limi
 
 async function getEmbedding(text: string, model: string, isQuery: boolean, session?: ILLMSession): Promise<number[] | null> {
   // Format text using the appropriate prompt template
-  const formattedText = isQuery ? formatQueryForEmbedding(text) : formatDocForEmbedding(text);
+  const formattedText = isQuery ? formatQueryForEmbedding(text, model) : formatDocForEmbedding(text, undefined, model);
   const result = session
     ? await session.embed(formattedText, { model, isQuery })
     : await getDefaultLlamaCpp().embed(formattedText, { model, isQuery });


### PR DESCRIPTION
## Problem

The default `embeddinggemma-300M` embedding model is English-centric and produces poor vector representations for CJK (Chinese, Japanese, Korean) text. Users working with multilingual document collections have no way to switch to a better embedding model without modifying source code.

## Solution

Add `QMD_EMBED_MODEL` environment variable to override the default embedding model at runtime.

## Changes

- `src/llm.ts`: `DEFAULT_EMBED_MODEL` now reads from `QMD_EMBED_MODEL` env var (falls back to `embeddinggemma-300M` for backward compatibility)
- `src/llm.ts`: `getDefaultLlamaCpp()` passes `QMD_EMBED_MODEL` to `LlamaCpp` config when set
- `src/llm.ts`: Add `isQwen3EmbeddingModel()` helper to detect Qwen3-Embedding model family
- `src/llm.ts`: `formatQueryForEmbedding()` and `formatDocForEmbedding()` auto-detect model family and apply the correct prompt format:
  - embeddinggemma: nomic-style `task: search result | query: ...` (unchanged)
  - Qwen3-Embedding: task-instruction format `Instruct: ...\nQuery: ...`
- `src/store.ts`: pass model URI to format functions for consistency between indexing and query time
- `README.md`: document `QMD_EMBED_MODEL` with usage example

## Usage

```sh
# Qwen3-Embedding-0.6B is multilingual (119 languages), MTEB top-ranked at its size
export QMD_EMBED_MODEL="hf:Qwen/Qwen3-Embedding-0.6B-GGUF/qwen3-embedding-0.6b-q8_0.gguf"

# Re-embed after switching models
qmd embed -f
```

## Notes

- Fully backward-compatible — no change when `QMD_EMBED_MODEL` is unset
- The reranker (`Qwen3-Reranker-0.6B`) already ships with QMD; this PR aligns the embedding side for users who want a consistent Qwen3 pipeline
- Only format detection logic added; no behavior change for default model
