### PR TITLE
feat(llm): add QMD_FORCE_CUDA env var to disable Vulkan offloading

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -545,10 +545,23 @@ export class LlamaCpp implements LLM {
    */
   private async ensureLlama(): Promise<Llama> {
     if (!this.llama) {
+      // QMD_FORCE_CPU=1 forces CPU-only mode (useful for older GPUs like Pascal)
+      // QMD_FORCE_CUDA=1 forces CUDA and disables Vulkan offloading
+      const forceCpu = process.env.QMD_FORCE_CPU === "1" || process.env.QMD_FORCE_CPU === "true";
+      const forceCuda = process.env.QMD_FORCE_CUDA === "1" || process.env.QMD_FORCE_CUDA === "true";
+      
+      let gpuSetting: "auto" | "cuda" | false = "auto";
+      if (forceCpu) {
+        gpuSetting = false;
+      } else if (forceCuda) {
+        gpuSetting = "cuda";
+      }
+      
       const llama = await getLlama({
         // attempt to build
-        build: "autoAttempt",
-        logLevel: LlamaLogLevel.error
+        build: "autoAttempt" as any,
+        logLevel: LlamaLogLevel.error,
+        gpu: gpuSetting,
       });
 
       if (llama.gpu === false) {


### PR DESCRIPTION
## Problem

On Windows VMs with para-virtualized GPUs (e.g., ExHyperV RTX 4090), QMD may use Vulkan offloading instead of pure CUDA mode even when CUDA is working correctly:

```
$ qmd status
GPU: vulkan (offloading: yes)
```

## Solution

Add `QMD_FORCE_CUDA` environment variable to force CUDA and disable Vulkan:

```bash
export QMD_FORCE_CUDA=1
qmd query "test"
```

This sets `gpu: "cuda"` in `getLlama()` options, bypassing the auto-detection that might choose Vulkan.

## Related

- Complements `QMD_FORCE_CPU` for older GPUs (#299)

Fixes #278