### PR TITLE
Fix launcher path for global installs

### DIFF
--- a/bin/qmd
+++ b/bin/qmd
@@ -1,8 +1,19 @@
 #!/bin/sh
+# Resolve symlinks so global installs (npm link / npm install -g) can find the
+# actual package directory instead of the global bin directory.
+SOURCE="$0"
+while [ -L "$SOURCE" ]; do
+  SOURCE_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+  TARGET="$(readlink "$SOURCE")"
+  case "$TARGET" in
+    /*) SOURCE="$TARGET" ;;
+    *) SOURCE="$SOURCE_DIR/$TARGET" ;;
+  esac
+done
+
 # Detect the runtime used to install this package and use the matching one
 # to avoid native module ABI mismatches (e.g., better-sqlite3 compiled for bun vs node)
-
-DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DIR="$(cd -P "$(dirname "$SOURCE")/.." && pwd)"
 
 # Check if we were installed with bun (look for bun.lock or bun-lockb)
 if [ -f "$DIR/bun.lock" ] || [ -f "$DIR/bun.lockb" ] || [ -n "$BUN_INSTALL" ]; then


### PR DESCRIPTION
This fixes `qmd` when installed globally.

Right now, after:

```sh
npm install -g @tobilu/qmd
qmd --help
```

the launcher can fail with:

```text
error: Module not found "/opt/homebrew/dist/cli/qmd.js"
```

The issue is that `bin/qmd` uses `$0` directly, which points at the symlinked global bin path instead of the real package path.

This change resolves the symlink first, then finds `dist/cli/qmd.js` from the actual install directory.

I reproduced the failure locally with the published npm package and verified that the patched version works with both `npm link` and the global `qmd` command.
