### PR TITLE
feat: env vars to control model lifecycle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -359,10 +359,11 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
   // else: DB-only mode — no external config, use existing store_collections
 
   // Create a per-store LlamaCpp instance — lazy-loads models on first use,
-  // auto-unloads after 5 min inactivity to free VRAM.
+  // auto-unloads after inactivity to free VRAM.
+  const inactivityMs = parseInt(process.env.QMD_INACTIVITY_TIMEOUT_MS || '', 10);
   const llm = new LlamaCpp({
-    inactivityTimeoutMs: 5 * 60 * 1000,
-    disposeModelsOnInactivity: true,
+    inactivityTimeoutMs: Number.isFinite(inactivityMs) ? inactivityMs : 5 * 60 * 1000,
+    disposeModelsOnInactivity: process.env.QMD_KEEP_MODELS_LOADED === '1' ? false : true,
   });
   internal.llm = llm;
 


### PR DESCRIPTION
## Summary

When running QMD MCP as a long-lived daemon on CPU-only servers, model reload after inactivity disposal is very expensive (15–120s depending on CPU capabilities like AVX-512 vs AVX2). This makes `disposeModelsOnInactivity: true` impractical for always-on deployments where RAM is not a concern.

### Changes

Two opt-in environment variables added to `src/index.ts`:

- **`QMD_KEEP_MODELS_LOADED=1`** — disables model disposal on inactivity. Contexts are still disposed and recreated on demand (fast, <1s). Models stay in RAM (~1–2GB for embedding + reranker).
- **`QMD_INACTIVITY_TIMEOUT_MS=<ms>`** — overrides the default 5-minute inactivity timeout.

Both are opt-in. Without them, behavior is identical to current.

### Use case

```ini
# systemd service
[Service]
Environment=QMD_KEEP_MODELS_LOADED=1
ExecStart=qmd mcp --http --port 8181
```

### Context

The per-store `LlamaCpp` instance checks `canUnloadLLM()` on timer fire, which inspects the global `defaultSessionManager` — but the per-store instance isn't registered with any session manager. This means `canUnloadLLM()` always returns `true`, and models are disposed after every inactivity window regardless of active MCP sessions. Fixing that architectural issue is a bigger change; these env vars provide an immediate workaround for production deployments.

## Test plan

- [ ] Verify default behavior unchanged (no env vars set)
- [ ] Verify `QMD_KEEP_MODELS_LOADED=1` prevents model disposal after 5+ min idle
- [ ] Verify `QMD_INACTIVITY_TIMEOUT_MS=60000` changes timeout to 1 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)