### PR TITLE
feat(cli): add --host flag and QMD_MCP_HOST for MCP HTTP bind address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- `qmd mcp --http --host <addr>` flag to control the bind address of the MCP
+  HTTP server. Defaults to `127.0.0.1` (loopback-only, same security posture
+  as before). Set to `0.0.0.0` to accept connections from other hosts (e.g.
+  containers, remote clients). Also configurable via `QMD_MCP_HOST` env var;
+  the CLI flag takes precedence.
+
 ### Fixes
 
 - Sync stale `bun.lock` (`better-sqlite3` 11.x → 12.x). CI and release

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -2376,6 +2376,7 @@ function parseCLI() {
       http: { type: "boolean" },
       daemon: { type: "boolean" },
       port: { type: "string" },
+      host: { type: "string" },
     },
     allowPositionals: true,
     strict: false, // Allow unknown options to pass through
@@ -3047,6 +3048,7 @@ if (isMain) {
 
       if (cli.values.http) {
         const port = Number(cli.values.port) || 8181;
+        const host = (cli.values.host as string | undefined) ?? process.env.QMD_MCP_HOST ?? "127.0.0.1";
 
         if (cli.values.daemon) {
           // Guard: check if already running
@@ -3065,9 +3067,10 @@ if (isMain) {
           const logPath = resolve(cacheDir, "mcp.log");
           const logFd = openSync(logPath, "w"); // truncate — fresh log per daemon run
           const selfPath = fileURLToPath(import.meta.url);
+          const baseArgs = ["mcp", "--http", "--port", String(port), "--host", host];
           const spawnArgs = selfPath.endsWith(".ts")
-            ? ["--import", pathJoin(dirname(selfPath), "..", "..", "node_modules", "tsx", "dist", "esm", "index.mjs"), selfPath, "mcp", "--http", "--port", String(port)]
-            : [selfPath, "mcp", "--http", "--port", String(port)];
+            ? ["--import", pathJoin(dirname(selfPath), "..", "..", "node_modules", "tsx", "dist", "esm", "index.mjs"), selfPath, ...baseArgs]
+            : [selfPath, ...baseArgs];
           const child = nodeSpawn(process.execPath, spawnArgs, {
             stdio: ["ignore", logFd, logFd],
             detached: true,
@@ -3076,7 +3079,7 @@ if (isMain) {
           closeSync(logFd); // parent's copy; child inherited the fd
 
           writeFileSync(pidPath, String(child.pid));
-          console.log(`Started on http://localhost:${port}/mcp (PID ${child.pid})`);
+          console.log(`Started on http://${host}:${port}/mcp (PID ${child.pid})`);
           console.log(`Logs: ${logPath}`);
           process.exit(0);
         }
@@ -3087,7 +3090,7 @@ if (isMain) {
         process.removeAllListeners("SIGINT");
         const { startMcpHttpServer } = await import("../mcp/server.js");
         try {
-          await startMcpHttpServer(port);
+          await startMcpHttpServer(port, { host });
         } catch (e: any) {
           if (e?.code === "EADDRINUSE") {
             console.error(`Port ${port} already in use. Try a different port with --port.`);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -538,9 +538,10 @@ export type HttpServerHandle = {
 
 /**
  * Start MCP server over Streamable HTTP (JSON responses, no SSE).
- * Binds to localhost only. Returns a handle for shutdown and port discovery.
+ * Binds to `options.host`, `QMD_MCP_HOST` env var, or `127.0.0.1` by default.
+ * Returns a handle for shutdown and port discovery.
  */
-export async function startMcpHttpServer(port: number, options?: { quiet?: boolean }): Promise<HttpServerHandle> {
+export async function startMcpHttpServer(port: number, options?: { quiet?: boolean; host?: string }): Promise<HttpServerHandle> {
   const store = await createStore({ dbPath: getDefaultDbPath() });
 
   // Pre-fetch default collection names for REST endpoint
@@ -571,6 +572,7 @@ export async function startMcpHttpServer(port: number, options?: { quiet?: boole
     return transport;
   }
 
+  const bindHost = options?.host ?? process.env.QMD_MCP_HOST ?? "127.0.0.1";
   const startTime = Date.now();
   const quiet = options?.quiet ?? false;
 
@@ -769,7 +771,7 @@ export async function startMcpHttpServer(port: number, options?: { quiet?: boole
 
   await new Promise<void>((resolve, reject) => {
     httpServer.on("error", reject);
-    httpServer.listen(port, "localhost", () => resolve());
+    httpServer.listen(port, bindHost, () => resolve());
   });
 
   const actualPort = (httpServer.address() as import("net").AddressInfo).port;

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1075,3 +1075,101 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
     expect(json.result.content.length).toBeGreaterThan(0);
   });
 });
+
+// =============================================================================
+// MCP HTTP Bind Host Tests (QMD_MCP_HOST / host option)
+// =============================================================================
+
+describe.skipIf(!!process.env.CI)("MCP HTTP bind host", () => {
+  const origIndexPath = process.env.INDEX_PATH;
+  const origConfigDir = process.env.QMD_CONFIG_DIR;
+  const origMcpHost = process.env.QMD_MCP_HOST;
+
+  // Reuse the httpTestDbPath and httpTestConfigDir variables are not in scope here,
+  // so we set up our own isolated DB for these tests.
+  let bindTestDbPath: string;
+  let bindTestConfigDir: string;
+
+  beforeAll(async () => {
+    bindTestDbPath = `/tmp/qmd-mcp-bind-test-${Date.now()}.sqlite`;
+    const db = openDatabase(bindTestDbPath);
+    initTestDatabase(db);
+    seedTestData(db);
+
+    const bindTestConfig: CollectionConfig = {
+      collections: { docs: { path: "/test/docs", pattern: "**/*.md" } }
+    };
+    syncConfigToDb(db, bindTestConfig);
+    db.close();
+
+    const configPrefix = join(tmpdir(), `qmd-mcp-bind-config-${Date.now()}`);
+    bindTestConfigDir = await mkdtemp(configPrefix);
+    await writeFile(join(bindTestConfigDir, "index.yml"), YAML.stringify(bindTestConfig));
+
+    process.env.INDEX_PATH = bindTestDbPath;
+    process.env.QMD_CONFIG_DIR = bindTestConfigDir;
+  });
+
+  afterAll(async () => {
+    if (origIndexPath !== undefined) process.env.INDEX_PATH = origIndexPath;
+    else delete process.env.INDEX_PATH;
+    if (origConfigDir !== undefined) process.env.QMD_CONFIG_DIR = origConfigDir;
+    else delete process.env.QMD_CONFIG_DIR;
+    if (origMcpHost !== undefined) process.env.QMD_MCP_HOST = origMcpHost;
+    else delete process.env.QMD_MCP_HOST;
+
+    try { unlinkSync(bindTestDbPath); } catch {}
+    try {
+      const files = await readdir(bindTestConfigDir);
+      for (const f of files) await unlink(join(bindTestConfigDir, f));
+      await rmdir(bindTestConfigDir);
+    } catch {}
+  });
+
+  test("accepts host option and binds to specified address", async () => {
+    const handle = await startMcpHttpServer(0, { quiet: true, host: "127.0.0.1" });
+    try {
+      const res = await fetch(`http://127.0.0.1:${handle.port}/health`);
+      expect(res.status).toBe(200);
+      const body = await res.json() as { status: string };
+      expect(body.status).toBe("ok");
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  test("uses QMD_MCP_HOST env var when no host option is given", async () => {
+    process.env.QMD_MCP_HOST = "127.0.0.1";
+    const handle = await startMcpHttpServer(0, { quiet: true });
+    try {
+      const res = await fetch(`http://127.0.0.1:${handle.port}/health`);
+      expect(res.status).toBe(200);
+    } finally {
+      await handle.stop();
+      delete process.env.QMD_MCP_HOST;
+    }
+  });
+
+  test("host option takes precedence over QMD_MCP_HOST", async () => {
+    process.env.QMD_MCP_HOST = "0.0.0.0";
+    const handle = await startMcpHttpServer(0, { quiet: true, host: "127.0.0.1" });
+    try {
+      const res = await fetch(`http://127.0.0.1:${handle.port}/health`);
+      expect(res.status).toBe(200);
+    } finally {
+      await handle.stop();
+      delete process.env.QMD_MCP_HOST;
+    }
+  });
+
+  test("defaults to 127.0.0.1 when neither option nor env var is set", async () => {
+    delete process.env.QMD_MCP_HOST;
+    const handle = await startMcpHttpServer(0, { quiet: true });
+    try {
+      const res = await fetch(`http://127.0.0.1:${handle.port}/health`);
+      expect(res.status).toBe(200);
+    } finally {
+      await handle.stop();
+    }
+  });
+});


### PR DESCRIPTION
Adds `QMD_MCP_HOST` to control the bind address of `qmd mcp --http` (default: `127.0.0.1`), for running inside Docker containers or on a remote host.

Submitted too early — closing to revise. Will reopen when it's properly ready.