### PR TITLE
fix(search): match snake_case identifiers in BM25 queries

### DIFF
--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -1720,8 +1720,9 @@ async function vectorIndex(model: string = DEFAULT_EMBED_MODEL, force: boolean =
 
 // Sanitize a term for FTS5: remove punctuation except apostrophes
 function sanitizeFTS5Term(term: string): string {
-  // Remove all non-alphanumeric except apostrophes (for contractions like "don't")
-  return term.replace(/[^\w']/g, '').trim();
+  // Replace punctuation with spaces so snake_case and similar identifiers
+  // are tokenized the same way as the FTS5 unicode61 index.
+  return term.replace(/[^\p{L}\p{N}']/gu, ' ').toLowerCase().trim();
 }
 
 // Build FTS5 query: phrase-aware with fallback to individual terms

--- a/src/store.ts
+++ b/src/store.ts
@@ -2032,7 +2032,7 @@ export function getTopLevelPathsWithoutContext(db: Database, collectionName: str
 // =============================================================================
 
 function sanitizeFTS5Term(term: string): string {
-  return term.replace(/[^\p{L}\p{N}']/gu, '').toLowerCase();
+  return term.replace(/[^\p{L}\p{N}']/gu, ' ').toLowerCase().trim();
 }
 
 /**

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -591,6 +591,33 @@ describe("CLI Output Formats", () => {
       expect(stdout.toLowerCase()).toContain("api");
     }
   });
+
+  test("search matches snake_case identifiers", async () => {
+    const env = await createIsolatedTestEnv("snake-case");
+    const fixtureDir = join(testDir, "snake-case-fixture");
+    await mkdir(fixtureDir, { recursive: true });
+    await writeFile(
+      join(fixtureDir, "sample.md"),
+      "# Sample\n\nFunction name: atomic_write_json\n\nAnother identifier: parse_http_response\n"
+    );
+
+    const add = await runQmd(["collection", "add", fixtureDir, "--name", "snake-case"], {
+      dbPath: env.dbPath,
+      configDir: env.configDir,
+    });
+    expect(add.exitCode).toBe(0);
+
+    const result = await runQmd(["search", "atomic_write_json", "--json"], {
+      dbPath: env.dbPath,
+      configDir: env.configDir,
+    });
+    expect(result.exitCode).toBe(0);
+
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].file).toContain("sample.md");
+    expect(parsed[0].snippet).toContain("atomic_write_json");
+  });
 });
 
 describe("CLI Search with Collection Filter", () => {

--- a/test/structured-search.test.ts
+++ b/test/structured-search.test.ts
@@ -396,7 +396,7 @@ describe("lex query syntax", () => {
 describe("buildFTS5Query (lex parser)", () => {
   // Mirror the function for unit testing
   function sanitizeFTS5Term(term: string): string {
-    return term.replace(/[^\p{L}\p{N}']/gu, '').toLowerCase();
+    return term.replace(/[^\p{L}\p{N}']/gu, ' ').toLowerCase().trim();
   }
 
   function buildFTS5Query(query: string): string | null {
@@ -485,7 +485,11 @@ describe("buildFTS5Query (lex parser)", () => {
     expect(buildFTS5Query("   ")).toBeNull();
   });
 
-  test("special chars in terms stripped", () => {
-    expect(buildFTS5Query("hello!world")).toBe('"helloworld"*');
+  test("special chars in terms are preserved as tokenized phrase prefixes", () => {
+    expect(buildFTS5Query("hello!world")).toBe('"hello world"*');
+  });
+
+  test("snake_case identifiers are split into searchable terms", () => {
+    expect(buildFTS5Query("atomic_write_json")).toBe('"atomic write json"*');
   });
 });


### PR DESCRIPTION
This fixes BM25 search for snake_case identifiers such as `atomic_write_json`.

What changed:
- replace non-alphanumeric characters with spaces instead of removing them during FTS5 term sanitization
- align the CLI-side sanitization logic with the store implementation
- add an end-to-end CLI test covering snake_case identifier search
- update structured search tests for the new tokenization behavior

Why:
SQLite FTS5 with the `unicode61` tokenizer splits `snake_case` into separate tokens at index time. The previous query sanitization removed underscores, turning `atomic_write_json` into `atomicwritejson`, which could not match the indexed tokens.

How I tested it:
- reproduced locally before the change:
  - `search "atomic_write_json"` returned `[]`
  - `search "atomic write json"` returned the expected document
- verified locally after the change:
  - `search "atomic_write_json"` returns the expected document
  - `search "parse_http_response"` returns the expected document
- ran targeted tests:
  - `test/structured-search.test.ts`
  - `test/cli.test.ts`

Fixes #305
