### PR TITLE
feat(mcp): expose plain query parameter for auto-expand search

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -270,11 +270,12 @@ Combine types for best results. First sub-query gets 2× weight — put your str
 
 | Goal | Approach |
 |------|----------|
+| General search (recommended) | Use \`query\` parameter — auto-expands via trained model |
 | Know exact term/name | \`lex\` only |
 | Concept search | \`vec\` only |
 | Best recall | \`lex\` + \`vec\` |
 | Complex/nuanced | \`lex\` + \`vec\` + \`hyde\` |
-| Unknown vocabulary | Use a standalone natural-language query (no typed lines) so the server can auto-expand it |
+| Unknown vocabulary | Use \`query\` parameter with natural language so the server auto-expands it |
 
 ## Examples
 
@@ -301,8 +302,14 @@ Intent-aware lex (C++ performance, not sports):
 \`\`\``,
       annotations: { readOnlyHint: true, openWorldHint: false },
       inputSchema: {
-        searches: z.array(subSearchSchema).min(1).max(10).describe(
-          "Typed sub-queries to execute (lex/vec/hyde). First gets 2x weight."
+        query: z.string().optional().describe(
+          "Plain text query — auto-expanded by the trained model into lex/vec/hyde " +
+          "variants, then fused via RRF and reranked. Recommended default for most searches. " +
+          "Mutually exclusive with 'searches'."
+        ),
+        searches: z.array(subSearchSchema).max(10).optional().describe(
+          "Typed sub-queries to execute (lex/vec/hyde). First gets 2x weight. " +
+          "Use for precise control over retrieval strategy. Mutually exclusive with 'query'."
         ),
         limit: z.number().optional().default(10).describe("Max results (default: 10)"),
         minScore: z.number().optional().default(0).describe("Min relevance 0-1 (default: 0)"),
@@ -318,29 +325,62 @@ Intent-aware lex (C++ performance, not sports):
         ),
       },
     },
-    async ({ searches, limit, minScore, candidateLimit, collections, intent, rerank }) => {
-      // Map to internal format
-      const queries: ExpandedQuery[] = searches.map(s => ({
-        type: s.type,
-        query: s.query,
-      }));
+    async ({ query, searches, limit, minScore, candidateLimit, collections, intent, rerank }) => {
+      // Validate: exactly one of query/searches should be provided
+      if (!query && (!searches || searches.length === 0)) {
+        return {
+          content: [{
+            type: "text" as const,
+            text: "Error: provide either 'query' (plain text) or 'searches' (typed sub-queries)",
+          }],
+          isError: true,
+        };
+      }
+      if (query && searches && searches.length > 0) {
+        return {
+          content: [{
+            type: "text" as const,
+            text: "Error: 'query' and 'searches' are mutually exclusive; provide only one",
+          }],
+          isError: true,
+        };
+      }
 
       // Use default collections if none specified
       const effectiveCollections = collections ?? defaultCollectionNames;
 
-      const results = await store.search({
-        queries,
-        collections: effectiveCollections.length > 0 ? effectiveCollections : undefined,
-        limit,
-        minScore,
-        rerank,
-        intent,
-      });
+      let results;
+      let primaryQuery: string;
 
-      // Use first lex or vec query for snippet extraction
-      const primaryQuery = searches.find(s => s.type === 'lex')?.query
-        || searches.find(s => s.type === 'vec')?.query
-        || searches[0]?.query || "";
+      if (query) {
+        primaryQuery = query;
+        results = await store.search({
+          query,
+          collections: effectiveCollections.length > 0 ? effectiveCollections : undefined,
+          limit,
+          minScore,
+          rerank,
+          intent,
+        });
+      } else {
+        const queries: ExpandedQuery[] = (searches ?? []).map(s => ({
+          type: s.type,
+          query: s.query,
+        }));
+
+        primaryQuery = searches?.find(s => s.type === 'lex')?.query
+          || searches?.find(s => s.type === 'vec')?.query
+          || searches?.[0]?.query || "";
+
+        results = await store.search({
+          queries,
+          collections: effectiveCollections.length > 0 ? effectiveCollections : undefined,
+          limit,
+          minScore,
+          rerank,
+          intent,
+        });
+      }
 
       const filtered: SearchResultItem[] = results.map(r => {
         const { line, snippet } = extractSnippet(r.bestChunk, primaryQuery, 300, undefined, undefined, intent);


### PR DESCRIPTION
## Problem

The SDK `search()` method accepts either `query` (plain string → auto-expanded by the trained model) or `queries` (pre-expanded typed sub-queries). The CLI `qmd query "text"` uses the `query` path, triggering the full pipeline: expansion → parallel BM25 + vector → RRF → reranking.

However, the MCP `query` tool only exposes the `queries` path via the `searches` parameter. There is no way to send a plain text query through MCP and get the full auto-expand pipeline.

The tool description Strategy table even says: *"Unknown vocabulary | Use a standalone natural-language query (no typed lines) so the server can auto-expand it"* — but the tool schema doesn't accept a standalone query.

## Fix

Add an optional `query` string parameter to the MCP `query` tool. When provided, route to `store.search({ query })` which calls `hybridQuery()` with auto-expansion. `query` and `searches` are mutually exclusive — providing both returns an error.

The `searches` parameter is made optional (was required). Validation ensures at least one of `query` or `searches` is provided.

Tool description Strategy table updated to recommend `query` as the default approach.

## Testing

Built and tested locally against a 7,791 document index:

| Query type | Latency | Results | Notes |
|-----------|---------|---------|-------|
| `query: "how does authentication work"` (cold) | 961ms | 5 | Expansion model loading |
| `query: "how does authentication work"` (warm) | 259ms | 5 | Cached — 3.7× faster |
| `query: "DEC-0054 sub-agent spawn protocol"` | 273ms | 5 | 93% top hit ✅ |
| `searches: [{type: "lex", query: "\"DEC-0054\""}]` | 197ms | 5 | Existing path, unchanged |
| `searches: [{type: "vec", query: "..."}]` | 622ms | 5 | Existing path, unchanged |

Existing `searches` parameter works identically to before — no breaking changes.

## Environment

- QMD: v2.0.1
- Platform: macOS (Apple Silicon)
- Node: v24.2.0