### PR TITLE
fix(deps): bump better-sqlite3 to ^12.4.5 for Node 25 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.1",
-    "better-sqlite3": "^11.0.0",
+    "better-sqlite3": "^12.4.5",
     "fast-glob": "^3.3.0",
     "node-llama-cpp": "^3.17.1",
     "picomatch": "^4.0.0",


### PR DESCRIPTION
## Problem

`npm install -g @tobilu/qmd` fails on Node 25 because qmd pins `better-sqlite3@^11.0.0`, which:

1. Has no prebuilt binaries for Node 25
2. Fails source compilation due to V8 API changes:

```
v8-object.h:957:37: error: expected expression
    I::ReadExternalPointerField<{internal::kFirstEmbedderDataTag,
```

## Solution

Bump `better-sqlite3` from `^11.0.0` to `^12.4.5`.

better-sqlite3 v12.4.5 added Node 25 support (prebuilds + engines) in [WiseLibs/better-sqlite3#1411](https://github.com/WiseLibs/better-sqlite3/pull/1411).

## Compatibility

- qmd declares `engines: { node: ">=22.0.0" }` which includes Node 25
- This change aligns the dependency graph with that engine declaration

Fixes #257