### PR TITLE
feat: add OpenAI-compatible and Gemini API embedding support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "2025-12-07-bm25-q",
@@ -12,7 +11,7 @@
         "picomatch": "^4.0.0",
         "sqlite-vec": "^0.1.7-alpha.2",
         "yaml": "^2.8.2",
-        "zod": "^4.2.1",
+        "zod": "4.2.1",
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.0",

--- a/docs/embedding-benchmark.md
+++ b/docs/embedding-benchmark.md
@@ -2,8 +2,8 @@
 
 **Date:** 2026-03-18
 **Machine:** Apple M3 Max (36GB RAM, 28GB VRAM), macOS 25.3.0
-**Dataset:** 63 chunks sampled from `dig_chat/outcome` (한국어+영어 혼합 ChatGPT 대화록)
-**Chunk size:** ~700 chars (첫 번째 의미 블록, YAML frontmatter 제외)
+**Dataset:** 63 chunks sampled from `dig_chat/outcome` (mixed Korean/English ChatGPT conversation logs)
+**Chunk size:** ~700 chars (first meaningful text block, YAML frontmatter stripped)
 **Script:** `scripts/benchmark-embed.ts`
 
 ## Results
@@ -18,51 +18,51 @@
 
 ## API Details
 
-- **OpenAI:** `POST /v1/embeddings` — input 배열로 배치 전송 (batch_size=32)
-- **Gemini:** `POST /v1beta/models/{model}:batchEmbedContents` — requests 배열로 배치 전송 (batch_size=32)
-- **Local:** node-llama-cpp + Metal (MPS) 자동 활성화, batch_size=8
+- **OpenAI:** `POST /v1/embeddings` — array input, batches of 32
+- **Gemini:** `POST /v1beta/models/{model}:batchEmbedContents` — requests array, batches of 32
+- **Local:** node-llama-cpp with Metal (MPS) auto-enabled, batches of 8
 
-> `asyncBatchEmbedContent`는 GCS 기반 대용량 비동기 API로 inline content 미지원 — 사용 불가
+> `asyncBatchEmbedContent` is a GCS-based async API for large-scale batch jobs and does not support inline content — not usable here.
 
-## Projected: dig_chat/outcome 전체 (7,149 파일, ~57,000 청크 추정)
+## Projected: full dig_chat/outcome (7,149 files, ~57,000 chunks estimated)
 
-| Model | 예상 시간 | 예상 비용 |
-|-------|:---------:|:---------:|
-| embeddinggemma-300M (local) | ~45분 | $0 |
-| text-embedding-3-small | ~15분 | ~$0.26 |
-| text-embedding-3-large | ~12분 | ~$1.70 |
-| gemini-embedding-001 | ~36분 | 무료 |
-| gemini-embedding-2-preview | ~39분 | 무료 |
+| Model | Estimated time | Estimated cost |
+|-------|:--------------:|:--------------:|
+| embeddinggemma-300M (local) | ~45 min | $0 |
+| text-embedding-3-small | ~15 min | ~$0.26 |
+| text-embedding-3-large | ~12 min | ~$1.70 |
+| gemini-embedding-001 | ~36 min | free |
+| gemini-embedding-2-preview | ~39 min | free |
 
-청크 수는 파일당 평균 ~8청크(한국어 15KB 기준, 900토큰/청크) 가정.
+Assumes ~8 chunks per file (based on 15KB Korean-text files at 900 tokens/chunk).
 
 ## Key Observations
 
-1. **속도 순위:** text-embedding-3-large ≒ small > gemini-001 ≒ gemini-2-preview > local GGUF
-   OpenAI가 Gemini보다 2~3배 빠른 건 배치 API 방식 차이가 아니라 인프라/모델 추론 속도 차이.
+1. **Speed ranking:** text-embedding-3-large ≈ small > gemini-001 ≈ gemini-2-preview > local GGUF.
+   OpenAI is 2–3× faster than Gemini — both use batch APIs, so the difference is infrastructure/model throughput, not batching strategy.
 
-2. **로컬 GGUF:** Metal(MPS) 자동 활성화됨에도 API 대비 느림. 72ms/chunk의 상당 부분은 모델 로딩 오버헤드 — 순수 추론만 약 48ms/chunk 추정. 오프라인/프라이버시 요건 시 적합.
+2. **Local GGUF:** Metal (MPS) is auto-enabled, but still slower than cloud APIs. The 72ms/chunk figure includes model load overhead — pure inference is ~48ms/chunk. Best for offline or privacy-sensitive workloads.
 
