### PR TITLE
feat: added optional parameter to specify which host interface to listen on when using http transport

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ qmd search <query>                # Full-text keyword search (BM25, no LLM)
 qmd vsearch <query>               # Vector similarity search (no reranking)
 qmd mcp                           # Start MCP server (stdio transport)
 qmd mcp --http [--port N]         # Start MCP server (HTTP, default port 8181)
+qmd mcp --http [--host H]         # Start MCP server (HTTP, default host localhost)
 qmd mcp --http --daemon           # Start as background daemon
 qmd mcp stop                      # Stop background MCP daemon
 ```

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ By default, QMD's MCP server uses stdio (launched as a subprocess by each client
 # Foreground (Ctrl-C to stop)
 qmd mcp --http                    # localhost:8181
 qmd mcp --http --port 8080        # custom port
+qmd mcp --http --host 0.0.0.0     # custom host
 
 # Background daemon
 qmd mcp --http --daemon           # start, writes PID to ~/.cache/qmd/mcp.pid

--- a/skills/qmd/references/mcp-setup.md
+++ b/skills/qmd/references/mcp-setup.md
@@ -42,9 +42,11 @@ qmd embed
 ## HTTP Mode
 
 ```bash
-qmd mcp --http              # Port 8181
-qmd mcp --http --daemon     # Background
-qmd mcp stop                # Stop daemon
+qmd mcp --http                # Port 8181, Host localhost
+qmd mcp --http --port 8080    # Custom port
+qmd mcp --http --host 0.0.0.0 # Custom host
+qmd mcp --http --daemon       # Background
+qmd mcp stop                  # Stop daemon
 ```
 
 ## Tools

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -3049,7 +3049,6 @@ if (isMain) {
       if (cli.values.http) {
         const port = Number(cli.values.port) || 8181;
         const host = cli.values.host || "localhost";
-        console.log(`THE host is ${host} and THE port is ${port}`);
 
         if (cli.values.daemon) {
           // Guard: check if already running

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -3048,7 +3048,7 @@ if (isMain) {
 
       if (cli.values.http) {
         const port = Number(cli.values.port) || 8181;
-        const host = cli.values.host || "localhost";
+        const host = typeof cli.values.host === "string" ? cli.values.host : "localhost";
 
         if (cli.values.daemon) {
           // Guard: check if already running
@@ -3069,7 +3069,7 @@ if (isMain) {
           const selfPath = fileURLToPath(import.meta.url);
           const spawnArgs = selfPath.endsWith(".ts")
             ? ["--import", pathJoin(dirname(selfPath), "..", "..", "node_modules", "tsx", "dist", "esm", "index.mjs"), selfPath, "mcp", "--http", "--port", String(port), "--host", host]
-            : [selfPath, "mcp", "--http", "--port", String(port), host];
+            : [selfPath, "mcp", "--http", "--port", String(port), "--host", host];
           const child = nodeSpawn(process.execPath, spawnArgs, {
             stdio: ["ignore", logFd, logFd],
             detached: true,

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -2376,6 +2376,7 @@ function parseCLI() {
       http: { type: "boolean" },
       daemon: { type: "boolean" },
       port: { type: "string" },
+      host: { type: "string" },
     },
     allowPositionals: true,
     strict: false, // Allow unknown options to pass through
@@ -3047,6 +3048,8 @@ if (isMain) {
 
       if (cli.values.http) {
         const port = Number(cli.values.port) || 8181;
+        const host = cli.values.host || "localhost";
+        console.log(`THE host is ${host} and THE port is ${port}`);
 
         if (cli.values.daemon) {
           // Guard: check if already running
@@ -3066,8 +3069,8 @@ if (isMain) {
           const logFd = openSync(logPath, "w"); // truncate — fresh log per daemon run
           const selfPath = fileURLToPath(import.meta.url);
           const spawnArgs = selfPath.endsWith(".ts")
-            ? ["--import", pathJoin(dirname(selfPath), "..", "..", "node_modules", "tsx", "dist", "esm", "index.mjs"), selfPath, "mcp", "--http", "--port", String(port)]
-            : [selfPath, "mcp", "--http", "--port", String(port)];
+            ? ["--import", pathJoin(dirname(selfPath), "..", "..", "node_modules", "tsx", "dist", "esm", "index.mjs"), selfPath, "mcp", "--http", "--port", String(port), "--host", host]
+            : [selfPath, "mcp", "--http", "--port", String(port), host];
           const child = nodeSpawn(process.execPath, spawnArgs, {
             stdio: ["ignore", logFd, logFd],
             detached: true,
@@ -3076,7 +3079,7 @@ if (isMain) {
           closeSync(logFd); // parent's copy; child inherited the fd
 
           writeFileSync(pidPath, String(child.pid));
-          console.log(`Started on http://localhost:${port}/mcp (PID ${child.pid})`);
+          console.log(`Started on http://${host}:${port}/mcp (PID ${child.pid})`);
           console.log(`Logs: ${logPath}`);
           process.exit(0);
         }
