### PR TITLE
feat: env vars to control model inactivity timeout (QMD_MODEL_KEEP_ALIVE, QMD_MODEL_TTL)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -359,10 +359,15 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
   // else: DB-only mode — no external config, use existing store_collections
 
   // Create a per-store LlamaCpp instance — lazy-loads models on first use,
-  // auto-unloads after 5 min inactivity to free VRAM.
+  // auto-unloads after inactivity to free VRAM.
+  //
+  // QMD_MODEL_KEEP_ALIVE=1  — disable inactivity timer entirely (models + contexts stay in RAM)
+  // QMD_MODEL_TTL=<seconds> — override inactivity timeout (default: 300s / 5 min)
+  const keepAlive = process.env.QMD_MODEL_KEEP_ALIVE === '1';
+  const ttlSec = Number(process.env.QMD_MODEL_TTL) || 300;
   const llm = new LlamaCpp({
-    inactivityTimeoutMs: 5 * 60 * 1000,
-    disposeModelsOnInactivity: true,
+    inactivityTimeoutMs: keepAlive ? 0 : ttlSec * 1000,
+    disposeModelsOnInactivity: !keepAlive,
   });
   internal.llm = llm;
 


### PR DESCRIPTION
## Problem

In MCP daemon mode on CPU-only servers, the 5-minute inactivity timer disposes model contexts. Recreating contexts takes 500-750ms, which can exceed tight RAG timeouts (1-2s) when combined with session init overhead.

There is currently no way to control this behavior without patching `dist/index.js`.

## Solution

Two environment variables:

- **`QMD_MODEL_KEEP_ALIVE=1`** — disables the inactivity timer entirely. Models and contexts stay in RAM for the lifetime of the process. Ideal for always-on MCP servers.
- **`QMD_MODEL_TTL=<seconds>`** — overrides the default 300s (5 min) inactivity timeout. Allows tuning without disabling entirely.

Default behavior is unchanged.

## Usage

```bash
# systemd service
[Service]
Environment=QMD_MODEL_KEEP_ALIVE=1
ExecStart=/path/to/qmd mcp --http

# or just increase timeout to 30 min
[Service]
Environment=QMD_MODEL_TTL=1800
ExecStart=/path/to/qmd mcp --http
```

## Impact

| Scenario | Without | QMD_MODEL_KEEP_ALIVE=1 |
|---|---|---|
| After 6 min idle | 750ms (context recreation) | 58ms (instant) |
| RAM usage | ~300MB freed after idle | ~300MB permanent |

Tested on AMD EPYC 8-core (no GPU), QMD 2.0.1.