### PR TITLE
fix: fallback to Vulkan/Metal when primary GPU backend fails to initialize

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -510,10 +510,29 @@ export class LlamaCpp implements LLM {
         try {
           llama = await getLlama({ gpu: preferred, logLevel: LlamaLogLevel.error });
         } catch {
-          llama = await getLlama({ gpu: false, logLevel: LlamaLogLevel.error });
-          process.stderr.write(
-            `QMD Warning: ${preferred} reported available but failed to initialize. Falling back to CPU.\n`
-          );
+          // Primary GPU backend failed — try fallback order before giving up
+          // This handles cases like CUDA PTX incompatibility on older GPUs (e.g. Pascal/GTX1060)
+          // running on Ubuntu 24.04 with GCC 13, where the prebuilt PTX doesn't match
+          const fallbackOrder = (["vulkan", "metal", "cuda"] as const).filter(g => g !== preferred && gpuTypes.includes(g));
+          let recovered = false;
+          for (const fallback of fallbackOrder) {
+            try {
+              llama = await getLlama({ gpu: fallback, logLevel: LlamaLogLevel.error });
+              process.stderr.write(
+                `QMD Warning: ${preferred} failed to initialize, using ${fallback} instead.\n`
+              );
+              recovered = true;
+              break;
+            } catch {
+              // continue to next fallback
+            }
+          }
+          if (!recovered) {
+            llama = await getLlama({ gpu: false, logLevel: LlamaLogLevel.error });
+            process.stderr.write(
+              `QMD Warning: ${preferred} reported available but failed to initialize. Falling back to CPU.\n`
+            );
+          }
         }
       } else {
         llama = await getLlama({ gpu: false, logLevel: LlamaLogLevel.error });


### PR DESCRIPTION
## Problem

When a GPU backend (e.g. CUDA) is detected as available but fails at runtime, `qmd embed` silently falls back to CPU — skipping embeddings entirely rather than trying another working backend.

**Affected setup:** NVIDIA Pascal GPUs (GTX 1060, compute cap 6.1) on Ubuntu 24.04 with GCC 13. The prebuilt CUDA binary in `node-llama-cpp` uses PTX compiled with a newer toolchain:

```
CUDA error: the provided PTX was compiled with an unsupported toolchain
```

Vulkan works correctly on these machines but was never attempted.

## Fix

After a GPU backend fails to initialize, try remaining backends (Vulkan → Metal → CPU) before giving up.

```
CUDA fails → try Vulkan → try Metal → CPU
```

On the affected setup, Vulkan recovers successfully and embeds run at ~7.7 KB/s.

## Why this matters

GTX 1060 (Pascal, 2016) is still widely used. Ubuntu 24.04 ships with GCC 13 which creates this PTX mismatch. Users on this very common combination silently get CPU-only embeddings with no clear error.

## Testing

Tested on:
- Ubuntu 24.04, GCC 13, CUDA 12.2, GTX 1060 6GB (compute 6.1)
- node-llama-cpp 3.17.1
- `qmd embed`: 260 chunks, 1m 15s on Vulkan ✓
- `qmd vsearch`: semantic results returned correctly ✓