### PR TITLE
feat(mcp): expose explain parameter for retrieval score traces

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -45,6 +45,21 @@ type SearchResultItem = {
   score: number;
   context: string | null;
   snippet: string;
+  explain?: {
+    ftsScores: number[];
+    vectorScores: number[];
+    rrf: {
+      rank: number;
+      positionScore: number;
+      weight: number;
+      baseScore: number;
+      topRankBonus: number;
+      totalScore: number;
+      contributions: { source: string; queryType: string; rank: number; rrfContribution: number }[];
+    };
+    rerankScore: number;
+    blendedScore: number;
+  };
 };
 
 type StatusResult = {
@@ -316,9 +331,13 @@ Intent-aware lex (C++ performance, not sports):
         rerank: z.boolean().optional().default(true).describe(
           "Rerank results using LLM (default: true). Set to false for faster results on CPU-only machines."
         ),
+        explain: z.boolean().optional().default(false).describe(
+          "Include retrieval score traces (FTS scores, vector scores, RRF fusion breakdown, " +
+          "rerank blend weights) in each result. Useful for debugging query quality and search tuning."
+        ),
       },
     },
-    async ({ searches, limit, minScore, candidateLimit, collections, intent, rerank }) => {
+    async ({ searches, limit, minScore, candidateLimit, collections, intent, rerank, explain }) => {
       // Map to internal format
       const queries: ExpandedQuery[] = searches.map(s => ({
         type: s.type,
@@ -335,6 +354,7 @@ Intent-aware lex (C++ performance, not sports):
         minScore,
         rerank,
         intent,
+        explain,
       });
 
       // Use first lex or vec query for snippet extraction
@@ -351,6 +371,7 @@ Intent-aware lex (C++ performance, not sports):
           score: Math.round(r.score * 100) / 100,
           context: r.context,
           snippet: addLineNumbers(snippet, line),
+          ...(r.explain ? { explain: r.explain } : {}),
         };
       });
 
@@ -678,6 +699,7 @@ export async function startMcpHttpServer(port: number, options?: { quiet?: boole
           limit: params.limit ?? 10,
           minScore: params.minScore ?? 0,
           intent: params.intent,
+          explain: params.explain ?? false,
         });
 
         // Use first lex or vec query for snippet extraction
@@ -694,6 +716,7 @@ export async function startMcpHttpServer(port: number, options?: { quiet?: boole
             score: Math.round(r.score * 100) / 100,
             context: r.context,
             snippet: addLineNumbers(snippet, line),
+            ...(r.explain ? { explain: r.explain } : {}),
           };
         });
 


### PR DESCRIPTION
## Problem

The CLI `qmd query --explain` flag includes detailed retrieval score traces per result — FTS scores, vector scores, RRF fusion breakdown, reranker blend weights, and per-source contributions. This is a shipped v2.0.1 feature.

However, the MCP `query` tool does not expose this option. MCP clients cannot debug query quality, understand score composition, or tune search parameters without dropping to the CLI.

## Fix

Add an optional `explain` boolean parameter to the MCP `query` tool (default: `false`). When enabled, pass `explain: true` through to `structuredSearch()` and include the `HybridQueryExplain` object on each result.

Changes:
- Extend `SearchResultItem` type with optional `explain` field
- Add `explain` to MCP tool input schema
- Pass `explain` through in both MCP tool handler and REST `/query` endpoint
- Conditionally include explain data in results (only when present, keeps response compact by default)

## Testing

Built and tested locally against a 7,665 document index:

| Query | explain | Result |
|-------|---------|--------|
| `searches: [{type: "lex", query: "boot gate"}]` | `true` | ftsScores, rrf breakdown, rerankScore, blendedScore all present |
| `searches: [{type: "lex", query: "boot gate"}]` | `false` | Standard result, no explain field |
| `searches: [{type: "lex", query: "boot gate"}]` | omitted | Same as false (default) |

Example explain output:

    {
      "ftsScores": [0.88],
      "vectorScores": [],
      "rrf": { "rank": 1, "totalScore": 0.083, "contributions": [{"source": "fts", "rank": 1, "weight": 2}] },
      "rerankScore": 0.502,
      "blendedScore": 0.875
    }

Existing queries without `explain` return results unchanged — no breaking changes.

## Environment

- QMD: v2.0.1
- Platform: macOS (Apple Silicon)
- Node: v24.2.0