### PR TITLE
fix: truncate oversized text before embedding to prevent GGML crash

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -800,13 +800,42 @@ export class LlamaCpp implements LLM {
   // Core API methods
   // ==========================================================================
 
+  /**
+   * Truncate text to fit within the embedding model's context window.
+   * Uses the model's own tokenizer for accurate token counting, then
+   * detokenizes back to text if truncation is needed.
+   * Returns the (possibly truncated) text and whether truncation occurred.
+   */
+  private async truncateToContextSize(text: string): Promise<{ text: string; truncated: boolean }> {
+    if (!this.embedModel) return { text, truncated: false };
+
+    const maxTokens = this.embedModel.trainContextSize;
+    if (maxTokens <= 0) return { text, truncated: false };
+
+    const tokens = this.embedModel.tokenize(text);
+    if (tokens.length <= maxTokens) return { text, truncated: false };
+
+    // Leave a small margin (4 tokens) for BOS/EOS overhead
+    const safeLimit = Math.max(1, maxTokens - 4);
+    const truncatedTokens = tokens.slice(0, safeLimit);
+    const truncatedText = this.embedModel.detokenize(truncatedTokens);
+    return { text: truncatedText, truncated: true };
+  }
+
   async embed(text: string, options: EmbedOptions = {}): Promise<EmbeddingResult | null> {
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();
 
     try {
       const context = await this.ensureEmbedContext();
-      const embedding = await context.getEmbeddingFor(text);
+
+      // Guard: truncate text that exceeds model context window to prevent GGML crash
+      const { text: safeText, truncated } = await this.truncateToContextSize(text);
+      if (truncated) {
+        console.warn(`⚠ Text truncated to fit embedding context (${this.embedModel?.trainContextSize} tokens)`);
+      }
+
+      const embedding = await context.getEmbeddingFor(safeText);
 
       return {
         embedding: Array.from(embedding.vector),
@@ -838,7 +867,11 @@ export class LlamaCpp implements LLM {
         const embeddings: ({ embedding: number[]; model: string } | null)[] = [];
         for (const text of texts) {
           try {
-            const embedding = await context.getEmbeddingFor(text);
+            const { text: safeText, truncated } = await this.truncateToContextSize(text);
+            if (truncated) {
+              console.warn(`⚠ Batch text truncated to fit embedding context (${this.embedModel?.trainContextSize} tokens)`);
+            }
+            const embedding = await context.getEmbeddingFor(safeText);
             this.touchActivity();
             embeddings.push({ embedding: Array.from(embedding.vector), model: this.embedModelUri });
           } catch (err) {
@@ -861,7 +894,11 @@ export class LlamaCpp implements LLM {
           const results: (EmbeddingResult | null)[] = [];
           for (const text of chunk) {
             try {
-              const embedding = await ctx.getEmbeddingFor(text);
+              const { text: safeText, truncated } = await this.truncateToContextSize(text);
+              if (truncated) {
+                console.warn(`⚠ Batch text truncated to fit embedding context (${this.embedModel?.trainContextSize} tokens)`);
+              }
+              const embedding = await ctx.getEmbeddingFor(safeText);
               this.touchActivity();
               results.push({ embedding: Array.from(embedding.vector), model: this.embedModelUri });
             } catch (err) {


### PR DESCRIPTION
## Problem

`qmd embed` crashes with a native SIGABRT when a text chunk exceeds the embedding model's context window (e.g., EmbeddingGemma-300M with 2048 token context). This is because `node-llama-cpp`'s `getEmbeddingFor()` passes oversized input directly to the GGML backend, which triggers an unrecoverable Metal/GGML abort — `try/catch` cannot intercept it.

Affected files include single-line JSON, minified code, or other documents that produce chunks larger than the model's `trainContextSize`.

## Fix

Added a `truncateToContextSize()` guard in `src/llm.ts` that runs before every `getEmbeddingFor()` call in both `embed()` and `embedBatch()`:

1. Tokenizes the input using the **model's own tokenizer** (accurate token count)
2. Compares against `model.trainContextSize`
3. If oversized: truncates to `trainContextSize - 4` tokens (margin for BOS/EOS), logs a warning
4. Passes the safe text to `getEmbeddingFor()`

## Design decisions

- **Truncate > Skip**: Partial embedding coverage is better than zero coverage
- **Model tokenizer > External estimate**: Eliminates token count mismatch between chunking and embedding phases
- **Dynamic context size**: Reads `trainContextSize` from the loaded model, works with any embedding model
- **Single-file change**: Only `src/llm.ts` modified — no changes to chunking logic or index format

## Testing

Verified with a 65,000-char input (~10K tokens) against EmbeddingGemma-300M (2048 context):

```
Input length: 65000 chars
⚠ Text truncated to fit embedding context (2048 tokens)
✅ Embedding succeeded! Vector dim: 768
```

Previously this input would crash the process with SIGABRT.

Fixes #303