### PR TITLE
feat(mcp): expose skipRerank and candidateLimit in query tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -159,6 +159,8 @@ export interface SearchOptions {
   limit?: number;
   /** Minimum score threshold */
   minScore?: number;
+  /** Maximum candidates to rerank (default: 40) */
+  candidateLimit?: number;
   /** Include explain traces */
   explain?: boolean;
 }
@@ -388,6 +390,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
           collections: collections.length > 0 ? collections : undefined,
           limit: opts.limit,
           minScore: opts.minScore,
+          candidateLimit: opts.candidateLimit,
           explain: opts.explain,
           intent: opts.intent,
           skipRerank,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -292,13 +292,16 @@ Intent-aware lex (C++ performance, not sports):
         candidateLimit: z.number().optional().describe(
           "Maximum candidates to rerank (default: 40, lower = faster but may miss results)"
         ),
+        skipRerank: z.boolean().optional().describe(
+          "Skip LLM reranking and use RRF fusion scores only. Much faster on CPU-only servers."
+        ),
         collections: z.array(z.string()).optional().describe("Filter to collections (OR match)"),
         intent: z.string().optional().describe(
           "Background context to disambiguate the query. Example: query='performance', intent='web page load times and Core Web Vitals'. Does not search on its own."
         ),
       },
     },
-    async ({ searches, limit, minScore, candidateLimit, collections, intent }) => {
+    async ({ searches, limit, minScore, candidateLimit, skipRerank, collections, intent }) => {
       // Map to internal format
       const queries: ExpandedQuery[] = searches.map(s => ({
         type: s.type,
@@ -313,7 +316,9 @@ Intent-aware lex (C++ performance, not sports):
         collections: effectiveCollections.length > 0 ? effectiveCollections : undefined,
         limit,
         minScore,
+        candidateLimit,
         intent,
+        ...(skipRerank ? { rerank: false } : {}),
       });
 
       // Use first lex or vec query for snippet extraction


### PR DESCRIPTION
## Problem

On CPU-only servers (no GPU), the LLM reranker model (Qwen3-Reranker-0.6B) takes ~2 seconds **per document** to score. A typical query with 20 candidates takes 30-40 seconds — far exceeding the 1-2s timeouts used by automated RAG hooks.

The internal `structuredSearch` already supports `skipRerank` and `candidateLimit`, but neither is exposed through the MCP `query` tool.

## Changes

- **`skipRerank`** (boolean, optional): added to MCP `query` tool schema. When `true`, returns results scored by RRF fusion only — no LLM rerank. Queries complete in 30-50ms instead of 30-40s.
- **`candidateLimit`**: was declared in the MCP schema but never forwarded to `store.search()`. Now passed through.
- Added `candidateLimit` to the `SearchOptions` interface.

## Use case

Automated RAG hooks (e.g. Telegram bot preprocessing) on VPS without GPU, where the reranker model is prohibitively slow. `skipRerank: true` gives fast approximate results; the LLM reranker remains available for interactive / CLI use.

## Performance

| | With rerank | skipRerank=true |
|---|---|---|
| Cold (model load) | 30-40s | 400-500ms |
| Warm | 30-40s (rerank dominates) | 30-50ms |

Tested on AMD EPYC 8-core (no GPU), QMD 2.0.1, node-llama-cpp 3.18.1.