-3. **비용 대비 성능:**
-   - 속도 우선 → `text-embedding-3-small` (저렴 + 빠름)
-   - 무료 + 3072차원 → `gemini-embedding-001` (속도 준수)
-   - 완전 로컬 → `embeddinggemma-300M` (느리지만 $0, 프라이버시 보장)
+3. **Cost/performance:**
+   - Speed-first → `text-embedding-3-small` (fast + cheap)
+   - Free + 3072 dims → `gemini-embedding-001` (solid throughput)
+   - Fully local → `embeddinggemma-300M` (slower, $0, private)
 
-4. **RAM 주의 (M3 Max 기준):** 로컬 embed 실행 시 RAM 여유가 적으면 VRAM(28GB)에 모델이 올라가 CPU RAM 영향은 적지만, Node.js 프로세스 자체 RAM 사용 주의.
+4. **RAM note (M3 Max):** With low free RAM, the embedding model loads into VRAM (28GB available), keeping CPU RAM impact minimal. However, the Node.js process itself still consumes CPU RAM.
 
 ## Recommended Config
 
 ```bash
-# 비용 최소 + 속도 균형 (추천)
+# Speed + cost balance (recommended)
 export QMD_EMBED_API_URL="https://api.openai.com/v1"
 export QMD_EMBED_API_KEY="sk-..."
 export QMD_EMBED_API_MODEL="text-embedding-3-small"
 
-# 완전 무료 + 고차원
+# Free + high-dimensional
 export QMD_EMBED_API_URL="https://generativelanguage.googleapis.com/v1beta"
 export QMD_EMBED_API_KEY="AIza..."
 export QMD_EMBED_API_MODEL="gemini-embedding-001"
 
-# 완전 로컬 (기본값, 추가 설정 불필요)
+# Fully local (default, no config needed)
 unset QMD_EMBED_API_URL
 ```

--- a/docs/embedding-benchmark.md
+++ b/docs/embedding-benchmark.md
@@ -1,0 +1,68 @@
+# Embedding Benchmark Results
+
+**Date:** 2026-03-18
+**Machine:** Apple M3 Max (36GB RAM, 28GB VRAM), macOS 25.3.0
+**Dataset:** 63 chunks sampled from `dig_chat/outcome` (한국어+영어 혼합 ChatGPT 대화록)
+**Chunk size:** ~700 chars (첫 번째 의미 블록, YAML frontmatter 제외)
+**Script:** `scripts/benchmark-embed.ts`
+
+## Results
+
+| Model | Total (63 chunks) | Per chunk | ~Tokens | ~Cost | Dims |
+|-------|:-----------------:|:---------:|--------:|------:|-----:|
+| embeddinggemma-300M (local) | 4,536ms | 72ms | 14,479 | $0 (local) | 768 |
+| text-embedding-3-small | 1,007ms | 16ms | 14,479 | $0.000290 | 1536 |
+| text-embedding-3-large | 829ms | 13ms | 14,479 | $0.001882 | 3072 |
+| gemini-embedding-001 | 2,388ms | 38ms | 14,479 | free | 3072 |
+| gemini-embedding-2-preview | 2,576ms | 41ms | 14,479 | free | 3072 |
+
+## API Details
+
+- **OpenAI:** `POST /v1/embeddings` — input 배열로 배치 전송 (batch_size=32)
+- **Gemini:** `POST /v1beta/models/{model}:batchEmbedContents` — requests 배열로 배치 전송 (batch_size=32)
+- **Local:** node-llama-cpp + Metal (MPS) 자동 활성화, batch_size=8
+
+> `asyncBatchEmbedContent`는 GCS 기반 대용량 비동기 API로 inline content 미지원 — 사용 불가
+
+## Projected: dig_chat/outcome 전체 (7,149 파일, ~57,000 청크 추정)
+
+| Model | 예상 시간 | 예상 비용 |
+|-------|:---------:|:---------:|
+| embeddinggemma-300M (local) | ~45분 | $0 |
+| text-embedding-3-small | ~15분 | ~$0.26 |
+| text-embedding-3-large | ~12분 | ~$1.70 |
+| gemini-embedding-001 | ~36분 | 무료 |
+| gemini-embedding-2-preview | ~39분 | 무료 |
+
+청크 수는 파일당 평균 ~8청크(한국어 15KB 기준, 900토큰/청크) 가정.
+
+## Key Observations
+
+1. **속도 순위:** text-embedding-3-large ≒ small > gemini-001 ≒ gemini-2-preview > local GGUF
+   OpenAI가 Gemini보다 2~3배 빠른 건 배치 API 방식 차이가 아니라 인프라/모델 추론 속도 차이.
+
+2. **로컬 GGUF:** Metal(MPS) 자동 활성화됨에도 API 대비 느림. 72ms/chunk의 상당 부분은 모델 로딩 오버헤드 — 순수 추론만 약 48ms/chunk 추정. 오프라인/프라이버시 요건 시 적합.
+
+3. **비용 대비 성능:**
+   - 속도 우선 → `text-embedding-3-small` (저렴 + 빠름)
+   - 무료 + 3072차원 → `gemini-embedding-001` (속도 준수)
+   - 완전 로컬 → `embeddinggemma-300M` (느리지만 $0, 프라이버시 보장)
+
+4. **RAM 주의 (M3 Max 기준):** 로컬 embed 실행 시 RAM 여유가 적으면 VRAM(28GB)에 모델이 올라가 CPU RAM 영향은 적지만, Node.js 프로세스 자체 RAM 사용 주의.
+
+## Recommended Config
+
+```bash
+# 비용 최소 + 속도 균형 (추천)
+export QMD_EMBED_API_URL="https://api.openai.com/v1"
+export QMD_EMBED_API_KEY="sk-..."
+export QMD_EMBED_API_MODEL="text-embedding-3-small"
+
+# 완전 무료 + 고차원
+export QMD_EMBED_API_URL="https://generativelanguage.googleapis.com/v1beta"
+export QMD_EMBED_API_KEY="AIza..."
+export QMD_EMBED_API_MODEL="gemini-embedding-001"
+
+# 완전 로컬 (기본값, 추가 설정 불필요)
+unset QMD_EMBED_API_URL
+```

