### PR TITLE
Add external model provider support for embedding & reranking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Changes
+
+- **External model providers** — embedding and reranking can now run on a
+  remote OpenAI-compatible server (e.g. oMLX with MLX models) instead of
+  local GGUF. Set `QMD_REMOTE_URL` to enable; without it, behavior is
+  unchanged. Query expansion stays on local LlamaCpp. Useful on
+  memory-constrained Macs where MLX models via oMLX are significantly
+  faster than node-llama-cpp GGUF.
+
 ### Fixes
 
 - Sync stale `bun.lock` (`better-sqlite3` 11.x → 12.x). CI and release

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -76,7 +76,9 @@ import {
   syncConfigToDb,
   type ReindexResult,
 } from "../store.js";
-import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, withLLMSession, pullModels, DEFAULT_EMBED_MODEL_URI, DEFAULT_GENERATE_MODEL_URI, DEFAULT_RERANK_MODEL_URI, DEFAULT_MODEL_CACHE_DIR } from "../llm.js";
+import { LlamaCpp, disposeDefaultLlamaCpp, getDefaultLlamaCpp, setDefaultLLM, withLLMSession, pullModels, DEFAULT_EMBED_MODEL_URI, DEFAULT_GENERATE_MODEL_URI, DEFAULT_RERANK_MODEL_URI, DEFAULT_MODEL_CACHE_DIR } from "../llm.js";
+import { RemoteLLM } from "../remote-llm.js";
+import { HybridLLM } from "../hybrid-llm.js";
 import {
   formatSearchResults,
   formatDocuments,
@@ -102,6 +104,19 @@ import { getEmbeddedQmdSkillContent, getEmbeddedQmdSkillFiles } from "../embedde
 // Enable production mode - allows using default database path
 // Tests must set INDEX_PATH or use createStore() with explicit path
 enableProductionMode();
+
+// Configure remote LLM if QMD_REMOTE_URL is set.
+// Routes embed/rerank to remote server, keeps generate/expandQuery local.
+if (process.env.QMD_REMOTE_URL) {
+  const remote = new RemoteLLM({
+    baseUrl: process.env.QMD_REMOTE_URL,
+    embedModel: process.env.QMD_REMOTE_EMBED_MODEL,
+    rerankModel: process.env.QMD_REMOTE_RERANK_MODEL,
+    apiKey: process.env.QMD_REMOTE_API_KEY,
+  });
+  const local = new LlamaCpp({});
+  setDefaultLLM(new HybridLLM(local, remote));
+}
 
 // =============================================================================
 // Store/DB lifecycle (no legacy singletons in store.ts)

--- a/src/hybrid-llm.ts
+++ b/src/hybrid-llm.ts
@@ -1,0 +1,60 @@
+/**
+ * hybrid-llm.ts - Combines local LlamaCpp (generate/expandQuery) with remote LLM (embed/rerank).
+ *
+ * When QMD_REMOTE_URL is set, this class routes:
+ * - embed/embedBatch/rerank → remote server (e.g. omlx with bge-m3, bge-reranker)
+ * - generate/expandQuery → local LlamaCpp (QMD fine-tuned model)
+ */
+
+import type {
+  LLM,
+  EmbedOptions,
+  EmbeddingResult,
+  GenerateOptions,
+  GenerateResult,
+  ModelInfo,
+  RerankOptions,
+  RerankResult,
+  RerankDocument,
+  Queryable,
+} from "./llm.js";
+
+export class HybridLLM implements LLM {
+  readonly isRemote = true;
+
+  constructor(
+    private local: LLM,
+    private remote: LLM,
+  ) {}
+
+  async embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null> {
+    return this.remote.embed(text, options);
+  }
+
+  async embedBatch(texts: string[]): Promise<(EmbeddingResult | null)[]> {
+    return this.remote.embedBatch(texts);
+  }
+
+  async rerank(query: string, documents: RerankDocument[], options?: RerankOptions): Promise<RerankResult> {
+    return this.remote.rerank(query, documents, options);
+  }
+
+  async generate(prompt: string, options?: GenerateOptions): Promise<GenerateResult | null> {
+    return this.local.generate(prompt, options);
+  }
+
+  async expandQuery(query: string, options?: { context?: string; includeLexical?: boolean }): Promise<Queryable[]> {
+    return this.local.expandQuery(query, options);
+  }
+
+  async modelExists(model: string): Promise<ModelInfo> {
+    // Try remote first, fallback to local
+    const remoteResult = await this.remote.modelExists(model);
+    if (remoteResult.exists) return remoteResult;
+    return this.local.modelExists(model);
+  }
+
+  async dispose(): Promise<void> {
+    await Promise.all([this.local.dispose(), this.remote.dispose()]);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,11 @@ import {
 } from "./store.js";
 import {
   LlamaCpp,
+  setDefaultLLM,
+  type LLM,
 } from "./llm.js";
+import { RemoteLLM } from "./remote-llm.js";
+import { HybridLLM } from "./hybrid-llm.js";
 import {
   setConfigSource,
   loadConfig,
@@ -116,6 +120,39 @@ export { getDefaultDbPath } from "./store.js";
 
 // Re-export Maintenance class for CLI housekeeping operations
 export { Maintenance } from "./maintenance.js";
+
+// Re-export remote LLM types for advanced consumers
+export { RemoteLLM, type RemoteLLMConfig } from "./remote-llm.js";
+export { HybridLLM } from "./hybrid-llm.js";
+
+/**
+ * Create the appropriate LLM instance based on environment configuration.
+ *
+ * When QMD_REMOTE_URL is set, creates a HybridLLM that routes:
+ * - embed/rerank → remote server (e.g. omlx with bge-m3, bge-reranker)
+ * - generate/expandQuery → local LlamaCpp (QMD fine-tuned model)
+ *
+ * Without QMD_REMOTE_URL, returns a standard LlamaCpp instance.
+ */
+function createLLM(): LLM {
+  const local = new LlamaCpp({
+    inactivityTimeoutMs: 5 * 60 * 1000,
+    disposeModelsOnInactivity: true,
+  });
+
+  const remoteUrl = process.env.QMD_REMOTE_URL;
+  if (remoteUrl) {
+    const remote = new RemoteLLM({
+      baseUrl: remoteUrl,
+      embedModel: process.env.QMD_REMOTE_EMBED_MODEL,
+      rerankModel: process.env.QMD_REMOTE_RERANK_MODEL,
+      apiKey: process.env.QMD_REMOTE_API_KEY,
+    });
+    return new HybridLLM(local, remote);
+  }
+
+  return local;
+}
 
 /**
  * Progress info emitted during update() for each file processed.
@@ -358,12 +395,9 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
   }
   // else: DB-only mode — no external config, use existing store_collections
 
-  // Create a per-store LlamaCpp instance — lazy-loads models on first use,
+  // Create a per-store LLM instance — lazy-loads models on first use,
   // auto-unloads after 5 min inactivity to free VRAM.
-  const llm = new LlamaCpp({
-    inactivityTimeoutMs: 5 * 60 * 1000,
-    disposeModelsOnInactivity: true,
-  });
+  const llm = createLLM();
   internal.llm = llm;
 
   const store: QMDStore = {

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -318,6 +318,11 @@ export interface LLM {
   embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null>;
 
   /**
+   * Batch embed multiple texts efficiently
+   */
+  embedBatch(texts: string[]): Promise<(EmbeddingResult | null)[]>;
+
+  /**
    * Generate text completion
    */
   generate(prompt: string, options?: GenerateOptions): Promise<GenerateResult | null>;
@@ -338,6 +343,12 @@ export interface LLM {
    * Returns list of documents with relevance scores (higher = more relevant)
    */
   rerank(query: string, documents: RerankDocument[], options?: RerankOptions): Promise<RerankResult>;
+
+  /**
+   * Whether this LLM uses a remote provider (affects text formatting).
+   * When true, embedding text is sent raw without task prefixes.
+   */
+  readonly isRemote?: boolean;
 
   /**
    * Dispose of resources
@@ -1274,11 +1285,11 @@ export class LlamaCpp implements LLM {
  * Coordinates with LlamaCpp idle timeout to prevent disposal during active sessions.
  */
 class LLMSessionManager {
-  private llm: LlamaCpp;
+  private llm: LLM;
   private _activeSessionCount = 0;
   private _inFlightOperations = 0;
 
-  constructor(llm: LlamaCpp) {
+  constructor(llm: LLM) {
     this.llm = llm;
   }
 
@@ -1314,7 +1325,7 @@ class LLMSessionManager {
     this._inFlightOperations = Math.max(0, this._inFlightOperations - 1);
   }
 
-  getLlamaCpp(): LlamaCpp {
+  getLLM(): LLM {
     return this.llm;
   }
 }
@@ -1417,18 +1428,18 @@ class LLMSession implements ILLMSession {
   }
 
   async embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null> {
-    return this.withOperation(() => this.manager.getLlamaCpp().embed(text, options));
+    return this.withOperation(() => this.manager.getLLM().embed(text, options));
   }
 
   async embedBatch(texts: string[]): Promise<(EmbeddingResult | null)[]> {
-    return this.withOperation(() => this.manager.getLlamaCpp().embedBatch(texts));
+    return this.withOperation(() => this.manager.getLLM().embedBatch(texts));
   }
 
   async expandQuery(
     query: string,
     options?: { context?: string; includeLexical?: boolean }
   ): Promise<Queryable[]> {
-    return this.withOperation(() => this.manager.getLlamaCpp().expandQuery(query, options));
+    return this.withOperation(() => this.manager.getLLM().expandQuery(query, options));
   }
 
   async rerank(
@@ -1436,7 +1447,7 @@ class LLMSession implements ILLMSession {
     documents: RerankDocument[],
     options?: RerankOptions
   ): Promise<RerankResult> {
-    return this.withOperation(() => this.manager.getLlamaCpp().rerank(query, documents, options));
+    return this.withOperation(() => this.manager.getLLM().rerank(query, documents, options));
   }
 }
 
@@ -1447,8 +1458,8 @@ let defaultSessionManager: LLMSessionManager | null = null;
  * Get the session manager for the default LlamaCpp instance.
  */
 function getSessionManager(): LLMSessionManager {
-  const llm = getDefaultLlamaCpp();
-  if (!defaultSessionManager || defaultSessionManager.getLlamaCpp() !== llm) {
+  const llm = getDefaultLLM();
+  if (!defaultSessionManager || defaultSessionManager.getLLM() !== llm) {
     defaultSessionManager = new LLMSessionManager(llm);
   }
   return defaultSessionManager;
@@ -1487,7 +1498,7 @@ export async function withLLMSession<T>(
  * Unlike withLLMSession, this does not use the global singleton.
  */
 export async function withLLMSessionForLlm<T>(
-  llm: LlamaCpp,
+  llm: LLM,
   fn: (session: ILLMSession) => Promise<T>,
   options?: LLMSessionOptions
 ): Promise<T> {
@@ -1514,33 +1525,49 @@ export function canUnloadLLM(): boolean {
 // Singleton for default LlamaCpp instance
 // =============================================================================
 
-let defaultLlamaCpp: LlamaCpp | null = null;
+let defaultLLMInstance: LLM | null = null;
 
 /**
- * Get the default LlamaCpp instance (creates one if needed)
+ * Get the default LLM instance (creates one if needed).
+ * Returns a LlamaCpp by default, or a HybridLLM/RemoteLLM if QMD_REMOTE_URL is set.
  */
-export function getDefaultLlamaCpp(): LlamaCpp {
-  if (!defaultLlamaCpp) {
+export function getDefaultLLM(): LLM {
+  if (!defaultLLMInstance) {
     const embedModel = process.env.QMD_EMBED_MODEL;
-    defaultLlamaCpp = new LlamaCpp(embedModel ? { embedModel } : {});
+    defaultLLMInstance = new LlamaCpp(embedModel ? { embedModel } : {});
   }
-  return defaultLlamaCpp;
+  return defaultLLMInstance;
+}
+
+/** @deprecated Use getDefaultLLM() instead */
+export function getDefaultLlamaCpp(): LlamaCpp {
+  return getDefaultLLM() as LlamaCpp;
 }
 
 /**
- * Set a custom default LlamaCpp instance (useful for testing)
+ * Set a custom default LLM instance (useful for testing or remote providers)
  */
+export function setDefaultLLM(llm: LLM | null): void {
+  defaultLLMInstance = llm;
+}
+
+/** @deprecated Use setDefaultLLM() instead */
 export function setDefaultLlamaCpp(llm: LlamaCpp | null): void {
-  defaultLlamaCpp = llm;
+  setDefaultLLM(llm);
 }
 
 /**
- * Dispose the default LlamaCpp instance if it exists.
+ * Dispose the default LLM instance if it exists.
  * Call this before process exit to prevent NAPI crashes.
  */
-export async function disposeDefaultLlamaCpp(): Promise<void> {
-  if (defaultLlamaCpp) {
-    await defaultLlamaCpp.dispose();
-    defaultLlamaCpp = null;
+export async function disposeDefaultLLM(): Promise<void> {
+  if (defaultLLMInstance) {
+    await defaultLLMInstance.dispose();
+    defaultLLMInstance = null;
   }
+}
+
+/** @deprecated Use disposeDefaultLLM() instead */
+export async function disposeDefaultLlamaCpp(): Promise<void> {
+  return disposeDefaultLLM();
 }

--- a/src/remote-llm.ts
+++ b/src/remote-llm.ts
@@ -1,0 +1,253 @@
+/**
+ * remote-llm.ts - Remote LLM provider for OpenAI-compatible embedding & reranking servers.
+ *
+ * Supports:
+ * - POST /v1/embeddings (OpenAI-compatible)
+ * - POST /v1/rerank (Cohere-compatible)
+ *
+ * Used with servers like omlx that serve MLX format models (e.g. bge-m3, bge-reranker).
+ */
+
+import type {
+  LLM,
+  EmbedOptions,
+  EmbeddingResult,
+  GenerateOptions,
+  GenerateResult,
+  ModelInfo,
+  RerankOptions,
+  RerankResult,
+  RerankDocument,
+  Queryable,
+} from "./llm.js";
+
+export type RemoteLLMConfig = {
+  /** Base URL for the API (e.g. "http://localhost:8000/v1") */
+  baseUrl: string;
+  /** Optional API key for authentication */
+  apiKey?: string;
+  /** Embedding model name (e.g. "bge-m3") */
+  embedModel?: string;
+  /** Reranking model name (e.g. "bge-reranker-v2-m3") */
+  rerankModel?: string;
+  /** Request timeout in ms for embeddings (default: 30000) */
+  timeoutMs?: number;
+  /** Request timeout in ms for reranking (default: 300000 = 5 min, reranking is slower) */
+  rerankTimeoutMs?: number;
+};
+
+const debug = !!process.env.QMD_REMOTE_DEBUG;
+
+export class RemoteLLM implements LLM {
+  private baseUrl: string;
+  private apiKey?: string;
+  private embedModel: string;
+  private rerankModel: string;
+  private timeoutMs: number;
+  private rerankTimeoutMs: number;
+
+  readonly isRemote = true;
+
+  constructor(config: RemoteLLMConfig) {
+    // Normalize: strip trailing slash
+    this.baseUrl = config.baseUrl.replace(/\/+$/, "");
+    this.apiKey = config.apiKey;
+    this.embedModel = config.embedModel ?? "bge-m3";
+    this.rerankModel = config.rerankModel ?? "bge-reranker-v2-m3";
+    this.timeoutMs = config.timeoutMs ?? 30_000;
+    this.rerankTimeoutMs = config.rerankTimeoutMs ?? 300_000;
+    if (debug) {
+      process.stderr.write(`[remote-llm] init baseUrl=${this.baseUrl} embed=${this.embedModel} rerank=${this.rerankModel}\n`);
+    }
+  }
+
+  private headers(): Record<string, string> {
+    const h: Record<string, string> = { "Content-Type": "application/json" };
+    if (this.apiKey) {
+      h["Authorization"] = `Bearer ${this.apiKey}`;
+    }
+    return h;
+  }
+
+  private async fetchWithTimeout(url: string, init: RequestInit, timeoutMs?: number): Promise<Response> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs ?? this.timeoutMs);
+    try {
+      const resp = await fetch(url, { ...init, signal: controller.signal });
+      if (!resp.ok) {
+        const body = await resp.text().catch(() => "");
+        throw new Error(`Remote LLM error ${resp.status}: ${body}`);
+      }
+      return resp;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async embed(text: string, _options?: EmbedOptions): Promise<EmbeddingResult | null> {
+    const results = await this.embedBatch([text]);
+    return results[0] ?? null;
+  }
+
+  async embedBatch(texts: string[]): Promise<(EmbeddingResult | null)[]> {
+    if (texts.length === 0) return [];
+
+    // Sanitize inputs to avoid remote tokenizer errors:
+    // 1. Replace empty/non-string entries with a space
+    // 2. Fix broken Unicode from chunk splitting (unpaired surrogates from emoji split mid-codepoint)
+    const sanitized = texts.map((t, i) => {
+      if (typeof t !== "string" || t.trim().length === 0) {
+        if (debug) process.stderr.write(`[remote-llm] warning: empty text at index ${i}, replacing with placeholder\n`);
+        return " ";
+      }
+      // Remove unpaired surrogates and replacement characters that crash remote tokenizers.
+      // This happens when chunking splits a surrogate pair (emoji) in half.
+      return t.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]|\uFFFD/g, "");
+    });
+
+    if (debug) {
+      process.stderr.write(`[remote-llm] POST ${this.baseUrl}/embeddings model=${this.embedModel} texts=${sanitized.length}\n`);
+    }
+    const start = Date.now();
+
+    try {
+      const resp = await this.fetchWithTimeout(`${this.baseUrl}/embeddings`, {
+        method: "POST",
+        headers: this.headers(),
+        body: JSON.stringify({
+          model: this.embedModel,
+          input: sanitized,
+        }),
+      });
+
+      const json = await resp.json() as {
+        data: { embedding: number[]; index: number }[];
+        model: string;
+      };
+
+      if (debug) {
+        const dim = json.data[0]?.embedding.length ?? 0;
+        process.stderr.write(`[remote-llm] embed done ${Date.now() - start}ms results=${json.data.length} dim=${dim}\n`);
+      }
+
+      // Map response back to input order
+      const resultMap = new Map<number, number[]>();
+      for (const item of json.data) {
+        resultMap.set(item.index, item.embedding);
+      }
+
+      return texts.map((_, i) => {
+        const embedding = resultMap.get(i);
+        if (!embedding) return null;
+        return { embedding, model: json.model || this.embedModel };
+      });
+    } catch (error) {
+      if (debug) {
+        const lengths = sanitized.map((t, i) => `[${i}]:${t.length}`).join(" ");
+        process.stderr.write(`[remote-llm] embed FAILED batch of ${sanitized.length}, retrying individually. lengths: ${lengths}\n`);
+      }
+      // Batch failed — retry each text individually to isolate bad inputs
+      const results: (EmbeddingResult | null)[] = [];
+      for (let i = 0; i < sanitized.length; i++) {
+        try {
+          const resp = await this.fetchWithTimeout(`${this.baseUrl}/embeddings`, {
+            method: "POST",
+            headers: this.headers(),
+            body: JSON.stringify({ model: this.embedModel, input: [sanitized[i]] }),
+          });
+          const json = await resp.json() as { data: { embedding: number[]; index: number }[]; model: string };
+          const emb = json.data[0]?.embedding;
+          results.push(emb ? { embedding: emb, model: json.model || this.embedModel } : null);
+        } catch (e) {
+          if (debug) {
+            const preview = sanitized[i]!.slice(0, 120).replace(/\n/g, "\\n");
+            process.stderr.write(`[remote-llm] embed single[${i}] FAILED len=${sanitized[i]!.length} preview="${preview}": ${e}\n`);
+          }
+          results.push(null);
+        }
+      }
+      return results;
+    }
+  }
+
+  async rerank(
+    query: string,
+    documents: RerankDocument[],
+    _options?: RerankOptions
+  ): Promise<RerankResult> {
+    if (documents.length === 0) {
+      return { results: [], model: this.rerankModel };
+    }
+
+    const texts = documents.map((d) => d.text);
+
+    if (debug) {
+      process.stderr.write(`[remote-llm] POST ${this.baseUrl}/rerank model=${this.rerankModel} docs=${texts.length} query="${query.slice(0, 60)}"\n`);
+    }
+    const start = Date.now();
+
+    try {
+      const resp = await this.fetchWithTimeout(`${this.baseUrl}/rerank`, {
+        method: "POST",
+        headers: this.headers(),
+        body: JSON.stringify({
+          model: this.rerankModel,
+          query,
+          documents: texts,
+          return_documents: false,
+        }),
+      }, this.rerankTimeoutMs);
+
+      const json = await resp.json() as {
+        results: { index: number; relevance_score: number }[];
+      };
+
+      if (debug) {
+        const top = json.results[0];
+        process.stderr.write(`[remote-llm] rerank done ${Date.now() - start}ms results=${json.results.length} top_score=${top?.relevance_score?.toFixed(4) ?? "N/A"}\n`);
+      }
+
+      const results = json.results.map((r) => ({
+        file: documents[r.index]?.file ?? "",
+        score: r.relevance_score,
+        index: r.index,
+      }));
+
+      return { results, model: this.rerankModel };
+    } catch (error) {
+      console.error("Remote rerank error:", error);
+      // Return all documents with score 0 as fallback
+      return {
+        results: documents.map((d, i) => ({ file: d.file, score: 0, index: i })),
+        model: this.rerankModel,
+      };
+    }
+  }
+
+  async generate(_prompt: string, _options?: GenerateOptions): Promise<GenerateResult | null> {
+    throw new Error("RemoteLLM does not support generate(). Use local LlamaCpp for query expansion.");
+  }
+
+  async expandQuery(_query: string, _options?: { context?: string; includeLexical?: boolean }): Promise<Queryable[]> {
+    throw new Error("RemoteLLM does not support expandQuery(). Use local LlamaCpp for query expansion.");
+  }
+
+  async modelExists(model: string): Promise<ModelInfo> {
+    try {
+      const resp = await this.fetchWithTimeout(`${this.baseUrl}/models`, {
+        method: "GET",
+        headers: this.headers(),
+      });
+      const json = await resp.json() as { data?: { id: string }[] };
+      const models = json.data ?? [];
+      const exists = models.some((m) => m.id === model);
+      return { name: model, exists };
+    } catch {
+      return { name: model, exists: false };
+    }
+  }
+
+  async dispose(): Promise<void> {
+    // No-op: no local resources to clean up
+  }
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -24,6 +24,7 @@ import {
   formatQueryForEmbedding,
   formatDocForEmbedding,
   withLLMSessionForLlm,
+  type LLM,
   type RerankDocument,
   type ILLMSession,
 } from "./llm.js";
@@ -62,7 +63,7 @@ export const CHUNK_WINDOW_CHARS = CHUNK_WINDOW_TOKENS * 4;  // 800 chars
  * Get the LlamaCpp instance for a store — prefers the store's own instance,
  * falls back to the global singleton.
  */
-function getLlm(store: Store): LlamaCpp {
+function getLlm(store: Store): LLM {
   return store.llm ?? getDefaultLlamaCpp();
 }
 
@@ -983,8 +984,8 @@ function ensureVecTableInternal(db: Database, dimensions: number): void {
 export type Store = {
   db: Database;
   dbPath: string;
-  /** Optional LlamaCpp instance for this store (overrides the global singleton) */
-  llm?: LlamaCpp;
+  /** Optional LLM instance for this store (overrides the global singleton) */
+  llm?: LLM;
   close: () => void;
   ensureVecTable: (dimensions: number) => void;
 
@@ -1323,8 +1324,12 @@ export async function generateEmbeddings(
   const totalDocs = docsToEmbed.length;
   const startTime = Date.now();
 
-  // Use store's LlamaCpp or global singleton, wrapped in a session
+  // Use store's LLM or global singleton, wrapped in a session
   const llm = getLlm(store);
+  // Remote LLMs handle formatting server-side; skip local task prefixes
+  const formatDoc = llm.isRemote
+    ? (text: string, title?: string) => title ? `${title}\n${text}` : text
+    : formatDocForEmbedding;
 
   // Create a session manager for this llm instance
   const result = await withLLMSessionForLlm(llm, async (session) => {
@@ -1370,7 +1375,7 @@ export async function generateEmbeddings(
 
       if (!vectorTableInitialized) {
         const firstChunk = batchChunks[0]!;
-        const firstText = formatDocForEmbedding(firstChunk.text, firstChunk.title);
+        const firstText = formatDoc(firstChunk.text, firstChunk.title);
         const firstResult = await session.embed(firstText);
         if (!firstResult) {
           throw new Error("Failed to get embedding dimensions from first chunk");
@@ -1385,7 +1390,7 @@ export async function generateEmbeddings(
       for (let batchStart = 0; batchStart < batchChunks.length; batchStart += BATCH_SIZE) {
         const batchEnd = Math.min(batchStart + BATCH_SIZE, batchChunks.length);
         const chunkBatch = batchChunks.slice(batchStart, batchEnd);
-        const texts = chunkBatch.map(chunk => formatDocForEmbedding(chunk.text, chunk.title));
+        const texts = chunkBatch.map(chunk => formatDoc(chunk.text, chunk.title));
 
         try {
           const embeddings = await session.embedBatch(texts);
@@ -1404,7 +1409,7 @@ export async function generateEmbeddings(
           // Batch failed — try individual embeddings as fallback
           for (const chunk of chunkBatch) {
             try {
-              const text = formatDocForEmbedding(chunk.text, chunk.title);
+              const text = formatDoc(chunk.text, chunk.title);
               const result = await session.embed(text);
               if (result) {
                 insertEmbedding(db, chunk.hash, chunk.seq, chunk.pos, new Float32Array(result.embedding), model, now);
@@ -2094,7 +2099,15 @@ export async function chunkDocumentByTokens(
   overlapTokens: number = CHUNK_OVERLAP_TOKENS,
   windowTokens: number = CHUNK_WINDOW_TOKENS
 ): Promise<{ text: string; pos: number; tokens: number }[]> {
-  const llm = getDefaultLlamaCpp();
+  // Tokenization requires an LLM with tokenize() method (LlamaCpp or a fake in tests).
+  // If the default LLM doesn't support tokenization (e.g. HybridLLM), fall back to char-based chunking.
+  const defaultLlm = getDefaultLlamaCpp();
+  const hasTokenizer = typeof (defaultLlm as any).tokenize === 'function';
+  if (!hasTokenizer) {
+    return chunkDocument(content, maxTokens * 4, overlapTokens * 4, windowTokens * 4)
+      .map(c => ({ text: c.text, pos: c.pos, tokens: Math.ceil(c.text.length / 4) }));
+  }
+  const llm = defaultLlm as LlamaCpp;
 
   // Use moderate chars/token estimate (prose ~4, code ~2, mixed ~3)
   // If chunks exceed limit, they'll be re-split with actual ratio
@@ -2907,12 +2920,15 @@ export async function searchVec(db: Database, query: string, model: string, limi
 // Embeddings
 // =============================================================================
 
-async function getEmbedding(text: string, model: string, isQuery: boolean, session?: ILLMSession, llmOverride?: LlamaCpp): Promise<number[] | null> {
-  // Format text using the appropriate prompt template
-  const formattedText = isQuery ? formatQueryForEmbedding(text, model) : formatDocForEmbedding(text, undefined, model);
+async function getEmbedding(text: string, model: string, isQuery: boolean, session?: ILLMSession, llmOverride?: LLM): Promise<number[] | null> {
+  const llm = llmOverride ?? getDefaultLlamaCpp();
+  // Remote LLMs handle formatting server-side; skip local task prefixes
+  const formattedText = llm.isRemote
+    ? text
+    : isQuery ? formatQueryForEmbedding(text, model) : formatDocForEmbedding(text, undefined, model);
   const result = session
     ? await session.embed(formattedText, { model, isQuery })
-    : await (llmOverride ?? getDefaultLlamaCpp()).embed(formattedText, { model, isQuery });
+    : await llm.embed(formattedText, { model, isQuery });
   return result?.embedding || null;
 }
 
@@ -2965,7 +2981,7 @@ export function insertEmbedding(
 // Query expansion
 // =============================================================================
 
-export async function expandQuery(query: string, model: string = DEFAULT_QUERY_MODEL, db: Database, intent?: string, llmOverride?: LlamaCpp): Promise<ExpandedQuery[]> {
+export async function expandQuery(query: string, model: string = DEFAULT_QUERY_MODEL, db: Database, intent?: string, llmOverride?: LLM): Promise<ExpandedQuery[]> {
   // Check cache first — stored as JSON preserving types
   const cacheKey = getCacheKey("expandQuery", { query, model, ...(intent && { intent }) });
   const cached = getCachedResult(db, cacheKey);
@@ -3004,7 +3020,7 @@ export async function expandQuery(query: string, model: string = DEFAULT_QUERY_M
 // Reranking
 // =============================================================================
 
-export async function rerank(query: string, documents: { file: string; text: string }[], model: string = DEFAULT_RERANK_MODEL, db: Database, intent?: string, llmOverride?: LlamaCpp): Promise<{ file: string; score: number }[]> {
+export async function rerank(query: string, documents: { file: string; text: string }[], model: string = DEFAULT_RERANK_MODEL, db: Database, intent?: string, llmOverride?: LLM): Promise<{ file: string; score: number }[]> {
   // Prepend intent to rerank query so the reranker scores with domain context
   const rerankQuery = intent ? `${intent}\n\n${query}` : query;
 
@@ -3797,7 +3813,9 @@ export async function hybridQuery(
 
     // Batch embed all vector queries in a single call
     const llm = getLlm(store);
-    const textsToEmbed = vecQueries.map(q => formatQueryForEmbedding(q.text));
+    const textsToEmbed = llm.isRemote
+      ? vecQueries.map(q => q.text)
+      : vecQueries.map(q => formatQueryForEmbedding(q.text));
     hooks?.onEmbedStart?.(textsToEmbed.length);
     const embedStart = Date.now();
     const embeddings = await llm.embedBatch(textsToEmbed);
@@ -4178,7 +4196,9 @@ export async function structuredSearch(
     );
     if (vecSearches.length > 0) {
       const llm = getLlm(store);
-      const textsToEmbed = vecSearches.map(s => formatQueryForEmbedding(s.query));
+      const textsToEmbed = llm.isRemote
+        ? vecSearches.map(s => s.query)
+        : vecSearches.map(s => formatQueryForEmbedding(s.query));
       hooks?.onEmbedStart?.(textsToEmbed.length);
       const embedStart = Date.now();
       const embeddings = await llm.embedBatch(textsToEmbed);

--- a/test/remote-llm.test.ts
+++ b/test/remote-llm.test.ts
@@ -1,0 +1,400 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { RemoteLLM, type RemoteLLMConfig } from "../src/remote-llm.js";
+import { HybridLLM } from "../src/hybrid-llm.js";
+import http from "http";
+
+// =============================================================================
+// Mock HTTP Server
+// =============================================================================
+
+let server: http.Server;
+let baseUrl: string;
+
+// Track last requests for assertions
+let lastRequest: { path: string; body: any } | null = null;
+
+function createMockServer(): Promise<{ server: http.Server; baseUrl: string }> {
+  return new Promise((resolve) => {
+    const srv = http.createServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk) => (body += chunk));
+      req.on("end", () => {
+        const parsed = body ? JSON.parse(body) : {};
+        lastRequest = { path: req.url || "", body: parsed };
+
+        res.setHeader("Content-Type", "application/json");
+
+        if (req.url === "/v1/embeddings") {
+          const input = parsed.input as string[];
+          const data = input.map((text: string, index: number) => ({
+            embedding: Array.from({ length: 768 }, (_, i) => Math.sin(i + text.length)),
+            index,
+          }));
+          res.end(JSON.stringify({ data, model: parsed.model }));
+        } else if (req.url === "/v1/rerank") {
+          const docs = parsed.documents as string[];
+          const results = docs.map((_: string, index: number) => ({
+            index,
+            relevance_score: 1 - index * 0.1,
+          }));
+          res.end(JSON.stringify({ results }));
+        } else if (req.url === "/v1/models") {
+          res.end(JSON.stringify({
+            data: [
+              { id: "bge-m3" },
+              { id: "bge-reranker-v2-m3" },
+            ],
+          }));
+        } else {
+          res.statusCode = 404;
+          res.end(JSON.stringify({ error: "not found" }));
+        }
+      });
+    });
+
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      if (typeof addr === "object" && addr) {
+        resolve({ server: srv, baseUrl: `http://127.0.0.1:${addr.port}/v1` });
+      }
+    });
+  });
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("RemoteLLM", () => {
+  beforeAll(async () => {
+    const mock = await createMockServer();
+    server = mock.server;
+    baseUrl = mock.baseUrl;
+  });
+
+  afterAll(() => {
+    server?.close();
+  });
+
+  beforeEach(() => {
+    lastRequest = null;
+  });
+
+  function createRemote(overrides?: Partial<RemoteLLMConfig>): RemoteLLM {
+    return new RemoteLLM({
+      baseUrl,
+      embedModel: "bge-m3",
+      rerankModel: "bge-reranker-v2-m3",
+      ...overrides,
+    });
+  }
+
+  test("isRemote is true", () => {
+    const remote = createRemote();
+    expect(remote.isRemote).toBe(true);
+  });
+
+  // ── Embedding ──────────────────────────────────────────────────────────
+
+  test("embed() returns embedding for single text", async () => {
+    const remote = createRemote();
+    const result = await remote.embed("hello world");
+    expect(result).not.toBeNull();
+    expect(result!.embedding).toHaveLength(768);
+    expect(result!.model).toBe("bge-m3");
+  });
+
+  test("embedBatch() sends correct request format", async () => {
+    const remote = createRemote();
+    const texts = ["hello", "world", "test"];
+    const results = await remote.embedBatch(texts);
+
+    expect(results).toHaveLength(3);
+    expect(results.every((r) => r !== null)).toBe(true);
+    expect(lastRequest?.path).toBe("/v1/embeddings");
+    expect(lastRequest?.body.model).toBe("bge-m3");
+    expect(lastRequest?.body.input).toEqual(texts);
+  });
+
+  test("embedBatch() returns empty array for empty input", async () => {
+    const remote = createRemote();
+    const results = await remote.embedBatch([]);
+    expect(results).toEqual([]);
+  });
+
+  test("embedBatch() preserves order via index field", async () => {
+    const remote = createRemote();
+    const results = await remote.embedBatch(["short", "a longer piece of text"]);
+    expect(results).toHaveLength(2);
+    // Different input lengths produce different embeddings
+    expect(results[0]!.embedding).not.toEqual(results[1]!.embedding);
+  });
+
+  // ── Reranking ──────────────────────────────────────────────────────────
+
+  test("rerank() sends correct request format", async () => {
+    const remote = createRemote();
+    const docs = [
+      { file: "a.md", text: "first document" },
+      { file: "b.md", text: "second document" },
+    ];
+    const result = await remote.rerank("test query", docs);
+
+    expect(lastRequest?.path).toBe("/v1/rerank");
+    expect(lastRequest?.body.model).toBe("bge-reranker-v2-m3");
+    expect(lastRequest?.body.query).toBe("test query");
+    expect(lastRequest?.body.documents).toEqual(["first document", "second document"]);
+    expect(lastRequest?.body.return_documents).toBe(false);
+
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0]!.file).toBe("a.md");
+    expect(result.results[0]!.score).toBeGreaterThan(0);
+    expect(result.model).toBe("bge-reranker-v2-m3");
+  });
+
+  test("rerank() returns empty results for empty documents", async () => {
+    const remote = createRemote();
+    const result = await remote.rerank("query", []);
+    expect(result.results).toEqual([]);
+  });
+
+  // ── Model Exists ───────────────────────────────────────────────────────
+
+  test("modelExists() returns true for available model", async () => {
+    const remote = createRemote();
+    const result = await remote.modelExists("bge-m3");
+    expect(result.exists).toBe(true);
+    expect(result.name).toBe("bge-m3");
+  });
+
+  test("modelExists() returns false for unknown model", async () => {
+    const remote = createRemote();
+    const result = await remote.modelExists("nonexistent-model");
+    expect(result.exists).toBe(false);
+  });
+
+  // ── Unsupported Operations ─────────────────────────────────────────────
+
+  test("generate() throws not supported", async () => {
+    const remote = createRemote();
+    await expect(remote.generate("hello")).rejects.toThrow("not support");
+  });
+
+  test("expandQuery() throws not supported", async () => {
+    const remote = createRemote();
+    await expect(remote.expandQuery("test")).rejects.toThrow("not support");
+  });
+
+  // ── Auth Header ────────────────────────────────────────────────────────
+
+  test("sends Authorization header when apiKey is set", async () => {
+    // Create a server that captures headers
+    let capturedAuth: string | undefined;
+    const authServer = http.createServer((req, res) => {
+      capturedAuth = req.headers.authorization;
+      let body = "";
+      req.on("data", (chunk) => (body += chunk));
+      req.on("end", () => {
+        res.setHeader("Content-Type", "application/json");
+        const parsed = JSON.parse(body);
+        const input = parsed.input as string[];
+        res.end(JSON.stringify({
+          data: input.map((_, i: number) => ({ embedding: [0, 1, 2], index: i })),
+          model: "test",
+        }));
+      });
+    });
+
+    await new Promise<void>((resolve) => authServer.listen(0, "127.0.0.1", resolve));
+    const addr = authServer.address();
+    const port = typeof addr === "object" && addr ? addr.port : 0;
+
+    try {
+      const remote = new RemoteLLM({
+        baseUrl: `http://127.0.0.1:${port}/v1`,
+        apiKey: "test-key-123",
+      });
+      await remote.embed("test");
+      expect(capturedAuth).toBe("Bearer test-key-123");
+    } finally {
+      authServer.close();
+    }
+  });
+
+  // ── Dispose ────────────────────────────────────────────────────────────
+
+  test("dispose() is a no-op", async () => {
+    const remote = createRemote();
+    await expect(remote.dispose()).resolves.toBeUndefined();
+  });
+});
+
+// =============================================================================
+// HybridLLM Tests
+// =============================================================================
+
+describe("HybridLLM", () => {
+  let mockServer: http.Server;
+  let mockBaseUrl: string;
+
+  beforeAll(async () => {
+    const mock = await createMockServer();
+    mockServer = mock.server;
+    mockBaseUrl = mock.baseUrl;
+  });
+
+  afterAll(() => {
+    mockServer?.close();
+  });
+
+  test("isRemote is true", () => {
+    const remote = new RemoteLLM({ baseUrl: mockBaseUrl });
+    const local = {
+      embed: async () => null,
+      embedBatch: async () => [],
+      generate: async () => ({ text: "gen", model: "local", done: true }),
+      expandQuery: async () => [{ type: "vec" as const, text: "expanded" }],
+      rerank: async () => ({ results: [], model: "local" }),
+      modelExists: async () => ({ name: "local", exists: true }),
+      dispose: async () => {},
+    };
+    const hybrid = new HybridLLM(local, remote);
+    expect(hybrid.isRemote).toBe(true);
+  });
+
+  test("routes embed to remote", async () => {
+    const remote = new RemoteLLM({ baseUrl: mockBaseUrl, embedModel: "bge-m3" });
+    const localCalled = { embed: false };
+    const local = {
+      embed: async () => { localCalled.embed = true; return null; },
+      embedBatch: async () => [],
+      generate: async () => null,
+      expandQuery: async () => [],
+      rerank: async () => ({ results: [], model: "local" }),
+      modelExists: async () => ({ name: "local", exists: false }),
+      dispose: async () => {},
+    };
+    const hybrid = new HybridLLM(local, remote);
+
+    const result = await hybrid.embed("test");
+    expect(result).not.toBeNull();
+    expect(result!.model).toBe("bge-m3");
+    expect(localCalled.embed).toBe(false);
+  });
+
+  test("routes embedBatch to remote", async () => {
+    const remote = new RemoteLLM({ baseUrl: mockBaseUrl });
+    const local = {
+      embed: async () => null,
+      embedBatch: async () => [],
+      generate: async () => null,
+      expandQuery: async () => [],
+      rerank: async () => ({ results: [], model: "local" }),
+      modelExists: async () => ({ name: "local", exists: false }),
+      dispose: async () => {},
+    };
+    const hybrid = new HybridLLM(local, remote);
+    const results = await hybrid.embedBatch(["a", "b"]);
+    expect(results).toHaveLength(2);
+  });
+
+  test("routes rerank to remote", async () => {
+    const remote = new RemoteLLM({ baseUrl: mockBaseUrl, rerankModel: "bge-reranker-v2-m3" });
+    const local = {
+      embed: async () => null,
+      embedBatch: async () => [],
+      generate: async () => null,
+      expandQuery: async () => [],
+      rerank: async () => ({ results: [], model: "local" }),
+      modelExists: async () => ({ name: "local", exists: false }),
+      dispose: async () => {},
+    };
+    const hybrid = new HybridLLM(local, remote);
+    const result = await hybrid.rerank("query", [{ file: "a.md", text: "doc" }]);
+    expect(result.model).toBe("bge-reranker-v2-m3");
+  });
+
+  test("routes generate to local", async () => {
+    const remote = new RemoteLLM({ baseUrl: mockBaseUrl });
+    const local = {
+      embed: async () => null,
+      embedBatch: async () => [],
+      generate: async () => ({ text: "local-generated", model: "qwen", done: true }),
+      expandQuery: async () => [],
+      rerank: async () => ({ results: [], model: "local" }),
+      modelExists: async () => ({ name: "local", exists: true }),
+      dispose: async () => {},
+    };
+    const hybrid = new HybridLLM(local, remote);
+    const result = await hybrid.generate("test prompt");
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe("local-generated");
+  });
+
+  test("routes expandQuery to local", async () => {
+    const remote = new RemoteLLM({ baseUrl: mockBaseUrl });
+    const local = {
+      embed: async () => null,
+      embedBatch: async () => [],
+      generate: async () => null,
+      expandQuery: async () => [{ type: "vec" as const, text: "expanded-locally" }],
+      rerank: async () => ({ results: [], model: "local" }),
+      modelExists: async () => ({ name: "local", exists: true }),
+      dispose: async () => {},
+    };
+    const hybrid = new HybridLLM(local, remote);
+    const results = await hybrid.expandQuery("test");
+    expect(results).toHaveLength(1);
+    expect(results[0]!.text).toBe("expanded-locally");
+  });
+
+  test("modelExists tries remote first then local", async () => {
+    const remote = new RemoteLLM({ baseUrl: mockBaseUrl });
+    const local = {
+      embed: async () => null,
+      embedBatch: async () => [],
+      generate: async () => null,
+      expandQuery: async () => [],
+      rerank: async () => ({ results: [], model: "local" }),
+      modelExists: async (model: string) => ({ name: model, exists: model === "local-only-model" }),
+      dispose: async () => {},
+    };
+    const hybrid = new HybridLLM(local, remote);
+
+    // Remote has bge-m3
+    const remoteModel = await hybrid.modelExists("bge-m3");
+    expect(remoteModel.exists).toBe(true);
+
+    // Falls back to local
+    const localModel = await hybrid.modelExists("local-only-model");
+    expect(localModel.exists).toBe(true);
+  });
+
+  test("dispose() calls both", async () => {
+    let localDisposed = false;
+    let remoteDisposed = false;
+    const remote = {
+      embed: async () => null,
+      embedBatch: async () => [],
+      generate: async () => null,
+      expandQuery: async () => [],
+      rerank: async () => ({ results: [] as any[], model: "remote" }),
+      modelExists: async () => ({ name: "remote", exists: false }),
+      dispose: async () => { remoteDisposed = true; },
+      isRemote: true as const,
+    };
+    const local = {
+      embed: async () => null,
+      embedBatch: async () => [],
+      generate: async () => null,
+      expandQuery: async () => [],
+      rerank: async () => ({ results: [] as any[], model: "local" }),
+      modelExists: async () => ({ name: "local", exists: false }),
+      dispose: async () => { localDisposed = true; },
+    };
+    const hybrid = new HybridLLM(local, remote);
+    await hybrid.dispose();
+    expect(localDisposed).toBe(true);
+    expect(remoteDisposed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Motivation

On a 2022 MacBook Pro (M1 Pro, 16GB RAM), running embedding and reranking
via node-llama-cpp with GGUF models is painfully slow — the limited unified
memory means models compete with the system for RAM, and CPU-fallback
inference is sluggish.

[oMLX](https://github.com/jundot/omlx) is an inference server optimized
for Apple Silicon that serves MLX-format models with built-in KV caching,
continuous batching, and Metal GPU acceleration. On the same hardware,
oMLX with Qwen3-Embedding-0.6B-mxfp8 + Qwen3-Reranker-0.6B-mxfp8
completes embedding of 469 documents in ~7 minutes (vs 30+ minutes with
node-llama-cpp GGUF), and query embedding finishes in ~300ms.

This PR adds a hybrid mode: embedding and reranking are offloaded to a
remote OpenAI-compatible server, while query expansion stays on local
LlamaCpp (since it uses a QMD fine-tuned model with a specialized output
format).

## Summary

- Add `RemoteLLM` class — OpenAI-compatible `/v1/embeddings` and Cohere-compatible `/v1/rerank` via HTTP
- Add `HybridLLM` — routes embed/rerank → remote, generate/expandQuery → local LlamaCpp
- Extend `LLM` interface with `embedBatch()` and `isRemote` property
- Decouple `Store`, session management, and CLI from `LlamaCpp` concrete type to `LLM` interface
- Wire up env-based configuration: set `QMD_REMOTE_URL` to enable, no env = fully local (backwards compatible)
- Batch retry with individual fallback on failure, Unicode surrogate sanitization for chunked text
- `QMD_REMOTE_DEBUG=1` for troubleshooting remote calls

### Environment variables

```bash
QMD_REMOTE_URL=http://localhost:8000/v1        # Enable remote embedding + reranking
QMD_REMOTE_EMBED_MODEL=bge-m3                  # Embedding model name (default: bge-m3)
QMD_REMOTE_RERANK_MODEL=bge-reranker-v2-m3     # Rerank model name (default: bge-reranker-v2-m3)
QMD_REMOTE_API_KEY=optional                    # Optional API key
QMD_REMOTE_DEBUG=1                             # Debug logging for remote calls
```

### Tested with

- oMLX serving `Qwen3-Embedding-0.6B-mxfp8` + `Qwen3-Reranker-0.6B-mxfp8` on Apple Silicon (M1 Pro 16GB)
- `qmd embed --force` — 469 docs embedded in ~7 min via remote
- `qmd query "terminal tools"` — full pipeline: local query expansion → remote embedding (300ms) → remote reranking

## Test plan

- [x] `npx vitest run test/remote-llm.test.ts` — 21 tests pass (mock HTTP server)
- [x] `npx vitest run test/sdk.test.ts` — 78 tests pass (backwards compat)
- [x] `npx vitest run test/store.test.ts` — no new regressions vs main
- [x] Without `QMD_REMOTE_URL` set — behavior completely unchanged
- [x] With `QMD_REMOTE_URL` set — embed/rerank route to remote, query expansion stays local