### PR TITLE
fix(embed): truncate oversized chunks to prevent context window crash

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -759,6 +759,11 @@ export class LlamaCpp implements LLM {
   // Chunks are max 800 tokens, so 800 + 200 + query ≈ 1100 tokens typical.
   // Use 2048 for safety margin. Still 17× less than auto (40960).
   private static readonly RERANK_CONTEXT_SIZE = 2048;
+
+  // Embedding models (embeddinggemma-300M, Qwen3-Embedding) use 2048 token context
+  // Reserve overhead for formatting (title/text prefixes, task instructions)
+  private static readonly EMBED_CONTEXT_SIZE = 2048;
+  private static readonly EMBED_TEMPLATE_OVERHEAD = 100;
   private async ensureRerankContexts(): Promise<Awaited<ReturnType<LlamaModel["createRankingContext"]>>[]> {
     if (this.rerankContexts.length === 0) {
       const model = await this.ensureRerankModel();
@@ -831,13 +836,32 @@ export class LlamaCpp implements LLM {
   // Core API methods
   // ==========================================================================
 
+  /**
+   * Truncate text to fit within embedding model's context window.
+   * Prevents SIGABRT crashes on oversized chunks.
+   */
+  private async truncateForEmbedding(text: string): Promise<string> {
+    const model = await this.ensureEmbedModel();
+    const tokens = model.tokenize(text);
+    const maxTokens = LlamaCpp.EMBED_CONTEXT_SIZE - LlamaCpp.EMBED_TEMPLATE_OVERHEAD;
+
+    if (tokens.length <= maxTokens) {
+      return text;
+    }
+
+    // Truncate to safe length
+    return model.detokenize(tokens.slice(0, maxTokens));
+  }
+
   async embed(text: string, options: EmbedOptions = {}): Promise<EmbeddingResult | null> {
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();
 
     try {
+      // Truncate text to prevent context window overflow
+      const truncated = await this.truncateForEmbedding(text);
       const context = await this.ensureEmbedContext();
-      const embedding = await context.getEmbeddingFor(text);
+      const embedding = await context.getEmbeddingFor(truncated);
 
       return {
         embedding: Array.from(embedding.vector),
@@ -860,6 +884,11 @@ export class LlamaCpp implements LLM {
     if (texts.length === 0) return [];
 
     try {
+      // Truncate all texts upfront to prevent context window overflow
+      const truncated = await Promise.all(
+        texts.map(text => this.truncateForEmbedding(text))
+      );
+
       const contexts = await this.ensureEmbedContexts();
       const n = contexts.length;
 
@@ -867,7 +896,7 @@ export class LlamaCpp implements LLM {
         // Single context: sequential (no point splitting)
         const context = contexts[0]!;
         const embeddings: ({ embedding: number[]; model: string } | null)[] = [];
-        for (const text of texts) {
+        for (const text of truncated) {
           try {
             const embedding = await context.getEmbeddingFor(text);
             this.touchActivity();
@@ -881,9 +910,9 @@ export class LlamaCpp implements LLM {
       }
 
       // Multiple contexts: split texts across contexts for parallel evaluation
-      const chunkSize = Math.ceil(texts.length / n);
+      const chunkSize = Math.ceil(truncated.length / n);
       const chunks = Array.from({ length: n }, (_, i) =>
-        texts.slice(i * chunkSize, (i + 1) * chunkSize)
+        truncated.slice(i * chunkSize, (i + 1) * chunkSize)
       );
 
       const chunkResults = await Promise.all(

--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -1621,18 +1621,14 @@ async function vectorIndex(model: string = DEFAULT_EMBED_MODEL, force: boolean =
   // Wrap all LLM embedding operations in a session for lifecycle management
   // Use 30 minute timeout for large collections
   await withLLMSession(async (session) => {
-    // Get embedding dimensions from first chunk
+    // Get embedding dimensions using a virtual probe text (guaranteed to succeed)
+    // This avoids dependency on the first chunk, which might be oversized
     progress.indeterminate();
-    const firstChunk = allChunks[0];
-    if (!firstChunk) {
-      throw new Error("No chunks available to embed");
+    const probeResult = await session.embed("dimension probe");
+    if (!probeResult) {
+      throw new Error("Failed to initialize embedding model");
     }
-    const firstText = formatDocForEmbedding(firstChunk.text, firstChunk.title);
-    const firstResult = await session.embed(firstText);
-    if (!firstResult) {
-      throw new Error("Failed to get embedding dimensions from first chunk");
-    }
-    ensureVecTable(db, firstResult.embedding.length);
+    ensureVecTable(db, probeResult.embedding.length);
 
     let chunksEmbedded = 0, errors = 0, bytesProcessed = 0;
     const startTime = Date.now();

--- a/test/oversized-chunk.test.ts
+++ b/test/oversized-chunk.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Test for Issue #303: qmd embed crash on oversized chunks
+ *
+ * Verifies that the embedding process handles chunks exceeding the model's
+ * 2048-token context window without crashing (SIGABRT).
+ *
+ * Run: npx vitest run --reporter=verbose test/oversized-chunk.test.ts
+ */
+
+import { describe, test, expect } from "vitest";
+import {
+  withLLMSession,
+  type ILLMSession,
+} from "../src/llm.js";
+import { formatDocForEmbedding } from "../src/store.js";
+
+// Skip if models are not downloaded
+const modelsAvailable = process.env.QMD_SKIP_MODEL_TESTS !== "1";
+
+describe.skipIf(!modelsAvailable)("Oversized chunk embedding (Issue #303)", () => {
+
+  // First test absorbs model compilation + download overhead
+  test("embed() truncates oversized text instead of crashing", async () => {
+    await withLLMSession(async (session: ILLMSession) => {
+      // ~2500 tokens (well over 2048 context window)
+      const oversized = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. ".repeat(200);
+
+      // Before fix: SIGABRT / "Failed to get embedding dimensions"
+      // After fix: truncates and returns valid embedding
+      const result = await session.embed(oversized);
+
+      expect(result).not.toBeNull();
+      expect(result!.embedding.length).toBeGreaterThan(0);
+    });
+  }, 180_000);
+
+  test("virtual probe returns valid embedding dimensions", async () => {
+    await withLLMSession(async (session: ILLMSession) => {
+      const result = await session.embed("dimension probe");
+
+      expect(result).not.toBeNull();
+      expect(result!.embedding.length).toBeGreaterThan(0);
+    });
+  }, 30_000);
+
+  test("embedBatch() handles mix of normal and oversized texts", async () => {
+    await withLLMSession(async (session: ILLMSession) => {
+      const normal = "This is a normal sized text for embedding.";
+      const oversized = "function example() { return 'data'; }\n".repeat(500);
+
+      const results = await session.embedBatch([normal, oversized, normal]);
+
+      expect(results).toHaveLength(3);
+      for (const r of results) {
+        expect(r).not.toBeNull();
+        expect(r!.embedding.length).toBeGreaterThan(0);
+      }
+
+      // All embeddings should have the same dimensions
+      const dim = results[0]!.embedding.length;
+      expect(results[1]!.embedding.length).toBe(dim);
+      expect(results[2]!.embedding.length).toBe(dim);
+    });
+  }, 30_000);
+
+  test("formatted oversized chunk with title does not crash", async () => {
+    await withLLMSession(async (session: ILLMSession) => {
+      const title = "Large Code File";
+      const content = "const x = " + "'a'.repeat(100);\n".repeat(500);
+      const formatted = formatDocForEmbedding(content, title);
+
+      const result = await session.embed(formatted);
+
+      expect(result).not.toBeNull();
+      expect(result!.embedding.length).toBeGreaterThan(0);
+    });
+  }, 30_000);
+
+});


### PR DESCRIPTION
The embedding model (embeddinggemma-300M) has a 2048-token context window. Chunks exceeding this limit cause node-llama-cpp to crash with SIGABRT on Apple Silicon, or silently return null embeddings.

While the chunker targets 900 tokens, edge cases (dense code, base64, format prefixes) can produce chunks that exceed the context window. The reranker already had truncation logic; the embedding path did not.

Changes:
- Add truncateForEmbedding() in LlamaCpp that tokenizes and truncates text exceeding the 2048-token context window (minus 100 overhead)
- Apply truncation in both embed() and embedBatch() before calling into node-llama-cpp, preventing SIGABRT and null results
- Replace first-chunk dimension probing with a virtual probe text, decoupling dimension detection from user data
- Add test/oversized-chunk.test.ts covering oversized single embed, mixed batch, and formatted chunks with titles

Normal chunks (<=900 tokens) are unaffected -- truncation only activates on abnormally large inputs that would otherwise crash or be silently dropped.

Fixes #303