### PR TITLE
feat(llm): add QMD_FORCE_CPU env var for older GPUs

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -545,10 +545,13 @@ export class LlamaCpp implements LLM {
    */
   private async ensureLlama(): Promise<Llama> {
     if (!this.llama) {
+      // QMD_FORCE_CPU=1 forces CPU-only mode (useful for older GPUs like Pascal)
+      const forceCpu = process.env.QMD_FORCE_CPU === "1" || process.env.QMD_FORCE_CPU === "true";
       const llama = await getLlama({
         // attempt to build
-        build: "autoAttempt",
-        logLevel: LlamaLogLevel.error
+        build: "autoAttempt" as any,
+        logLevel: LlamaLogLevel.error,
+        gpu: forceCpu ? false : "auto",
       });
 
       if (llama.gpu === false) {


### PR DESCRIPTION
## Problem

On older NVIDIA architectures (e.g., Pascal), `qmd query` fails with:

```
[node-llama-cpp] CUDA error: the function requires an architectural feature absent from the device
```

## Workaround (Before)

Users had to run:
```bash
CUDA_VISIBLE_DEVICES="" qmd query "test"
```

## Solution

Add `QMD_FORCE_CPU` environment variable:

```bash
export QMD_FORCE_CPU=1
qmd query "test"

# Or one-time:
QMD_FORCE_CPU=1 qmd query "test"
```

This disables GPU acceleration and forces CPU-only mode by passing `gpu: false` to `getLlama()`.

Fixes #299