### PR TITLE
fix(mcp): include collection name in status output

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -502,7 +502,7 @@ Intent-aware lex (C++ performance, not sports):
       ];
 
       for (const col of status.collections) {
-        summary.push(`    - ${col.path} (${col.documents} docs)`);
+        summary.push(`    - ${col.name}: ${col.path} (${col.documents} docs)`);
       }
 
       return {


### PR DESCRIPTION
## Problem

The MCP `status` tool returns collection paths but not names:

```
Collections: 13
    - /path/to/docs (58 docs)
```

Agents using the MCP bridge cannot discover valid collection names for filtered queries. The CLI `qmd status` already displays names alongside paths.

## Fix

Include `col.name` in the status output (one-line change):

```
Collections: 13
    - decisions: /path/to/docs (58 docs)
```

## Testing

Built and tested locally. MCP status tool now returns collection names. No breaking changes — existing output format is preserved with the name prepended.