### PR TITLE
feat: support remote OpenAI-compatible embedding via QMD_EMBED_API_URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support remote OpenAI-compatible embedding API via `QMD_EMBED_API_URL`.
+  When set, `embed` and `embedBatch` delegate to the remote `/v1/embeddings`
+  endpoint instead of loading a local GGUF model. Useful for GPU offloading
+  (e.g. llama-server, Ollama) or cloud APIs (OpenAI, LiteLLM).
+  Optional: `QMD_EMBED_API_KEY` (Bearer token), `QMD_EMBED_API_MODEL` (model
+  name, default `text-embedding-3-small`). Fixes #403.
+
 ### Fixes
 
 - Sync stale `bun.lock` (`better-sqlite3` 11.x → 12.x). CI and release

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -305,6 +305,72 @@ export async function pullModels(
 }
 
 // =============================================================================
+// Remote Embed Client
+// =============================================================================
+
+/**
+ * OpenAI-compatible remote embedding client.
+ *
+ * Activated when `QMD_EMBED_API_URL` is set. Sends texts to a remote
+ * `/v1/embeddings` endpoint (Ollama, OpenAI, LiteLLM, vLLM, etc.) instead
+ * of running a local GGUF model via node-llama-cpp.
+ *
+ * Environment variables:
+ *   QMD_EMBED_API_URL   Base URL of the embedding server (e.g. http://localhost:11434/v1)
+ *   QMD_EMBED_API_KEY   Optional API key sent as Bearer token
+ *   QMD_EMBED_API_MODEL Model name to pass in the request body (default: "text-embedding-3-small")
+ */
+class RemoteEmbedClient {
+  private readonly baseUrl: string;
+  private readonly apiKey: string | undefined;
+  private readonly model: string;
+
+  constructor() {
+    this.baseUrl = (process.env.QMD_EMBED_API_URL ?? "").replace(/\/+$/, "");
+    this.apiKey = process.env.QMD_EMBED_API_KEY;
+    this.model = process.env.QMD_EMBED_API_MODEL ?? "text-embedding-3-small";
+  }
+
+  async embed(text: string): Promise<EmbeddingResult | null> {
+    const results = await this.embedBatch([text]);
+    return results[0] ?? null;
+  }
+
+  async embedBatch(texts: string[]): Promise<(EmbeddingResult | null)[]> {
+    if (texts.length === 0) return [];
+
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (this.apiKey) headers["Authorization"] = `Bearer ${this.apiKey}`;
+
+    try {
+      const res = await fetch(`${this.baseUrl}/embeddings`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ input: texts, model: this.model }),
+      });
+
+      if (!res.ok) {
+        const msg = await res.text().catch(() => String(res.status));
+        console.error(`QMD remote embed API error ${res.status}: ${msg}`);
+        return texts.map(() => null);
+      }
+
+      const json = await res.json() as {
+        data: { embedding: number[]; index: number }[];
+        model: string;
+      };
+
+      // Sort by index to guarantee input order is preserved
+      const sorted = [...json.data].sort((a, b) => a.index - b.index);
+      return sorted.map(d => ({ embedding: d.embedding, model: json.model }));
+    } catch (err) {
+      console.error("QMD remote embed fetch error:", err);
+      return texts.map(() => null);
+    }
+  }
+}
+
+// =============================================================================
 // LLM Interface
 // =============================================================================
 
