### PR TITLE
fix(store): respect QMD_EMBED_MODEL env var in DEFAULT_EMBED_MODEL

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -44,7 +44,7 @@ import {
 // =============================================================================
 
 const HOME = process.env.HOME || "/tmp";
-export const DEFAULT_EMBED_MODEL = "embeddinggemma";
+export const DEFAULT_EMBED_MODEL = process.env.QMD_EMBED_MODEL ?? "embeddinggemma";
 export const DEFAULT_RERANK_MODEL = "ExpedientFalcon/qwen3-reranker:0.6b-q8_0";
 export const DEFAULT_QUERY_MODEL = "Qwen/Qwen3-1.7B";
 export const DEFAULT_GLOB = "**/*.md";


### PR DESCRIPTION
## Problem

When `QMD_EMBED_MODEL` is set to a custom embedding model (e.g. Qwen3-Embedding), **search queries use the wrong prompt template**, degrading search quality.

This is because `store.ts` hardcodes `DEFAULT_EMBED_MODEL = "embeddinggemma"`, and this value is passed through the call chain:

```
store.ts hybridQuery/vectorSearchQuery/structuredSearch
  → store.searchVec(query, DEFAULT_EMBED_MODEL, ...)
    → getEmbedding(query, "embeddinggemma", true, session)
      → formatQueryForEmbedding(query, "embeddinggemma")
```

In `formatQueryForEmbedding` (llm.ts:38), since `modelUri` is `"embeddinggemma"` (truthy), it does **not** fall through to `process.env.QMD_EMBED_MODEL`. Then `isQwen3EmbeddingModel("embeddinggemma")` returns `false`, so the query is formatted with the embeddinggemma template (`task: search result | query: ...`) instead of the Qwen3 instruct template.

This means documents are embedded with the correct Qwen3 format (because `llm.ts` reads the env var), but queries use the wrong format — causing a mismatch that hurts search quality.

## Solution

Make `store.ts` read `QMD_EMBED_MODEL` with the same fallback pattern as `llm.ts`:

```ts
// Before
export const DEFAULT_EMBED_MODEL = "embeddinggemma";

// After
export const DEFAULT_EMBED_MODEL = process.env.QMD_EMBED_MODEL ?? "embeddinggemma";
```

## Relation to #332

PR #332 fixes the **display** issue in `qmd.ts` (showing the wrong model name during `qmd embed`). This PR fixes the **functional** bug in `store.ts` where search queries use the wrong prompt template. The two fixes are complementary.

Fixes #328

Co-Authored-By: Oz <oz-agent@warp.dev>