### PR TITLE
feat: add per-collection score boost multiplier

### DIFF
--- a/src/collections.ts
+++ b/src/collections.ts
@@ -30,6 +30,7 @@ export interface Collection {
   context?: ContextMap;      // Optional context definitions
   update?: string;           // Optional bash command to run during qmd update
   includeByDefault?: boolean; // Include in queries by default (default: true)
+  boost?: number;            // Score multiplier for search results (default: 1.0)
 }
 
 /**
@@ -189,7 +190,7 @@ export function getDefaultCollectionNames(): string[] {
  */
 export function updateCollectionSettings(
   name: string,
-  settings: { update?: string | null; includeByDefault?: boolean }
+  settings: { update?: string | null; includeByDefault?: boolean; boost?: number }
 ): boolean {
   const config = loadConfig();
   const collection = config.collections[name];
@@ -210,6 +211,13 @@ export function updateCollectionSettings(
     } else {
       collection.includeByDefault = settings.includeByDefault;
     }
+  }
+
+  if (settings.boost !== undefined) {
+    collection.boost = settings.boost;
+  } else if ('boost' in settings) {
+    // Explicitly passed undefined = remove the field (reset to default 1.0)
+    delete collection.boost;
   }
 
   saveConfig(config);

--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -1303,8 +1303,10 @@ function collectionList(): void {
     const yamlColl = getCollectionFromYaml(coll.name);
     const excluded = yamlColl?.includeByDefault === false;
     const excludeTag = excluded ? ` ${c.yellow}[excluded]${c.reset}` : '';
+    const boost = yamlColl?.boost;
+    const boostTag = boost !== undefined && boost !== 1.0 ? ` ${c.green}[boost: ${boost}x]${c.reset}` : '';
 
-    console.log(`${c.cyan}${coll.name}${c.reset} ${c.dim}(qmd://${coll.name}/)${c.reset}${excludeTag}`);
+    console.log(`${c.cyan}${coll.name}${c.reset} ${c.dim}(qmd://${coll.name}/)${c.reset}${excludeTag}${boostTag}`);
     console.log(`  ${c.dim}Pattern:${c.reset}  ${coll.glob_pattern}`);
     console.log(`  ${c.dim}Files:${c.reset}    ${coll.active_count}`);
     console.log(`  ${c.dim}Updated:${c.reset}  ${timeAgo}`);
@@ -2653,6 +2655,41 @@ if (isMain) {
           break;
         }
 
+        case "boost": {
+          const name = cli.args[1];
+          const value = cli.args[2];
+          if (!name) {
+            console.error("Usage: qmd collection boost <name> [multiplier]");
+            console.error("  Set or show the score boost multiplier for a collection.");
+            console.error("  Default is 1.0 (no boost). Values > 1.0 increase ranking priority.");
+            console.error("");
+            console.error("Examples:");
+            console.error("  qmd collection boost notes 1.5    # Boost notes results by 50%");
+            console.error("  qmd collection boost notes        # Show current boost");
+            console.error("  qmd collection boost notes 1.0    # Reset to default");
+            process.exit(1);
+          }
+          const { getCollection, updateCollectionSettings } = await import("./collections.js");
+          const col = getCollection(name);
+          if (!col) {
+            console.error(`Collection not found: ${name}`);
+            process.exit(1);
+          }
+          if (value === undefined) {
+            // Show current boost
+            console.log(`Collection '${name}' boost: ${col.boost ?? 1.0}`);
+          } else {
+            const boost = parseFloat(value);
+            if (isNaN(boost) || boost <= 0) {
+              console.error("Boost must be a positive number (e.g., 1.0, 1.5, 2.0)");
+              process.exit(1);
+            }
+            updateCollectionSettings(name, { boost: boost === 1.0 ? undefined : boost });
+            console.log(`✓ Collection '${name}' boost set to ${boost}`);
+          }
+          break;
+        }
+
         case "show":
         case "info": {
           const name = cli.args[1];
@@ -2670,6 +2707,9 @@ if (isMain) {
           console.log(`  Path:     ${col.path}`);
           console.log(`  Pattern:  ${col.pattern}`);
           console.log(`  Include:  ${col.includeByDefault !== false ? 'yes (default)' : 'no'}`);
+          if (col.boost !== undefined && col.boost !== 1.0) {
+            console.log(`  Boost:    ${col.boost}x`);
+          }
           if (col.update) {
             console.log(`  Update:   ${col.update}`);
           }
@@ -2690,6 +2730,7 @@ if (isMain) {
           console.log("  remove <name>             Remove a collection");
           console.log("  rename <old> <new>        Rename a collection");
           console.log("  show <name>               Show collection details");
+          console.log("  boost <name> [value]      Set/show score boost multiplier (default: 1.0)");
           console.log("  update-cmd <name> [cmd]   Set pre-update command (e.g., 'git pull')");
           console.log("  include <name>            Include in default queries");
           console.log("  exclude <name>            Exclude from default queries");

--- a/src/store.ts
+++ b/src/store.ts
@@ -790,9 +790,10 @@ export type Store = {
   cleanupOrphanedVectors: () => number;
   vacuumDatabase: () => void;
 
-  // Context
+  // Context & boost
   getContextForFile: (filepath: string) => string | null;
   getContextForPath: (collectionName: string, path: string) => string | null;
+  getBoostForFile: (filepath: string) => number;
   getCollectionByName: (name: string) => { name: string; pwd: string; glob_pattern: string } | null;
   getCollectionsWithoutContext: () => { name: string; pwd: string; doc_count: number }[];
   getTopLevelPathsWithoutContext: (collectionName: string) => string[];
@@ -873,9 +874,10 @@ export function createStore(dbPath?: string): Store {
     cleanupOrphanedVectors: () => cleanupOrphanedVectors(db),
     vacuumDatabase: () => vacuumDatabase(db),
 
-    // Context
+    // Context & boost
     getContextForFile: (filepath: string) => getContextForFile(db, filepath),
     getContextForPath: (collectionName: string, path: string) => getContextForPath(db, collectionName, path),
+    getBoostForFile: (filepath: string) => getBoostForFile(filepath),
     getCollectionByName: (name: string) => getCollectionByName(db, name),
     getCollectionsWithoutContext: () => getCollectionsWithoutContext(db),
     getTopLevelPathsWithoutContext: (collectionName: string) => getTopLevelPathsWithoutContext(db, collectionName),
@@ -1725,6 +1727,34 @@ export function getContextForFile(db: Database, filepath: string): string | null
 
   // Join all contexts with double newline
   return contexts.length > 0 ? contexts.join('\n\n') : null;
+}
+
+/**
+ * Get the boost multiplier for a file based on its collection.
+ * Returns the collection's boost value, or 1.0 if not set.
+ */
+export function getBoostForFile(filepath: string): number {
+  if (!filepath) return 1.0;
+
+  const parsedVirtual = filepath.startsWith('qmd://') ? parseVirtualPath(filepath) : null;
+  let collectionName: string | null = null;
+
+  if (parsedVirtual) {
+    collectionName = parsedVirtual.collectionName;
+  } else {
+    const collections = collectionsListCollections();
+    for (const coll of collections) {
+      if (!coll?.path) continue;
+      if (filepath.startsWith(coll.path + '/') || filepath === coll.path) {
+        collectionName = coll.name;
+        break;
+      }
+    }
+  }
+
+  if (!collectionName) return 1.0;
+  const coll = getCollection(collectionName);
+  return coll?.boost ?? 1.0;
 }
 
 /**
@@ -3060,7 +3090,8 @@ export async function hybridQuery(
     else if (rrfRank <= 10) rrfWeight = 0.60;
     else rrfWeight = 0.40;
     const rrfScore = 1 / rrfRank;
-    const blendedScore = rrfWeight * rrfScore + (1 - rrfWeight) * r.score;
+    const baseScore = rrfWeight * rrfScore + (1 - rrfWeight) * r.score;
+    const blendedScore = baseScore * store.getBoostForFile(r.file);
 
     const candidate = candidateMap.get(r.file);
     const chunkInfo = docChunkMap.get(r.file);
@@ -3357,7 +3388,8 @@ export async function structuredSearch(
     else if (rrfRank <= 10) rrfWeight = 0.60;
     else rrfWeight = 0.40;
     const rrfScore = 1 / rrfRank;
-    const blendedScore = rrfWeight * rrfScore + (1 - rrfWeight) * r.score;
+    const baseScore = rrfWeight * rrfScore + (1 - rrfWeight) * r.score;
+    const blendedScore = baseScore * store.getBoostForFile(r.file);
 
     const candidate = candidateMap.get(r.file);
     const chunkInfo = docChunkMap.get(r.file);

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1099,6 +1099,88 @@ describe("Path Context", () => {
 });
 
 // =============================================================================
+// Boost Tests
+// =============================================================================
+
+// Helper to set collection boost in YAML config
+async function setCollectionBoost(collectionName: string, boost: number | undefined): Promise<void> {
+  const configPath = join(testConfigDir, "index.yml");
+  const { readFile } = await import("node:fs/promises");
+  const content = await readFile(configPath, "utf-8");
+  const config = YAML.parse(content) as CollectionConfig;
+
+  if (!config.collections[collectionName]) {
+    throw new Error(`Collection ${collectionName} not found`);
+  }
+
+  if (boost === undefined || boost === 1.0) {
+    delete config.collections[collectionName].boost;
+  } else {
+    config.collections[collectionName].boost = boost;
+  }
+
+  await writeFile(configPath, YAML.stringify(config));
+}
+
+describe("Boost", () => {
+  test("getBoostForFile returns 1.0 for unknown paths", async () => {
+    const store = await createTestStore();
+    expect(store.getBoostForFile("/some/random/path.md")).toBe(1.0);
+    expect(store.getBoostForFile("")).toBe(1.0);
+    await cleanupTestDb(store);
+  });
+
+  test("getBoostForFile returns 1.0 when no boost set", async () => {
+    const store = await createTestStore();
+    const collectionName = await createTestCollection({ pwd: "/test/notes", glob: "**/*.md" });
+
+    expect(store.getBoostForFile("qmd://" + collectionName + "/readme.md")).toBe(1.0);
+    await cleanupTestDb(store);
+  });
+
+  test("getBoostForFile returns configured boost", async () => {
+    const store = await createTestStore();
+    const collectionName = await createTestCollection({ pwd: "/test/notes", glob: "**/*.md" });
+    await setCollectionBoost(collectionName, 1.5);
+
+    expect(store.getBoostForFile("qmd://" + collectionName + "/readme.md")).toBe(1.5);
+    await cleanupTestDb(store);
+  });
+
+  test("getBoostForFile resolves boost from filesystem path", async () => {
+    const store = await createTestStore();
+    const collectionName = await createTestCollection({ pwd: "/test/notes", glob: "**/*.md" });
+    await setCollectionBoost(collectionName, 2.0);
+
+    expect(store.getBoostForFile("/test/notes/readme.md")).toBe(2.0);
+    await cleanupTestDb(store);
+  });
+
+  test("getBoostForFile returns 1.0 after boost is reset", async () => {
+    const store = await createTestStore();
+    const collectionName = await createTestCollection({ pwd: "/test/notes", glob: "**/*.md" });
+    await setCollectionBoost(collectionName, 1.5);
+    expect(store.getBoostForFile("qmd://" + collectionName + "/readme.md")).toBe(1.5);
+
+    await setCollectionBoost(collectionName, undefined);
+    expect(store.getBoostForFile("qmd://" + collectionName + "/readme.md")).toBe(1.0);
+    await cleanupTestDb(store);
+  });
+
+  test("different collections can have different boosts", async () => {
+    const store = await createTestStore();
+    const notes = await createTestCollection({ pwd: "/test/notes", glob: "**/*.md", name: "notes" });
+    const docs = await createTestCollection({ pwd: "/test/docs", glob: "**/*.md", name: "docs" });
+    await setCollectionBoost(notes, 1.5);
+    await setCollectionBoost(docs, 0.8);
+
+    expect(store.getBoostForFile("qmd://notes/readme.md")).toBe(1.5);
+    expect(store.getBoostForFile("qmd://docs/api.md")).toBe(0.8);
+    await cleanupTestDb(store);
+  });
+});
+
+// =============================================================================
 // Collection Tests
 // =============================================================================
 


### PR DESCRIPTION
Closes #280

Adds a configurable `boost` multiplier per collection that scales the final blended score in hybrid and structured search.

**Usage:**

```bash
qmd collection boost notes 1.5    # Boost results by 50%
qmd collection boost notes        # Show current boost
qmd collection boost notes 1.0    # Reset to default
```

**Implementation:**

- `collections.ts`: Add `boost` field to `Collection` interface and `updateCollectionSettings()`
- `store.ts`: Add `getBoostForFile()` that resolves collection from virtual/filesystem path and returns boost. Applied as `baseScore * boost` in `hybridQuery()` and `structuredSearch()` after RRF fusion + reranking
- `qmd.ts`: Add `collection boost` CLI command, display boost in `collection list` and `collection show`
- `store.test.ts`: 6 unit tests covering unknown paths, default behavior, configured boost, filesystem path resolution, reset, and multi-collection scenarios

**Design decisions:**

- Boost is multiplicative on the final blended score (post-reranking), preserving reranker integrity
- Default `1.0` is fully backward compatible, no behavior change without explicit config
- Setting `1.0` removes the field from YAML config
- Values must be positive; values > 1.0 boost, < 1.0 demote