### PR TITLE
feat(embed): add Google AI embedding provider

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.0",
+        "@types/picomatch": "^4.0.2",
         "tsx": "^4.0.0",
         "vitest": "^3.0.0",
       },
@@ -258,6 +259,8 @@
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
+
+    "@types/picomatch": ["@types/picomatch@4.0.2", "", {}, "sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA=="],
 
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 

--- a/migrate-schema.ts
+++ b/migrate-schema.ts
@@ -7,6 +7,7 @@
  * collection management.
  */
 
+// @ts-expect-error bun:sqlite is only available under Bun runtime
 import { Database } from "bun:sqlite";
 import { join } from "path";
 import { homedir } from "os";

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",
+    "@types/picomatch": "^4.0.2",
     "tsx": "^4.0.0",
     "vitest": "^3.0.0"
   },

--- a/src/bench-rerank.ts
+++ b/src/bench-rerank.ts
@@ -110,17 +110,15 @@ async function benchmarkConfig(
 
   // Create contexts. On CPU, split threads evenly across contexts.
   const cpuThreads = !llama.gpu ? Math.floor(llama.cpuMathCores / parallelism) : 0;
-  const contexts = [];
+  const contexts: Awaited<ReturnType<typeof model.createRankingContext>>[] = [];
   for (let i = 0; i < parallelism; i++) {
     try {
       contexts.push(await model.createRankingContext({
         contextSize: CONTEXT_SIZE,
-        flashAttention: flash,
         ...(cpuThreads > 0 ? { threads: cpuThreads } : {}),
       }));
     } catch {
       if (contexts.length === 0) {
-        // Try without flash
         contexts.push(await model.createRankingContext({
           contextSize: CONTEXT_SIZE,
           ...(cpuThreads > 0 ? { threads: cpuThreads } : {}),
@@ -193,7 +191,7 @@ async function main() {
   console.log("═══════════════════════════════════════════════════════════════\n");
 
   // Detect GPU
-  const gpuTypes = await getLlamaGpuTypes();
+  const gpuTypes = await getLlamaGpuTypes("supported");
   const preferred = (["cuda", "metal", "vulkan"] as const).find(g => gpuTypes.includes(g));
 
   let llama: Llama;

--- a/src/google-embed.ts
+++ b/src/google-embed.ts
@@ -1,0 +1,126 @@
+import type { EmbeddingResult, EmbedOptions } from "./llm.js";
+
+export const GOOGLE_EMBED_MODEL = "gemini-embedding-001";
+export const GOOGLE_EMBED_DIMENSIONS = 3072;
+
+const MODEL_NAME = `models/${GOOGLE_EMBED_MODEL}`;
+const BASE_URL = `https://generativelanguage.googleapis.com/v1beta/${MODEL_NAME}`;
+const BATCH_LIMIT = 100;
+const MAX_RETRIES = 3;
+
+type TaskType = "RETRIEVAL_DOCUMENT" | "RETRIEVAL_QUERY";
+
+interface EmbedContentRequest {
+  model: string;
+  content: { parts: { text: string }[] };
+  taskType: TaskType;
+  outputDimensionality: number;
+}
+
+export class GoogleAIEmbedder {
+  private apiKey: string;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  private get headers(): Record<string, string> {
+    return {
+      "Content-Type": "application/json",
+      "x-goog-api-key": this.apiKey,
+    };
+  }
+
+  async embed(text: string, options: EmbedOptions = {}): Promise<EmbeddingResult | null> {
+    const taskType: TaskType = options.isQuery ? "RETRIEVAL_QUERY" : "RETRIEVAL_DOCUMENT";
+    const url = `${BASE_URL}:embedContent`;
+
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: this.headers,
+        body: JSON.stringify({
+          model: MODEL_NAME,
+          content: { parts: [{ text }] },
+          taskType,
+          outputDimensionality: GOOGLE_EMBED_DIMENSIONS,
+        }),
+      });
+
+      if (!res.ok) {
+        const body = (await res.text()).slice(0, 200);
+        console.warn(`Google embed API error ${res.status}: ${body}`);
+        return null;
+      }
+
+      const data = await res.json() as { embedding?: { values?: number[] } };
+      const vals = data?.embedding?.values;
+      if (!Array.isArray(vals) || vals.length !== GOOGLE_EMBED_DIMENSIONS) {
+        console.warn(`Google embed: unexpected response shape or dimensionality`);
+        return null;
+      }
+      return { embedding: vals, model: GOOGLE_EMBED_MODEL };
+    } catch (err) {
+      console.warn("Google embed request failed:", err);
+      return null;
+    }
+  }
+
+  async embedBatch(texts: string[], isQuery = false): Promise<(EmbeddingResult | null)[]> {
+    if (texts.length === 0) return [];
+
+    const taskType: TaskType = isQuery ? "RETRIEVAL_QUERY" : "RETRIEVAL_DOCUMENT";
+    const results: (EmbeddingResult | null)[] = new Array(texts.length).fill(null);
+
+    for (let start = 0; start < texts.length; start += BATCH_LIMIT) {
+      const chunk = texts.slice(start, start + BATCH_LIMIT);
+      const requests: EmbedContentRequest[] = chunk.map((text) => ({
+        model: MODEL_NAME,
+        content: { parts: [{ text }] },
+        taskType,
+        outputDimensionality: GOOGLE_EMBED_DIMENSIONS,
+      }));
+
+      let retries = 0;
+      while (retries < MAX_RETRIES) {
+        try {
+          const url = `${BASE_URL}:batchEmbedContents`;
+          const res = await fetch(url, {
+            method: "POST",
+            headers: this.headers,
+            body: JSON.stringify({ requests }),
+          });
+
+          if (res.status === 429) {
+            const retryAfter = parseInt(res.headers.get("Retry-After") ?? "5", 10);
+            console.warn(`Google embed rate limited, retrying in ${retryAfter}s...`);
+            await new Promise(r => setTimeout(r, retryAfter * 1000));
+            retries++;
+            continue;
+          }
+
+          if (!res.ok) {
+            const body = (await res.text()).slice(0, 200);
+            console.warn(`Google batch embed API error ${res.status}: ${body}`);
+            break;
+          }
+
+          const data = await res.json() as { embeddings?: { values: number[] }[] };
+          const embeddings = data.embeddings ?? [];
+          for (let i = 0; i < embeddings.length; i++) {
+            const emb = embeddings[i];
+            if (emb?.values && emb.values.length === GOOGLE_EMBED_DIMENSIONS) {
+              results[start + i] = { embedding: emb.values, model: GOOGLE_EMBED_MODEL };
+            }
+          }
+          break;
+        } catch (err) {
+          console.warn("Google batch embed request failed:", err);
+          break;
+        }
+      }
+    }
+
+    return results;
+  }
+}

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -18,6 +18,7 @@ import {
 import { homedir } from "os";
 import { join } from "path";
 import { existsSync, mkdirSync, statSync, unlinkSync, readdirSync, readFileSync, writeFileSync } from "fs";
+import { GoogleAIEmbedder, GOOGLE_EMBED_MODEL } from "./google-embed.js";
 
 // =============================================================================
 // Embedding Formatting Functions
@@ -137,7 +138,7 @@ export type LLMSessionOptions = {
  */
 export interface ILLMSession {
   embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null>;
-  embedBatch(texts: string[]): Promise<(EmbeddingResult | null)[]>;
+  embedBatch(texts: string[], isQuery?: boolean): Promise<(EmbeddingResult | null)[]>;
   expandQuery(query: string, options?: { context?: string; includeLexical?: boolean }): Promise<Queryable[]>;
   rerank(query: string, documents: RerankDocument[], options?: RerankOptions): Promise<RerankResult>;
   /** Whether this session is still valid (not released or aborted) */
@@ -297,6 +298,11 @@ export interface LLM {
    * Get embeddings for text
    */
   embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null>;
+
+  /**
+   * Batch embed multiple texts
+   */
+  embedBatch(texts: string[], isQuery?: boolean): Promise<(EmbeddingResult | null)[]>;
 
   /**
    * Generate text completion
@@ -1314,7 +1320,7 @@ class LLMSession implements ILLMSession {
     return this.withOperation(() => this.manager.getLlamaCpp().embed(text, options));
   }
 
-  async embedBatch(texts: string[]): Promise<(EmbeddingResult | null)[]> {
+  async embedBatch(texts: string[], _isQuery?: boolean): Promise<(EmbeddingResult | null)[]> {
     return this.withOperation(() => this.manager.getLlamaCpp().embedBatch(texts));
   }
 
@@ -1417,4 +1423,106 @@ export async function disposeDefaultLlamaCpp(): Promise<void> {
     await defaultLlamaCpp.dispose();
     defaultLlamaCpp = null;
   }
+}
+
+// =============================================================================
+// Embed Provider Configuration
+// =============================================================================
+
+export type EmbedProvider = "local" | "google";
+let embedProvider: EmbedProvider = "local";
+let googleApiKey: string | null = null;
+
+export function setEmbedProvider(provider: EmbedProvider): void { embedProvider = provider; }
+export function getEmbedProvider(): EmbedProvider { return embedProvider; }
+export function setGoogleApiKey(key: string): void { googleApiKey = key; }
+export function needsEmbedFormatting(): boolean { return embedProvider !== "google"; }
+
+/** Returns the model tag used for storing/querying embeddings based on active provider. */
+export function getActiveEmbedModel(): string {
+  return embedProvider === "google" ? GOOGLE_EMBED_MODEL : DEFAULT_EMBED_MODEL;
+}
+
+// Initialize from env vars
+if (process.env.QMD_EMBED_PROVIDER === "google" || process.env.QMD_EMBED_PROVIDER === "local") {
+  embedProvider = process.env.QMD_EMBED_PROVIDER;
+}
+if (process.env.GEMINI_API_KEY) {
+  googleApiKey = process.env.GEMINI_API_KEY;
+}
+
+// =============================================================================
+// GoogleHybridLLM — Google embeddings + local LLM for everything else
+// =============================================================================
+
+export class GoogleHybridLLM implements LLM {
+  private localLlm: LlamaCpp;
+  private googleEmbedder: GoogleAIEmbedder;
+
+  constructor(localLlm: LlamaCpp, apiKey: string) {
+    this.localLlm = localLlm;
+    this.googleEmbedder = new GoogleAIEmbedder(apiKey);
+  }
+
+  async embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null> {
+    return this.googleEmbedder.embed(text, options);
+  }
+
+  async embedBatch(texts: string[], isQuery = false): Promise<(EmbeddingResult | null)[]> {
+    return this.googleEmbedder.embedBatch(texts, isQuery);
+  }
+
+  async generate(prompt: string, options?: GenerateOptions): Promise<GenerateResult | null> {
+    return this.localLlm.generate(prompt, options);
+  }
+
+  async expandQuery(query: string, options?: { context?: string; includeLexical?: boolean }): Promise<Queryable[]> {
+    return this.localLlm.expandQuery(query, options);
+  }
+
+  async rerank(query: string, documents: RerankDocument[], options?: RerankOptions): Promise<RerankResult> {
+    return this.localLlm.rerank(query, documents, options);
+  }
+
+  async modelExists(model: string): Promise<ModelInfo> {
+    return this.localLlm.modelExists(model);
+  }
+
+  async dispose(): Promise<void> {
+    await this.localLlm.dispose();
+  }
+}
+
+// =============================================================================
+// Default LLM (hybrid or local)
+// =============================================================================
+
+let defaultHybridLLM: GoogleHybridLLM | null = null;
+
+/**
+ * Get the default LLM instance.
+ * Returns GoogleHybridLLM when Google embed provider is configured, otherwise LlamaCpp.
+ */
+export function getDefaultLLM(): LLM {
+  if (embedProvider === "google") {
+    if (!googleApiKey) {
+      throw new Error("GEMINI_API_KEY is required when QMD_EMBED_PROVIDER=google");
+    }
+    if (!defaultHybridLLM) {
+      defaultHybridLLM = new GoogleHybridLLM(getDefaultLlamaCpp(), googleApiKey);
+    }
+    return defaultHybridLLM;
+  }
+  return getDefaultLlamaCpp();
+}
+
+/**
+ * Dispose the default hybrid LLM if it exists.
+ */
+export async function disposeDefaultLLM(): Promise<void> {
+  if (defaultHybridLLM) {
+    await defaultHybridLLM.dispose();
+    defaultHybridLLM = null;
+  }
+  await disposeDefaultLlamaCpp();
 }

--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -70,7 +70,8 @@ import {
   createStore,
   getDefaultDbPath,
 } from "./store.js";
-import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, withLLMSession, pullModels, DEFAULT_EMBED_MODEL_URI, DEFAULT_GENERATE_MODEL_URI, DEFAULT_RERANK_MODEL_URI, DEFAULT_MODEL_CACHE_DIR } from "./llm.js";
+import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, withLLMSession, pullModels, DEFAULT_EMBED_MODEL_URI, DEFAULT_GENERATE_MODEL_URI, DEFAULT_RERANK_MODEL_URI, DEFAULT_MODEL_CACHE_DIR, setEmbedProvider, setGoogleApiKey, getEmbedProvider, needsEmbedFormatting, getDefaultLLM, disposeDefaultLLM, type EmbeddingResult } from "./llm.js";
+import { GOOGLE_EMBED_MODEL, GOOGLE_EMBED_DIMENSIONS } from "./google-embed.js";
 import {
   formatSearchResults,
   formatDocuments,
@@ -297,6 +298,7 @@ async function showStatus(): Promise<void> {
   console.log(`${c.bold}QMD Status${c.reset}\n`);
   console.log(`Index: ${dbPath}`);
   console.log(`Size:  ${formatBytes(indexSize)}`);
+  console.log(`Embed: ${getEmbedProvider() === "google" ? `Google AI (${GOOGLE_EMBED_MODEL})` : "Local (embeddinggemma)"}`);
 
   // MCP daemon status (check PID file liveness)
   const mcpCacheDir = process.env.XDG_CACHE_HOME
@@ -1600,39 +1602,40 @@ async function vectorIndex(model: string = DEFAULT_EMBED_MODEL, force: boolean =
   // Hide cursor during embedding
   cursor.hide();
 
-  // Wrap all LLM embedding operations in a session for lifecycle management
-  // Use 30 minute timeout for large collections
-  await withLLMSession(async (session) => {
-    // Get embedding dimensions from first chunk
+  const useGoogle = getEmbedProvider() === "google";
+
+  const embedChunks = async (doEmbed: (text: string) => Promise<EmbeddingResult | null>, doEmbedBatch: (texts: string[]) => Promise<(EmbeddingResult | null)[]>) => {
+    // Get embedding dimensions — known for Google, probe for local
     progress.indeterminate();
-    const firstChunk = allChunks[0];
-    if (!firstChunk) {
-      throw new Error("No chunks available to embed");
+    if (useGoogle) {
+      ensureVecTable(db, GOOGLE_EMBED_DIMENSIONS);
+    } else {
+      const firstChunk = allChunks[0];
+      if (!firstChunk) throw new Error("No chunks available to embed");
+      const firstText = needsEmbedFormatting() ? formatDocForEmbedding(firstChunk.text, firstChunk.title) : firstChunk.text;
+      const firstResult = await doEmbed(firstText);
+      if (!firstResult) throw new Error("Failed to get embedding dimensions from first chunk");
+      ensureVecTable(db, firstResult.embedding.length);
     }
-    const firstText = formatDocForEmbedding(firstChunk.text, firstChunk.title);
-    const firstResult = await session.embed(firstText);
-    if (!firstResult) {
-      throw new Error("Failed to get embedding dimensions from first chunk");
-    }
-    ensureVecTable(db, firstResult.embedding.length);
 
     let chunksEmbedded = 0, errors = 0, bytesProcessed = 0;
     const startTime = Date.now();
 
-    // Batch embedding for better throughput
-    // Process in batches of 32 to balance memory usage and efficiency
-    const BATCH_SIZE = 32;
+    // Google API supports up to 100 per batch; local llama.cpp needs smaller batches
+    const BATCH_SIZE = useGoogle ? 100 : 32;
 
     for (let batchStart = 0; batchStart < allChunks.length; batchStart += BATCH_SIZE) {
       const batchEnd = Math.min(batchStart + BATCH_SIZE, allChunks.length);
       const batch = allChunks.slice(batchStart, batchEnd);
 
       // Format texts for embedding
-      const texts = batch.map(chunk => formatDocForEmbedding(chunk.text, chunk.title));
+      const texts = needsEmbedFormatting()
+        ? batch.map(chunk => formatDocForEmbedding(chunk.text, chunk.title))
+        : batch.map(chunk => chunk.text);
 
       try {
         // Batch embed all texts at once
-        const embeddings = await session.embedBatch(texts);
+        const embeddings = await doEmbedBatch(texts);
 
         // Insert each embedding
         for (let i = 0; i < batch.length; i++) {
@@ -1652,8 +1655,8 @@ async function vectorIndex(model: string = DEFAULT_EMBED_MODEL, force: boolean =
         // If batch fails, try individual embeddings as fallback
         for (const chunk of batch) {
           try {
-            const text = formatDocForEmbedding(chunk.text, chunk.title);
-            const result = await session.embed(text);
+            const text = needsEmbedFormatting() ? formatDocForEmbedding(chunk.text, chunk.title) : chunk.text;
+            const result = await doEmbed(text);
             if (result) {
               insertEmbedding(db, chunk.hash, chunk.seq, chunk.pos, new Float32Array(result.embedding), model, now);
               chunksEmbedded++;
@@ -1695,7 +1698,24 @@ async function vectorIndex(model: string = DEFAULT_EMBED_MODEL, force: boolean =
     if (errors > 0) {
       console.log(`${c.yellow}⚠ ${errors} chunks failed${c.reset}`);
     }
-  }, { maxDuration: 30 * 60 * 1000, name: 'embed-command' });
+  };
+
+  if (useGoogle) {
+    // Google provider: no local LLM session needed
+    const llm = getDefaultLLM();
+    await embedChunks(
+      (text) => llm.embed(text),
+      (texts) => llm.embedBatch(texts, false),
+    );
+  } else {
+    // Local provider: use lifecycle-managed LLM session (30 min timeout)
+    await withLLMSession(async (session) => {
+      await embedChunks(
+        (text) => session.embed(text),
+        (texts) => session.embedBatch(texts),
+      );
+    }, { maxDuration: 30 * 60 * 1000, name: 'embed-command' });
+  }
 
   closeDb();
 }
@@ -2263,6 +2283,7 @@ function parseCLI() {
       mask: { type: "string" },  // glob pattern
       // Embed options
       force: { type: "boolean", short: "f" },
+      provider: { type: "string" },  // embedding provider: local or google
       // Update options
       pull: { type: "boolean" },  // git pull before update
       refresh: { type: "boolean" },
@@ -2717,9 +2738,24 @@ if (isMain) {
       await updateCollections();
       break;
 
-    case "embed":
-      await vectorIndex(DEFAULT_EMBED_MODEL, !!cli.values.force);
+    case "embed": {
+      const provider = cli.values.provider as string | undefined;
+      if (provider && provider !== "local" && provider !== "google") {
+        console.error(`Error: invalid provider "${provider}". Must be "local" or "google".`);
+        process.exit(1);
+      }
+      if (provider === "google") {
+        if (!process.env.GEMINI_API_KEY) {
+          console.error("Error: GEMINI_API_KEY environment variable required for Google provider");
+          process.exit(1);
+        }
+        setEmbedProvider("google");
+        setGoogleApiKey(process.env.GEMINI_API_KEY);
+      }
+      const embedModel = getEmbedProvider() === "google" ? GOOGLE_EMBED_MODEL : DEFAULT_EMBED_MODEL;
+      await vectorIndex(embedModel, !!cli.values.force);
       break;
+    }
 
     case "pull": {
       const refresh = cli.values.refresh === undefined ? false : Boolean(cli.values.refresh);

--- a/src/store.ts
+++ b/src/store.ts
@@ -19,8 +19,11 @@ import { realpathSync, statSync, mkdirSync } from "node:fs";
 import {
   LlamaCpp,
   getDefaultLlamaCpp,
+  getDefaultLLM,
+  getActiveEmbedModel,
   formatQueryForEmbedding,
   formatDocForEmbedding,
+  needsEmbedFormatting,
   type RerankDocument,
   type ILLMSession,
 } from "./llm.js";
@@ -2241,11 +2244,13 @@ export async function searchVec(db: Database, query: string, model: string, limi
 // =============================================================================
 
 async function getEmbedding(text: string, model: string, isQuery: boolean, session?: ILLMSession): Promise<number[] | null> {
-  // Format text using the appropriate prompt template
-  const formattedText = isQuery ? formatQueryForEmbedding(text) : formatDocForEmbedding(text);
+  // Google provider handles task differentiation via API taskType parameter — skip nomic formatting
+  const formattedText = needsEmbedFormatting()
+    ? (isQuery ? formatQueryForEmbedding(text) : formatDocForEmbedding(text))
+    : text;
   const result = session
     ? await session.embed(formattedText, { model, isQuery })
-    : await getDefaultLlamaCpp().embed(formattedText, { model, isQuery });
+    : await getDefaultLLM().embed(formattedText, { model, isQuery });
   return result?.embedding || null;
 }
 
@@ -2984,11 +2989,13 @@ export async function hybridQuery(
     }
 
     // Batch embed all vector queries in a single call
-    const llm = getDefaultLlamaCpp();
-    const textsToEmbed = vecQueries.map(q => formatQueryForEmbedding(q.text));
+    const llm = getDefaultLLM();
+    const textsToEmbed = needsEmbedFormatting()
+      ? vecQueries.map(q => formatQueryForEmbedding(q.text))
+      : vecQueries.map(q => q.text);
     hooks?.onEmbedStart?.(textsToEmbed.length);
     const embedStart = Date.now();
-    const embeddings = await llm.embedBatch(textsToEmbed);
+    const embeddings = await llm.embedBatch(textsToEmbed, true);
     hooks?.onEmbedDone?.(Date.now() - embedStart);
 
     // Run sqlite-vec lookups with pre-computed embeddings
@@ -2997,7 +3004,7 @@ export async function hybridQuery(
       if (!embedding) continue;
 
       const vecResults = await store.searchVec(
-        vecQueries[i]!.text, DEFAULT_EMBED_MODEL, 20, collection,
+        vecQueries[i]!.text, getActiveEmbedModel(), 20, collection,
         undefined, embedding
       );
       if (vecResults.length > 0) {
@@ -3143,7 +3150,7 @@ export async function vectorSearchQuery(
   const queryTexts = [query, ...vecExpanded.map(q => q.text)];
   const allResults = new Map<string, VectorSearchResult>();
   for (const q of queryTexts) {
-    const vecResults = await store.searchVec(q, DEFAULT_EMBED_MODEL, limit, collection);
+    const vecResults = await store.searchVec(q, getActiveEmbedModel(), limit, collection);
     for (const r of vecResults) {
       const existing = allResults.get(r.filepath);
       if (!existing || r.score > existing.score) {
@@ -3273,11 +3280,13 @@ export async function structuredSearch(
   if (hasVectors) {
     const vecSearches = searches.filter(s => s.type === 'vec' || s.type === 'hyde');
     if (vecSearches.length > 0) {
-      const llm = getDefaultLlamaCpp();
-      const textsToEmbed = vecSearches.map(s => formatQueryForEmbedding(s.query));
+      const llm = getDefaultLLM();
+      const textsToEmbed = needsEmbedFormatting()
+        ? vecSearches.map(s => formatQueryForEmbedding(s.query))
+        : vecSearches.map(s => s.query);
       hooks?.onEmbedStart?.(textsToEmbed.length);
       const embedStart = Date.now();
-      const embeddings = await llm.embedBatch(textsToEmbed);
+      const embeddings = await llm.embedBatch(textsToEmbed, true);
       hooks?.onEmbedDone?.(Date.now() - embedStart);
 
       for (let i = 0; i < vecSearches.length; i++) {
@@ -3286,7 +3295,7 @@ export async function structuredSearch(
 
         for (const coll of collectionList) {
           const vecResults = await store.searchVec(
-            vecSearches[i]!.query, DEFAULT_EMBED_MODEL, 20, coll,
+            vecSearches[i]!.query, getActiveEmbedModel(), 20, coll,
             undefined, embedding
           );
           if (vecResults.length > 0) {

--- a/src/test-preload.ts
+++ b/src/test-preload.ts
@@ -1,11 +1,11 @@
 /**
  * Test preload file to ensure proper cleanup of native resources.
  *
- * Uses bun:test afterAll to properly dispose of llama.cpp Metal
- * resources before the process exits, avoiding GGML_ASSERT failures.
+ * Properly disposes llama.cpp Metal resources before the process exits,
+ * avoiding GGML_ASSERT failures.
  */
-import { afterAll } from "bun:test";
-import { disposeDefaultLlamaCpp } from "./llm";
+import { afterAll } from "vitest";
+import { disposeDefaultLlamaCpp } from "./llm.js";
 
 // Global afterAll runs after all test files complete
 afterAll(async () => {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,5 @@
+// Bun globals
+declare namespace globalThis {
+  // eslint-disable-next-line no-var
+  var Bun: unknown;
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1093,7 +1093,7 @@ describe("mcp http daemon", () => {
 
       const res = await fetch(`http://localhost:${port}/health`);
       expect(res.status).toBe(200);
-      const body = await res.json();
+      const body = await res.json() as { status: string };
       expect(body.status).toBe("ok");
     } finally {
       proc.kill("SIGTERM");

--- a/test/eval-bm25.test.ts
+++ b/test/eval-bm25.test.ts
@@ -17,7 +17,7 @@ import {
   searchFTS,
   insertDocument,
   insertContent,
-} from "../src/store";
+} from "../src/store.js";
 
 // Set INDEX_PATH before importing store to prevent using global index
 const tempDir = mkdtempSync(join(tmpdir(), "qmd-eval-unit-"));

--- a/test/eval.test.ts
+++ b/test/eval.test.ts
@@ -35,8 +35,9 @@ import {
   reciprocalRankFusion,
   DEFAULT_EMBED_MODEL,
   type RankedResult,
-} from "../src/store";
-import { getDefaultLlamaCpp, formatDocForEmbedding, disposeDefaultLlamaCpp } from "../src/llm";
+  type SearchResult,
+} from "../src/store.js";
+import { getDefaultLlamaCpp, formatDocForEmbedding, disposeDefaultLlamaCpp } from "../src/llm.js";
 
 // Eval queries with expected documents
 const evalQueries: {
@@ -222,7 +223,7 @@ describe.skipIf(!!process.env.CI)("Vector Search", () => {
     let hits = 0;
     for (const { query, expectedDoc } of easyQueries) {
       const results = await searchVec(db, query, DEFAULT_EMBED_MODEL, 5);
-      if (results.slice(0, 3).some(r => matchesExpected(r.filepath, expectedDoc))) hits++;
+      if (results.slice(0, 3).some((r: SearchResult) => matchesExpected(r.filepath, expectedDoc))) hits++;
     }
     expect(hits / easyQueries.length).toBeGreaterThanOrEqual(0.6);
   }, 60000);
@@ -234,7 +235,7 @@ describe.skipIf(!!process.env.CI)("Vector Search", () => {
     let hits = 0;
     for (const { query, expectedDoc } of mediumQueries) {
       const results = await searchVec(db, query, DEFAULT_EMBED_MODEL, 5);
-      if (results.slice(0, 3).some(r => matchesExpected(r.filepath, expectedDoc))) hits++;
+      if (results.slice(0, 3).some((r: SearchResult) => matchesExpected(r.filepath, expectedDoc))) hits++;
     }
     // Vector search should do better on semantic queries than BM25
     expect(hits / mediumQueries.length).toBeGreaterThanOrEqual(0.4);
@@ -247,7 +248,7 @@ describe.skipIf(!!process.env.CI)("Vector Search", () => {
     let hits = 0;
     for (const { query, expectedDoc } of hardQueries) {
       const results = await searchVec(db, query, DEFAULT_EMBED_MODEL, 5);
-      if (results.some(r => matchesExpected(r.filepath, expectedDoc))) hits++;
+      if (results.some((r: SearchResult) => matchesExpected(r.filepath, expectedDoc))) hits++;
     }
     expect(hits / hardQueries.length).toBeGreaterThanOrEqual(0.3);
   }, 60000);
@@ -258,7 +259,7 @@ describe.skipIf(!!process.env.CI)("Vector Search", () => {
     let hits = 0;
     for (const { query, expectedDoc } of evalQueries) {
       const results = await searchVec(db, query, DEFAULT_EMBED_MODEL, 5);
-      if (results.slice(0, 3).some(r => matchesExpected(r.filepath, expectedDoc))) hits++;
+      if (results.slice(0, 3).some((r: SearchResult) => matchesExpected(r.filepath, expectedDoc))) hits++;
     }
     expect(hits / evalQueries.length).toBeGreaterThanOrEqual(0.5);
   }, 60000);
@@ -297,7 +298,7 @@ describe.skipIf(!!process.env.CI)("Hybrid Search (RRF)", () => {
     // FTS results
     const ftsResults = searchFTS(db, query, 20);
     if (ftsResults.length > 0) {
-      rankedLists.push(ftsResults.map(r => ({
+      rankedLists.push(ftsResults.map((r: SearchResult) => ({
         file: r.filepath,
         displayPath: r.displayPath,
         title: r.title,
@@ -309,7 +310,7 @@ describe.skipIf(!!process.env.CI)("Hybrid Search (RRF)", () => {
     // Vector results
     const vecResults = await searchVec(db, query, DEFAULT_EMBED_MODEL, 20);
     if (vecResults.length > 0) {
-      rankedLists.push(vecResults.map(r => ({
+      rankedLists.push(vecResults.map((r: SearchResult) => ({
         file: r.filepath,
         displayPath: r.displayPath,
         title: r.title,

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -10,14 +10,14 @@ import { openDatabase, loadSqliteVec } from "../src/db.js";
 import type { Database } from "../src/db.js";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getDefaultLlamaCpp, disposeDefaultLlamaCpp } from "../src/llm";
+import { getDefaultLlamaCpp, disposeDefaultLlamaCpp } from "../src/llm.js";
 import { unlinkSync } from "node:fs";
 import { mkdtemp, writeFile, readdir, unlink, rmdir } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import YAML from "yaml";
-import type { CollectionConfig } from "../src/collections";
-import { setConfigIndexName } from "../src/collections";
+import type { CollectionConfig } from "../src/collections.js";
+import { setConfigIndexName } from "../src/collections.js";
 
 // =============================================================================
 // Test Database Setup
@@ -194,8 +194,8 @@ import {
   DEFAULT_RERANK_MODEL,
   DEFAULT_MULTI_GET_MAX_BYTES,
   createStore,
-} from "../src/store";
-import type { RankedResult } from "../src/store";
+} from "../src/store.js";
+import type { RankedResult, SearchResult } from "../src/store.js";
 // Note: searchResultsToMcpCsv no longer used in MCP - using structuredContent instead
 
 // =============================================================================
@@ -279,7 +279,7 @@ describe("MCP Server", () => {
 
     test("formats results as structured content", () => {
       const results = searchFTS(testDb, "api", 10);
-      const filtered = results.map(r => ({
+      const filtered = results.map((r: SearchResult) => ({
         file: r.displayPath,
         title: r.title,
         score: Math.round(r.score * 100) / 100,
@@ -349,7 +349,7 @@ describe("MCP Server", () => {
       const fused = reciprocalRankFusion([list1, list2]);
       expect(fused.length).toBe(3);
       // B appears in both lists, should have higher score
-      const bResult = fused.find(r => r.file === "/b");
+      const bResult = fused.find((r: RankedResult) => r.file === "/b");
       expect(bResult).toBeDefined();
     });
 
@@ -373,7 +373,7 @@ describe("MCP Server", () => {
       // Original query → FTS (probe)
       const probeFts = searchFTS(testDb, query, 20);
       if (probeFts.length > 0) {
-        rankedLists.push(probeFts.map(r => ({
+        rankedLists.push(probeFts.map((r: SearchResult) => ({
           file: r.filepath, displayPath: r.displayPath,
           title: r.title, body: r.body || "", score: r.score,
         })));
@@ -384,7 +384,7 @@ describe("MCP Server", () => {
         if (q.type === 'lex') {
           const ftsResults = searchFTS(testDb, q.text, 20);
           if (ftsResults.length > 0) {
-            rankedLists.push(ftsResults.map(r => ({
+            rankedLists.push(ftsResults.map((r: SearchResult) => ({
               file: r.filepath, displayPath: r.displayPath,
               title: r.title, body: r.body || "", score: r.score,
             })));
@@ -401,7 +401,7 @@ describe("MCP Server", () => {
       const candidates = fused.slice(0, 10);
       const reranked = await rerank(
         query,
-        candidates.map(c => ({ file: c.file, text: c.body })),
+        candidates.map((c: RankedResult) => ({ file: c.file, text: c.body })),
         DEFAULT_RERANK_MODEL,
         testDb
       );
@@ -802,7 +802,7 @@ describe("MCP Server", () => {
 
     test("search results have correct structure for structuredContent", () => {
       const results = searchFTS(testDb, "readme", 5);
-      const structured = results.map(r => ({
+      const structured = results.map((r: SearchResult) => ({
         file: r.displayPath,
         title: r.title,
         score: Math.round(r.score * 100) / 100,
@@ -870,8 +870,8 @@ describe("MCP Server", () => {
 // HTTP Transport Tests
 // =============================================================================
 
-import { startMcpHttpServer, type HttpServerHandle } from "../src/mcp";
-import { enableProductionMode } from "../src/store";
+import { startMcpHttpServer, type HttpServerHandle } from "../src/mcp.js";
+import { enableProductionMode } from "../src/store.js";
 
 describe("MCP HTTP Transport", () => {
   let handle: HttpServerHandle;
@@ -937,7 +937,7 @@ describe("MCP HTTP Transport", () => {
     const res = await fetch(`${baseUrl}/health`);
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("application/json");
-    const body = await res.json();
+    const body = await res.json() as { status: string; uptime: number };
     expect(body.status).toBe("ok");
     expect(typeof body.uptime).toBe("number");
   });

--- a/test/multi-collection-filter.test.ts
+++ b/test/multi-collection-filter.test.ts
@@ -78,7 +78,7 @@ describe("filterByCollections", () => {
     const filtered = filterByCollections(mixedResults, ["docs", "notes"]);
     expect(filtered).toHaveLength(1);
     // Should match via filepath (docs), not file (notes)
-    expect(filtered[0].filepath).toBe("qmd://docs/readme.md");
+    expect(filtered[0]!.filepath).toBe("qmd://docs/readme.md");
   });
 });
 

--- a/test/store.helpers.unit.test.ts
+++ b/test/store.helpers.unit.test.ts
@@ -15,7 +15,7 @@ import {
   normalizeDocid,
   isDocid,
   handelize,
-} from "../src/store";
+} from "../src/store.js";
 
 // =============================================================================
 // Path Utilities


### PR DESCRIPTION
## Summary
- Add Google Gemini as an alternative embedding provider (`--provider google` or `QMD_EMBED_PROVIDER=google`)
- Introduce `GoogleHybridLLM` that delegates embeddings to Google API while keeping local llama.cpp for query expansion and reranking
- Add embed provider abstraction (`getDefaultLLM()`, `needsEmbedFormatting()`, `getActiveEmbedModel()`) so search paths work with both providers
- Fix TypeScript strictness issues across tests and migrate test-preload from bun:test to vitest

## Test plan
- [ ] Run `qmd embed` (local provider, default) — verify no regression
- [ ] Run `GEMINI_API_KEY=... qmd embed --provider google` — verify Google embeddings are stored
- [ ] Run `qmd query` / `qmd vsearch` after Google embed — verify vector search works
- [ ] Run `qmd status` — verify provider is displayed
- [ ] Run `npx vitest run test/` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)