### PR TITLE
fix(embed): skip oversized chunks instead of crashing

### DIFF
--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -1627,10 +1627,25 @@ async function vectorIndex(model: string = DEFAULT_EMBED_MODEL, force: boolean =
     if (!firstChunk) {
       throw new Error("No chunks available to embed");
     }
-    const firstText = formatDocForEmbedding(firstChunk.text, firstChunk.title);
-    const firstResult = await session.embed(firstText);
+    
+    // Find first chunk that can be embedded to get dimensions
+    let firstResult: { embedding: number[] } | null = null;
+    let dimensionsChecked = 0;
+    for (let i = 0; i < allChunks.length && !firstResult; i++) {
+      const chunk = allChunks[i];
+      if (!chunk) continue;
+      dimensionsChecked++;
+      const text = formatDocForEmbedding(chunk.text, chunk.title);
+      try {
+        firstResult = await session.embed(text);
+      } catch (err) {
+        // Skip chunks that exceed context window or fail embedding
+        console.error(`${c.yellow}⚠ Skipping oversized/failed chunk ${i} ("${chunk.displayName}")${c.reset}`);
+      }
+    }
+    
     if (!firstResult) {
-      throw new Error("Failed to get embedding dimensions from first chunk");
+      throw new Error("Failed to get embedding dimensions from any chunk - all chunks may exceed context window");
     }
     ensureVecTable(db, firstResult.embedding.length);
 


### PR DESCRIPTION
## Problem

`qmd embed` crashes when the first chunk exceeds the embedding model context window (2048 tokens for EmbeddingGemma-300M):

```
Error: Failed to get embedding dimensions from first chunk
```

On Apple Silicon, this can also trigger a GGML Metal cleanup assertion resulting in SIGABRT.

## Solution

Instead of failing on the first chunk, try embedding chunks sequentially until one succeeds:

1. Iterate through chunks attempting to embed each one
2. Log warning for chunks that fail (oversized, context window exceeded)
3. Use first successful embedding to determine vector dimensions
4. Only throw error if ALL chunks fail

## Behavior Changes

- **Before**: Crash if first chunk exceeds context window
- **After**: Skip oversized chunks with warning, continue with valid chunks

Fixes #303