### PR TITLE
fix(index): deactivate stale docs on empty collection updates

### DIFF
--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -1428,11 +1428,11 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
   });
 
   const total = files.length;
-  if (total === 0) {
+  const hasNoFiles = total === 0;
+  if (hasNoFiles) {
     progress.clear();
     console.log("No files found matching pattern.");
-    closeDb();
-    return;
+    // Continue so the deactivation pass can mark previously indexed docs as inactive.
   }
 
   let indexed = 0, updated = 0, unchanged = 0, processed = 0;

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -395,6 +395,43 @@ describe("CLI Update Command", () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain("Updating");
   });
+
+  test("deactivates stale docs when collection has zero matching files", async () => {
+    const { dbPath, configDir } = await createIsolatedTestEnv("update-empty");
+    const collectionDir = join(testDir, `update-empty-${Date.now()}`);
+    await mkdir(collectionDir, { recursive: true });
+
+    const docPath = join(collectionDir, "only.md");
+    const token = `stale-proof-${Date.now()}`;
+    await writeFile(
+      docPath,
+      `---
+date: 2026-03-06
+---
+# Empty Collection Deactivation
+${token}
+`
+    );
+
+    const add = await runQmd(
+      ["collection", "add", collectionDir, "--name", "empty-check"],
+      { dbPath, configDir }
+    );
+    expect(add.exitCode).toBe(0);
+
+    const before = await runQmd(["get", "qmd://empty-check/only.md"], { dbPath, configDir });
+    expect(before.exitCode).toBe(0);
+    expect(before.stdout).toContain(token);
+
+    unlinkSync(docPath);
+
+    const update = await runQmd(["update"], { dbPath, configDir });
+    expect(update.exitCode).toBe(0);
+    expect(update.stdout).toContain("No files found matching pattern.");
+
+    const after = await runQmd(["get", "qmd://empty-check/only.md"], { dbPath, configDir });
+    expect(after.exitCode).toBe(1);
+  });
 });
 
 describe("CLI Add-Context Command", () => {


### PR DESCRIPTION
This fixes a stale-index edge case in `qmd update` when a collection has zero matching files.

Current behavior:
if a collection previously had indexed docs, then all files are removed, `qmd update` prints `No files found matching pattern.` and returns early for that collection. Because of the early return, the deactivation pass does not run, so old rows can remain active and still show up in `qmd get` / `qmd search`.

Repro:
1. `qmd collection add /tmp/example --name example`
2. Create `/tmp/example/only.md` with markdown content and run `qmd update`
3. Verify it exists: `qmd get qmd://example/only.md`
4. Delete `/tmp/example/only.md`
5. Run `qmd update` again
6. Observe: update prints `No files found matching pattern.`, but `qmd get qmd://example/only.md` can still return the deleted doc

Expected:
when a collection has zero current files, previously indexed docs for that collection should be deactivated.

Change:
keep the explicit no-files message, but do not exit early. The update flow now continues into the deactivation path so previously indexed docs in that collection are marked inactive.
