### PR TITLE
fix: support multiple concurrent HTTP clients

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -14,6 +14,7 @@ import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mc
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { WebStandardStreamableHTTPServerTransport }
   from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import {
   createStore,
@@ -552,12 +553,31 @@ export type HttpServerHandle = {
  */
 export async function startMcpHttpServer(port: number, options?: { quiet?: boolean }): Promise<HttpServerHandle> {
   const store = createStore();
-  const mcpServer = createMcpServer(store);
-  const transport = new WebStandardStreamableHTTPServerTransport({
-    sessionIdGenerator: () => randomUUID(),
-    enableJsonResponse: true,
-  });
-  await mcpServer.connect(transport);
+
+  // Session map: each client gets its own McpServer + Transport pair (MCP spec requirement).
+  // The store is shared — it's stateless SQLite, safe for concurrent access.
+  const sessions = new Map<string, WebStandardStreamableHTTPServerTransport>();
+
+  async function createSession(): Promise<WebStandardStreamableHTTPServerTransport> {
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      enableJsonResponse: true,
+      onsessioninitialized: (sessionId: string) => {
+        sessions.set(sessionId, transport);
+        log(`${ts()} New session ${sessionId} (${sessions.size} active)`);
+      },
+    });
+    const server = createMcpServer(store);
+    await server.connect(transport);
+
+    transport.onclose = () => {
+      if (transport.sessionId) {
+        sessions.delete(transport.sessionId);
+      }
+    };
+
+    return transport;
+  }
 
   const startTime = Date.now();
   const quiet = options?.quiet ?? false;
@@ -669,8 +689,38 @@ export async function startMcpHttpServer(port: number, options?: { quiet?: boole
         for (const [k, v] of Object.entries(nodeReq.headers)) {
           if (typeof v === "string") headers[k] = v;
         }
+
+        // Route to existing session or create new one on initialize
+        const sessionId = headers["mcp-session-id"];
+        let transport: WebStandardStreamableHTTPServerTransport;
+
+        if (sessionId) {
+          const existing = sessions.get(sessionId);
+          if (!existing) {
+            nodeRes.writeHead(404, { "Content-Type": "application/json" });
+            nodeRes.end(JSON.stringify({
+              jsonrpc: "2.0",
+              error: { code: -32001, message: "Session not found" },
+              id: body?.id ?? null,
+            }));
+            return;
+          }
+          transport = existing;
+        } else if (isInitializeRequest(body)) {
+          transport = await createSession();
+        } else {
+          nodeRes.writeHead(400, { "Content-Type": "application/json" });
+          nodeRes.end(JSON.stringify({
+            jsonrpc: "2.0",
+            error: { code: -32000, message: "Bad Request: Missing session ID" },
+            id: body?.id ?? null,
+          }));
+          return;
+        }
+
         const request = new Request(url, { method: "POST", headers, body: rawBody });
         const response = await transport.handleRequest(request, { parsedBody: body });
+
         nodeRes.writeHead(response.status, Object.fromEntries(response.headers));
         nodeRes.end(Buffer.from(await response.arrayBuffer()));
         log(`${ts()} POST /mcp ${label} (${Date.now() - reqStart}ms)`);
@@ -678,11 +728,34 @@ export async function startMcpHttpServer(port: number, options?: { quiet?: boole
       }
 
       if (pathname === "/mcp") {
-        const url = `http://localhost:${port}${pathname}`;
         const headers: Record<string, string> = {};
         for (const [k, v] of Object.entries(nodeReq.headers)) {
           if (typeof v === "string") headers[k] = v;
         }
+
+        // GET/DELETE must have a valid session
+        const sessionId = headers["mcp-session-id"];
+        if (!sessionId) {
+          nodeRes.writeHead(400, { "Content-Type": "application/json" });
+          nodeRes.end(JSON.stringify({
+            jsonrpc: "2.0",
+            error: { code: -32000, message: "Bad Request: Missing session ID" },
+            id: null,
+          }));
+          return;
+        }
+        const transport = sessions.get(sessionId);
+        if (!transport) {
+          nodeRes.writeHead(404, { "Content-Type": "application/json" });
+          nodeRes.end(JSON.stringify({
+            jsonrpc: "2.0",
+            error: { code: -32001, message: "Session not found" },
+            id: null,
+          }));
+          return;
+        }
+
+        const url = `http://localhost:${port}${pathname}`;
         const rawBody = nodeReq.method !== "GET" && nodeReq.method !== "HEAD" ? await collectBody(nodeReq) : undefined;
         const request = new Request(url, { method: nodeReq.method || "GET", headers, ...(rawBody ? { body: rawBody } : {}) });
         const response = await transport.handleRequest(request);
@@ -711,7 +784,10 @@ export async function startMcpHttpServer(port: number, options?: { quiet?: boole
   const stop = async () => {
     if (stopping) return;
     stopping = true;
-    await transport.close();
+    for (const transport of sessions.values()) {
+      await transport.close();
+    }
+    sessions.clear();
     httpServer.close();
     store.close();
     await disposeDefaultLlamaCpp();


### PR DESCRIPTION
## Summary

The HTTP MCP server (`qmd mcp --http`) is effectively single-session: one `WebStandardStreamableHTTPServerTransport` is created at startup and connected to one `McpServer`. Once the first client initializes, all subsequent clients are rejected with `"Server already initialized"` — making the HTTP mode unusable for reconnect, crash recovery, or multi-client scenarios.

This PR replaces the singleton with a per-session architecture following the [MCP SDK's canonical pattern](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/examples/server/simpleStreamableHttp.ts): each `initialize` request creates its own `McpServer` + `Transport` pair, stored in a `Map<sessionId, Transport>`. The shared `Store` (SQLite) is stateless and safe for concurrent access.

### Changes

- **`createSession()` factory** — creates a fresh `McpServer` + `Transport` per client, using `onsessioninitialized` callback to register sessions at the right time
- **POST `/mcp` routing** — looks up existing sessions by `mcp-session-id` header; creates new session on `initialize`; returns 404 for unknown sessions, 400 for missing session ID (per MCP spec)
- **GET/DELETE `/mcp`** — same session lookup with proper 400/404 distinction
- **Shutdown** — iterates and closes all active sessions
- **No changes** to `createMcpServer()`, tool registrations, the stdio transport, or the REST `/query` endpoint

### Why one McpServer per session?

The MCP SDK's `Protocol.connect()` enforces a [strict 1:1 binding](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/shared/protocol.ts#L215-L218) between server and transport — calling `connect()` twice throws. Additionally, sharing a `McpServer` across transports risks cross-wiring responses due to JSON-RPC message ID collisions.

## Test plan

Tested locally with concurrent clients over HTTP:

- [x] Two+ clients initialize independently (unique session IDs)
- [x] Each client makes tool calls on its own session
- [x] Third client joins while first two are active
- [x] Bogus/unknown session ID → 404
- [x] Missing session ID on non-initialize request → 400
- [x] DELETE cleans up session; subsequent use rejected
- [x] Re-initialize on existing session → rejected ("Server already initialized")
- [x] Health endpoint unaffected
- [x] Session survives 20+ sequential requests
- [x] 10 rapid session creations all succeed
- [x] Single-client behavior unchanged (backwards compatible)
- [x] Stdio transport path untouched

Fixes #195, closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)