### PR TITLE
fix: pin zod to exact 4.2.1 to prevent tsc build failure 

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "picomatch": "^4.0.0",
     "sqlite-vec": "^0.1.7-alpha.2",
     "yaml": "^2.8.2",
-    "zod": "^4.2.1"
+    "zod": "4.2.1"
   },
   "optionalDependencies": {
     "sqlite-vec-darwin-arm64": "^0.1.7-alpha.2",


### PR DESCRIPTION
## Summary

- Removes the caret from `"zod": "^4.2.1"` → `"zod": "4.2.1"` in package.json 
																																														 
## Problem 
																																														 
When building from source with `npm install`, the caret range allows npm to resolve zod 4.3.x, which introduces breaking type changes against `@modelcontextprotocol/sdk`. This causes `tsc`
to fail with type errors in `src/mcp/server.ts`. 
											 
Published npm installs are unaffected because they ship pre-compiled `dist/` and skip the build step. 
																																														 
## Reproduction
																																														 
```sh 
git clone https://github.com/tobi/qmd && cd qmd
npm install # resolves zod 4.3.6 
npm run build # tsc fails 

``` 
Fixes #379 
