### PR TITLE
fix: skip cleanup when sqlite-vec is unavailable

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -1695,6 +1695,16 @@ export function cleanupOrphanedVectors(db: Database): number {
     return 0;
   }
 
+  // The schema entry can exist even when sqlite-vec itself is unavailable
+  // (for example when reopening a DB without vec0 loaded). In that case,
+  // touching the virtual table throws "no such module: vec0" and cleanup
+  // should degrade gracefully like the rest of the vector features.
+  try {
+    db.prepare(`SELECT 1 FROM vectors_vec LIMIT 0`).get();
+  } catch {
+    return 0;
+  }
+
   // Count orphaned vectors first
   const countResult = db.prepare(`
     SELECT COUNT(*) as c FROM content_vectors cv

--- a/test/store.helpers.unit.test.ts
+++ b/test/store.helpers.unit.test.ts
@@ -15,6 +15,7 @@ import {
   normalizeDocid,
   isDocid,
   handelize,
+  cleanupOrphanedVectors,
 } from "../src/store";
 
 // =============================================================================
@@ -78,6 +79,33 @@ describe("Path Utilities", () => {
     const result = getRealPath("/tmp");
     expect(result).toBeTruthy();
     expect(result === "/tmp" || result === "/private/tmp").toBe(true);
+  });
+});
+
+// =============================================================================
+// Handelize Tests
+// =============================================================================
+
+describe("cleanupOrphanedVectors", () => {
+  test("returns 0 when vec table exists in schema but sqlite-vec is unavailable", () => {
+    const prepare = (sql: string) => {
+      if (sql.includes("sqlite_master") && sql.includes("vectors_vec")) {
+        return { get: () => ({ name: "vectors_vec" }) };
+      }
+      if (sql.includes("SELECT 1 FROM vectors_vec LIMIT 0")) {
+        return { get: () => { throw new Error("no such module: vec0"); } };
+      }
+      throw new Error(`Unexpected SQL in test: ${sql}`);
+    };
+
+    const db = {
+      prepare,
+      exec: () => {
+        throw new Error("cleanup should not execute vector deletes when sqlite-vec is unavailable");
+      },
+    } as any;
+
+    expect(cleanupOrphanedVectors(db)).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- skip orphaned vector cleanup when `sqlite-vec` is unavailable
- add a focused regression test for a database whose schema still references `vectors_vec` but cannot load `vec0`

## Problem
`qmd cleanup` called `cleanupOrphanedVectors()` unconditionally after checking only for a `vectors_vec` schema entry. Reopening a database without `sqlite-vec` loaded can still leave that schema entry visible, but touching the virtual table then fails with `no such module: vec0`.

## Fix
Probe `vectors_vec` with a no-op query before running cleanup. If the virtual table cannot be accessed, return `0` and skip vector cleanup so the rest of `qmd cleanup` can continue.

## Validation
- `npx vitest run --reporter=verbose test/store.helpers.unit.test.ts`
- `npm run build`

## Repo rules checked
- no `CONTRIBUTING.md` found
- no PR template found under `.github/`
- checked `.github/workflows/ci.yml`; it validates installs and test runs on Node and Bun

Closes #380.
