### PR TITLE
sync stale bun.lock, guard against future lockfile drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,8 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install sqlite
 
-      - run: bun install
+      - name: Verify lockfile is up-to-date
+        run: bun install --frozen-lockfile
 
       - name: Tests
         run: bun test --timeout 60000 --preload ./src/test-preload.ts test/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Install SQLite
         run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
 
-      - run: bun install
+      - name: Verify lockfile is up-to-date
+        run: bun install --frozen-lockfile
+
       - run: bun test --timeout 60000 --preload ./src/test-preload.ts test/
         env:
           CI: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixes
+
+- Sync stale `bun.lock` (`better-sqlite3` 11.x → 12.x). CI and release
+  script now use `--frozen-lockfile` to prevent recurrence. #386
+  (thanks @Mic92)
+
 ## [2.0.1] - 2026-03-10
 
 ### Changes

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "2025-12-07-bm25-q",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.1",
-        "better-sqlite3": "^11.0.0",
+        "better-sqlite3": "^12.4.5",
         "fast-glob": "^3.3.0",
         "node-llama-cpp": "^3.17.1",
         "picomatch": "^4.0.0",
@@ -22,8 +22,9 @@
       "optionalDependencies": {
         "sqlite-vec-darwin-arm64": "^0.1.7-alpha.2",
         "sqlite-vec-darwin-x64": "^0.1.7-alpha.2",
+        "sqlite-vec-linux-arm64": "^0.1.7-alpha.2",
         "sqlite-vec-linux-x64": "^0.1.7-alpha.2",
-        "sqlite-vec-win32-x64": "^0.1.7-alpha.2",
+        "sqlite-vec-windows-x64": "^0.1.7-alpha.2",
       },
       "peerDependencies": {
         "typescript": "^5.9.3",
@@ -241,7 +242,7 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
-    "better-sqlite3": ["better-sqlite3@11.10.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ=="],
+    "better-sqlite3": ["better-sqlite3@12.6.2", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA=="],
 
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -29,6 +29,14 @@ if [[ -n "$(git status --porcelain)" ]]; then
   exit 1
 fi
 
+# Verify bun.lock is in sync with package.json
+if ! bun install --frozen-lockfile &>/dev/null; then
+  echo "Error: bun.lock is out of sync with package.json" >&2
+  echo "Run 'bun install' and commit the updated lockfile." >&2
+  exit 1
+fi
+echo "bun.lock: in sync ✓"
+
 # Read current version
 CURRENT=$(jq -r .version package.json)
 echo "Current version: $CURRENT"


### PR DESCRIPTION
bun.lock still resolved better-sqlite3 to 11.x after package.json was bumped to ^12.4.5 in v2.0.0. This breaks sandboxed builds (e.g. Nix with bun2nix) where network access is unavailable to resolve the mismatch.

CI and the publish workflow now use --frozen-lockfile so drift is caught immediately. The release script also validates lockfile consistency before tagging.

Closes #386