### PR TITLE
fix: pass --index flag through to MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- **MCP `--index` flag ignored**: `qmd --index myproject mcp` now correctly opens the named index instead of always falling back to `index.sqlite`. Both stdio and HTTP transports accept the resolved DB path from the CLI. Daemon mode also forwards `--index` to the spawned child process. (#343)
 - Sync stale `bun.lock` (`better-sqlite3` 11.x → 12.x). CI and release
   script now use `--frozen-lockfile` to prevent recurrence. #386
   (thanks @Mic92)

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -3065,9 +3065,10 @@ if (isMain) {
           const logPath = resolve(cacheDir, "mcp.log");
           const logFd = openSync(logPath, "w"); // truncate — fresh log per daemon run
           const selfPath = fileURLToPath(import.meta.url);
+          const indexArgs = cli.values.index ? ["--index", cli.values.index as string] : [];
           const spawnArgs = selfPath.endsWith(".ts")
-            ? ["--import", pathJoin(dirname(selfPath), "..", "..", "node_modules", "tsx", "dist", "esm", "index.mjs"), selfPath, "mcp", "--http", "--port", String(port)]
-            : [selfPath, "mcp", "--http", "--port", String(port)];
+            ? ["--import", pathJoin(dirname(selfPath), "..", "..", "node_modules", "tsx", "dist", "esm", "index.mjs"), selfPath, ...indexArgs, "mcp", "--http", "--port", String(port)]
+            : [selfPath, ...indexArgs, "mcp", "--http", "--port", String(port)];
           const child = nodeSpawn(process.execPath, spawnArgs, {
             stdio: ["ignore", logFd, logFd],
             detached: true,
@@ -3087,7 +3088,7 @@ if (isMain) {
         process.removeAllListeners("SIGINT");
         const { startMcpHttpServer } = await import("../mcp/server.js");
         try {
-          await startMcpHttpServer(port);
+          await startMcpHttpServer(port, { dbPath: getDbPath() });
         } catch (e: any) {
           if (e?.code === "EADDRINUSE") {
             console.error(`Port ${port} already in use. Try a different port with --port.`);
@@ -3098,7 +3099,7 @@ if (isMain) {
       } else {
         // Default: stdio transport
         const { startMcpServer } = await import("../mcp/server.js");
-        await startMcpServer();
+        await startMcpServer({ dbPath: getDbPath() });
       }
       break;
     }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -519,8 +519,8 @@ Intent-aware lex (C++ performance, not sports):
 // Transport: stdio (default)
 // =============================================================================
 
-export async function startMcpServer(): Promise<void> {
-  const store = await createStore({ dbPath: getDefaultDbPath() });
+export async function startMcpServer(options?: { dbPath?: string }): Promise<void> {
+  const store = await createStore({ dbPath: options?.dbPath ?? getDefaultDbPath() });
   const server = await createMcpServer(store);
   const transport = new StdioServerTransport();
   await server.connect(transport);
@@ -540,8 +540,8 @@ export type HttpServerHandle = {
  * Start MCP server over Streamable HTTP (JSON responses, no SSE).
  * Binds to localhost only. Returns a handle for shutdown and port discovery.
  */
-export async function startMcpHttpServer(port: number, options?: { quiet?: boolean }): Promise<HttpServerHandle> {
-  const store = await createStore({ dbPath: getDefaultDbPath() });
+export async function startMcpHttpServer(port: number, options?: { quiet?: boolean; dbPath?: string }): Promise<HttpServerHandle> {
+  const store = await createStore({ dbPath: options?.dbPath ?? getDefaultDbPath() });
 
   // Pre-fetch default collection names for REST endpoint
   const defaultCollectionNames = await store.getDefaultCollectionNames();

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1075,3 +1075,101 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
     expect(json.result.content.length).toBeGreaterThan(0);
   });
 });
+
+// =============================================================================
+// --index flag: dbPath parameter tests
+// =============================================================================
+
+describe.skipIf(!!process.env.CI)("MCP dbPath parameter (--index flag)", () => {
+  let handle: HttpServerHandle;
+  let baseUrl: string;
+  let dbPathTestDb: string;
+  let dbPathConfigDir: string;
+  let origIndexPath: string | undefined;
+  let origConfigDir: string | undefined;
+
+  beforeAll(async () => {
+    // Snapshot env inside beforeAll to avoid stale captures from module-load time
+    origIndexPath = process.env.INDEX_PATH;
+    origConfigDir = process.env.QMD_CONFIG_DIR;
+
+    // Create isolated test database
+    dbPathTestDb = `/tmp/qmd-mcp-dbpath-test-${Date.now()}.sqlite`;
+    const db = openDatabase(dbPathTestDb);
+    initTestDatabase(db);
+    seedTestData(db);
+
+    // Sync config into SQLite
+    const dbPathTestConfig: CollectionConfig = {
+      collections: {
+        docs: {
+          path: "/test/docs",
+          pattern: "**/*.md",
+        }
+      }
+    };
+    syncConfigToDb(db, dbPathTestConfig);
+    db.close();
+
+    // Create isolated YAML config
+    const configPrefix = join(tmpdir(), `qmd-mcp-dbpath-config-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    dbPathConfigDir = await mkdtemp(configPrefix);
+    await writeFile(join(dbPathConfigDir, "index.yml"), YAML.stringify(dbPathTestConfig));
+
+    // Clear INDEX_PATH to prove dbPath parameter works on its own
+    delete process.env.INDEX_PATH;
+    process.env.QMD_CONFIG_DIR = dbPathConfigDir;
+
+    // Start server with explicit dbPath (simulates --index flag)
+    handle = await startMcpHttpServer(0, { quiet: true, dbPath: dbPathTestDb });
+    baseUrl = `http://localhost:${handle.port}`;
+  });
+
+  afterAll(async () => {
+    await handle.stop();
+
+    // Restore env
+    if (origIndexPath !== undefined) process.env.INDEX_PATH = origIndexPath;
+    else delete process.env.INDEX_PATH;
+    if (origConfigDir !== undefined) process.env.QMD_CONFIG_DIR = origConfigDir;
+    else delete process.env.QMD_CONFIG_DIR;
+
+    try { unlinkSync(dbPathTestDb); } catch {}
+    try {
+      const files = await readdir(dbPathConfigDir);
+      for (const f of files) await unlink(join(dbPathConfigDir, f));
+      await rmdir(dbPathConfigDir);
+    } catch {}
+  });
+
+  /** Send a JSON-RPC message to /mcp and return the parsed response. */
+  let sessionId: string | null = null;
+  async function mcpReq(body: object): Promise<{ status: number; json: any }> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "Accept": "application/json, text/event-stream",
+    };
+    if (sessionId) headers["mcp-session-id"] = sessionId;
+    const res = await fetch(`${baseUrl}/mcp`, { method: "POST", headers, body: JSON.stringify(body) });
+    const sid = res.headers.get("mcp-session-id");
+    if (sid) sessionId = sid;
+    return { status: res.status, json: await res.json() };
+  }
+
+  test("server uses dbPath instead of default index.sqlite", async () => {
+    await mcpReq({
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "test", version: "1.0" } },
+    });
+
+    const { status, json } = await mcpReq({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "query", arguments: { searches: [{ type: "lex", query: "readme" }] } },
+    });
+
+    expect(status).toBe(200);
+    expect(json.result).toBeDefined();
+    expect(json.result.content.length).toBeGreaterThan(0);
+    expect(json.result.content[0].text).toContain("readme");
+  });
+});


### PR DESCRIPTION
## Summary

- `startMcpServer()` and `startMcpHttpServer()` now accept an optional `dbPath` parameter instead of always calling `createStore()` with no arguments
- The CLI passes the resolved `storeDbPathOverride` (set by `--index`) when dispatching to MCP stdio and HTTP transports
- Daemon mode (`--daemon`) forwards `--index` to the spawned child process args

## Problem

`qmd --index myproject mcp` silently ignores the `--index` flag. The MCP server always opens `~/.cache/qmd/index.sqlite` instead of `~/.cache/qmd/myproject.sqlite`.

**Root cause:** `src/mcp.ts` imports `createStore` directly from `store.ts` and calls it with no arguments, bypassing the `storeDbPathOverride` that `setIndexName()` sets in `qmd.ts`.

## Changes

| File | Change |
|------|--------|
| `src/mcp.ts` | Add optional `dbPath` param to `startMcpServer()` and `startMcpHttpServer()` |
| `src/qmd.ts` | Pass `storeDbPathOverride` to both MCP entry points; forward `--index` in daemon spawn args |
| `test/mcp.test.ts` | New test: starts HTTP server with explicit `dbPath` (no `INDEX_PATH` env), verifies search works |
| `CHANGELOG.md` | Entry under `[Unreleased]` |

## Test plan

- [x] New test `"server uses dbPath instead of default index.sqlite"` — starts HTTP MCP server with `dbPath`, clears `INDEX_PATH` env, searches seeded data
- [x] All existing MCP tests pass (57 passed)
- [x] TypeScript builds cleanly (`bun run build`)
- [ ] Manual: `qmd --index foo mcp` opens `foo.sqlite` via stdio
- [ ] Manual: `qmd --index foo mcp --http` opens `foo.sqlite` via HTTP
- [ ] Manual: `qmd --index foo mcp --http --daemon` spawns child with `--index foo`

Fixes #343