### PR TITLE
feat: add remote embedding provider support (Gemini, OpenAI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Remote embedding providers** — use cloud embedding APIs (Gemini, OpenAI)
+  instead of local GGUF models. Configure in `~/.config/qmd/index.yml`:
+  ```yaml
+  embedding:
+    provider: gemini  # or "openai"
+    model: gemini-embedding-2-preview
+    api_key: ${GOOGLE_API_KEY}
+    dimensions: 3072  # optional
+  ```
+  Supports both single and batch embedding via the Gemini `embedContent` /
+  `batchEmbedContents` endpoints and OpenAI-compatible `/v1/embeddings`.
+  Falls back to `GOOGLE_API_KEY` / `OPENAI_API_KEY` env vars when
+  `api_key` is not set. Local GGUF remains the default when no remote
+  provider is configured — zero breaking changes. #403
+
 ### Fixes
 
 - Sync stale `bun.lock` (`better-sqlite3` 11.x → 12.x). CI and release

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -98,6 +98,7 @@ import {
   loadConfig,
 } from "../collections.js";
 import { getEmbeddedQmdSkillContent, getEmbeddedQmdSkillFiles } from "../embedded-skills.js";
+import { createRemoteEmbeddingProvider } from "../remote-embedding.js";
 
 // Enable production mode - allows using default database path
 // Tests must set INDEX_PATH or use createStore() with explicit path
@@ -117,6 +118,11 @@ function getStore(): ReturnType<typeof createStore> {
     try {
       const config = loadConfig();
       syncConfigToDb(store.db, config);
+      // Attach remote embedding provider if configured
+      const remoteProvider = createRemoteEmbeddingProvider(config);
+      if (remoteProvider) {
+        store.remoteEmbedding = remoteProvider;
+      }
     } catch {
       // Config may not exist yet — that's fine, DB works without it
     }
@@ -421,7 +427,13 @@ async function showStatus(): Promise<void> {
       return match ? `https://huggingface.co/${match[1]}` : uri;
     };
     console.log(`\n${c.bold}Models${c.reset}`);
-    console.log(`  Embedding:   ${hfLink(DEFAULT_EMBED_MODEL_URI)}`);
+    const storeInstance = getStore();
+    if (storeInstance.remoteEmbedding) {
+      const re = storeInstance.remoteEmbedding;
+      console.log(`  Embedding:   ${c.green}${re.provider}${c.reset} ${re.model}${re.dimensions ? ` (${re.dimensions}d)` : ''} ${c.dim}(remote)${c.reset}`);
+    } else {
+      console.log(`  Embedding:   ${hfLink(DEFAULT_EMBED_MODEL_URI)}`);
+    }
     console.log(`  Reranking:   ${hfLink(DEFAULT_RERANK_MODEL_URI)}`);
     console.log(`  Generation:  ${hfLink(DEFAULT_GENERATE_MODEL_URI)}`);
   }
@@ -1637,7 +1649,10 @@ async function vectorIndex(
     return;
   }
 
-  console.log(`${c.dim}Model: ${model}${c.reset}\n`);
+  const displayModel = storeInstance.remoteEmbedding
+    ? `${storeInstance.remoteEmbedding.modelUri} (remote)`
+    : model;
+  console.log(`${c.dim}Model: ${displayModel}${c.reset}\n`);
   if (batchOptions?.maxDocsPerBatch !== undefined || batchOptions?.maxBatchBytes !== undefined) {
     const maxDocsPerBatch = batchOptions.maxDocsPerBatch ?? DEFAULT_EMBED_MAX_DOCS_PER_BATCH;
     const maxBatchBytes = batchOptions.maxBatchBytes ?? DEFAULT_EMBED_MAX_BATCH_BYTES;

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -9,6 +9,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join, dirname } from "path";
 import { homedir } from "os";
 import YAML from "yaml";
+import type { RemoteEmbeddingConfig } from "./remote-embedding.js";
 
 // ============================================================================
 // Types
@@ -39,6 +40,7 @@ export interface Collection {
 export interface CollectionConfig {
   global_context?: string;                    // Context applied to all collections
   collections: Record<string, Collection>;    // Collection name -> config
+  embedding?: RemoteEmbeddingConfig;          // Optional remote embedding provider
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,7 @@ import {
   type NamedCollection,
   type ContextMap,
 } from "./collections.js";
+import { createRemoteEmbeddingProvider, type RemoteEmbeddingConfig } from "./remote-embedding.js";
 
 // Re-export types for SDK consumers
 export type {
@@ -103,6 +104,7 @@ export type {
   CollectionConfig,
   NamedCollection,
   ContextMap,
+  RemoteEmbeddingConfig,
 };
 
 // Re-export the internal Store type for advanced consumers
@@ -345,18 +347,28 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
   // Track whether we have a YAML config path for write-through
   const hasYamlConfig = !!options.configPath;
 
-  // Sync config into SQLite store_collections
+  // Sync config into SQLite store_collections and attach remote embedding
+  let resolvedConfig: CollectionConfig | undefined;
   if (options.configPath) {
     // YAML mode: inject config source for write-through, sync to DB
     setConfigSource({ configPath: options.configPath });
-    const config = loadConfig();
-    syncConfigToDb(db, config);
+    resolvedConfig = loadConfig();
+    syncConfigToDb(db, resolvedConfig);
   } else if (options.config) {
     // Inline config mode: inject config source for mutations, sync to DB
     setConfigSource({ config: options.config });
     syncConfigToDb(db, options.config);
+    resolvedConfig = options.config;
   }
   // else: DB-only mode — no external config, use existing store_collections
+
+  // Attach remote embedding provider if configured
+  if (resolvedConfig) {
+    const remoteProvider = createRemoteEmbeddingProvider(resolvedConfig);
+    if (remoteProvider) {
+      internal.remoteEmbedding = remoteProvider;
+    }
+  }
 
   // Create a per-store LlamaCpp instance — lazy-loads models on first use,
   // auto-unloads after 5 min inactivity to free VRAM.

--- a/src/remote-embedding.ts
+++ b/src/remote-embedding.ts
@@ -1,0 +1,319 @@
+/**
+ * remote-embedding.ts - Remote embedding provider support for QMD
+ *
+ * Supports OpenAI-compatible and Gemini embedding APIs as alternatives
+ * to local GGUF models via node-llama-cpp.
+ */
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Configuration for a remote embedding provider.
+ * Parsed from the `embedding` section of index.yml.
+ */
+export interface RemoteEmbeddingConfig {
+  provider: "openai" | "gemini";
+  model: string;
+  api_key?: string;
+  base_url?: string;
+  dimensions?: number;
+}
+
+/**
+ * Result from a remote embedding call.
+ */
+export interface RemoteEmbeddingResult {
+  embedding: number[];
+  model: string;
+}
+
+// =============================================================================
+// API Key Resolution
+// =============================================================================
+
+/**
+ * Resolve an API key from config, supporting ${ENV_VAR} syntax and env fallbacks.
+ */
+export function resolveApiKey(config: RemoteEmbeddingConfig): string {
+  let key = config.api_key;
+
+  // Resolve ${ENV_VAR} references
+  if (key && /^\$\{(.+)\}$/.test(key)) {
+    const envVar = key.match(/^\$\{(.+)\}$/)![1]!;
+    key = process.env[envVar];
+  }
+
+  // Fallback to well-known env vars
+  if (!key) {
+    if (config.provider === "gemini") {
+      key = process.env.GOOGLE_API_KEY;
+    } else if (config.provider === "openai") {
+      key = process.env.OPENAI_API_KEY;
+    }
+  }
+
+  if (!key) {
+    const envHint = config.provider === "gemini" ? "GOOGLE_API_KEY" : "OPENAI_API_KEY";
+    throw new Error(
+      `No API key found for ${config.provider} embedding provider. ` +
+      `Set api_key in config or export ${envHint}.`
+    );
+  }
+
+  return key;
+}
+
+// =============================================================================
+// Gemini Provider
+// =============================================================================
+
+const GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
+
+async function geminiEmbed(
+  text: string,
+  model: string,
+  apiKey: string,
+): Promise<number[]> {
+  const url = `${GEMINI_BASE_URL}/models/${model}:embedContent`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-goog-api-key": apiKey,
+    },
+    body: JSON.stringify({
+      content: { parts: [{ text }] },
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Gemini embedding API error (${response.status}): ${body}`);
+  }
+
+  const data = await response.json() as {
+    embedding: { values: number[] };
+  };
+  return data.embedding.values;
+}
+
+async function geminiBatchEmbed(
+  texts: string[],
+  model: string,
+  apiKey: string,
+): Promise<number[][]> {
+  if (texts.length === 0) return [];
+  if (texts.length === 1) {
+    const result = await geminiEmbed(texts[0]!, model, apiKey);
+    return [result];
+  }
+
+  const url = `${GEMINI_BASE_URL}/models/${model}:batchEmbedContents`;
+  const requests = texts.map(text => ({
+    model: `models/${model}`,
+    content: { parts: [{ text }] },
+  }));
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-goog-api-key": apiKey,
+    },
+    body: JSON.stringify({ requests }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Gemini batch embedding API error (${response.status}): ${body}`);
+  }
+
+  const data = await response.json() as {
+    embeddings: { values: number[] }[];
+  };
+  return data.embeddings.map(e => e.values);
+}
+
+// =============================================================================
+// OpenAI-compatible Provider
+// =============================================================================
+
+const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
+
+async function openaiEmbed(
+  input: string | string[],
+  model: string,
+  apiKey: string,
+  baseUrl?: string,
+  dimensions?: number,
+): Promise<number[][]> {
+  const url = `${(baseUrl || OPENAI_DEFAULT_BASE_URL).replace(/\/+$/, '')}/embeddings`;
+
+  const body: Record<string, unknown> = { model, input };
+  if (dimensions) {
+    body.dimensions = dimensions;
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const respBody = await response.text();
+    throw new Error(`OpenAI embedding API error (${response.status}): ${respBody}`);
+  }
+
+  const data = await response.json() as {
+    data: { embedding: number[]; index: number }[];
+  };
+
+  // Sort by index to maintain input order
+  return data.data
+    .sort((a, b) => a.index - b.index)
+    .map(d => d.embedding);
+}
+
+// =============================================================================
+// Remote Embedding Provider (unified interface)
+// =============================================================================
+
+/**
+ * A remote embedding provider that wraps either Gemini or OpenAI-compatible APIs.
+ * Implements the same embed/embedBatch pattern as LlamaCpp for drop-in use.
+ */
+export class RemoteEmbeddingProvider {
+  private config: RemoteEmbeddingConfig;
+  private apiKey: string;
+
+  constructor(config: RemoteEmbeddingConfig) {
+    this.config = config;
+    this.apiKey = resolveApiKey(config);
+  }
+
+  get provider(): string {
+    return this.config.provider;
+  }
+
+  get model(): string {
+    return this.config.model;
+  }
+
+  get dimensions(): number | undefined {
+    return this.config.dimensions;
+  }
+
+  /**
+   * Get the model identifier string used for display/storage.
+   */
+  get modelUri(): string {
+    return `${this.config.provider}:${this.config.model}`;
+  }
+
+  /**
+   * Embed a single text. Returns the embedding vector.
+   */
+  async embed(text: string): Promise<RemoteEmbeddingResult> {
+    let embedding: number[];
+
+    if (this.config.provider === "gemini") {
+      embedding = await geminiEmbed(text, this.config.model, this.apiKey);
+    } else {
+      const results = await openaiEmbed(text, this.config.model, this.apiKey, this.config.base_url, this.config.dimensions);
+      embedding = results[0]!;
+    }
+
+    // Truncate to configured dimensions if needed
+    if (this.config.dimensions && embedding.length > this.config.dimensions) {
+      embedding = embedding.slice(0, this.config.dimensions);
+    }
+
+    return { embedding, model: this.modelUri };
+  }
+
+  /**
+   * Embed multiple texts efficiently using batch APIs.
+   * Gemini supports up to 100 texts per batch call.
+   * OpenAI supports multiple inputs in a single call.
+   */
+  async embedBatch(texts: string[]): Promise<RemoteEmbeddingResult[]> {
+    if (texts.length === 0) return [];
+
+    let allEmbeddings: number[][];
+
+    if (this.config.provider === "gemini") {
+      // Gemini batch API supports up to 100 items
+      const GEMINI_BATCH_SIZE = 100;
+      allEmbeddings = [];
+      for (let i = 0; i < texts.length; i += GEMINI_BATCH_SIZE) {
+        const batch = texts.slice(i, i + GEMINI_BATCH_SIZE);
+        const batchResults = await geminiBatchEmbed(batch, this.config.model, this.apiKey);
+        allEmbeddings.push(...batchResults);
+      }
+    } else {
+      // OpenAI: send all at once (API handles batching internally)
+      // For very large batches, chunk to avoid request size limits
+      const OPENAI_BATCH_SIZE = 2048;
+      allEmbeddings = [];
+      for (let i = 0; i < texts.length; i += OPENAI_BATCH_SIZE) {
+        const batch = texts.slice(i, i + OPENAI_BATCH_SIZE);
+        const batchResults = await openaiEmbed(batch, this.config.model, this.apiKey, this.config.base_url, this.config.dimensions);
+        allEmbeddings.push(...batchResults);
+      }
+    }
+
+    // Truncate dimensions if configured
+    if (this.config.dimensions) {
+      allEmbeddings = allEmbeddings.map(emb =>
+        emb.length > this.config.dimensions! ? emb.slice(0, this.config.dimensions!) : emb
+      );
+    }
+
+    return allEmbeddings.map(embedding => ({
+      embedding,
+      model: this.modelUri,
+    }));
+  }
+}
+
+// =============================================================================
+// Factory & Config Parsing
+// =============================================================================
+
+/**
+ * Parse the embedding config from a CollectionConfig.
+ * Returns null if no remote embedding is configured.
+ */
+export function parseEmbeddingConfig(
+  config: { embedding?: RemoteEmbeddingConfig }
+): RemoteEmbeddingConfig | null {
+  if (!config.embedding) return null;
+
+  const { provider, model } = config.embedding;
+  if (!provider || !model) return null;
+
+  if (provider !== "openai" && provider !== "gemini") {
+    throw new Error(
+      `Unsupported embedding provider: "${provider}". Supported: "openai", "gemini".`
+    );
+  }
+
+  return config.embedding;
+}
+
+/**
+ * Create a RemoteEmbeddingProvider from config, or return null if not configured.
+ */
+export function createRemoteEmbeddingProvider(
+  config: { embedding?: RemoteEmbeddingConfig }
+): RemoteEmbeddingProvider | null {
+  const embeddingConfig = parseEmbeddingConfig(config);
+  if (!embeddingConfig) return null;
+  return new RemoteEmbeddingProvider(embeddingConfig);
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -33,6 +33,7 @@ import type {
   CollectionConfig,
   ContextMap,
 } from "./collections.js";
+import type { RemoteEmbeddingProvider } from "./remote-embedding.js";
 
 // =============================================================================
 // Configuration
@@ -985,6 +986,8 @@ export type Store = {
   dbPath: string;
   /** Optional LlamaCpp instance for this store (overrides the global singleton) */
   llm?: LlamaCpp;
+  /** Optional remote embedding provider (overrides local GGUF for embeddings) */
+  remoteEmbedding?: RemoteEmbeddingProvider;
   close: () => void;
   ensureVecTable: (dimensions: number) => void;
 
@@ -1022,7 +1025,7 @@ export type Store = {
 
   // Search
   searchFTS: (query: string, limit?: number, collectionName?: string) => SearchResult[];
-  searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => Promise<SearchResult[]>;
+  searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[], remoteProvider?: RemoteEmbeddingProvider) => Promise<SearchResult[]>;
 
   // Query expansion & reranking
   expandQuery: (query: string, model?: string, intent?: string) => Promise<ExpandedQuery[]>;
@@ -1305,10 +1308,11 @@ export async function generateEmbeddings(
   options?: EmbedOptions
 ): Promise<EmbedResult> {
   const db = store.db;
-  const model = options?.model ?? DEFAULT_EMBED_MODEL;
   const now = new Date().toISOString();
   const { maxDocsPerBatch, maxBatchBytes } = resolveEmbedOptions(options);
   const encoder = new TextEncoder();
+  const remote = store.remoteEmbedding;
+  const model = remote ? remote.modelUri : (options?.model ?? DEFAULT_EMBED_MODEL);
 
   if (options?.force) {
     clearAllEmbeddings(db);
@@ -1323,7 +1327,12 @@ export async function generateEmbeddings(
   const totalDocs = docsToEmbed.length;
   const startTime = Date.now();
 
-  // Use store's LlamaCpp or global singleton, wrapped in a session
+  // Remote embedding path — no LlamaCpp session needed
+  if (remote) {
+    return generateEmbeddingsRemote(store, remote, model, docsToEmbed, totalBytes, totalDocs, now, maxDocsPerBatch, maxBatchBytes, options);
+  }
+
+  // Local GGUF path — use store's LlamaCpp or global singleton, wrapped in a session
   const llm = getLlm(store);
 
   // Create a session manager for this llm instance
@@ -1447,6 +1456,134 @@ export async function generateEmbeddings(
 }
 
 /**
+ * Generate embeddings using a remote provider (Gemini, OpenAI, etc.).
+ * Skips nomic-style prefixes — remote models handle their own formatting.
+ * Uses char-based chunking (no local tokenizer needed).
+ */
+async function generateEmbeddingsRemote(
+  store: Store,
+  remote: RemoteEmbeddingProvider,
+  model: string,
+  docsToEmbed: PendingEmbeddingDoc[],
+  totalBytes: number,
+  totalDocs: number,
+  now: string,
+  maxDocsPerBatch: number,
+  maxBatchBytes: number,
+  options?: EmbedOptions,
+): Promise<EmbedResult> {
+  const db = store.db;
+  const encoder = new TextEncoder();
+  const startTime = Date.now();
+  let chunksEmbedded = 0;
+  let errors = 0;
+  let bytesProcessed = 0;
+  let totalChunks = 0;
+  let vectorTableInitialized = false;
+  const BATCH_SIZE = 64; // Remote APIs handle larger batches efficiently
+
+  const batches = buildEmbeddingBatches(docsToEmbed, maxDocsPerBatch, maxBatchBytes);
+
+  for (const batchMeta of batches) {
+    const batchDocs = getEmbeddingDocsForBatch(db, batchMeta);
+    const batchChunks: ChunkItem[] = [];
+    const batchBytes = batchMeta.reduce((sum, doc) => sum + Math.max(0, doc.bytes), 0);
+
+    for (const doc of batchDocs) {
+      if (!doc.body.trim()) continue;
+      const title = extractTitle(doc.body, doc.path);
+      // Use char-based chunking for remote providers (no local tokenizer dependency)
+      const chunks = chunkDocument(doc.body);
+      for (let seq = 0; seq < chunks.length; seq++) {
+        batchChunks.push({
+          hash: doc.hash,
+          title,
+          text: chunks[seq]!.text,
+          seq,
+          pos: chunks[seq]!.pos,
+          tokens: 0, // Not applicable for remote
+          bytes: encoder.encode(chunks[seq]!.text).length,
+        });
+      }
+    }
+
+    totalChunks += batchChunks.length;
+
+    if (batchChunks.length === 0) {
+      bytesProcessed += batchBytes;
+      options?.onProgress?.({ chunksEmbedded, totalChunks, bytesProcessed, totalBytes, errors });
+      continue;
+    }
+
+    // Initialize vector table from first embedding dimensions
+    if (!vectorTableInitialized) {
+      const firstResult = await remote.embed(batchChunks[0]!.text);
+      store.ensureVecTable(firstResult.embedding.length);
+      vectorTableInitialized = true;
+    }
+
+    const totalBatchChunkBytes = batchChunks.reduce((sum, chunk) => sum + chunk.bytes, 0);
+    let batchChunkBytesProcessed = 0;
+
+    for (let batchStart = 0; batchStart < batchChunks.length; batchStart += BATCH_SIZE) {
+      const batchEnd = Math.min(batchStart + BATCH_SIZE, batchChunks.length);
+      const chunkBatch = batchChunks.slice(batchStart, batchEnd);
+      // Remote providers: send raw text without nomic-style prefixes
+      const texts = chunkBatch.map(chunk => chunk.text);
+
+      try {
+        const embeddings = await remote.embedBatch(texts);
+        for (let i = 0; i < chunkBatch.length; i++) {
+          const chunk = chunkBatch[i]!;
+          const result = embeddings[i];
+          if (result) {
+            insertEmbedding(db, chunk.hash, chunk.seq, chunk.pos, new Float32Array(result.embedding), model, now);
+            chunksEmbedded++;
+          } else {
+            errors++;
+          }
+          batchChunkBytesProcessed += chunk.bytes;
+        }
+      } catch (err) {
+        // Batch failed — try individual embeddings as fallback
+        console.error("Remote batch embedding error, falling back to individual:", err);
+        for (const chunk of chunkBatch) {
+          try {
+            const result = await remote.embed(chunk.text);
+            insertEmbedding(db, chunk.hash, chunk.seq, chunk.pos, new Float32Array(result.embedding), model, now);
+            chunksEmbedded++;
+          } catch {
+            errors++;
+          }
+          batchChunkBytesProcessed += chunk.bytes;
+        }
+      }
+
+      const proportionalBytes = totalBatchChunkBytes === 0
+        ? batchBytes
+        : Math.min(batchBytes, Math.round((batchChunkBytesProcessed / totalBatchChunkBytes) * batchBytes));
+      options?.onProgress?.({
+        chunksEmbedded,
+        totalChunks,
+        bytesProcessed: bytesProcessed + proportionalBytes,
+        totalBytes,
+        errors,
+      });
+    }
+
+    bytesProcessed += batchBytes;
+    options?.onProgress?.({ chunksEmbedded, totalChunks, bytesProcessed, totalBytes, errors });
+  }
+
+  return {
+    docsProcessed: totalDocs,
+    chunksEmbedded,
+    errors,
+    durationMs: Date.now() - startTime,
+  };
+}
+
+/**
  * Create a new store instance with the given database path.
  * If no path is provided, uses the default path (~/.cache/qmd/index.sqlite).
  *
@@ -1498,7 +1635,7 @@ export function createStore(dbPath?: string): Store {
 
     // Search
     searchFTS: (query: string, limit?: number, collectionName?: string) => searchFTS(db, query, limit, collectionName),
-    searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => searchVec(db, query, model, limit, collectionName, session, precomputedEmbedding),
+    searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[], remoteProvider?: RemoteEmbeddingProvider) => searchVec(db, query, model, limit, collectionName, session, precomputedEmbedding, remoteProvider),
 
     // Query expansion & reranking
     expandQuery: (query: string, model?: string, intent?: string) => expandQuery(query, model, db, intent, store.llm),
@@ -2817,11 +2954,11 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
 // Vector Search
 // =============================================================================
 
-export async function searchVec(db: Database, query: string, model: string, limit: number = 20, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]): Promise<SearchResult[]> {
+export async function searchVec(db: Database, query: string, model: string, limit: number = 20, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[], remoteProvider?: RemoteEmbeddingProvider): Promise<SearchResult[]> {
   const tableExists = db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'`).get();
   if (!tableExists) return [];
 
-  const embedding = precomputedEmbedding ?? await getEmbedding(query, model, true, session);
+  const embedding = precomputedEmbedding ?? await getEmbedding(query, model, true, session, undefined, remoteProvider);
   if (!embedding) return [];
 
   // IMPORTANT: We use a two-step query approach here because sqlite-vec virtual tables
@@ -2907,8 +3044,19 @@ export async function searchVec(db: Database, query: string, model: string, limi
 // Embeddings
 // =============================================================================
 
-async function getEmbedding(text: string, model: string, isQuery: boolean, session?: ILLMSession, llmOverride?: LlamaCpp): Promise<number[] | null> {
-  // Format text using the appropriate prompt template
+async function getEmbedding(text: string, model: string, isQuery: boolean, session?: ILLMSession, llmOverride?: LlamaCpp, remoteProvider?: RemoteEmbeddingProvider): Promise<number[] | null> {
+  // Remote providers: send raw text without nomic-style prefixes
+  if (remoteProvider) {
+    try {
+      const result = await remoteProvider.embed(text);
+      return result.embedding;
+    } catch (error) {
+      console.error("Remote embedding error:", error);
+      return null;
+    }
+  }
+
+  // Local GGUF: format text using the appropriate prompt template
   const formattedText = isQuery ? formatQueryForEmbedding(text, model) : formatDocForEmbedding(text, undefined, model);
   const result = session
     ? await session.embed(formattedText, { model, isQuery })
@@ -3796,16 +3944,30 @@ export async function hybridQuery(
     }
 
     // Batch embed all vector queries in a single call
-    const llm = getLlm(store);
-    const textsToEmbed = vecQueries.map(q => formatQueryForEmbedding(q.text));
-    hooks?.onEmbedStart?.(textsToEmbed.length);
-    const embedStart = Date.now();
-    const embeddings = await llm.embedBatch(textsToEmbed);
-    hooks?.onEmbedDone?.(Date.now() - embedStart);
+    const remote = store.remoteEmbedding;
+    let precomputedEmbeddings: (number[] | null)[];
+
+    if (remote) {
+      // Remote providers: send raw text without nomic-style prefixes
+      const textsToEmbed = vecQueries.map(q => q.text);
+      hooks?.onEmbedStart?.(textsToEmbed.length);
+      const embedStart = Date.now();
+      const results = await remote.embedBatch(textsToEmbed);
+      precomputedEmbeddings = results.map(r => r.embedding);
+      hooks?.onEmbedDone?.(Date.now() - embedStart);
+    } else {
+      const llm = getLlm(store);
+      const textsToEmbed = vecQueries.map(q => formatQueryForEmbedding(q.text));
+      hooks?.onEmbedStart?.(textsToEmbed.length);
+      const embedStart = Date.now();
+      const embeddings = await llm.embedBatch(textsToEmbed);
+      precomputedEmbeddings = embeddings.map(e => e?.embedding ?? null);
+      hooks?.onEmbedDone?.(Date.now() - embedStart);
+    }
 
     // Run sqlite-vec lookups with pre-computed embeddings
     for (let i = 0; i < vecQueries.length; i++) {
-      const embedding = embeddings[i]?.embedding;
+      const embedding = precomputedEmbeddings[i];
       if (!embedding) continue;
 
       const vecResults = await store.searchVec(
@@ -4041,7 +4203,7 @@ export async function vectorSearchQuery(
   const queryTexts = [query, ...vecExpanded.map(q => q.query)];
   const allResults = new Map<string, VectorSearchResult>();
   for (const q of queryTexts) {
-    const vecResults = await store.searchVec(q, DEFAULT_EMBED_MODEL, limit, collection);
+    const vecResults = await store.searchVec(q, DEFAULT_EMBED_MODEL, limit, collection, undefined, undefined, store.remoteEmbedding);
     for (const r of vecResults) {
       const existing = allResults.get(r.filepath);
       if (!existing || r.score > existing.score) {
@@ -4177,15 +4339,28 @@ export async function structuredSearch(
         s.type === 'vec' || s.type === 'hyde'
     );
     if (vecSearches.length > 0) {
-      const llm = getLlm(store);
-      const textsToEmbed = vecSearches.map(s => formatQueryForEmbedding(s.query));
-      hooks?.onEmbedStart?.(textsToEmbed.length);
-      const embedStart = Date.now();
-      const embeddings = await llm.embedBatch(textsToEmbed);
-      hooks?.onEmbedDone?.(Date.now() - embedStart);
+      const remote = store.remoteEmbedding;
+      let precomputedEmbeddings: (number[] | null)[];
+
+      if (remote) {
+        const textsToEmbed = vecSearches.map(s => s.query);
+        hooks?.onEmbedStart?.(textsToEmbed.length);
+        const embedStart = Date.now();
+        const results = await remote.embedBatch(textsToEmbed);
+        precomputedEmbeddings = results.map(r => r.embedding);
+        hooks?.onEmbedDone?.(Date.now() - embedStart);
+      } else {
+        const llm = getLlm(store);
+        const textsToEmbed = vecSearches.map(s => formatQueryForEmbedding(s.query));
+        hooks?.onEmbedStart?.(textsToEmbed.length);
+        const embedStart = Date.now();
+        const embeddings = await llm.embedBatch(textsToEmbed);
+        precomputedEmbeddings = embeddings.map(e => e?.embedding ?? null);
+        hooks?.onEmbedDone?.(Date.now() - embedStart);
+      }
 
       for (let i = 0; i < vecSearches.length; i++) {
-        const embedding = embeddings[i]?.embedding;
+        const embedding = precomputedEmbeddings[i];
         if (!embedding) continue;
 
         for (const coll of collectionList) {

--- a/test/remote-embedding.test.ts
+++ b/test/remote-embedding.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Tests for remote embedding provider support.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  RemoteEmbeddingProvider,
+  resolveApiKey,
+  parseEmbeddingConfig,
+  createRemoteEmbeddingProvider,
+  type RemoteEmbeddingConfig,
+} from "../src/remote-embedding.js";
+
+// =============================================================================
+// resolveApiKey
+// =============================================================================
+
+describe("resolveApiKey", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("uses literal api_key from config", () => {
+    const config: RemoteEmbeddingConfig = {
+      provider: "gemini",
+      model: "gemini-embedding-2-preview",
+      api_key: "my-literal-key",
+    };
+    expect(resolveApiKey(config)).toBe("my-literal-key");
+  });
+
+  it("resolves ${ENV_VAR} syntax", () => {
+    process.env.MY_API_KEY = "resolved-key-from-env";
+    const config: RemoteEmbeddingConfig = {
+      provider: "gemini",
+      model: "gemini-embedding-2-preview",
+      api_key: "${MY_API_KEY}",
+    };
+    expect(resolveApiKey(config)).toBe("resolved-key-from-env");
+  });
+
+  it("falls back to GOOGLE_API_KEY for gemini provider", () => {
+    process.env.GOOGLE_API_KEY = "google-fallback-key";
+    const config: RemoteEmbeddingConfig = {
+      provider: "gemini",
+      model: "gemini-embedding-2-preview",
+    };
+    expect(resolveApiKey(config)).toBe("google-fallback-key");
+  });
+
+  it("falls back to OPENAI_API_KEY for openai provider", () => {
+    process.env.OPENAI_API_KEY = "openai-fallback-key";
+    const config: RemoteEmbeddingConfig = {
+      provider: "openai",
+      model: "text-embedding-3-small",
+    };
+    expect(resolveApiKey(config)).toBe("openai-fallback-key");
+  });
+
+  it("throws when no key is available", () => {
+    delete process.env.GOOGLE_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    const config: RemoteEmbeddingConfig = {
+      provider: "gemini",
+      model: "gemini-embedding-2-preview",
+    };
+    expect(() => resolveApiKey(config)).toThrow(/No API key found/);
+  });
+
+  it("does not resolve partial ${} patterns", () => {
+    process.env.GOOGLE_API_KEY = "fallback";
+    const config: RemoteEmbeddingConfig = {
+      provider: "gemini",
+      model: "gemini-embedding-2-preview",
+      api_key: "not-${a-var}",
+    };
+    // Should use the literal value (it's not a pure ${VAR} pattern)
+    expect(resolveApiKey(config)).toBe("not-${a-var}");
+  });
+});
+
+// =============================================================================
+// parseEmbeddingConfig
+// =============================================================================
+
+describe("parseEmbeddingConfig", () => {
+  it("returns null when no embedding config", () => {
+    expect(parseEmbeddingConfig({})).toBeNull();
+    expect(parseEmbeddingConfig({ embedding: undefined })).toBeNull();
+  });
+
+  it("returns null when missing provider or model", () => {
+    expect(parseEmbeddingConfig({
+      embedding: { provider: "gemini" } as any,
+    })).toBeNull();
+    expect(parseEmbeddingConfig({
+      embedding: { model: "foo" } as any,
+    })).toBeNull();
+  });
+
+  it("throws on unsupported provider", () => {
+    expect(() => parseEmbeddingConfig({
+      embedding: { provider: "unknown" as any, model: "foo" },
+    })).toThrow(/Unsupported embedding provider/);
+  });
+
+  it("parses valid gemini config", () => {
+    const config = parseEmbeddingConfig({
+      embedding: {
+        provider: "gemini",
+        model: "gemini-embedding-2-preview",
+        dimensions: 3072,
+      },
+    });
+    expect(config).toEqual({
+      provider: "gemini",
+      model: "gemini-embedding-2-preview",
+      dimensions: 3072,
+    });
+  });
+
+  it("parses valid openai config", () => {
+    const config = parseEmbeddingConfig({
+      embedding: {
+        provider: "openai",
+        model: "text-embedding-3-small",
+        base_url: "http://localhost:8080/v1",
+      },
+    });
+    expect(config).toEqual({
+      provider: "openai",
+      model: "text-embedding-3-small",
+      base_url: "http://localhost:8080/v1",
+    });
+  });
+});
+
+// =============================================================================
+// createRemoteEmbeddingProvider
+// =============================================================================
+
+describe("createRemoteEmbeddingProvider", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("returns null when no embedding config", () => {
+    expect(createRemoteEmbeddingProvider({})).toBeNull();
+  });
+
+  it("creates a provider with valid config", () => {
+    process.env.GOOGLE_API_KEY = "test-key";
+    const provider = createRemoteEmbeddingProvider({
+      embedding: {
+        provider: "gemini",
+        model: "gemini-embedding-2-preview",
+        dimensions: 3072,
+      },
+    });
+    expect(provider).not.toBeNull();
+    expect(provider!.provider).toBe("gemini");
+    expect(provider!.model).toBe("gemini-embedding-2-preview");
+    expect(provider!.modelUri).toBe("gemini:gemini-embedding-2-preview");
+    expect(provider!.dimensions).toBe(3072);
+  });
+});
+
+// =============================================================================
+// RemoteEmbeddingProvider
+// =============================================================================
+
+describe("RemoteEmbeddingProvider", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  describe("Gemini provider", () => {
+    it("calls the correct endpoint for single embed", async () => {
+      process.env.GOOGLE_API_KEY = "test-gemini-key";
+      const provider = new RemoteEmbeddingProvider({
+        provider: "gemini",
+        model: "gemini-embedding-2-preview",
+      });
+
+      const mockResponse = {
+        ok: true,
+        json: async () => ({
+          embedding: { values: [0.1, 0.2, 0.3] },
+        }),
+        text: async () => "",
+      };
+
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse as any);
+
+      const result = await provider.embed("hello world");
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [url, opts] = fetchSpy.mock.calls[0]!;
+      expect(url).toContain("generativelanguage.googleapis.com");
+      expect(url).toContain("gemini-embedding-2-preview:embedContent");
+      expect((opts as any).headers["x-goog-api-key"]).toBe("test-gemini-key");
+      expect(result.embedding).toEqual([0.1, 0.2, 0.3]);
+      expect(result.model).toBe("gemini:gemini-embedding-2-preview");
+    });
+
+    it("calls batch endpoint for multiple texts", async () => {
+      process.env.GOOGLE_API_KEY = "test-gemini-key";
+      const provider = new RemoteEmbeddingProvider({
+        provider: "gemini",
+        model: "gemini-embedding-2-preview",
+      });
+
+      const mockResponse = {
+        ok: true,
+        json: async () => ({
+          embeddings: [
+            { values: [0.1, 0.2] },
+            { values: [0.3, 0.4] },
+          ],
+        }),
+        text: async () => "",
+      };
+
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse as any);
+
+      const results = await provider.embedBatch(["hello", "world"]);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [url] = fetchSpy.mock.calls[0]!;
+      expect(url).toContain("batchEmbedContents");
+      expect(results).toHaveLength(2);
+      expect(results[0]!.embedding).toEqual([0.1, 0.2]);
+      expect(results[1]!.embedding).toEqual([0.3, 0.4]);
+    });
+
+    it("truncates to configured dimensions", async () => {
+      process.env.GOOGLE_API_KEY = "test-key";
+      const provider = new RemoteEmbeddingProvider({
+        provider: "gemini",
+        model: "test-model",
+        dimensions: 2,
+      });
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          embedding: { values: [0.1, 0.2, 0.3, 0.4] },
+        }),
+        text: async () => "",
+      } as any);
+
+      const result = await provider.embed("test");
+      expect(result.embedding).toEqual([0.1, 0.2]);
+    });
+
+    it("throws on API error", async () => {
+      process.env.GOOGLE_API_KEY = "test-key";
+      const provider = new RemoteEmbeddingProvider({
+        provider: "gemini",
+        model: "test-model",
+      });
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: false,
+        status: 403,
+        text: async () => "Forbidden",
+      } as any);
+
+      await expect(provider.embed("test")).rejects.toThrow(/Gemini embedding API error \(403\)/);
+    });
+  });
+
+  describe("OpenAI provider", () => {
+    it("calls the correct endpoint for single embed", async () => {
+      process.env.OPENAI_API_KEY = "test-openai-key";
+      const provider = new RemoteEmbeddingProvider({
+        provider: "openai",
+        model: "text-embedding-3-small",
+      });
+
+      const mockResponse = {
+        ok: true,
+        json: async () => ({
+          data: [{ embedding: [0.5, 0.6, 0.7], index: 0 }],
+        }),
+        text: async () => "",
+      };
+
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse as any);
+
+      const result = await provider.embed("hello");
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [url, opts] = fetchSpy.mock.calls[0]!;
+      expect(url).toBe("https://api.openai.com/v1/embeddings");
+      expect((opts as any).headers["Authorization"]).toBe("Bearer test-openai-key");
+      expect(result.embedding).toEqual([0.5, 0.6, 0.7]);
+      expect(result.model).toBe("openai:text-embedding-3-small");
+    });
+
+    it("uses custom base_url", async () => {
+      process.env.OPENAI_API_KEY = "test-key";
+      const provider = new RemoteEmbeddingProvider({
+        provider: "openai",
+        model: "local-model",
+        base_url: "http://localhost:8080/v1",
+      });
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ embedding: [1, 2, 3], index: 0 }],
+        }),
+        text: async () => "",
+      } as any);
+
+      await provider.embed("test");
+
+      const [url] = vi.mocked(globalThis.fetch).mock.calls[0]!;
+      expect(url).toBe("http://localhost:8080/v1/embeddings");
+    });
+
+    it("sends dimensions when configured", async () => {
+      process.env.OPENAI_API_KEY = "test-key";
+      const provider = new RemoteEmbeddingProvider({
+        provider: "openai",
+        model: "text-embedding-3-small",
+        dimensions: 256,
+      });
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ embedding: Array(256).fill(0), index: 0 }],
+        }),
+        text: async () => "",
+      } as any);
+
+      await provider.embed("test");
+
+      const [, opts] = vi.mocked(globalThis.fetch).mock.calls[0]!;
+      const body = JSON.parse((opts as any).body);
+      expect(body.dimensions).toBe(256);
+    });
+
+    it("handles batch embedding with correct index ordering", async () => {
+      process.env.OPENAI_API_KEY = "test-key";
+      const provider = new RemoteEmbeddingProvider({
+        provider: "openai",
+        model: "test-model",
+      });
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { embedding: [0.3, 0.4], index: 1 }, // Out of order
+            { embedding: [0.1, 0.2], index: 0 },
+          ],
+        }),
+        text: async () => "",
+      } as any);
+
+      const results = await provider.embedBatch(["first", "second"]);
+      expect(results[0]!.embedding).toEqual([0.1, 0.2]); // Sorted by index
+      expect(results[1]!.embedding).toEqual([0.3, 0.4]);
+    });
+  });
+
+  describe("empty batch", () => {
+    it("returns empty array for empty input", async () => {
+      process.env.GOOGLE_API_KEY = "test-key";
+      const provider = new RemoteEmbeddingProvider({
+        provider: "gemini",
+        model: "test-model",
+      });
+
+      const results = await provider.embedBatch([]);
+      expect(results).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds support for remote embedding APIs as an alternative to the local GGUF embedding model. Users can configure a remote provider in `index.yml` and use cloud embedding models like Gemini Embedding 2 or OpenAI's text-embedding-3-* family.

Addresses #403

## Changes

### New: `src/remote-embedding.ts` (319 lines)
- `RemoteEmbeddingProvider` class with `embed()` and `embedBatch()` methods
- **Gemini provider**: uses `embedContent` + `batchEmbedContents` endpoints (batches of 100)
- **OpenAI provider**: uses `/v1/embeddings` endpoint (supports custom `base_url` for local inference servers)
- API key resolution: `${ENV_VAR}` syntax in YAML, env fallbacks (`GOOGLE_API_KEY` / `OPENAI_API_KEY`), or literal values
- Factory function + config parser

### Modified: `src/store.ts`
- `Store` type gains optional `remoteEmbedding` field
- `generateEmbeddings()` routes to new `generateEmbeddingsRemote()` when provider is set
- Remote path uses char-based chunking (no local tokenizer dependency) and skips nomic-style prefixes
- `getEmbedding()`, `searchVec()`, `hybridQuery()`, `structuredSearch()`, `vectorSearchQuery()` all thread the remote provider through

### Modified: `src/cli/qmd.ts`
- `getStore()` creates and attaches remote provider from YAML config
- `qmd status` displays remote model info (e.g. `gemini gemini-embedding-2-preview (3072d) (remote)`)
- `qmd embed` shows correct model name for remote providers

### Config format (`index.yml`)
```yaml
embedding:
  provider: gemini  # or "openai"
  model: gemini-embedding-2-preview
  api_key: \${GOOGLE_API_KEY}  # env var, literal, or fallback
  dimensions: 3072  # optional
```

### Tests: `test/remote-embedding.test.ts` (22 tests)
- API key resolution (literal, env var, fallbacks, missing)
- Config parsing (valid, invalid, missing fields)
- Gemini + OpenAI API calls with mocked fetch (endpoints, headers, batch, dimensions, errors)

## Design Decisions

- **Zero breaking changes** — local GGUF remains the default when no `embedding` section is in config
- **No nomic-style prefixes** for remote providers — they handle their own formatting
- **Reranking + query expansion stay on local models** — only the embedding path changes
- **Batch-efficient** — Gemini batches of 100 via `batchEmbedContents`, OpenAI sends arrays natively
- **Char-based chunking** for remote path avoids needing a local tokenizer

## Testing

- Unit tests: all 22 pass
- Live tested with Gemini Embedding 2 (`gemini-embedding-2-preview`, 3072 dimensions):
  - `qmd embed` successfully generates embeddings via Gemini API
  - `qmd vsearch` returns correctly ranked results using remote embeddings
  - `qmd status` shows `gemini gemini-embedding-2-preview (3072d) (remote)`
- Existing tests: all pass (no regressions)