### PR TITLE
fix(cli): add runtime-aware bin wrapper for bun/node compatibility

### DIFF
--- a/bin/qmd
+++ b/bin/qmd
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Detect the runtime used to install this package and use the matching one
+# to avoid native module ABI mismatches (e.g., better-sqlite3 compiled for bun vs node)
+
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Check if we were installed with bun (look for bun.lock or bun-lockb)
+if [ -f "$DIR/bun.lock" ] || [ -f "$DIR/bun.lockb" ] || [ -n "$BUN_INSTALL" ]; then
+  exec bun "$DIR/dist/qmd.js" "$@"
+else
+  exec node "$DIR/dist/qmd.js" "$@"
+fi

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "Query Markup Documents - On-device hybrid search for markdown files with BM25, vector search, and LLM reranking",
   "type": "module",
   "bin": {
-    "qmd": "dist/qmd.js"
+    "qmd": "bin/qmd"
   },
   "files": [
+    "bin/",
     "dist/",
     "LICENSE",
     "CHANGELOG.md"


### PR DESCRIPTION
## Problem

Installing qmd via `bun install -g @tobilu/qmd` compiles native modules (better-sqlite3) against bun's internal ABI. But the CLI shebang `#!/usr/bin/env node` runs it with the system Node.js, causing:

```
Error: The module '.../better_sqlite3.node'
was compiled against a different Node.js version using NODE_MODULE_VERSION 141.
This version of Node.js requires NODE_MODULE_VERSION 127.
```

## Solution

Add a shell wrapper (`bin/qmd`) that detects the install runtime:

1. Check for `bun.lock`/`bun.lockb` in package directory
2. Check for `BUN_INSTALL` environment variable
3. If either exists, use `bun` to run the CLI
4. Otherwise, fall back to `node`

This ensures native modules run with the same runtime they were compiled for.

## Changes

- Create `bin/qmd` shell wrapper with runtime detection
- Update `package.json` bin entry to use wrapper
- Add `bin/` to files array

Fixes #319