@@ -3087,7 +3090,7 @@ if (isMain) {
         process.removeAllListeners("SIGINT");
         const { startMcpHttpServer } = await import("../mcp/server.js");
         try {
-          await startMcpHttpServer(port);
+          await startMcpHttpServer(port, host);
         } catch (e: any) {
           if (e?.code === "EADDRINUSE") {
             console.error(`Port ${port} already in use. Try a different port with --port.`);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -538,9 +538,9 @@ export type HttpServerHandle = {
 
 /**
  * Start MCP server over Streamable HTTP (JSON responses, no SSE).
- * Binds to localhost only. Returns a handle for shutdown and port discovery.
+ * Binds to localhost unless specified. Returns a handle for shutdown and port discovery.
  */
-export async function startMcpHttpServer(port: number, options?: { quiet?: boolean }): Promise<HttpServerHandle> {
+export async function startMcpHttpServer(port: number, host: string = "localhost", options?: { quiet?: boolean }): Promise<HttpServerHandle> {
   const store = await createStore({ dbPath: getDefaultDbPath() });
 
   // Pre-fetch default collection names for REST endpoint
@@ -678,7 +678,7 @@ export async function startMcpHttpServer(port: number, options?: { quiet?: boole
         const rawBody = await collectBody(nodeReq);
         const body = JSON.parse(rawBody);
         const label = describeRequest(body);
-        const url = `http://localhost:${port}${pathname}`;
+        const url = `http://${host}:${port}${pathname}`;
         const headers: Record<string, string> = {};
         for (const [k, v] of Object.entries(nodeReq.headers)) {
           if (typeof v === "string") headers[k] = v;
@@ -749,7 +749,7 @@ export async function startMcpHttpServer(port: number, options?: { quiet?: boole
           return;
         }
 
-        const url = `http://localhost:${port}${pathname}`;
+        const url = `http://${host}:${port}${pathname}`;
         const rawBody = nodeReq.method !== "GET" && nodeReq.method !== "HEAD" ? await collectBody(nodeReq) : undefined;
         const request = new Request(url, { method: nodeReq.method || "GET", headers, ...(rawBody ? { body: rawBody } : {}) });
         const response = await transport.handleRequest(request);
@@ -769,7 +769,7 @@ export async function startMcpHttpServer(port: number, options?: { quiet?: boole
 
   await new Promise<void>((resolve, reject) => {
     httpServer.on("error", reject);
-    httpServer.listen(port, "localhost", () => resolve());
+    httpServer.listen(port, host, () => resolve());
   });
 
   const actualPort = (httpServer.address() as import("net").AddressInfo).port;
@@ -797,7 +797,7 @@ export async function startMcpHttpServer(port: number, options?: { quiet?: boole
     process.exit(0);
   });
 
-  log(`QMD MCP server listening on http://localhost:${actualPort}/mcp`);
+  log(`QMD MCP server listening on http://${host}:${actualPort}/mcp`);
   return { httpServer, port: actualPort, stop };
 }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1323,8 +1323,8 @@ describe("mcp http daemon", () => {
   }
 
   /** Spawn a foreground HTTP server (non-blocking) and return the process */
-  function spawnHttpServer(port: number): import("child_process").ChildProcess {
-    const proc = spawn(tsxBin, [qmdScript, "mcp", "--http", "--port", String(port)], {
+  function spawnHttpServer(port: number, host: string = "localhost"): import("child_process").ChildProcess {
+    const proc = spawn(tsxBin, [qmdScript, "mcp", "--http", "--port", String(port), "--host", host], {
       cwd: fixturesDir,
       env: {
         ...process.env,
@@ -1397,6 +1397,42 @@ describe("mcp http daemon", () => {
       expect(ready).toBe(true);
 
       const res = await fetch(`http://localhost:${port}/health`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.status).toBe("ok");
+    } finally {
+      proc.kill("SIGTERM");
+      await new Promise(r => proc.on("close", r));
+    }
+  });
+
+  test("foreground HTTP server starts on host 127.0.0.1 and responds to health check", async () => {
+    const port = randomPort();
+    const proc = spawnHttpServer(port, "127.0.0.1");
+
+    try {
+      const ready = await waitForServer(port);
+      expect(ready).toBe(true);
+
+      const res = await fetch(`http://127.0.0.1:${port}/health`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.status).toBe("ok");
+    } finally {
+      proc.kill("SIGTERM");
+      await new Promise(r => proc.on("close", r));
+    }
+  });
+
+  test("foreground HTTP server starts on host 0.0.0.0 and responds to health check", async () => {
+    const port = randomPort();
+    const proc = spawnHttpServer(port, "0.0.0.0");
+
+    try {
+      const ready = await waitForServer(port);
+      expect(ready).toBe(true);
+
+      const res = await fetch(`http://0.0.0.0:${port}/health`);
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.status).toBe("ok");

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -934,7 +934,7 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
     process.env.INDEX_PATH = httpTestDbPath;
     process.env.QMD_CONFIG_DIR = httpTestConfigDir;
 
-    handle = await startMcpHttpServer(0, { quiet: true }); // OS-assigned ephemeral port
+    handle = await startMcpHttpServer(0, "localhost", { quiet: true }); // OS-assigned ephemeral port
     baseUrl = `http://localhost:${handle.port}`;
   });
 


### PR DESCRIPTION
Treatment of the hard-coded "localhost" interface can vary by machine environment. This causes a problem specifically when trying to connect from a Docker service (ex: Open-WebUI via MCP) to QMD using host.docker.internal to localhost - it fails to connect. Specifying the 0.0.0.0 interface allows the connection, but alternatives should also be possible.

The --host parameter is optional, and defaults to the original behavior. Documentation and tests were added to support the change, while preserving the style. All tests pass.