### PR TITLE
fix(multi-get): support brace expansion patterns in glob matching

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -968,7 +968,7 @@ function multiGet(pattern: string, maxLines?: number, maxBytes: number = DEFAULT
   const db = getDb();
 
   // Check if it's a comma-separated list or a glob pattern
-  const isCommaSeparated = pattern.includes(',') && !pattern.includes('*') && !pattern.includes('?');
+  const isCommaSeparated = pattern.includes(',') && !pattern.includes('*') && !pattern.includes('?') && !pattern.includes('{');
 
   let files: { filepath: string; displayPath: string; bodyLength: number; collection?: string; path?: string }[];
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -2245,7 +2245,7 @@ export function matchFilesByGlob(db: Database, pattern: string): { filepath: str
 
   const isMatch = picomatch(pattern);
   return allFiles
-    .filter(f => isMatch(f.virtual_path) || isMatch(f.path))
+    .filter(f => isMatch(f.virtual_path) || isMatch(f.path) || isMatch(f.collection + '/' + f.path))
     .map(f => ({
       filepath: f.virtual_path,  // Virtual path for precise lookup
       displayPath: f.path,        // Relative path for display
@@ -3354,7 +3354,7 @@ export function findDocuments(
   pattern: string,
   options: { includeBody?: boolean; maxBytes?: number } = {}
 ): { docs: MultiGetResult[]; errors: string[] } {
-  const isCommaSeparated = pattern.includes(',') && !pattern.includes('*') && !pattern.includes('?');
+  const isCommaSeparated = pattern.includes(',') && !pattern.includes('*') && !pattern.includes('?') && !pattern.includes('{');
   const errors: string[] = [];
   const maxBytes = options.maxBytes ?? DEFAULT_MULTI_GET_MAX_BYTES;
 

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1757,6 +1757,55 @@ describe("Document Retrieval", () => {
 
       await cleanupTestDb(store);
     });
+
+    test("findDocuments supports brace expansion patterns", async () => {
+      const store = await createTestStore();
+      const collectionName = await createTestCollection();
+
+      await insertTestDocument(store.db, collectionName, {
+        name: "doc1",
+        filepath: "/path/doc1.md",
+        displayPath: "doc1.md",
+      });
+      await insertTestDocument(store.db, collectionName, {
+        name: "doc2",
+        filepath: "/path/doc2.md",
+        displayPath: "doc2.md",
+      });
+      await insertTestDocument(store.db, collectionName, {
+        name: "doc3",
+        filepath: "/path/doc3.md",
+        displayPath: "doc3.md",
+      });
+
+      const { docs, errors } = store.findDocuments("{doc1,doc2}.md");
+      expect(errors).toHaveLength(0);
+      expect(docs).toHaveLength(2);
+
+      await cleanupTestDb(store);
+    });
+
+    test("findDocuments supports brace expansion with collection prefix", async () => {
+      const store = await createTestStore();
+      const collectionName = await createTestCollection();
+
+      await insertTestDocument(store.db, collectionName, {
+        name: "readme",
+        filepath: "/path/readme.md",
+        displayPath: "readme.md",
+      });
+      await insertTestDocument(store.db, collectionName, {
+        name: "changelog",
+        filepath: "/path/changelog.md",
+        displayPath: "changelog.md",
+      });
+
+      const { docs, errors } = store.findDocuments(`${collectionName}/{readme,changelog}.md`);
+      expect(errors).toHaveLength(0);
+      expect(docs).toHaveLength(2);
+
+      await cleanupTestDb(store);
+    });
   });
 
 });
@@ -2112,6 +2161,48 @@ describe("Fuzzy Matching", () => {
     const matches = store.matchFilesByGlob("journals/*.md");
     expect(matches).toHaveLength(2);
     expect(matches.every(m => m.displayPath.startsWith("journals/"))).toBe(true);
+
+    await cleanupTestDb(store);
+  });
+
+  test("matchFilesByGlob matches collection/path patterns", async () => {
+    const store = await createTestStore();
+    const collectionName = await createTestCollection();
+
+    await insertTestDocument(store.db, collectionName, {
+      filepath: "/p/readme.md",
+      displayPath: "readme.md",
+    });
+    await insertTestDocument(store.db, collectionName, {
+      filepath: "/p/changelog.md",
+      displayPath: "changelog.md",
+    });
+
+    const matches = store.matchFilesByGlob(`${collectionName}/*.md`);
+    expect(matches).toHaveLength(2);
+
+    await cleanupTestDb(store);
+  });
+
+  test("matchFilesByGlob matches brace expansion", async () => {
+    const store = await createTestStore();
+    const collectionName = await createTestCollection();
+
+    await insertTestDocument(store.db, collectionName, {
+      filepath: "/p/readme.md",
+      displayPath: "readme.md",
+    });
+    await insertTestDocument(store.db, collectionName, {
+      filepath: "/p/changelog.md",
+      displayPath: "changelog.md",
+    });
+    await insertTestDocument(store.db, collectionName, {
+      filepath: "/p/license.md",
+      displayPath: "license.md",
+    });
+
+    const matches = store.matchFilesByGlob(`${collectionName}/{readme,changelog}.md`);
+    expect(matches).toHaveLength(2);
 
     await cleanupTestDb(store);
   });


### PR DESCRIPTION
## Summary

- Brace expansion patterns like `{doc1,doc2}.md` or `collection/{a,b}.md` were incorrectly parsed as comma-separated file lists instead of being passed to the glob matcher (picomatch). The comma-detection heuristic checked for `*` and `?` but not `{`, so any pattern containing `{a,b}` was split on the comma and treated as two separate file lookups.
- `matchFilesByGlob` only matched against `qmd://collection/path` (virtual path) and `path` (relative to collection root), but not `collection/path` — so glob patterns prefixed with a collection name never matched anything.

## Changes

1. **`src/store.ts` (findDocuments)**: Add `!pattern.includes('{')` to the `isCommaSeparated` check so brace patterns route to picomatch
2. **`src/cli/qmd.ts` (multiGet)**: Same fix for the CLI code path
3. **`src/store.ts` (matchFilesByGlob)**: Add `collection/path` as a third matching target alongside `virtual_path` and `path`
4. **`test/store.test.ts`**: 4 new tests covering brace expansion, collection-prefixed brace patterns, and collection/path glob matching

## Test plan

- [x] All 205 store tests pass (including 4 new)
- [x] All 56 MCP tests pass
- [x] Build succeeds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)