### PR TITLE
fix(llm): respect explicit CPU-only GPU env

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -208,9 +208,33 @@ export const DEFAULT_EMBED_MODEL_URI = DEFAULT_EMBED_MODEL;
 export const DEFAULT_RERANK_MODEL_URI = DEFAULT_RERANK_MODEL;
 export const DEFAULT_GENERATE_MODEL_URI = DEFAULT_GENERATE_MODEL;
 
+type RequestedGpuBackend = "auto" | "cuda" | "metal" | "vulkan" | false;
+
 // Local model cache directory
 const MODEL_CACHE_DIR = join(homedir(), ".cache", "qmd", "models");
 export const DEFAULT_MODEL_CACHE_DIR = MODEL_CACHE_DIR;
+
+export function resolveRequestedGpuBackend(env: NodeJS.ProcessEnv = process.env): RequestedGpuBackend {
+  const raw = env.QMD_GPU?.trim() || env.NODE_LLAMA_CPP_GPU?.trim();
+  if (!raw) {
+    return "auto";
+  }
+
+  const normalized = raw.toLowerCase();
+  if (
+    normalized === "false" ||
+    normalized === "0" ||
+    normalized === "off" ||
+    normalized === "none" ||
+    normalized === "cpu"
+  ) {
+    return false;
+  }
+  if (normalized === "cuda" || normalized === "metal" || normalized === "vulkan") {
+    return normalized;
+  }
+  return "auto";
+}
 
 export type PullResult = {
   model: string;
@@ -545,11 +569,39 @@ export class LlamaCpp implements LLM {
    */
   private async ensureLlama(): Promise<Llama> {
     if (!this.llama) {
-      const llama = await getLlama({
-        // attempt to build
-        build: "autoAttempt",
-        logLevel: LlamaLogLevel.error
-      });
+      const requestedGpu = resolveRequestedGpuBackend();
+
+      let llama: Llama;
+      if (requestedGpu === false) {
+        llama = await getLlama({
+          gpu: false,
+          build: "autoAttempt",
+          logLevel: LlamaLogLevel.error
+        });
+      } else if (requestedGpu !== "auto") {
+        try {
+          llama = await getLlama({
+            gpu: requestedGpu,
+            build: "autoAttempt",
+            logLevel: LlamaLogLevel.error
+          });
+        } catch {
+          llama = await getLlama({
+            gpu: false,
+            build: "autoAttempt",
+            logLevel: LlamaLogLevel.error
+          });
+          process.stderr.write(
+            `QMD Warning: ${requestedGpu} was requested but failed to initialize. Falling back to CPU.\n`
+          );
+        }
+      } else {
+        llama = await getLlama({
+          // attempt to build
+          build: "autoAttempt",
+          logLevel: LlamaLogLevel.error
+        });
+      }
 
       if (llama.gpu === false) {
         process.stderr.write(

--- a/test/llm-config.test.ts
+++ b/test/llm-config.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { resolveRequestedGpuBackend } from "../src/llm.js";
+
+describe("resolveRequestedGpuBackend", () => {
+  test("defaults to auto when no env is set", () => {
+    expect(resolveRequestedGpuBackend({})).toBe("auto");
+  });
+
+  test("respects explicit CPU-only env values", () => {
+    expect(resolveRequestedGpuBackend({ QMD_GPU: "false" })).toBe(false);
+    expect(resolveRequestedGpuBackend({ QMD_GPU: "cpu" })).toBe(false);
+    expect(resolveRequestedGpuBackend({ NODE_LLAMA_CPP_GPU: "0" })).toBe(false);
+    expect(resolveRequestedGpuBackend({ NODE_LLAMA_CPP_GPU: "off" })).toBe(false);
+  });
+
+  test("accepts explicit backend overrides", () => {
+    expect(resolveRequestedGpuBackend({ QMD_GPU: "cuda" })).toBe("cuda");
+    expect(resolveRequestedGpuBackend({ QMD_GPU: "metal" })).toBe("metal");
+    expect(resolveRequestedGpuBackend({ QMD_GPU: "vulkan" })).toBe("vulkan");
+  });
+
+  test("treats unrecognized values as auto", () => {
+    expect(resolveRequestedGpuBackend({ QMD_GPU: "true" })).toBe("auto");
+    expect(resolveRequestedGpuBackend({ QMD_GPU: "auto" })).toBe("auto");
+    expect(resolveRequestedGpuBackend({ QMD_GPU: "maybe" })).toBe("auto");
+  });
+});


### PR DESCRIPTION
## Summary

QMD currently always probes GPU backends before falling back to CPU. That is reasonable for the default path, but it ignores explicit operator intent in CPU-only deployments where the caller already knows GPU should be disabled.

This PR teaches the LLM layer to respect `QMD_GPU` / `NODE_LLAMA_CPP_GPU` when they explicitly request CPU-only mode.

## Problem

In CPU-only or deliberately CPU-pinned environments, callers often set environment like:

- `QMD_GPU=false`
- `QMD_GPU=cpu`
- `NODE_LLAMA_CPP_GPU=0`

Today QMD still probes GPU backends first, which means:

- unnecessary GPU/CUDA/Metal/Vulkan probing work
- avoidable warnings and noise
- confusing behavior when the operator explicitly asked for CPU mode

## Root Cause

`ensureLlama()` currently always follows the auto-detect path:

1. call `getLlamaGpuTypes()`
2. pick a preferred backend if available
3. fall back to CPU only after probe/initialization attempts

There is no early exit for explicit CPU-only env configuration.

## What Changed

- added `resolveRequestedGpuBackend()` helper
- respect `QMD_GPU` first, then `NODE_LLAMA_CPP_GPU`
- if either explicitly requests CPU-only (`false`, `0`, `off`, `none`, `cpu`), skip GPU probing and initialize directly with `gpu: false`
- also allow explicit backend overrides (`cuda`, `metal`, `vulkan`) to bypass the auto-detect path
- added focused unit tests for env parsing

## Why this shape

I kept the default behavior unchanged when no explicit env is set.

So the normal path is still:

- auto-detect available GPU backends
- prefer CUDA > Metal > Vulkan
- fall back to CPU

The only behavior change is when the caller explicitly asks for CPU-only or a specific backend.

## Verification

Ran:

- `./node_modules/.bin/vitest run test/llm-config.test.ts`

I also ran the full `npm test` suite locally; it still hits pre-existing long-running integration timeouts in unrelated MCP/expansion tests, so I am not presenting that as a clean signal for this change.

## Notes

I did a quick pass for nearby PRs/issues before opening this and did not find an existing QMD PR that specifically addresses explicit CPU-only env handling in `ensureLlama()`.
