### PR TITLE
fix(llm): make rerank context size configurable via QMD_RERANK_CONTEXT_SIZE

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -382,6 +382,21 @@ export type LlamaCppConfig = {
 // Default inactivity timeout: 5 minutes (keep models warm during typical search sessions)
 const DEFAULT_INACTIVITY_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_EXPAND_CONTEXT_SIZE = 2048;
+const DEFAULT_RERANK_CONTEXT_SIZE = 2048;
+
+function resolveRerankContextSize(): number {
+  const envValue = process.env.QMD_RERANK_CONTEXT_SIZE?.trim();
+  if (!envValue) return DEFAULT_RERANK_CONTEXT_SIZE;
+
+  const parsed = Number.parseInt(envValue, 10);
+  if (!Number.isInteger(parsed) || parsed < 512 || parsed > 32768) {
+    process.stderr.write(
+      `QMD Warning: invalid QMD_RERANK_CONTEXT_SIZE="${envValue}", using default ${DEFAULT_RERANK_CONTEXT_SIZE}.\n`
+    );
+    return DEFAULT_RERANK_CONTEXT_SIZE;
+  }
+  return parsed;
+}
 
 function resolveExpandContextSize(configValue?: number): number {
   if (configValue !== undefined) {
@@ -758,8 +773,9 @@ export class LlamaCpp implements LLM {
    */
   // Qwen3 reranker template adds ~200 tokens overhead (system prompt, tags, etc.)
   // Chunks are max 800 tokens, so 800 + 200 + query ≈ 1100 tokens typical.
-  // Use 2048 for safety margin. Still 17× less than auto (40960).
-  private static readonly RERANK_CONTEXT_SIZE = 2048;
+  // Default 2048 for safety margin. Still 17x less than auto (40960).
+  // Override via QMD_RERANK_CONTEXT_SIZE env var (512-32768) for CJK or long content.
+  private static readonly RERANK_CONTEXT_SIZE = resolveRerankContextSize();
   private async ensureRerankContexts(): Promise<Awaited<ReturnType<LlamaModel["createRankingContext"]>>[]> {
     if (this.rerankContexts.length === 0) {
       const model = await this.ensureRerankModel();


### PR DESCRIPTION
Fixes #291

## Summary

Makes `RERANK_CONTEXT_SIZE` configurable via the `QMD_RERANK_CONTEXT_SIZE` environment variable, defaulting to 2048 for backwards compatibility. This follows the existing pattern used by `QMD_EXPAND_CONTEXT_SIZE`.

CJK content and long query expansions can exceed the 2048 default - the truncation logic (added previously) prevents crashes but aggressively truncates content. Users can now set `QMD_RERANK_CONTEXT_SIZE=4096` to avoid truncation on CJK corpora.

## Changes

- Read `QMD_RERANK_CONTEXT_SIZE` from environment, parse as integer
- Validate range (512-32768), fall back to 2048 on invalid values
- Updated comment to document the env var

## Test plan

- [ ] `QMD_RERANK_CONTEXT_SIZE=4096 qmd query "test"` uses 4096 context
- [ ] Default behavior unchanged without env var
- [ ] Invalid values (negative, non-numeric) fall back to 2048
- [ ] `npm run build` passes
- [ ] `npx vitest run test/` passes

This contribution was developed with AI assistance (Claude Code).