### PR TITLE
fix(nix): correct CLI entry point path in wrapper

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
             cp package.json $out/lib/qmd/
 
             makeWrapper ${pkgs.bun}/bin/bun $out/bin/qmd \
-              --add-flags "$out/lib/qmd/src/qmd.ts" \
+              --add-flags "$out/lib/qmd/src/cli/qmd.ts" \
               --set DYLD_LIBRARY_PATH "${pkgs.sqlite.out}/lib" \
               --set LD_LIBRARY_PATH "${pkgs.sqlite.out}/lib"
           '';


### PR DESCRIPTION
Fix the wrapper to point at `src/cli/qmd.ts` instead of `src/qmd.ts`, which no longer exists after the CLI was moved.