--- a/scripts/benchmark-embed.ts
+++ b/scripts/benchmark-embed.ts
@@ -1,0 +1,359 @@
+#!/usr/bin/env bun
+/**
+ * benchmark-embed.ts - Embedding speed & cost benchmark
+ *
+ * Samples 64 files from dig_chat/outcome and measures wall-clock time
+ * and estimated cost for each model (OpenAI, Gemini, local GGUF).
+ *
+ * Usage:
+ *   source ~/.oh-my-zsh/custom/apikey.env
+ *   bun scripts/benchmark-embed.ts
+ *
+ * Required env vars:
+ *   OPENAI_API_KEY   - for OpenAI models
+ *   GEMINI_API_KEY   - for Gemini models
+ */
+
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+import { LlamaCpp, DEFAULT_EMBED_MODEL_URI, DEFAULT_MODEL_CACHE_DIR } from "../src/llm";
+
+// =============================================================================
+// Config
+// =============================================================================
+
+const OUTCOME_DIR = "/Users/jaesolshin/Documents/GitHub/dig_chat/outcome";
+const SAMPLE_SIZE = 64;
+const API_BATCH_SIZE = 32;
+const LOCAL_BATCH_SIZE = 8;
+const MAX_CHARS = 700;
+
+interface ModelConfig {
+  label: string;
+  apiType: "openai" | "gemini" | "local";
+  baseUrl?: string;
+  model?: string;
+  costPer1MTokens: number | null;
+  dims: number | null;
+}
+
+const MODELS: ModelConfig[] = [
+  {
+    label: "embeddinggemma-300M (local)",
+    apiType: "local",
+    costPer1MTokens: 0,
+    dims: 768,
+  },
+  {
+    label: "text-embedding-3-small",
+    apiType: "openai",
+    baseUrl: "https://api.openai.com/v1",
+    model: "text-embedding-3-small",
+    costPer1MTokens: 0.020,
+    dims: 1536,
+  },
+  {
+    label: "text-embedding-3-large",
+    apiType: "openai",
+    baseUrl: "https://api.openai.com/v1",
+    model: "text-embedding-3-large",
+    costPer1MTokens: 0.130,
+    dims: 3072,
+  },
+  {
+    label: "gemini-embedding-001",
+    apiType: "gemini",
+    baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+    model: "gemini-embedding-001",
+    costPer1MTokens: null,
+    dims: null,
+  },
+  {
+    label: "gemini-embedding-2-preview",
+    apiType: "gemini",
+    baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+    model: "gemini-embedding-2-preview",
+    costPer1MTokens: null,
+    dims: null,
+  },
+];
+
+// =============================================================================
+// File sampling
+// =============================================================================
+
+function sampleFiles(dir: string, n: number): string[] {
+  let files: string[] = [];
+  try {
+    files = readdirSync(dir)
+      .filter((f) => f.endsWith(".md"))
+      .map((f) => join(dir, f));
+  } catch {
+    console.error(`Cannot read directory: ${dir}`);
+    process.exit(1);
+  }
+
+  if (files.length === 0) {
+    console.error("No .md files found in", dir);
+    process.exit(1);
+  }
+
+  const sized = files
+    .map((f) => {
+      try { return { path: f, size: statSync(f).size }; }
+      catch { return { path: f, size: 0 }; }
+    })
+    .filter((f) => f.size > 0)
+    .sort((a, b) => a.size - b.size);
+
+  const third = Math.floor(sized.length / 3);
+  const perBucket = Math.floor(n / 3);
+  const remainder = n - perBucket * 3;
+
+  const pick = (arr: typeof sized, count: number) => {
+    if (arr.length <= count) return arr;
+    const step = arr.length / count;
+    return Array.from({ length: count }, (_, i) => arr[Math.floor(i * step)]!);
+  };
+
+  return [
+    ...pick(sized.slice(0, third), perBucket),
+    ...pick(sized.slice(third, third * 2), perBucket),
+    ...pick(sized.slice(third * 2), perBucket + remainder),
+  ].map((f) => f.path);
+}
+
+// =============================================================================
+// Text extraction & token estimation
+// =============================================================================
+
+function extractChunk(content: string, maxChars = MAX_CHARS): string {
+  const parts = content.split("---");
+  const body = parts.length >= 3 ? parts.slice(2).join("---") : content;
+  return body.trim().slice(0, maxChars);
+}
+
+function estimateTokens(texts: string[]): number {
+  const totalChars = texts.reduce((s, t) => s + t.length, 0);
+  return Math.ceil(totalChars / 3); // conservative for mixed Korean/English
+}
+
+// =============================================================================
+// API calls
+// =============================================================================
+
+async function embedOpenAI(
+  texts: string[], baseUrl: string, model: string, apiKey: string
+): Promise<{ dims: number }> {
+  const resp = await fetch(`${baseUrl}/embeddings`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+    body: JSON.stringify({ model, input: texts }),
+  });
+  if (!resp.ok) {
+    const err = await resp.text();
+    throw new Error(`OpenAI error ${resp.status}: ${err.slice(0, 200)}`);
+  }
+  const data = await resp.json() as { data: { index: number; embedding: number[] }[] };
+  return { dims: data.data[0]?.embedding.length ?? 0 };
+}
+
+async function embedGeminiBatch(
+  texts: string[], baseUrl: string, model: string, apiKey: string
+): Promise<{ dims: number }> {
+  const modelId = model.startsWith("models/") ? model : `models/${model}`;
+  const url = `${baseUrl}/${modelId}:batchEmbedContents?key=${apiKey}`;
+  const requests = texts.map((text) => ({
+    model: modelId,
+    content: { parts: [{ text }] },
+  }));
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ requests }),
+  });
+  if (!resp.ok) {
+    const err = await resp.text();
+    throw new Error(`Gemini error ${resp.status}: ${err.slice(0, 200)}`);
+  }
+  const data = await resp.json() as { embeddings: { values: number[] }[] };
+  return { dims: data.embeddings[0]?.values.length ?? 0 };
+}
+
+// =============================================================================
+// Benchmark runner
+// =============================================================================
+
+interface BenchResult {
+  label: string;
+  totalMs: number;
+  perChunkMs: number;
+  estimatedTokens: number;
+  estimatedCost: number | null;
+  dims: number;
+  error?: string;
+}
+
+async function benchmarkModel(
+  model: ModelConfig,
+  chunks: string[],
+  llamaCpp: LlamaCpp
+): Promise<BenchResult> {
+  const openaiKey = process.env.OPENAI_API_KEY ?? "";
+  const geminiKey = process.env.GEMINI_API_KEY ?? "";
+
+  if (model.apiType === "openai" && !openaiKey) {
+    return errorResult(model, "OPENAI_API_KEY not set");
+  }
+  if (model.apiType === "gemini" && !geminiKey) {
+    return errorResult(model, "GEMINI_API_KEY not set");
+  }
+
+  const estimatedTokens = estimateTokens(chunks);
+  const start = performance.now();
+  let actualDims = model.dims ?? 0;
+  const batchSize = model.apiType === "local" ? LOCAL_BATCH_SIZE : API_BATCH_SIZE;
+
+  try {
+    for (let i = 0; i < chunks.length; i += batchSize) {
+      const batch = chunks.slice(i, i + batchSize);
+
+      if (model.apiType === "local") {
+        const results = await llamaCpp.embedBatch(batch);
+        const first = results.find((r: typeof results[number]) => r !== null);
+        if (first) actualDims = first.embedding.length;
+      } else if (model.apiType === "openai") {
+        const { dims } = await embedOpenAI(batch, model.baseUrl!, model.model!, openaiKey);
+        if (dims > 0) actualDims = dims;
+      } else {
+        const { dims } = await embedGeminiBatch(batch, model.baseUrl!, model.model!, geminiKey);
+        if (dims > 0) actualDims = dims;
+      }
+    }
+  } catch (err) {
+    return {
+      label: model.label,
+      totalMs: Math.round(performance.now() - start),
+      perChunkMs: 0,
+      estimatedTokens,
+      estimatedCost: null,
+      dims: actualDims,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  const totalMs = Math.round(performance.now() - start);
+  const estimatedCost =
+    model.costPer1MTokens !== null
+      ? (estimatedTokens / 1_000_000) * model.costPer1MTokens
+      : null;
+
+  return {
+    label: model.label,
+    totalMs,
+    perChunkMs: Math.round(totalMs / chunks.length),
+    estimatedTokens,
+    estimatedCost,
+    dims: actualDims,
+  };
+}
+
+function errorResult(model: ModelConfig, error: string): BenchResult {
+  return { label: model.label, totalMs: 0, perChunkMs: 0, estimatedTokens: 0, estimatedCost: null, dims: model.dims ?? 0, error };
+}
+
+// =============================================================================
+// Output
+// =============================================================================
+
+function pad(s: string, width: number, right = false): string {
+  return right ? s.padStart(width) : s.padEnd(width);
+}
+
+function formatCost(cost: number | null): string {
+  if (cost === null) return "free";
+  if (cost === 0) return "$0 (local)";
+  return `$${cost.toFixed(6)}`;
+}
+
+function printTable(results: BenchResult[], chunkCount: number): void {
+  console.log(`\n[Embedding Benchmark] ${chunkCount} chunks from dig_chat/outcome\n`);
+
+  const header = [
+    pad("Model", 32),
+    pad("Time(ms)", 10, true),
+    pad("Per chunk", 11, true),
+    pad("~Tokens", 9, true),
+    pad("~Cost", 14, true),
+    pad("Dims", 6, true),
+  ].join(" | ");
+
+  const sep = "-".repeat(header.length);
+  console.log(header);
+  console.log(sep);
+
+  for (const r of results) {
+    if (r.error) {
+      console.log(
+        [pad(r.label, 32), pad("SKIP", 10, true), pad("-", 11, true), pad("-", 9, true), pad("-", 14, true), pad("-", 6, true)].join(" | ") +
+        `  (${r.error})`
+      );
+    } else {
+      console.log(
+        [
+          pad(r.label, 32),
+          pad(r.totalMs.toLocaleString(), 10, true),
+          pad(`${r.perChunkMs}ms`, 11, true),
+          pad(r.estimatedTokens.toLocaleString(), 9, true),
+          pad(formatCost(r.estimatedCost), 14, true),
+          pad(String(r.dims), 6, true),
+        ].join(" | ")
+      );
+    }
+  }
+
+  console.log(sep);
+  console.log();
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+async function main(): Promise<void> {
+  console.log("Sampling files...");
+  const filePaths = sampleFiles(OUTCOME_DIR, SAMPLE_SIZE);
+  const chunks = filePaths
+    .map((p) => { try { return extractChunk(readFileSync(p, "utf-8")); } catch { return ""; } })
+    .filter((c) => c.length > 10);
+  console.log(`Sampled ${filePaths.length} files → ${chunks.length} non-empty chunks.\n`);
+
+  // Initialize local LlamaCpp (lazy-loads on first embed call)
+  const llamaCpp = new LlamaCpp({
+    embedModel: DEFAULT_EMBED_MODEL_URI,
+    modelCacheDir: DEFAULT_MODEL_CACHE_DIR,
+    disposeModelsOnInactivity: false,
+  });
+
+  const results: BenchResult[] = [];
+
+  for (const model of MODELS) {
+    process.stdout.write(`Testing ${model.label}... `);
+    const result = await benchmarkModel(model, chunks, llamaCpp);
+    if (result.error) {
+      console.log(`SKIPPED (${result.error})`);
+    } else {
+      console.log(`done in ${result.totalMs.toLocaleString()}ms`);
+    }
+    results.push(result);
+  }
+
+  await llamaCpp.dispose();
+
+  printTable(results, chunks.length);
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -30,13 +30,89 @@ export function isQwen3EmbeddingModel(modelUri: string): boolean {
   return /qwen.*embed/i.test(modelUri) || /embed.*qwen/i.test(modelUri);
 }
 
+// =============================================================================
+// Embedding API Support (OpenAI-compatible + Gemini)
+// =============================================================================
+
+type EmbedApiType = "openai" | "gemini";
+
+/**
+ * Returns true if external embedding API is configured via QMD_EMBED_API_URL.
+ */
+export function isApiEmbeddingConfigured(): boolean {
+  return !!process.env.QMD_EMBED_API_URL;
+}
+
+/**
+ * Detect API type from the base URL.
+ * URLs containing "googleapis.com" use Gemini format; all others use OpenAI-compatible format.
+ */
+function getEmbedApiType(url: string): EmbedApiType {
+  return url.includes("googleapis.com") ? "gemini" : "openai";
+}
+
+/**
+ * Call external embedding API (OpenAI-compatible or Gemini) for a batch of texts.
+ * Returns embeddings in input order.
+ */
+async function callEmbeddingApi(texts: string[]): Promise<(number[] | null)[]> {
+  const baseUrl = process.env.QMD_EMBED_API_URL!;
+  const apiKey = process.env.QMD_EMBED_API_KEY ?? "";
+  const model = process.env.QMD_EMBED_API_MODEL ?? "text-embedding-3-small";
+  const apiType = getEmbedApiType(baseUrl);
+
+  if (apiType === "gemini") {
+    const modelId = model.startsWith("models/") ? model : `models/${model}`;
+    const url = `${baseUrl}/${modelId}:embedContent?key=${apiKey}`;
+    // Gemini only supports single embedContent; call in parallel for batch
+    return await Promise.all(
+      texts.map(async text => {
+        const resp = await fetch(url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content: { parts: [{ text }] } }),
+        });
+        if (!resp.ok) {
+          const errText = await resp.text();
+          throw new Error(`Gemini embedding API error ${resp.status}: ${errText}`);
+        }
+        const data = await resp.json() as { embedding: { values: number[] } };
+        return data.embedding?.values ?? null;
+      })
+    );
+  } else {
+    // OpenAI-compatible
+    const url = `${baseUrl}/embeddings`;
+    const body = { model, input: texts };
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+    const resp = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) {
+      const errText = await resp.text();
+      throw new Error(`OpenAI embedding API error ${resp.status}: ${errText}`);
+    }
+    const data = await resp.json() as { data: { index: number; embedding: number[] }[] };
+    const result: (number[] | null)[] = new Array(texts.length).fill(null);
+    for (const item of data.data) {
+      result[item.index] = item.embedding;
+    }
+    return result;
+  }
+}
+
 /**
  * Format a query for embedding.
  * Uses nomic-style task prefix format for embeddinggemma (default).
  * Uses Qwen3-Embedding instruct format when a Qwen embedding model is active.
+ * API mode (uri starts with "api:"): returns raw text without any prefix.
  */
 export function formatQueryForEmbedding(query: string, modelUri?: string): string {
-  const uri = modelUri ?? process.env.QMD_EMBED_MODEL ?? DEFAULT_EMBED_MODEL;
+  const uri = modelUri ?? (isApiEmbeddingConfigured() ? `api:${process.env.QMD_EMBED_API_MODEL ?? ""}` : (process.env.QMD_EMBED_MODEL ?? DEFAULT_EMBED_MODEL));
+  if (uri.startsWith("api:")) return query;
   if (isQwen3EmbeddingModel(uri)) {
     return `Instruct: Retrieve relevant documents for the given query\nQuery: ${query}`;
   }
@@ -47,9 +123,11 @@ export function formatQueryForEmbedding(query: string, modelUri?: string): strin
  * Format a document for embedding.
  * Uses nomic-style format with title and text fields (default).
  * Qwen3-Embedding encodes documents as raw text without special prefixes.
+ * API mode (uri starts with "api:"): returns raw text without any prefix.
  */
 export function formatDocForEmbedding(text: string, title?: string, modelUri?: string): string {
-  const uri = modelUri ?? process.env.QMD_EMBED_MODEL ?? DEFAULT_EMBED_MODEL;
+  const uri = modelUri ?? (isApiEmbeddingConfigured() ? `api:${process.env.QMD_EMBED_API_MODEL ?? ""}` : (process.env.QMD_EMBED_MODEL ?? DEFAULT_EMBED_MODEL));
+  if (uri.startsWith("api:")) return title ? `${title}\n${text}` : text;
   if (isQwen3EmbeddingModel(uri)) {
     // Qwen3-Embedding: documents are raw text, no task prefix
     return title ? `${title}\n${text}` : text;
@@ -854,7 +932,20 @@ export class LlamaCpp implements LLM {
     return { text: truncatedText, truncated: true };
   }
 
-  async embed(text: string, options: EmbedOptions = {}): Promise<EmbeddingResult | null> {
+  async embed(text: string, _options: EmbedOptions = {}): Promise<EmbeddingResult | null> {
+    if (isApiEmbeddingConfigured()) {
+      try {
+        const results = await callEmbeddingApi([text]);
+        const vec = results[0];
+        if (!vec) return null;
+        const model = `api:${process.env.QMD_EMBED_API_MODEL ?? ""}`;
+        return { embedding: vec, model };
+      } catch (error) {
+        console.error("API embedding error:", error);
+        return null;
+      }
+    }
+
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();
 
@@ -885,10 +976,22 @@ export class LlamaCpp implements LLM {
    */
   async embedBatch(texts: string[]): Promise<(EmbeddingResult | null)[]> {
     if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
-    // Ping activity at start to keep models alive during this operation
-    this.touchActivity();
 
     if (texts.length === 0) return [];
+
+    if (isApiEmbeddingConfigured()) {
+      try {
+        const vecs = await callEmbeddingApi(texts);
+        const model = `api:${process.env.QMD_EMBED_API_MODEL ?? ""}`;
+        return vecs.map(vec => vec ? { embedding: vec, model } : null);
+      } catch (error) {
+        console.error("API batch embedding error:", error);
+        return texts.map(() => null);
+      }
+    }
+
+    // Ping activity at start to keep models alive during this operation
+    this.touchActivity();
 
     try {
       const contexts = await this.ensureEmbedContexts();
@@ -975,7 +1078,7 @@ export class LlamaCpp implements LLM {
         temperature,
         topK: 20,
         topP: 0.8,
-        onTextChunk: (text) => {
+        onTextChunk: (text: string) => {
           result += text;
         },
       });
@@ -1019,7 +1122,6 @@ export class LlamaCpp implements LLM {
     await this.ensureGenerateModel();
 
     const includeLexical = options.includeLexical ?? true;
-    const context = options.context;
 
     const grammar = await llama.createGrammar({
       grammar: `
@@ -1068,7 +1170,7 @@ export class LlamaCpp implements LLM {
         return queryTerms.some(term => lower.includes(term));
       };
 
-      const queryables: Queryable[] = lines.map(line => {
+      const queryables: Queryable[] = lines.map((line: string) => {
         const colonIdx = line.indexOf(":");
         if (colonIdx === -1) return null;
         const type = line.slice(0, colonIdx).trim();
@@ -1076,7 +1178,7 @@ export class LlamaCpp implements LLM {
         const text = line.slice(colonIdx + 1).trim();
         if (!hasQueryTerm(text)) return null;
         return { type: type as QueryType, text };
-      }).filter((q): q is Queryable => q !== null);
+      }).filter((q: Queryable | null): q is Queryable => q !== null);
 
       // Filter out lex entries if not requested
       const filtered = includeLexical ? queryables : queryables.filter(q => q.type !== 'lex');
@@ -1106,7 +1208,7 @@ export class LlamaCpp implements LLM {
   async rerank(
     query: string,
     documents: RerankDocument[],
-    options: RerankOptions = {}
+    _options: RerankOptions = {}
   ): Promise<RerankResult> {
     if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
     // Ping activity at start to keep models alive during this operation


### PR DESCRIPTION
## What

Adds external embedding API support as an alternative to local GGUF models. Three environment variables activate API mode:

| Variable | Description | Example |
|----------|-------------|---------|
| \`QMD_EMBED_API_URL\` | Base URL (presence activates API mode) | \`https://api.openai.com/v1\` |
| \`QMD_EMBED_API_KEY\` | API key | \`sk-...\` |
| \`QMD_EMBED_API_MODEL\` | Model name | \`text-embedding-3-small\` |

API type is auto-detected from the URL — no extra config needed:
- URL contains \`googleapis.com\` → Gemini (\`batchEmbedContents\` endpoint)
- Otherwise → OpenAI-compatible format (works with Ollama, LM Studio, OpenAI, etc.)

## Usage

\`\`\`bash
# OpenAI
export QMD_EMBED_API_URL="https://api.openai.com/v1"
export QMD_EMBED_API_KEY="sk-..."
export QMD_EMBED_API_MODEL="text-embedding-3-small"
qmd embed && qmd vsearch "test query"

# Gemini (free tier)
export QMD_EMBED_API_URL="https://generativelanguage.googleapis.com/v1beta"
export QMD_EMBED_API_KEY="AIza..."
export QMD_EMBED_API_MODEL="gemini-embedding-001"
qmd embed && qmd vsearch "test query"

# Ollama (OpenAI-compatible)
export QMD_EMBED_API_URL="http://localhost:11434/v1"
export QMD_EMBED_API_MODEL="nomic-embed-text"
qmd embed && qmd vsearch "test query"
\`\`\`

## Why

Local GGUF embedding is great for privacy and offline use, but has tradeoffs:
- Requires downloading a model (~300MB+)
- Slower on CPU, needs Metal/CUDA for reasonable speed
- Limited model selection

API mode is useful when:
- Speed matters (cloud APIs are 2–5× faster in practice)
- You want higher-dimensional embeddings (3072 vs 768)
- Running in CI or on a machine without GPU

## Implementation notes

- \`formatQueryForEmbedding\` / \`formatDocForEmbedding\` return raw text when \`modelUri\` starts with \`api:\` — cloud models don't use nomic-style task prefixes
- Model stored in \`content_vectors.model\` as \`api:<model-name>\` — switching between local and API requires re-embedding (same as switching local models, existing behavior)
- Vector dimension is set dynamically on first embed, so any dimension works without schema changes

## Benchmark (63 chunks, Korean+English, M3 Max)

| Model | Per chunk | Cost (63 chunks) | Dims |
|-------|:---------:|:----------------:|-----:|
| embeddinggemma-300M local | 72ms | \$0 | 768 |
| text-embedding-3-small | 16ms | \$0.000290 | 1536 |
| text-embedding-3-large | 13ms | \$0.001882 | 3072 |
| gemini-embedding-001 | 38ms | free | 3072 |
| gemini-embedding-2-preview | 41ms | free | 3072 |

Full benchmark results + script in \`docs/embedding-benchmark.md\` and \`scripts/benchmark-embed.ts\`.

## Relation to other PRs

#406 and #415 also address remote embedding — worth noting the differences:

- **#406** introduces a new \`src/remote-embedding.ts\` class and \`index.yml\` config file for provider setup
- **#415** adds an OpenAI-compatible remote server mode (focused on oMLX/Apple Silicon)
- **This PR** uses env vars only (\`QMD_EMBED_API_URL\` / \`QMD_EMBED_API_KEY\` / \`QMD_EMBED_API_MODEL\`), consistent with QMD's existing configuration pattern (\`QMD_EMBED_MODEL\`, \`QMD_EMBED_CTX_SIZE\`, etc.), and integrates directly into \`llm.ts\` with a minimal diff (~130 lines added). No new files or config formats needed.

Happy to collaborate with the other authors or adjust the approach based on feedback.