### PR TITLE
fix(mcp): support Windows HOME and enable production mode

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -22,6 +22,7 @@ import {
   addLineNumbers,
   structuredSearch,
   DEFAULT_MULTI_GET_MAX_BYTES,
+  enableProductionMode,
 } from "./store.js";
 import type { Store, StructuredSubSearch } from "./store.js";
 import { getCollection, getGlobalContext, getDefaultCollectionNames } from "./collections.js";
@@ -542,6 +543,7 @@ Intent-aware lex (C++ performance, not sports):
 // =============================================================================
 
 export async function startMcpServer(): Promise<void> {
+  enableProductionMode();
   const store = createStore();
   const server = createMcpServer(store);
   const transport = new StdioServerTransport();
@@ -563,6 +565,7 @@ export type HttpServerHandle = {
  * Binds to localhost only. Returns a handle for shutdown and port discovery.
  */
 export async function startMcpHttpServer(port: number, options?: { quiet?: boolean }): Promise<HttpServerHandle> {
+  enableProductionMode();
   const store = createStore();
 
   // Session map: each client gets its own McpServer + Transport pair (MCP spec requirement).

--- a/src/store.ts
+++ b/src/store.ts
@@ -43,7 +43,7 @@ import {
 // Configuration
 // =============================================================================
 
-const HOME = process.env.HOME || "/tmp";
+const HOME = process.env.HOME || process.env.USERPROFILE || "/tmp";
 export const DEFAULT_EMBED_MODEL = "embeddinggemma";
 export const DEFAULT_RERANK_MODEL = "ExpedientFalcon/qwen3-reranker:0.6b-q8_0";
 export const DEFAULT_QUERY_MODEL = "Qwen/Qwen3-1.7B";


### PR DESCRIPTION
## Problem

MCP server returns 0 documents on Windows even though CLI works correctly.

## Root Cause

Two bugs:

1. **store.ts:46** - `HOME` fallback only checks `process.env.HOME`, which is undefined on Windows (uses `USERPROFILE`). This causes database path to resolve to `/tmp/.cache/qmd/index.sqlite` instead of the correct Windows path.

2. **mcp.ts** - `startMcpServer()` and `startMcpHttpServer()` do not call `enableProductionMode()` before `createStore()`, causing the production database path to not be properly initialized.

## Solution

1. Change HOME fallback to: `process.env.HOME || process.env.USERPROFILE || "/tmp"`
2. Add `enableProductionMode()` call in both MCP server functions before `createStore()`

## Testing

- Verified the fix maintains backward compatibility on Unix systems
- Windows users should now see MCP server use the same database as CLI

Fixes #277