@@ -855,6 +921,10 @@ export class LlamaCpp implements LLM {
   }
 
   async embed(text: string, options: EmbedOptions = {}): Promise<EmbeddingResult | null> {
+    if (process.env.QMD_EMBED_API_URL) {
+      return new RemoteEmbedClient().embed(text);
+    }
+
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();
 
@@ -884,6 +954,10 @@ export class LlamaCpp implements LLM {
    * Uses Promise.all for parallel embedding - node-llama-cpp handles batching internally
    */
   async embedBatch(texts: string[]): Promise<(EmbeddingResult | null)[]> {
+    if (process.env.QMD_EMBED_API_URL) {
+      return new RemoteEmbedClient().embedBatch(texts);
+    }
+
     if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -7,7 +7,7 @@
  * rerank functions first to trigger model downloads.
  */
 
-import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
+import { describe, test, expect, beforeAll, afterAll, afterEach, vi } from "vitest";
 import {
   LlamaCpp,
   getDefaultLlamaCpp,
@@ -720,5 +720,163 @@ describe.skipIf(!!process.env.CI)("LLM Session Management", () => {
         })
       ).rejects.toThrow("Custom test error");
     });
+  });
+});
+
+// =============================================================================
+// Remote Embed API Tests (QMD_EMBED_API_URL)
+// =============================================================================
+
+describe("RemoteEmbedClient via LlamaCpp (QMD_EMBED_API_URL)", () => {
+  const FAKE_URL = "http://fake-embed-server/v1";
+
+  afterEach(() => {
+    delete process.env.QMD_EMBED_API_URL;
+    delete process.env.QMD_EMBED_API_KEY;
+    delete process.env.QMD_EMBED_API_MODEL;
+    vi.restoreAllMocks();
+  });
+
+  test("delegates embed() to remote API when QMD_EMBED_API_URL is set", async () => {
+    const mockEmbedding = Array.from({ length: 768 }, (_, i) => i / 768);
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: [{ embedding: mockEmbedding, index: 0 }],
+        model: "text-embedding-remote",
+      }),
+    } as Response);
+
+    process.env.QMD_EMBED_API_URL = FAKE_URL;
+    const llm = new LlamaCpp({});
+    const result = await llm.embed("hello world");
+
+    expect(result).not.toBeNull();
+    expect(result!.embedding).toHaveLength(768);
+    expect(result!.embedding[0]).toBeCloseTo(mockEmbedding[0]!);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(String(url)).toContain("/embeddings");
+    expect((init as RequestInit).method).toBe("POST");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.input).toEqual(["hello world"]);
+  });
+
+  test("includes Authorization header when QMD_EMBED_API_KEY is set", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: [{ embedding: [0.1], index: 0 }], model: "m" }),
+    } as Response);
+
+    process.env.QMD_EMBED_API_URL = FAKE_URL;
+    process.env.QMD_EMBED_API_KEY = "sk-test-key";
+    const llm = new LlamaCpp({});
+    await llm.embed("test");
+
+    const [, init] = fetchSpy.mock.calls[0]!;
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer sk-test-key");
+  });
+
+  test("omits Authorization header when QMD_EMBED_API_KEY is not set", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: [{ embedding: [0.1], index: 0 }], model: "m" }),
+    } as Response);
+
+    process.env.QMD_EMBED_API_URL = FAKE_URL;
+    const llm = new LlamaCpp({});
+    await llm.embed("test");
+
+    const [, init] = fetchSpy.mock.calls[0]!;
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers["Authorization"]).toBeUndefined();
+  });
+
+  test("embedBatch() sends all texts in one request and preserves order", async () => {
+    const embeddings = [
+      Array.from({ length: 4 }, () => 0.1),
+      Array.from({ length: 4 }, () => 0.2),
+      Array.from({ length: 4 }, () => 0.3),
+    ];
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        // Return in reverse order to test index-based sorting
+        data: [
+          { embedding: embeddings[2]!, index: 2 },
+          { embedding: embeddings[0]!, index: 0 },
+          { embedding: embeddings[1]!, index: 1 },
+        ],
+        model: "text-embedding-remote",
+      }),
+    } as Response);
+
+    process.env.QMD_EMBED_API_URL = FAKE_URL;
+    const llm = new LlamaCpp({});
+    const results = await llm.embedBatch(["a", "b", "c"]);
+
+    expect(results).toHaveLength(3);
+    expect(fetchSpy).toHaveBeenCalledOnce(); // single batch request
+    const body = JSON.parse((fetchSpy.mock.calls[0]![1] as RequestInit).body as string);
+    expect(body.input).toEqual(["a", "b", "c"]);
+    // Results should be in original order
+    expect(results[0]!.embedding[0]).toBeCloseTo(0.1);
+    expect(results[1]!.embedding[0]).toBeCloseTo(0.2);
+    expect(results[2]!.embedding[0]).toBeCloseTo(0.3);
+  });
+
+  test("embed() returns null on HTTP error and does not throw", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => "Internal Server Error",
+    } as Response);
+
+    process.env.QMD_EMBED_API_URL = FAKE_URL;
+    const llm = new LlamaCpp({});
+    const result = await llm.embed("test");
+
+    expect(result).toBeNull();
+  });
+
+  test("embed() returns null on network failure and does not throw", async () => {
+    vi.spyOn(global, "fetch").mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    process.env.QMD_EMBED_API_URL = FAKE_URL;
+    const llm = new LlamaCpp({});
+    const result = await llm.embed("test");
+
+    expect(result).toBeNull();
+  });
+
+  test("uses QMD_EMBED_API_MODEL as model field in request", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: [{ embedding: [0.5], index: 0 }], model: "custom-model" }),
+    } as Response);
+
+    process.env.QMD_EMBED_API_URL = FAKE_URL;
+    process.env.QMD_EMBED_API_MODEL = "custom-model";
+    const llm = new LlamaCpp({});
+    await llm.embed("test");
+
+    const body = JSON.parse((fetchSpy.mock.calls[0]![1] as RequestInit).body as string);
+    expect(body.model).toBe("custom-model");
+  });
+
+  test("does NOT call local node-llama-cpp when QMD_EMBED_API_URL is set", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: [{ embedding: [0.1], index: 0 }], model: "m" }),
+    } as Response);
+
+    process.env.QMD_EMBED_API_URL = FAKE_URL;
+    const llm = new LlamaCpp({}) as any;
+    const ensureEmbedSpy = vi.spyOn(llm, "ensureEmbedContext").mockResolvedValue({} as any);
+
+    await llm.embed("test");
+
+    expect(ensureEmbedSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Adds support for routing embedding calls to a remote OpenAI-compatible API (e.g. Ollama, llama-server) via `QMD_EMBED_API_URL`, for environments where loading a local GGUF model isn't practical.

Submitted too early — closing to revise. Will reopen when it's properly ready.