### PR TITLE
feat(embed): make excludeDirs configurable via QMD_EXCLUDE_DIRS

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -69,6 +69,7 @@ import {
   DEFAULT_RERANK_MODEL,
   DEFAULT_GLOB,
   DEFAULT_MULTI_GET_MAX_BYTES,
+  getExcludeDirs,
   createStore,
   getDefaultDbPath,
   reindexCollection,
@@ -1467,7 +1468,6 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
   const db = getDb();
   const resolvedPwd = pwd || getPwd();
   const now = new Date().toISOString();
-  const excludeDirs = ["node_modules", ".git", ".cache", "vendor", "dist", "build"];
 
   // Clear Ollama cache on index
   clearCache(db);
@@ -1481,7 +1481,7 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
 
   progress.indeterminate();
   const allIgnore = [
-    ...excludeDirs.map(d => `**/${d}/**`),
+    ...getExcludeDirs().map(d => `**/${d}/**`),
     ...(ignorePatterns || []),
   ];
   const allFiles: string[] = await fastGlob(globPattern, {

--- a/src/store.ts
+++ b/src/store.ts
@@ -47,6 +47,13 @@ export const DEFAULT_MULTI_GET_MAX_BYTES = 10 * 1024; // 10KB
 export const DEFAULT_EMBED_MAX_DOCS_PER_BATCH = 64;
 export const DEFAULT_EMBED_MAX_BATCH_BYTES = 64 * 1024 * 1024; // 64MB
 
+const BASE_EXCLUDE_DIRS = ["node_modules", ".git", ".cache", "vendor", "dist", "build"];
+
+export function getExcludeDirs(): string[] {
+  const extra = process.env.QMD_EXCLUDE_DIRS?.split(',').map(d => d.trim()).filter(Boolean) ?? [];
+  return [...BASE_EXCLUDE_DIRS, ...extra];
+}
+
 // Chunking: 900 tokens per chunk with 15% overlap
 // Increased from 800 to accommodate smart chunking finding natural break points
 export const CHUNK_SIZE_TOKENS = 900;
@@ -1087,10 +1094,9 @@ export async function reindexCollection(
 ): Promise<ReindexResult> {
   const db = store.db;
   const now = new Date().toISOString();
-  const excludeDirs = ["node_modules", ".git", ".cache", "vendor", "dist", "build"];
 
   const allIgnore = [
-    ...excludeDirs.map(d => `**/${d}/**`),
+    ...getExcludeDirs().map(d => `**/${d}/**`),
     ...(options?.ignorePatterns || []),
   ];
   const allFiles: string[] = await fastGlob(globPattern, {

--- a/test/store.helpers.unit.test.ts
+++ b/test/store.helpers.unit.test.ts
@@ -16,6 +16,7 @@ import {
   isDocid,
   handelize,
   cleanupOrphanedVectors,
+  getExcludeDirs,
 } from "../src/store";
 
 // =============================================================================
@@ -242,5 +243,58 @@ describe("handelize", () => {
     expect(isDocid("#123456")).toBe(true);
     expect(isDocid("bad-id")).toBe(false);
     expect(isDocid("12345")).toBe(false);
+  });
+});
+
+// =============================================================================
+// getExcludeDirs Tests
+// =============================================================================
+
+describe("getExcludeDirs", () => {
+  test("returns default exclude dirs when env var is unset", () => {
+    const original = process.env.QMD_EXCLUDE_DIRS;
+    delete process.env.QMD_EXCLUDE_DIRS;
+
+    const dirs = getExcludeDirs();
+    expect(dirs).toContain("node_modules");
+    expect(dirs).toContain(".git");
+    expect(dirs).toContain("vendor");
+    expect(dirs).toContain("dist");
+    expect(dirs).toContain("build");
+    expect(dirs).toContain(".cache");
+
+    if (original) process.env.QMD_EXCLUDE_DIRS = original;
+  });
+
+  test("appends custom dirs from QMD_EXCLUDE_DIRS", () => {
+    const original = process.env.QMD_EXCLUDE_DIRS;
+    process.env.QMD_EXCLUDE_DIRS = ".obsidian,tmp";
+
+    const dirs = getExcludeDirs();
+    expect(dirs).toContain("node_modules");
+    expect(dirs).toContain(".obsidian");
+    expect(dirs).toContain("tmp");
+
+    if (original) {
+      process.env.QMD_EXCLUDE_DIRS = original;
+    } else {
+      delete process.env.QMD_EXCLUDE_DIRS;
+    }
+  });
+
+  test("handles whitespace in QMD_EXCLUDE_DIRS", () => {
+    const original = process.env.QMD_EXCLUDE_DIRS;
+    process.env.QMD_EXCLUDE_DIRS = " .obsidian , tmp , ";
+
+    const dirs = getExcludeDirs();
+    expect(dirs).toContain(".obsidian");
+    expect(dirs).toContain("tmp");
+    expect(dirs).not.toContain("");
+
+    if (original) {
+      process.env.QMD_EXCLUDE_DIRS = original;
+    } else {
+      delete process.env.QMD_EXCLUDE_DIRS;
+    }
   });
 });


### PR DESCRIPTION
Fixes #271

## Summary

The exclude directory list (`node_modules`, `.git`, `.cache`, `vendor`, `dist`, `build`) was hardcoded in two separate places with no way to extend it. Users with non-standard layouts (Obsidian vaults, temp directories, etc.) couldn't exclude additional directories from indexing.

## Changes

- Add `QMD_EXCLUDE_DIRS` env var (comma-separated) to append custom directories to the default exclude list
- Extract `getExcludeDirs()` helper in `store.ts` to eliminate the duplication between `store.ts` and `cli/qmd.ts`
- Add 3 unit tests covering default behavior, custom dirs, and whitespace handling

## Usage

```bash
# Exclude .obsidian and tmp directories during indexing
QMD_EXCLUDE_DIRS=".obsidian,tmp" qmd collection add ~/vault --name notes
```

Default behavior is unchanged when the env var is unset.

This contribution was developed with AI assistance (Claude Code).