### PR TITLE
fix(mcp): read version from package.json instead of hardcoding

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -9,6 +9,8 @@
 
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
 import { fileURLToPath } from "url";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -78,6 +80,16 @@ function formatSearchSummary(results: SearchResultItem[], query: string): string
     lines.push(`${r.docid} ${Math.round(r.score * 100)}% ${r.file} - ${r.title}`);
   }
   return lines.join('\n');
+}
+
+function getPackageVersion(): string {
+  try {
+    const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "../../package.json");
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+    return pkg.version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
 }
 
 // =============================================================================
@@ -157,7 +169,7 @@ async function buildInstructions(store: QMDStore): Promise<string> {
  */
 async function createMcpServer(store: QMDStore): Promise<McpServer> {
   const server = new McpServer(
-    { name: "qmd", version: "0.9.9" },
+    { name: "qmd", version: getPackageVersion() },
     { instructions: await buildInstructions(store) },
   );
 


### PR DESCRIPTION
## Problem

The MCP server reports `version: "0.9.9"` in its `initialize` handshake regardless of the actual installed version. The value is hardcoded in `src/mcp/server.ts` and was never updated across the 1.x and 2.x release trains:

```typescript
const server = new McpServer(
  { name: "qmd", version: "0.9.9" },  // hardcoded
);
```

Any tooling or agent that reads `serverInfo.version` from the MCP handshake gets a stale value.

## Fix

Read version from `package.json` at startup via a `getPackageVersion()` helper. Falls back to `"unknown"` if the file can't be read. Path resolution accounts for the compiled output location (`dist/mcp/server.js` → `../../package.json`).

## Testing

Built and tested locally. MCP `initialize` response now returns the correct version from `package.json`:

| | Before | After |
|---|--------|-------|
| `serverInfo.version` | `0.9.9` | `2.0.1` |

Verified via a benchmark script that connects directly to the MCP HTTP transport and reads the `initialize` response.

## Environment

- QMD: v2.0.1
- Platform: macOS (Apple Silicon)
- Node: v24.2.0