### PR TITLE
feat(update): add -c flag to update specific collections

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -494,7 +494,7 @@ async function showStatus(): Promise<void> {
   closeDb();
 }
 
-async function updateCollections(): Promise<void> {
+async function updateCollections(collectionFilter?: string[]): Promise<void> {
   const db = getDb();
   const storeInstance = getStore();
   // Collections are defined in YAML; no duplicate cleanup needed.
@@ -502,7 +502,17 @@ async function updateCollections(): Promise<void> {
   // Clear Ollama cache on update
   clearCache(db);
 
-  const collections = listCollections(db);
+  let collections = listCollections(db);
+
+  // Filter by collection names if specified
+  if (collectionFilter && collectionFilter.length > 0) {
+    collections = collections.filter(c => collectionFilter.includes(c.name));
+    if (collections.length === 0) {
+      console.log(`${c.dim}No matching collections found. Available: ${listCollections(db).map(c => c.name).join(', ')}${c.reset}`);
+      closeDb();
+      return;
+    }
+  }
 
   if (collections.length === 0) {
     console.log(`${c.dim}No collections found. Run 'qmd collection add .' to index markdown files.${c.reset}`);
@@ -2950,7 +2960,7 @@ if (isMain) {
       break;
 
     case "update":
-      await updateCollections();
+      await updateCollections(cli.opts.collection);
       break;
 
     case "embed":


### PR DESCRIPTION
## Problem

The `-c/--collection` flag works with search commands but not with `qmd update`. Users with many collections have to update all of them even when they only want to re-index specific ones.

## Solution

Add collection filtering support to `updateCollections()` function:

```bash
qmd update -c notes              # Update only notes collection
qmd update -c notes -c docs      # Update multiple specific collections  
qmd update                       # Update all (existing behavior)
```

## Changes

- Add optional `collectionFilter` parameter to `updateCollections()`
- Filter collections list when `-c` flag is provided
- Show helpful message if no collections match the filter

Fixes #298