### PR TITLE
fix: remove $BUN_INSTALL check from launcher to prevent false Bun detection

### DIFF
--- a/bin/qmd
+++ b/bin/qmd
@@ -15,8 +15,12 @@ done
 # to avoid native module ABI mismatches (e.g., better-sqlite3 compiled for bun vs node)
 DIR="$(cd -P "$(dirname "$SOURCE")/.." && pwd)"
 
-# Check if we were installed with bun (look for bun.lock or bun-lockb)
-if [ -f "$DIR/bun.lock" ] || [ -f "$DIR/bun.lockb" ] || [ -n "$BUN_INSTALL" ]; then
+# Check if we were installed with bun (look for bun.lock or bun-lockb).
+# $BUN_INSTALL is intentionally NOT checked here — it only indicates that bun
+# exists on the system, not that it was used to install this package.  When QMD
+# is installed via npm, native modules are compiled for Node and running them
+# under bun causes ABI mismatches (e.g. sqlite-vec "no such module: vec0").
+if [ -f "$DIR/bun.lock" ] || [ -f "$DIR/bun.lockb" ]; then
   exec bun "$DIR/dist/cli/qmd.js" "$@"
 else
   exec node "$DIR/dist/cli/qmd.js" "$@"


### PR DESCRIPTION
## Summary
- Removes the `$BUN_INSTALL` environment variable check from `bin/qmd` launcher
- Relies only on `bun.lock`/`bun.lockb` lockfiles to detect Bun installs
- Prevents ABI mismatches when QMD is installed via npm on systems that also have Bun

## Problem
When Bun is installed on the system, `$BUN_INSTALL` is always set (e.g. `~/.bun`), even if QMD was installed via `npm i -g`. The launcher incorrectly picks Bun, causing native modules (`better-sqlite3`, `sqlite-vec`) compiled for Node to fail with `no such module: vec0`.

## Test plan
- [ ] Install QMD via `npm i -g @tobilu/qmd` on a system with Bun installed
- [ ] Verify `qmd embed` and `qmd query` work without errors
- [ ] Install QMD via `bun add -g @tobilu/qmd` and verify it still uses Bun

Fixes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)