### PR TITLE
docs: fix Qwen3-Embedding GGUF filename case (404 on download)

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ This is useful for multilingual corpora (e.g. Chinese, Japanese, Korean) where
 
 ```sh
 # Use Qwen3-Embedding-0.6B for better multilingual (CJK) support
-export QMD_EMBED_MODEL="hf:Qwen/Qwen3-Embedding-0.6B-GGUF/qwen3-embedding-0.6b-q8_0.gguf"
+export QMD_EMBED_MODEL="hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf"
 
 # After changing the model, re-embed all collections:
 qmd embed -f

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -192,7 +192,7 @@ export type RerankDocument = {
 
 // HuggingFace model URIs for node-llama-cpp
 // Format: hf:<user>/<repo>/<file>
-// Override via QMD_EMBED_MODEL env var (e.g. hf:Qwen/Qwen3-Embedding-0.6B-GGUF/qwen3-embedding-0.6b-q8_0.gguf)
+// Override via QMD_EMBED_MODEL env var (e.g. hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf)
 const DEFAULT_EMBED_MODEL = process.env.QMD_EMBED_MODEL ?? "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";
 const DEFAULT_RERANK_MODEL = "hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf";
 // const DEFAULT_GENERATE_MODEL = "hf:ggml-org/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf";


### PR DESCRIPTION
## Problem

Following the README instructions for custom embedding model setup fails with a 404 error:

```sh
export QMD_EMBED_MODEL="hf:Qwen/Qwen3-Embedding-0.6B-GGUF/qwen3-embedding-0.6b-q8_0.gguf"
qmd embed -f
# => 404 Not Found
```

HuggingFace filenames are case-sensitive. The actual filename in the repo is `Qwen3-Embedding-0.6B-Q8_0.gguf` (original case), not `qwen3-embedding-0.6b-q8_0.gguf` (lowercase).

## Fix

Corrected the filename case in:
- `README.md` (line 344) — the documented `QMD_EMBED_MODEL` example
- `src/llm.ts` (line 195) — the comment example

Co-Authored-By: Oz <oz-agent@warp.dev>