### PR TITLE
fix(db): add macOS Homebrew SQLite support for Bun and restore actionable errors

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -4,19 +4,51 @@
  * Provides a unified Database export that works under both Bun (bun:sqlite)
  * and Node.js (better-sqlite3). The APIs are nearly identical — the main
  * difference is the import path.
+ *
+ * On macOS, Apple's system SQLite is compiled with SQLITE_OMIT_LOAD_EXTENSION,
+ * which prevents loading native extensions like sqlite-vec. When running under
+ * Bun we call Database.setCustomSQLite() to swap in Homebrew's full-featured
+ * SQLite build before creating any database instances.
  */
 
 export const isBun = typeof globalThis.Bun !== "undefined";
 
 let _Database: any;
-let _sqliteVecLoad: (db: any) => void;
+let _sqliteVecLoad: ((db: any) => void) | null;
 
 if (isBun) {
   // Dynamic string prevents tsc from resolving bun:sqlite on Node.js builds
   const bunSqlite = "bun:" + "sqlite";
-  _Database = (await import(/* @vite-ignore */ bunSqlite)).Database;
-  const { getLoadablePath } = await import("sqlite-vec");
-  _sqliteVecLoad = (db: any) => db.loadExtension(getLoadablePath());
+  const BunDatabase = (await import(/* @vite-ignore */ bunSqlite)).Database;
+
+  // See: https://bun.com/docs/runtime/sqlite#setcustomsqlite
+  if (process.platform === "darwin") {
+    const homebrewPaths = [
+      "/opt/homebrew/opt/sqlite/lib/libsqlite3.dylib",  // Apple Silicon
+      "/usr/local/opt/sqlite/lib/libsqlite3.dylib",     // Intel
+    ];
+    for (const p of homebrewPaths) {
+      try {
+        BunDatabase.setCustomSQLite(p);
+        break;
+      } catch {}
+    }
+  }
+
+  _Database = BunDatabase;
+
+  // setCustomSQLite may have silently failed — test that extensions actually work.
+  try {
+    const { getLoadablePath } = await import("sqlite-vec");
+    const vecPath = getLoadablePath();
+    const testDb = new BunDatabase(":memory:");
+    testDb.loadExtension(vecPath);
+    testDb.close();
+    _sqliteVecLoad = (db: any) => db.loadExtension(vecPath);
+  } catch {
+    // Vector search won't work, but BM25 and other operations are unaffected.
+    _sqliteVecLoad = null;
+  }
 } else {
   _Database = (await import("better-sqlite3")).default;
   const sqliteVec = await import("sqlite-vec");
@@ -48,7 +80,17 @@ export interface Statement {
 
 /**
  * Load the sqlite-vec extension into a database.
+ *
+ * Throws with platform-specific fix instructions when the extension is
+ * unavailable.
  */
 export function loadSqliteVec(db: Database): void {
+  if (!_sqliteVecLoad) {
+    const hint = isBun && process.platform === "darwin"
+      ? "On macOS with Bun, install Homebrew SQLite: brew install sqlite\n" +
+        "Or install qmd with npm instead: npm install -g @tobilu/qmd"
+      : "Ensure the sqlite-vec native module is installed correctly.";
+    throw new Error(`sqlite-vec extension is unavailable. ${hint}`);
+  }
   _sqliteVecLoad(db);
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -631,9 +631,10 @@ function initializeDatabase(db: Database): void {
     loadSqliteVec(db);
     verifySqliteVecLoaded(db);
     _sqliteVecAvailable = true;
-  } catch {
+  } catch (err) {
     // sqlite-vec is optional — vector search won't work but FTS is fine
     _sqliteVecAvailable = false;
+    console.warn(getErrorMessage(err));
   }
   db.exec("PRAGMA journal_mode = WAL");
   db.exec("PRAGMA foreign_keys = ON");


### PR DESCRIPTION
## Problem

On macOS, `qmd embed` and `qmd query` fail under Bun with a cryptic error in `store.ts:770`:

```
sqlite-vec is not available. Vector operations require a SQLite build with extension loading support.
```

Two issues cause this:

1. **`bun:sqlite` uses Apple's system SQLite**, which is compiled with `SQLITE_OMIT_LOAD_EXTENSION` — native extensions like sqlite-vec cannot be loaded.
2. **The v2.0 refactor silently swallows the failure** in `initializeDatabase()`, setting `_sqliteVecAvailable = false` without any warning. The pre-2.0 code threw with actionable instructions ("Install Homebrew SQLite...") but this was replaced with a bare `catch {}`.

Reported in #363. Related: #238, #184, #161.

## Solution

**`src/db.ts`**:
- Call `Database.setCustomSQLite()` on macOS to swap Apple's SQLite with Homebrew's full-featured build. This is the pattern used by [sqlite-vec's own Bun example](https://github.com/asg017/sqlite-vec/blob/main/examples/simple-bun/demo.ts) and [Bun's docs](https://bun.com/docs/runtime/sqlite).
- Eagerly validate that extension loading works at init time (not at first query), so problems surface immediately.
- Throw with platform-specific fix instructions in `loadSqliteVec()` when the extension is unavailable.

**`src/store.ts`**:
- Log the error via `console.warn()` in `initializeDatabase()` instead of silently catching, so users see why vector search is disabled.

## Testing

1. **Node (unchanged path)**: `node dist/cli/qmd.js embed` works as before via better-sqlite3.
2. **Bun + macOS + Homebrew SQLite**: `bun dist/cli/qmd.js embed` works via `setCustomSQLite()`.
3. **Bun + macOS + no Homebrew**: User sees a clear warning with fix instructions. BM25 search still works.
4. **`qmd status` / `qmd search`**: Always work regardless of sqlite-vec availability.

## Configuration

Requires `brew install sqlite` on macOS when running under Bun. No change needed for Node users.