### PR TITLE
Fix QMD when running under WSL (Windows Subsystem for Linux)

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -270,7 +270,8 @@ export function isAbsolutePath(path: string): boolean {
   if (path.startsWith('/')) {
     // Check if it's a Git Bash style path like /c/ or /c/Users (C-Z only, not A or B)
     // Requires path[2] === '/' to distinguish from Unix paths like /c or /cache
-    if (path.length >= 3 && path[2] === '/') {
+    // Skipped on WSL where /c/ is a valid drvfs mount point, not a drive letter
+    if (!isWSL() && path.length >= 3 && path[2] === '/') {
       const driveLetter = path[1];
       if (driveLetter && /[c-zC-Z]/.test(driveLetter)) {
         return true;
@@ -294,6 +295,14 @@ export function isAbsolutePath(path: string): boolean {
  */
 export function normalizePathSeparators(path: string): string {
   return path.replace(/\\/g, '/');
+}
+
+/**
+ * Detect if running inside WSL (Windows Subsystem for Linux).
+ * On WSL, paths like /c/work/... are valid drvfs mount points, not Git Bash paths.
+ */
+function isWSL(): boolean {
+  return !!(process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP);
 }
 
 /**
@@ -348,8 +357,9 @@ export function resolve(...paths: string[]): string {
     if (firstPath.length >= 2 && /[a-zA-Z]/.test(firstPath[0]!) && firstPath[1] === ':') {
       windowsDrive = firstPath.slice(0, 2);
       result = firstPath.slice(2);
-    } else if (firstPath.startsWith('/') && firstPath.length >= 3 && firstPath[2] === '/') {
+    } else if (!isWSL() && firstPath.startsWith('/') && firstPath.length >= 3 && firstPath[2] === '/') {
       // Git Bash style: /c/ -> C: (C-Z drives only, not A or B)
+      // Skipped on WSL where /c/ is a valid drvfs mount point, not a drive letter
       const driveLetter = firstPath[1];
       if (driveLetter && /[c-zC-Z]/.test(driveLetter)) {
         windowsDrive = driveLetter.toUpperCase() + ':';
@@ -380,8 +390,9 @@ export function resolve(...paths: string[]): string {
       if (p.length >= 2 && /[a-zA-Z]/.test(p[0]!) && p[1] === ':') {
         windowsDrive = p.slice(0, 2);
         result = p.slice(2);
-      } else if (p.startsWith('/') && p.length >= 3 && p[2] === '/') {
+      } else if (!isWSL() && p.startsWith('/') && p.length >= 3 && p[2] === '/') {
         // Git Bash style (C-Z drives only, not A or B)
+        // Skipped on WSL where /c/ is a valid drvfs mount point, not a drive letter
         const driveLetter = p[1];
         if (driveLetter && /[c-zC-Z]/.test(driveLetter)) {
           windowsDrive = driveLetter.toUpperCase() + ':';


### PR DESCRIPTION
## Problem

On WSL (Windows Subsystem for Linux), paths like `/c/work/...` are valid **drvfs mount points** (Windows drives mounted under `/c/`, `/d/`, etc.), not Git Bash drive-letter shortcuts.

The existing code in `isAbsolutePath()` and `resolve()` detects `/c/` as a Windows `C:` path and converts it to `C:/work/...`. This breaks `qmd collection add` entirely on WSL when using drvfs paths — the collection root gets mangled and no files are indexed.

The workaround in use today is to `rsync` content from the drvfs mount to a native wslfs path (e.g. `/tmp/`) before indexing — adding unnecessary complexity and a sync step.

## Root cause

The Git Bash path detection heuristic (`/c/` → `C:`) runs unconditionally on all platforms. On Linux it's usually harmless because real Linux paths don't start with `/c/` followed by a slash. But on WSL, drvfs mounts `/c/`, `/d/`, etc. as legitimate Unix paths, triggering the false positive.

## Fix

Detect WSL via `process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP` (standard environment variables set by WSL) and skip the Git Bash branch in three places:

- `isAbsolutePath()` 
- `resolve()` — first-path branch
- `resolve()` — subsequent-paths branch

On WSL, `/c/work/foo` is treated as a regular Unix absolute path, which is correct.

## Testing

Verified on WSL 1 (kernel 4.4.0-26100-Microsoft):

```
$ node dist/cli/qmd.js collection add /c/work/desktop/supportsite/foundation --name test
Creating collection 'test'...
Collection: /c/work/desktop/supportsite/foundation (**/*.md)

Indexed: 62 new, 0 updated, 0 unchanged, 0 removed
✓ Collection 'test' created successfully

$ node dist/cli/qmd.js search "camera setup"
qmd://test/product/ui-workflows/index.md:37 ...
Score: 78%
```

Before this fix, `collection add` with a drvfs path silently created an empty or broken collection.