### PR TITLE
feat: Modal.com remote GPU inference backend

### DIFF
--- a/.github/workflows/build-llama-server.yml
+++ b/.github/workflows/build-llama-server.yml
@@ -1,0 +1,53 @@
+name: Build llama-server CUDA image
+
+on:
+  push:
+    branches: [feat/modal-inference]
+    paths:
+      - 'modal/Dockerfile.llama-server'
+      - '.github/workflows/build-llama-server.yml'
+  workflow_dispatch:
+    inputs:
+      llama_cpp_tag:
+        description: 'llama.cpp tag to build (e.g. b8179)'
+        required: false
+        default: 'b8179'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/qmd-llama-server
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./modal
+          file: ./modal/Dockerfile.llama-server
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.llama_cpp_tag || 'b8179' }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          build-args: |
+            LLAMA_CPP_TAG=${{ inputs.llama_cpp_tag || 'b8179' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-llama-server.yml
+++ b/.github/workflows/build-llama-server.yml
@@ -12,6 +12,10 @@ on:
         description: 'llama.cpp tag to build (e.g. b8179)'
         required: false
         default: 'b8179'
+      cuda_architectures:
+        description: 'CUDA architectures (e.g. 75 for T4)'
+        required: false
+        default: '75'
 
 env:
   REGISTRY: ghcr.io
@@ -45,9 +49,10 @@ jobs:
           file: ./modal/Dockerfile.llama-server
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.llama_cpp_tag || 'b8179' }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.llama_cpp_tag || 'b8179' }}-sm${{ inputs.cuda_architectures || '75' }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           build-args: |
             LLAMA_CPP_TAG=${{ inputs.llama_cpp_tag || 'b8179' }}
+            CUDA_ARCHITECTURES=${{ inputs.cuda_architectures || '75' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ texts/
 !finetune/*.md
 !docs/*.md
 !docs/superpowers/specs/*.md
+!docs/superpowers/plans/*.md
 finetune/outputs/
 finetune/data/train/
 .claude/

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ texts/
 !skills/**/*.md
 !finetune/*.md
 !docs/*.md
+!docs/superpowers/specs/*.md
 finetune/outputs/
 finetune/data/train/
 .claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changes
+
+- Added: Optional Modal.com inference backend for remote GPU inference (`qmd modal deploy`)
+
 ### Fixes
 
 - Sync stale `bun.lock` (`better-sqlite3` 11.x → 12.x). CI and release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,10 @@ qmd mcp                           # Start MCP server (stdio transport)
 qmd mcp --http [--port N]         # Start MCP server (HTTP, default port 8181)
 qmd mcp --http --daemon           # Start as background daemon
 qmd mcp stop                      # Stop background MCP daemon
+qmd modal deploy                  # Deploy Modal inference (remote GPU)
+qmd modal status                  # Check Modal deployment status
+qmd modal test                    # Smoke test embed + generate
+qmd modal destroy                 # Tear down Modal deployment
 ```
 
 ## Collection Management
@@ -131,11 +135,39 @@ npx vitest run --reporter=verbose test/
 bun test --preload ./src/test-preload.ts test/
 ```
 
+## Modal Inference (Remote GPU)
+
+Optional remote GPU inference via Modal.com for users without a local GPU.
+Runs the same 3 GGUF models on a T4 GPU using llama-server (llama.cpp HTTP server).
+
+```sh
+# Prerequisites: pip install modal && modal token set
+
+# Deploy (creates GPU snapshot, ~1 min first time)
+qmd modal deploy
+
+# Query uses Modal automatically when deployed
+qmd query "search terms"
+
+# Tear down
+qmd modal destroy
+```
+
+Config keys in `~/.config/qmd/index.yml`:
+- `modal.inference` (bool, default false) — enable/disable Modal inference
+- `modal.gpu` (string, default "T4") — GPU type
+- `modal.scaledown_window` (number, default 15) — idle timeout in seconds
+
+Architecture: 3 llama-server subprocesses per container (embed/expand/rerank),
+pre-built Docker image at `ghcr.io/ofekby/qmd-llama-server:b8179-sm75`,
+GPU memory snapshots for ~6s cold starts. JS calls Modal via `modal` npm SDK.
+
 ## Architecture
 
 - SQLite FTS5 for full-text search (BM25)
 - sqlite-vec for vector similarity search
-- node-llama-cpp for embeddings (embeddinggemma), reranking (qwen3-reranker), and query expansion (Qwen3)
+- node-llama-cpp for local embeddings (embeddinggemma), reranking (qwen3-reranker), and query expansion (Qwen3)
+- Modal.com for optional remote GPU inference (same models via llama-server)
 - Reciprocal Rank Fusion (RRF) for combining results
 - Smart chunking: 900 tokens/chunk with 15% overlap, prefers markdown headings as boundaries
 

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "picomatch": "^4.0.0",
         "sqlite-vec": "^0.1.7-alpha.2",
         "yaml": "^2.8.2",
-        "zod": "^4.2.1",
+        "zod": "4.2.1",
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.0",
@@ -20,6 +20,7 @@
         "vitest": "^3.0.0",
       },
       "optionalDependencies": {
+        "modal": "^0.7.3",
         "sqlite-vec-darwin-arm64": "^0.1.7-alpha.2",
         "sqlite-vec-darwin-x64": "^0.1.7-alpha.2",
         "sqlite-vec-linux-arm64": "^0.1.7-alpha.2",
@@ -32,6 +33,18 @@
     },
   },
   "packages": {
+    "@cbor-extract/cbor-extract-darwin-arm64": ["@cbor-extract/cbor-extract-darwin-arm64@2.2.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZKZ/F8US7JR92J4DMct6cLW/Y66o2K576+zjlEN/MevH70bFIsB10wkZEQPLzl2oNh2SMGy55xpJ9JoBRl5DOA=="],
+
+    "@cbor-extract/cbor-extract-darwin-x64": ["@cbor-extract/cbor-extract-darwin-x64@2.2.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-32b1mgc+P61Js+KW9VZv/c+xRw5EfmOcPx990JbCBSkYJFY0l25VinvyyWfl+3KjibQmAcYwmyzKF9J4DyKP/Q=="],
+
+    "@cbor-extract/cbor-extract-linux-arm": ["@cbor-extract/cbor-extract-linux-arm@2.2.2", "", { "os": "linux", "cpu": "arm" }, "sha512-tNg0za41TpQfkhWjptD+0gSD2fggMiDCSacuIeELyb2xZhr7PrhPe5h66Jc67B/5dmpIhI2QOUtv4SBsricyYQ=="],
+
+    "@cbor-extract/cbor-extract-linux-arm64": ["@cbor-extract/cbor-extract-linux-arm64@2.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-wfqgzqCAy/Vn8i6WVIh7qZd0DdBFaWBjPdB6ma+Wihcjv0gHqD/mw3ouVv7kbbUNrab6dKEx/w3xQZEdeXIlzg=="],
+
+    "@cbor-extract/cbor-extract-linux-x64": ["@cbor-extract/cbor-extract-linux-x64@2.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-rpiLnVEsqtPJ+mXTdx1rfz4RtUGYIUg2rUAZgd1KjiC1SehYUSkJN7Yh+aVfSjvCGtVP0/bfkQkXpPXKbmSUaA=="],
+
+    "@cbor-extract/cbor-extract-win32-x64": ["@cbor-extract/cbor-extract-win32-x64@2.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA=="],
+
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
@@ -84,6 +97,10 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
 
+    "@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
+
+    "@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
+
     "@hono/node-server": ["@hono/node-server@1.19.7", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw=="],
 
     "@huggingface/jinja": ["@huggingface/jinja@0.5.5", "", {}, "sha512-xRlzazC+QZwr6z4ixEqYHo9fgwhTZ3xNSdljlKfUFGZSdlvt166DljRELFUfFytlYOYvo3vTisA/AFOuOAzFQQ=="],
@@ -91,6 +108,8 @@
     "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
     "@kwsites/file-exists": ["@kwsites/file-exists@1.1.1", "", { "dependencies": { "debug": "^4.1.1" } }, "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw=="],
 
@@ -129,6 +148,26 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
     "@reflink/reflink": ["@reflink/reflink@0.1.19", "", { "optionalDependencies": { "@reflink/reflink-darwin-arm64": "0.1.19", "@reflink/reflink-darwin-x64": "0.1.19", "@reflink/reflink-linux-arm64-gnu": "0.1.19", "@reflink/reflink-linux-arm64-musl": "0.1.19", "@reflink/reflink-linux-x64-gnu": "0.1.19", "@reflink/reflink-linux-x64-musl": "0.1.19", "@reflink/reflink-win32-arm64-msvc": "0.1.19", "@reflink/reflink-win32-x64-msvc": "0.1.19" } }, "sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA=="],
 
@@ -224,6 +263,8 @@
 
     "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
+    "abort-controller-x": ["abort-controller-x@0.4.3", "", {}, "sha512-VtUwTNU8fpMwvWGn4xE93ywbogTYsuT+AUxAXOeelbXuQVIwNmC5YLeho9sH4vZ4ITW8414TTAOG1nW6uIVHCA=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
@@ -261,6 +302,10 @@
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "cbor-extract": ["cbor-extract@2.2.2", "", { "dependencies": { "node-gyp-build-optional-packages": "5.1.1" }, "optionalDependencies": { "@cbor-extract/cbor-extract-darwin-arm64": "2.2.2", "@cbor-extract/cbor-extract-darwin-x64": "2.2.2", "@cbor-extract/cbor-extract-linux-arm": "2.2.2", "@cbor-extract/cbor-extract-linux-arm64": "2.2.2", "@cbor-extract/cbor-extract-linux-x64": "2.2.2", "@cbor-extract/cbor-extract-win32-x64": "2.2.2" }, "bin": { "download-cbor-prebuilds": "bin/download-prebuilds.js" } }, "sha512-hlSxxI9XO2yQfe9g6msd3g4xCfDqK5T5P0fRMLuaLHhxn4ViPrm+a+MUfhrvH2W962RGxcBwEGzLQyjbDG1gng=="],
+
+    "cbor-x": ["cbor-x@1.6.4", "", { "optionalDependencies": { "cbor-extract": "^2.2.2" } }, "sha512-UGKHjp6RHC6QuZ2yy5LCKm7MojM4716DwoSaqwQpaH4DvZvbBTGcoDNTiG9Y2lByXZYFEs9WRkS5tLl96IrF1Q=="],
 
     "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
@@ -456,9 +501,13 @@
 
     "lifecycle-utils": ["lifecycle-utils@3.1.1", "", {}, "sha512-gNd3OvhFNjHykJE3uGntz7UuPzWlK9phrIdXxU9Adis0+ExkwnZibfxCJWiWWZ+a6VbKiZrb+9D9hCQWd4vjTg=="],
 
+    "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
+
     "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
 
     "log-symbols": ["log-symbols@7.0.1", "", { "dependencies": { "is-unicode-supported": "^2.0.0", "yoctocolors": "^2.1.1" } }, "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
@@ -492,6 +541,8 @@
 
     "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
+    "modal": ["modal@0.7.3", "", { "dependencies": { "cbor-x": "^1.6.0", "long": "^5.3.1", "nice-grpc": "^2.1.12", "protobufjs": "^7.5.0", "smol-toml": "^1.3.3", "uuid": "^11.1.0" } }, "sha512-4CliqNF15sZPBGpSoCj5Y9fd8fTp1ONrBLIJiC4amm/Qzc1rn8CH45SVzSu+1DokHCIRiZqQ1xMhRKpDvDCkBw=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@5.1.6", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
@@ -500,11 +551,17 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
+    "nice-grpc": ["nice-grpc@2.1.14", "", { "dependencies": { "@grpc/grpc-js": "^1.14.0", "abort-controller-x": "^0.4.0", "nice-grpc-common": "^2.0.2" } }, "sha512-GK9pKNxlvnU5FAdaw7i2FFuR9CqBspcE+if2tqnKXBcE0R8525wj4BZvfcwj7FjvqbssqKxRHt2nwedalbJlww=="],
+
+    "nice-grpc-common": ["nice-grpc-common@2.0.2", "", { "dependencies": { "ts-error": "^1.0.6" } }, "sha512-7RNWbls5kAL1QVUOXvBsv1uO0wPQK3lHv+cY1gwkTzirnG1Nop4cBJZubpgziNbaVc/bl9QJcyvsf/NQxa3rjQ=="],
+
     "node-abi": ["node-abi@3.87.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ=="],
 
     "node-addon-api": ["node-addon-api@8.5.0", "", {}, "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A=="],
 
     "node-api-headers": ["node-api-headers@1.8.0", "", {}, "sha512-jfnmiKWjRAGbdD1yQS28bknFM1tbHC1oucyuMPjmkEs+kpiu76aRs40WlTmBmyEgzDM76ge1DQ7XJ3R5deiVjQ=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.1.1", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-test": "build-test.js", "node-gyp-build-optional-packages-optional": "optional.js" } }, "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw=="],
 
     "node-llama-cpp": ["node-llama-cpp@3.17.1", "", { "dependencies": { "@huggingface/jinja": "^0.5.5", "async-retry": "^1.3.3", "bytes": "^3.1.2", "chalk": "^5.6.2", "chmodrp": "^1.0.2", "cmake-js": "^8.0.0", "cross-spawn": "^7.0.6", "env-var": "^7.5.0", "filenamify": "^6.0.0", "fs-extra": "^11.3.0", "ignore": "^7.0.4", "ipull": "^3.9.5", "is-unicode-supported": "^2.1.0", "lifecycle-utils": "^3.1.1", "log-symbols": "^7.0.1", "nanoid": "^5.1.6", "node-addon-api": "^8.5.0", "ora": "^9.3.0", "pretty-ms": "^9.3.0", "proper-lockfile": "^4.1.2", "semver": "^7.7.1", "simple-git": "^3.32.2", "slice-ansi": "^8.0.0", "stdout-update": "^4.0.1", "strip-ansi": "^7.1.2", "validate-npm-package-name": "^7.0.2", "which": "^6.0.1", "yargs": "^17.7.2" }, "optionalDependencies": { "@node-llama-cpp/linux-arm64": "3.17.1", "@node-llama-cpp/linux-armv7l": "3.17.1", "@node-llama-cpp/linux-x64": "3.17.1", "@node-llama-cpp/linux-x64-cuda": "3.17.1", "@node-llama-cpp/linux-x64-cuda-ext": "3.17.1", "@node-llama-cpp/linux-x64-vulkan": "3.17.1", "@node-llama-cpp/mac-arm64-metal": "3.17.1", "@node-llama-cpp/mac-x64": "3.17.1", "@node-llama-cpp/win-arm64": "3.17.1", "@node-llama-cpp/win-x64": "3.17.1", "@node-llama-cpp/win-x64-cuda": "3.17.1", "@node-llama-cpp/win-x64-cuda-ext": "3.17.1", "@node-llama-cpp/win-x64-vulkan": "3.17.1" }, "peerDependencies": { "typescript": ">=5.0.0" }, "optionalPeers": ["typescript"], "bin": { "node-llama-cpp": "dist/cli/cli.js", "nlc": "dist/cli/cli.js" } }, "sha512-f+eYXag3kFeMwLrTTSTtyt+4p2etJGvTPXEdipYy7EqSZha9ZFBpGYNftxZwbdTiqh/qyNSe3TeZve5tkq5OPQ=="],
 
@@ -547,6 +604,8 @@
     "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
     "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
+
+    "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
@@ -620,6 +679,8 @@
 
     "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
 
+    "smol-toml": ["smol-toml@1.6.0", "", {}, "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "sqlite-vec": ["sqlite-vec@0.1.7-alpha.2", "", { "optionalDependencies": { "sqlite-vec-darwin-arm64": "0.1.7-alpha.2", "sqlite-vec-darwin-x64": "0.1.7-alpha.2", "sqlite-vec-linux-arm64": "0.1.7-alpha.2", "sqlite-vec-linux-x64": "0.1.7-alpha.2", "sqlite-vec-windows-x64": "0.1.7-alpha.2" } }, "sha512-rNgRCv+4V4Ed3yc33Qr+nNmjhtrMnnHzXfLVPeGb28Dx5mmDL3Ngw/Wk8vhCGjj76+oC6gnkmMG8y73BZWGBwQ=="],
@@ -678,6 +739,8 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
+    "ts-error": ["ts-error@1.0.6", "", {}, "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA=="],
+
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
@@ -695,6 +758,8 @@
     "url-join": ["url-join@4.0.1", "", {}, "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
 

--- a/docs/modal-inference-backend-design.md
+++ b/docs/modal-inference-backend-design.md
@@ -1,0 +1,319 @@
+# Modal Inference Backend for QMD
+
+## Summary
+
+Add optional remote GPU inference via Modal.com, allowing users without a local GPU to run QMD's three GGUF models (embedding, reranking, query expansion) on a cheap cloud GPU. The Modal function is a dumb model server exposing raw inference primitives — all prompt formatting and search logic stays in QMD's JS codebase.
+
+## Architecture Overview
+
+```
+User machine (JS/TS)                          Modal (Python)
+┌─────────────────────────┐                   ┌──────────────────────────┐
+│  src/llm.ts             │                   │  modal/serve.py          │
+│  ┌───────────────────┐  │                   │  ┌────────────────────┐  │
+│  │ Prompt formatting  │  │                   │  │ QMDInference class │  │
+│  │ Grammar logic      │  │   JS SDK (gRPC)   │  │                    │  │
+│  │ Result parsing     │──┼──────────────────►│  │ embed()   - raw    │  │
+│  │                    │  │                   │  │ generate() - raw   │  │
+│  │ ModalBackend       │  │                   │  │ score()   - raw    │  │
+│  └───────────────────┘  │                   │  └────────────────────┘  │
+│                         │                   │                          │
+│  src/store.ts           │                   │  T4 GPU (default)        │
+│  (unchanged logic)      │                   │  3 GGUF models in image  │
+└─────────────────────────┘                   └──────────────────────────┘
+```
+
+## Python Modal Service (`modal/serve.py`)
+
+A single Python file shipped in the QMD repo. Defines and deploys the Modal function.
+
+### Image Build
+
+- Base image with `llama-cpp-python` installed with CUDA support
+- Downloads all 3 GGUF models from HuggingFace at image build time:
+  - `hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf` (~300MB)
+  - `hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf` (~640MB)
+  - `hf:tobil/qmd-query-expansion-1.7B-gguf/qmd-query-expansion-1.7B-q4_k_m.gguf` (~1.1GB)
+- Models baked into image — no runtime downloads
+
+### Class Definition
+
+```python
+import modal
+
+app = modal.App("qmd-inference")
+
+# gpu and scaledown_window are passed as CLI args during deploy
+@app.cls(
+    gpu=gpu_config,                     # Configurable, default "T4"
+    scaledown_window=idle_timeout,      # Configurable, default 15 seconds
+    allow_concurrent_inputs=10,         # Handle burst queries on single container
+    enable_memory_snapshot=True,        # Snapshot model state after loading
+)
+class QMDInference:
+    @modal.enter(snap=True)
+    def load_models(self):
+        """Load all 3 models + warmup. Captured in memory snapshot."""
+        from llama_cpp import Llama
+
+        self.embed_model = Llama(
+            model_path="/models/embeddinggemma-300M-Q8_0.gguf",
+            embedding=True,
+            n_ctx=2048,
+        )
+        self.rerank_model = Llama(
+            model_path="/models/qwen3-reranker-0.6b-q8_0.gguf",
+            n_ctx=2048,
+        )
+        self.expand_model = Llama(
+            model_path="/models/qmd-query-expansion-1.7B-q4_k_m.gguf",
+            n_ctx=2048,
+        )
+        # Warmup passes to pre-fill caches before snapshot
+        self.embed_model.embed("warmup")
+        self.expand_model("warmup", max_tokens=1)
+
+    @modal.method()
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Raw embedding — no prompt formatting."""
+        return [self.embed_model.embed(text) for text in texts]
+
+    @modal.method()
+    def generate(self, prompt: str, grammar: str | None, max_tokens: int) -> str:
+        """Raw completion with optional GBNF grammar constraint."""
+        kwargs = {"prompt": prompt, "max_tokens": max_tokens}
+        if grammar:
+            from llama_cpp import LlamaGrammar
+            kwargs["grammar"] = LlamaGrammar.from_string(grammar)
+        result = self.expand_model(**kwargs)
+        return result["choices"][0]["text"]
+
+    @modal.method()
+    def score(self, pairs: list[tuple[str, str]]) -> list[float]:
+        """Raw cross-encoder scoring of (query, document) pairs."""
+        scores = []
+        for query, document in pairs:
+            # Use rerank model to score relevance
+            result = self.rerank_model.create_completion(
+                prompt=f"{query}\n{document}",
+                max_tokens=1,
+                logprobs=True,
+            )
+            scores.append(result["choices"][0]["logprobs"]["token_logprobs"][0])
+        return scores
+
+    @modal.method()
+    def ping(self) -> bool:
+        """Health check — verifies function is reachable and models loaded."""
+        return True
+```
+
+### Container Behavior
+
+- `scaledown_window=15` — container shuts down 15s after last request (cost-efficient for burst patterns)
+- `allow_concurrent_inputs=10` — single container handles bursts without triggering scale-up
+- `enable_memory_snapshot=True` + `@modal.enter(snap=True)` — after first deploy, subsequent cold starts restore from memory snapshot instead of re-loading ~2GB of models
+- No `min_containers` / `keep_warm` — scales to zero when idle
+- Single container by design (no max_containers param exists, but concurrency + low traffic pattern means no scale-up)
+
+### Deploy CLI
+
+`modal/serve.py` also acts as a CLI entry point:
+
+```sh
+python modal/serve.py deploy --gpu T4 --scaledown-window 15
+python modal/serve.py status
+python modal/serve.py destroy
+```
+
+## QMD Config
+
+### New Config Keys
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `modal.inference` | boolean | `false` | Enable Modal-based inference |
+| `modal.gpu` | string | `"T4"` | GPU type for the Modal container |
+| `modal.scaledown_window` | number | `15` | Seconds before idle container shuts down |
+
+### Auth
+
+Reads from `~/.modal.toml` (Modal's native auth file, created by user running `modal token set`). QMD does not store Modal credentials — it relies on Modal's own config.
+
+## CLI Commands
+
+### `qmd modal deploy`
+
+1. Check `python3` is available on PATH
+   - If missing: `Error: python3 not found. Install Python 3.10+ to deploy Modal functions. See https://python.org`
+2. Check `modal` Python package is installed (`python3 -c "import modal"`)
+   - If missing: `Error: Modal Python package not found. Run: pip install modal`
+3. Check `~/.modal.toml` exists
+   - If missing: `Error: Modal not authenticated. Run: modal token set`
+4. Read `modal.gpu` and `modal.scaledown_window` from QMD config
+5. Shell out to `python3 modal/serve.py deploy --gpu <gpu> --scaledown-window <timeout>`
+6. On success: auto-set `modal.inference = true` in QMD config
+7. Print confirmation with deployed function name
+
+### `qmd modal status`
+
+Check if the Modal function is deployed and reachable. Calls `ping()` method.
+
+### `qmd modal destroy`
+
+Tears down the deployed Modal function. Sets `modal.inference = false`.
+
+## JS Runtime Integration (`src/modal.ts`)
+
+### ModalBackend Class
+
+```typescript
+class ModalBackend {
+  private client: modal.Client
+  private fn: modal.Function  // Reference to deployed QMDInference
+
+  /**
+   * Raw embedding — caller is responsible for prompt formatting.
+   */
+  async embed(texts: string[]): Promise<number[][]>
+
+  /**
+   * Raw text generation with optional GBNF grammar.
+   * Caller passes the fully formatted prompt and grammar string.
+   */
+  async generate(prompt: string, grammar: string | null, maxTokens: number): Promise<string>
+
+  /**
+   * Raw cross-encoder scoring.
+   * Caller passes pre-formatted (query, document) pairs.
+   */
+  async score(pairs: [string, string][]): Promise<number[]>
+
+  /**
+   * Health check.
+   */
+  async ping(): Promise<boolean>
+}
+```
+
+### Initialization
+
+- Created lazily on first inference call
+- Reads `~/.modal.toml` for auth (via `modal` npm package)
+- Resolves the deployed `qmd-inference` function reference
+- If function not found or auth missing: immediate hard fail with clear error message
+
+### Retry Logic (Connection Errors Only)
+
+```
+attempt 1 → connection error → immediate retry
+          → connection error → wait 100ms → retry
+          → connection error → throw with full stacktrace and reason
+
+Non-connection errors (auth, not found, etc.) → immediate throw, no retry
+```
+
+### Integration in `src/llm.ts`
+
+The existing inference call sites in `llm.ts` get a conditional swap:
+
+```typescript
+// At each inference call site (embed, generate, rerank)
+if (config.get("modal.inference")) {
+  return modalBackend.embed(texts)
+} else {
+  return localLlama.embed(texts)
+}
+```
+
+`src/store.ts` functions (`generateEmbeddings`, `searchVec`, `expandQuery`, `rerank`) remain unchanged — they call `llm.ts` which handles the backend swap transparently.
+
+### Startup Validation
+
+When `modal.inference = true`:
+- On MCP server startup: call `ping()` to verify Modal function is reachable
+- On CLI command: same `ping()` check before executing
+- Failure: hard fail with full error, no fallback to local
+
+## Error Messages
+
+### Deploy-Time Errors
+
+```
+Error: python3 not found on PATH.
+Modal deployment requires Python 3.10+.
+Install it from https://python.org or via your package manager.
+
+Error: Python 'modal' package not found.
+Install it with: pip install modal
+Then authenticate with: modal token set
+
+Error: Modal not authenticated. No ~/.modal.toml found.
+Run: modal token set
+to authenticate with your Modal account.
+
+Error: Modal deployment failed.
+<full stderr from python process>
+```
+
+### Runtime Errors
+
+```
+Error: Modal inference is enabled but the deployed function is not reachable.
+Run 'qmd modal status' to check deployment, or 'qmd modal deploy' to redeploy.
+<full error details / stacktrace>
+
+Error: Modal inference is enabled but ~/.modal.toml is missing or invalid.
+Run: modal token set
+```
+
+## File Layout
+
+### New Files
+
+```
+modal/
+  serve.py            # Modal app definition + deploy CLI
+  requirements.txt    # llama-cpp-python, modal (for reference — installed in Modal image)
+src/
+  modal.ts            # ModalBackend class (JS SDK client)
+```
+
+### Modified Files
+
+```
+src/llm.ts            # Conditional: local vs modal backend at inference call sites
+src/cli/qmd.ts        # New 'qmd modal deploy|status|destroy' subcommands
+src/config.ts         # New config keys: modal.inference, modal.gpu, modal.scaledown_window
+package.json          # Add 'modal' npm dependency
+```
+
+## Dependencies
+
+### Deploy-Time (user's machine)
+
+- `python3` (3.10+)
+- `modal` pip package (for `modal deploy` CLI)
+
+### Runtime (user's machine)
+
+- `modal` npm package (v0.6+) — JS SDK for calling deployed function
+
+### Modal Image (cloud)
+
+- `llama-cpp-python` with CUDA support
+- 3 GGUF model files (baked into image)
+
+## Design Decisions
+
+1. **Dumb model server** — Modal function exposes raw `embed()`, `generate()`, `score()`. All prompt formatting, grammar construction, and result parsing stays in JS. Zero duplication, zero drift risk.
+
+2. **Memory snapshots** — `enable_memory_snapshot=True` with `@modal.enter(snap=True)` captures loaded models in memory. Subsequent cold starts restore from snapshot instead of re-loading ~2GB of model weights.
+
+3. **Single container** — `allow_concurrent_inputs=10` handles burst patterns on one container. 15s idle timeout scales to zero quickly. No `keep_warm` to minimize cost.
+
+4. **JS SDK for runtime** — The `modal` npm package calls deployed functions directly via gRPC. No HTTP endpoints, no URL management. Auth handled by Modal tokens.
+
+5. **Python only for deploy** — Users need Python + `modal` pip package only for the one-time `qmd modal deploy`. Runtime is pure JS.
+
+6. **No fallback** — When `modal.inference = true`, local models are never used. Clear failure modes prevent confusing mixed results. Connection errors get 2 retries (immediate + 100ms), then hard fail.

--- a/docs/modal-inference-backend-design.md
+++ b/docs/modal-inference-backend-design.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Add optional remote GPU inference via Modal.com, allowing users without a local GPU to run QMD's three GGUF models (embedding, reranking, query expansion) on a cheap cloud GPU. The Modal function is a dumb model server exposing raw inference primitives — all prompt formatting and search logic stays in QMD's JS codebase.
+Add optional remote GPU inference via Modal.com, allowing users without a local GPU to run QMD's three GGUF models (embedding, reranking, query expansion) on a cheap cloud GPU. The Modal function is a dumb model server exposing raw inference primitives (`embed()`, `generate()`, `ping()`) — all prompt formatting (including chat templates and special tokens), grammar construction, and search logic stays in QMD's JS codebase. Reranking is handled via `generate()` — the JS side constructs the full Qwen3-Reranker chat-templated prompt and passes it as a completion request.
 
 ## Architecture Overview
 
@@ -15,7 +15,7 @@ User machine (JS/TS)                          Modal (Python)
 │  │ Grammar logic      │  │   JS SDK (gRPC)   │  │                    │  │
 │  │ Result parsing     │──┼──────────────────►│  │ embed()   - raw    │  │
 │  │                    │  │                   │  │ generate() - raw   │  │
-│  │ ModalBackend       │  │                   │  │ score()   - raw    │  │
+│  │ ModalBackend       │  │                   │  │ ping()    - health │  │
 │  └───────────────────┘  │                   │  └────────────────────┘  │
 │                         │                   │                          │
 │  src/store.ts           │                   │  T4 GPU (default)        │
@@ -47,7 +47,7 @@ app = modal.App("qmd-inference")
 @app.cls(
     gpu=gpu_config,                     # Configurable, default "T4"
     scaledown_window=idle_timeout,      # Configurable, default 15 seconds
-    allow_concurrent_inputs=10,         # Handle burst queries on single container
+    allow_concurrent_inputs=4,          # See Design Decisions for concurrency rationale
     enable_memory_snapshot=True,        # Snapshot model state after loading
 )
 class QMDInference:
@@ -71,36 +71,43 @@ class QMDInference:
         )
         # Warmup passes to pre-fill caches before snapshot
         self.embed_model.embed("warmup")
+        self.rerank_model("warmup", max_tokens=1)
         self.expand_model("warmup", max_tokens=1)
 
     @modal.method()
     def embed(self, texts: list[str]) -> list[list[float]]:
-        """Raw embedding — no prompt formatting."""
-        return [self.embed_model.embed(text) for text in texts]
+        """Raw embedding — no prompt formatting.
+        Returns shape [n_texts, embed_dim].
+        Note: llama-cpp-python's Llama.embed() returns List[List[float]].
+        We normalize to always return one embedding vector per input text.
+        """
+        result = []
+        for text in texts:
+            vec = self.embed_model.embed(text)
+            # Llama.embed() returns List[List[float]] — take first element
+            # to normalize to a single vector per input text
+            if isinstance(vec[0], list):
+                result.append(vec[0])
+            else:
+                result.append(vec)
+        return result
 
     @modal.method()
-    def generate(self, prompt: str, grammar: str | None, max_tokens: int) -> str:
-        """Raw completion with optional GBNF grammar constraint."""
+    def generate(self, prompt: str, grammar: str | None, max_tokens: int,
+                 model: str = "expand") -> str:
+        """Raw completion with optional GBNF grammar constraint.
+        No chat template application — the caller must construct the full
+        prompt including any special tokens (e.g. <|im_start|>, <|im_end|>).
+        Used for both query expansion (model="expand") and reranking
+        (model="rerank") since both go through raw completion.
+        """
+        llm = self.rerank_model if model == "rerank" else self.expand_model
         kwargs = {"prompt": prompt, "max_tokens": max_tokens}
         if grammar:
             from llama_cpp import LlamaGrammar
             kwargs["grammar"] = LlamaGrammar.from_string(grammar)
-        result = self.expand_model(**kwargs)
+        result = llm(**kwargs)
         return result["choices"][0]["text"]
-
-    @modal.method()
-    def score(self, pairs: list[tuple[str, str]]) -> list[float]:
-        """Raw cross-encoder scoring of (query, document) pairs."""
-        scores = []
-        for query, document in pairs:
-            # Use rerank model to score relevance
-            result = self.rerank_model.create_completion(
-                prompt=f"{query}\n{document}",
-                max_tokens=1,
-                logprobs=True,
-            )
-            scores.append(result["choices"][0]["logprobs"]["token_logprobs"][0])
-        return scores
 
     @modal.method()
     def ping(self) -> bool:
@@ -111,7 +118,7 @@ class QMDInference:
 ### Container Behavior
 
 - `scaledown_window=15` — container shuts down 15s after last request (cost-efficient for burst patterns)
-- `allow_concurrent_inputs=10` — single container handles bursts without triggering scale-up
+- `allow_concurrent_inputs=4` — single container handles bursts without triggering scale-up. llama-cpp-python serializes GPU inference internally, so concurrent requests queue at the CUDA level rather than causing OOM, but lower concurrency reduces latency variance
 - `enable_memory_snapshot=True` + `@modal.enter(snap=True)` — after first deploy, subsequent cold starts restore from memory snapshot instead of re-loading ~2GB of models
 - No `min_containers` / `keep_warm` — scales to zero when idle
 - Single container by design (no max_containers param exists, but concurrency + low traffic pattern means no scale-up)
@@ -127,6 +134,8 @@ python modal/serve.py destroy
 ```
 
 ## QMD Config
+
+The `modal.*` config keys live in QMD's existing config file at `~/.config/qmd/index.yml` (managed by `src/collections.ts`). These are global settings, not per-collection.
 
 ### New Config Keys
 
@@ -151,9 +160,9 @@ Reads from `~/.modal.toml` (Modal's native auth file, created by user running `m
 3. Check `~/.modal.toml` exists
    - If missing: `Error: Modal not authenticated. Run: modal token set`
 4. Read `modal.gpu` and `modal.scaledown_window` from QMD config
-5. Shell out to `python3 modal/serve.py deploy --gpu <gpu> --scaledown-window <timeout>`
+5. Shell out to `python3 modal/serve.py deploy --gpu <gpu> --scaledown-window <timeout>`. The JS CLI resolves `modal/serve.py` relative to the QMD package installation directory (via `import.meta.url` resolution from the compiled JS in `dist/`). The `modal/` directory must be included in `package.json`'s `files` array.
 6. On success: auto-set `modal.inference = true` in QMD config
-7. Print confirmation with deployed function name
+7. Print confirmation with deployed function name and a brief cost note: "GPU: T4 (~$0.59/hr, billed per second, scales to zero when idle)"
 
 ### `qmd modal status`
 
@@ -162,6 +171,16 @@ Check if the Modal function is deployed and reachable. Calls `ping()` method.
 ### `qmd modal destroy`
 
 Tears down the deployed Modal function. Sets `modal.inference = false`.
+
+### `qmd modal test`
+
+Runs a small end-to-end smoke test to verify the deployed function works correctly:
+
+1. Calls `embed()` with a short test string, verifies the response is a well-formed embedding vector (array of floats with expected dimensionality)
+2. Calls `generate()` with a short prompt, verifies the response is a non-empty string of generated tokens
+3. Prints pass/fail for each check
+
+This catches model loading or CUDA issues that `ping()` alone would not detect (e.g., models loaded but producing garbage output, CUDA out-of-memory during inference).
 
 ## JS Runtime Integration (`src/modal.ts`)
 
@@ -179,15 +198,11 @@ class ModalBackend {
 
   /**
    * Raw text generation with optional GBNF grammar.
-   * Caller passes the fully formatted prompt and grammar string.
+   * Caller passes the fully formatted prompt (including all special tokens)
+   * and grammar string. Used for both query expansion and reranking.
    */
-  async generate(prompt: string, grammar: string | null, maxTokens: number): Promise<string>
-
-  /**
-   * Raw cross-encoder scoring.
-   * Caller passes pre-formatted (query, document) pairs.
-   */
-  async score(pairs: [string, string][]): Promise<number[]>
+  async generate(prompt: string, grammar: string | null, maxTokens: number,
+                 model?: "expand" | "rerank"): Promise<string>
 
   /**
    * Health check.
@@ -195,6 +210,10 @@ class ModalBackend {
   async ping(): Promise<boolean>
 }
 ```
+
+`ModalBackend` should implement the existing `LLM` interface from `src/llm.ts` so it can be swapped in transparently. Session management (`withLLMSession`, `canUnload`, inactivity timeouts) becomes a no-op in Modal mode since there are no local models to manage.
+
+**Chat template responsibility:** The JS side must construct full chat-templated prompts (including `<|im_start|>`, `<|im_end|>` special tokens) for both query expansion and reranking before sending to `generate()`. The Python `generate()` does raw completion only — it does not apply any chat template.
 
 ### Initialization
 
@@ -205,10 +224,12 @@ class ModalBackend {
 
 ### Retry Logic (Connection Errors Only)
 
+3 total attempts: initial call, 1 immediate retry, 1 retry after 100ms.
+
 ```
-attempt 1 → connection error → immediate retry
-          → connection error → wait 100ms → retry
-          → connection error → throw with full stacktrace and reason
+attempt 1 (initial)   → connection error → immediate retry
+attempt 2 (retry)     → connection error → wait 100ms → retry
+attempt 3 (final)     → connection error → throw with full stacktrace and reason
 
 Non-connection errors (auth, not found, etc.) → immediate throw, no retry
 ```
@@ -283,9 +304,9 @@ src/
 
 ```
 src/llm.ts            # Conditional: local vs modal backend at inference call sites
-src/cli/qmd.ts        # New 'qmd modal deploy|status|destroy' subcommands
+src/cli/qmd.ts        # New 'qmd modal deploy|status|destroy|test' subcommands
 src/config.ts         # New config keys: modal.inference, modal.gpu, modal.scaledown_window
-package.json          # Add 'modal' npm dependency
+package.json          # Add 'modal' npm dependency; add "modal/" to `files` array so serve.py ships with the npm package
 ```
 
 ## Dependencies
@@ -306,14 +327,18 @@ package.json          # Add 'modal' npm dependency
 
 ## Design Decisions
 
-1. **Dumb model server** — Modal function exposes raw `embed()`, `generate()`, `score()`. All prompt formatting, grammar construction, and result parsing stays in JS. Zero duplication, zero drift risk.
+1. **Dumb model server** — Modal function exposes raw `embed()`, `generate()`, `ping()`. All prompt formatting (including chat templates with special tokens), grammar construction, and result parsing stays in JS. Reranking goes through `generate()` with the JS side constructing the full Qwen3-Reranker chat-templated prompt. Zero duplication, zero drift risk.
 
 2. **Memory snapshots** — `enable_memory_snapshot=True` with `@modal.enter(snap=True)` captures loaded models in memory. Subsequent cold starts restore from snapshot instead of re-loading ~2GB of model weights.
 
-3. **Single container** — `allow_concurrent_inputs=10` handles burst patterns on one container. 15s idle timeout scales to zero quickly. No `keep_warm` to minimize cost.
+3. **Single container** — `allow_concurrent_inputs=4` handles burst patterns on one container. llama-cpp-python serializes GPU inference internally, so concurrent requests queue at the CUDA level rather than causing OOM, but lower concurrency (4 instead of 10) reduces latency variance. 15s idle timeout scales to zero quickly. No `keep_warm` to minimize cost.
 
 4. **JS SDK for runtime** — The `modal` npm package calls deployed functions directly via gRPC. No HTTP endpoints, no URL management. Auth handled by Modal tokens.
 
 5. **Python only for deploy** — Users need Python + `modal` pip package only for the one-time `qmd modal deploy`. Runtime is pure JS.
 
-6. **No fallback** — When `modal.inference = true`, local models are never used. Clear failure modes prevent confusing mixed results. Connection errors get 2 retries (immediate + 100ms), then hard fail.
+6. **No fallback** — When `modal.inference = true`, local models are never used. Clear failure modes prevent confusing mixed results. Connection errors get 3 total attempts (initial call, 1 immediate retry, 1 retry after 100ms), then hard fail.
+
+7. **JS SDK risk** — The `modal` npm SDK is beta (v0.6). If it becomes unavailable, a fallback to HTTP web endpoints is straightforward since the Python side can expose the same methods via `@modal.web_endpoint`.
+
+8. **GBNF grammar compatibility** — GBNF grammar syntax compatibility between node-llama-cpp and llama-cpp-python must be verified during implementation. Both use llama.cpp's grammar parser under the hood so they should be identical, but edge cases should be tested.

--- a/docs/modal-inference-backend-design.md
+++ b/docs/modal-inference-backend-design.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Add optional remote GPU inference via Modal.com, allowing users without a local GPU to run QMD's three GGUF models (embedding, reranking, query expansion) on a cheap cloud GPU. The Modal function is a dumb model server exposing raw inference primitives (`embed()`, `generate()`, `ping()`) — all prompt formatting (including chat templates and special tokens), grammar construction, and search logic stays in QMD's JS codebase. Reranking is handled via `generate()` — the JS side constructs the full Qwen3-Reranker chat-templated prompt and passes it as a completion request.
+Add optional remote GPU inference via Modal.com, allowing users without a local GPU to run QMD's three GGUF models (embedding, reranking, query expansion) on a cheap cloud GPU. The Modal function is a dumb model server exposing raw inference primitives (`embed()`, `generate()`, `rerank()`, `ping()`) — all prompt formatting (including chat templates and special tokens), grammar construction, and search logic stays in QMD's JS codebase. Reranking uses a dedicated `rerank()` method that leverages `create_chat_completion()` for model-native template handling (analogous to node-llama-cpp's `rankAll()`).
 
 ## Architecture Overview
 
@@ -15,6 +15,7 @@ User machine (JS/TS)                          Modal (Python)
 │  │ Grammar logic      │  │   JS SDK (gRPC)   │  │                    │  │
 │  │ Result parsing     │──┼──────────────────►│  │ embed()   - raw    │  │
 │  │                    │  │                   │  │ generate() - raw   │  │
+│  │                    │  │                   │  │ rerank()  - scores │  │
 │  │ ModalBackend       │  │                   │  │ ping()    - health │  │
 │  └───────────────────┘  │                   │  └────────────────────┘  │
 │                         │                   │                          │
@@ -108,6 +109,35 @@ class QMDInference:
             kwargs["grammar"] = LlamaGrammar.from_string(grammar)
         result = llm(**kwargs)
         return result["choices"][0]["text"]
+
+    @modal.method()
+    def rerank(self, query: str, texts: list[str]) -> list[float]:
+        """Cross-encoder scoring using Qwen3-Reranker.
+        Uses create_chat_completion() which applies the model's native
+        chat template automatically (same as node-llama-cpp's rankAll).
+        """
+        scores = []
+        for text in texts:
+            response = self.rerank_model.create_chat_completion(
+                messages=[
+                    {"role": "system", "content": "Judge whether the Document meets the requirements of the Query. Note that the answer can only be \"yes\" or \"no\"."},
+                    {"role": "user", "content": f"<Query>{query}</Query>\n<Document>{text}</Document>"}
+                ],
+                max_tokens=1,
+                logprobs=True,
+                top_logprobs=5,
+            )
+            # Extract the "yes" probability as the relevance score
+            # (standard Qwen3-Reranker scoring approach)
+            logprobs_data = response["choices"][0]["logprobs"]["content"][0]["top_logprobs"]
+            yes_prob = 0.0
+            for lp in logprobs_data:
+                if lp["token"].lower().strip() == "yes":
+                    import math
+                    yes_prob = math.exp(lp["logprob"])
+                    break
+            scores.append(yes_prob)
+        return scores
 
     @modal.method()
     def ping(self) -> bool:
@@ -205,6 +235,13 @@ class ModalBackend {
                  model?: "expand" | "rerank"): Promise<string>
 
   /**
+   * Cross-encoder reranking using Qwen3-Reranker.
+   * Python side uses create_chat_completion() for model-native template handling.
+   * Returns relevance scores (0-1) for each text.
+   */
+  async rerank(query: string, texts: string[]): Promise<number[]>
+
+  /**
    * Health check.
    */
   async ping(): Promise<boolean>
@@ -213,7 +250,7 @@ class ModalBackend {
 
 `ModalBackend` should implement the existing `LLM` interface from `src/llm.ts` so it can be swapped in transparently. Session management (`withLLMSession`, `canUnload`, inactivity timeouts) becomes a no-op in Modal mode since there are no local models to manage.
 
-**Chat template responsibility:** The JS side must construct full chat-templated prompts (including `<|im_start|>`, `<|im_end|>` special tokens) for both query expansion and reranking before sending to `generate()`. The Python `generate()` does raw completion only — it does not apply any chat template.
+**Chat template responsibility:** The JS side must construct full chat-templated prompts (including `<|im_start|>`, `<|im_end|>` special tokens) for query expansion before sending to `generate()`. The Python `generate()` does raw completion only — it does not apply any chat template. Reranking uses the dedicated `rerank()` method, which handles the Qwen3-Reranker chat template via `create_chat_completion()` on the Python side.
 
 ### Initialization
 
@@ -305,7 +342,7 @@ src/
 ```
 src/llm.ts            # Conditional: local vs modal backend at inference call sites
 src/cli/qmd.ts        # New 'qmd modal deploy|status|destroy|test' subcommands
-src/config.ts         # New config keys: modal.inference, modal.gpu, modal.scaledown_window
+src/collections.ts    # New config keys: modal.inference, modal.gpu, modal.scaledown_window
 package.json          # Add 'modal' npm dependency; add "modal/" to `files` array so serve.py ships with the npm package
 ```
 
@@ -327,7 +364,7 @@ package.json          # Add 'modal' npm dependency; add "modal/" to `files` arra
 
 ## Design Decisions
 
-1. **Dumb model server** — Modal function exposes raw `embed()`, `generate()`, `ping()`. All prompt formatting (including chat templates with special tokens), grammar construction, and result parsing stays in JS. Reranking goes through `generate()` with the JS side constructing the full Qwen3-Reranker chat-templated prompt. Zero duplication, zero drift risk.
+1. **Dumb model server** — Modal function exposes raw `embed()`, `generate()`, `rerank()`, `ping()`. All prompt formatting (including chat templates with special tokens), grammar construction, and result parsing stays in JS. The `rerank()` method is the one exception to the "dumb server" principle: it uses `create_chat_completion()` for model-native template handling, analogous to how node-llama-cpp's `rankAll()` handles the Qwen3-Reranker chat template internally. This is necessary because `rankAll()` is a high-level API with no visible prompt template to reverse-engineer on the JS side. Zero duplication, zero drift risk.
 
 2. **Memory snapshots** — `enable_memory_snapshot=True` with `@modal.enter(snap=True)` captures loaded models in memory. Subsequent cold starts restore from snapshot instead of re-loading ~2GB of model weights.
 

--- a/docs/modal-inference-plan.md
+++ b/docs/modal-inference-plan.md
@@ -1,0 +1,627 @@
+# Modal Inference Backend — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add optional remote GPU inference via Modal.com so users without a local GPU can run QMD's three GGUF models on a cheap cloud T4.
+
+**Architecture:** Python Modal service (`modal/serve.py`) exposes `embed()`, `generate()`, `rerank()`, `ping()` methods on a T4 GPU with memory snapshots. JS `ModalBackend` class (`src/modal.ts`) calls it via the `modal` npm SDK. All prompt formatting stays in JS. Controlled by `modal.*` config keys in QMD's YAML config.
+
+**Tech Stack:** Modal Python SDK (deploy), `modal` npm SDK v0.6+ (runtime), `llama-cpp-python` (inference), vitest (tests)
+
+**Spec:** `docs/modal-inference-backend-design.md`
+
+---
+
+## Task 1: Config Keys for Modal
+
+Add `modal.*` config keys to the existing YAML config system.
+
+**Files:**
+- Modify: `src/collections.ts` — extend `CollectionConfig` interface and load/save logic
+- Test: `test/modal-config.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Test that modal config keys can be read/written via the existing config system.
+
+```typescript
+// test/modal-config.test.ts
+// Test: loadConfig returns modal defaults when no modal keys present
+// Test: saveConfig persists modal.inference, modal.gpu, modal.scaledown_window
+// Test: round-trip — save then load preserves modal values
+// Use setConfigSource({ config: {...} }) for in-memory testing (existing pattern)
+```
+
+- [ ] **Step 2: Run test, confirm it fails**
+
+Run: `npx vitest run test/modal-config.test.ts`
+
+- [ ] **Step 3: Implement config changes**
+
+In `src/collections.ts`:
+- Add `modal?` field to `CollectionConfig` interface:
+  ```typescript
+  modal?: {
+    inference?: boolean;      // default false
+    gpu?: string;             // default "T4"
+    scaledown_window?: number; // default 15
+  }
+  ```
+- The YAML round-trip handles new keys automatically, but the TypeScript interface must be extended for type safety.
+- Add helper functions:
+  ```typescript
+  // getModalConfig() — reads config, returns modal block with defaults applied
+  // setModalConfig(partial) — loads config, merges partial into modal block, saves
+  ```
+
+- [ ] **Step 4: Run test, confirm it passes**
+
+Run: `npx vitest run test/modal-config.test.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/collections.ts test/modal-config.test.ts
+git commit -m "feat: add modal config keys to CollectionConfig"
+```
+
+---
+
+## Task 2: Python Modal Service (`modal/serve.py`)
+
+Create the Modal app definition that loads all 3 GGUF models and exposes raw inference.
+
+**Files:**
+- Create: `modal/serve.py`
+- Create: `modal/requirements.txt`
+
+- [ ] **Step 1: Create `modal/requirements.txt`**
+
+Just a reference file (deps installed in Modal image, not locally):
+```
+modal
+llama-cpp-python
+huggingface-hub
+```
+
+- [ ] **Step 2: Write `modal/serve.py`**
+
+Structure the file in three sections:
+
+**Section A — Image definition:**
+- Use `modal.Image.debian_slim(python_version="3.11")`
+- pip install `llama-cpp-python` with CUDA (use the `--extra-index-url` for CUDA wheels)
+- pip install `huggingface-hub` for model download
+- Use `.run_commands()` to download all 3 GGUF models from HuggingFace into `/models/` during image build
+  - Use `huggingface_hub.hf_hub_download(repo_id, filename, local_dir="/models/")`
+  - Three calls: embeddinggemma, qwen3-reranker, qmd-query-expansion
+
+**Section B — QMDInference class:**
+- `@app.cls(gpu=gpu_config, scaledown_window=idle_timeout, allow_concurrent_inputs=4, enable_memory_snapshot=True)`
+- gpu_config and idle_timeout read from CLI args with defaults "T4" and 15
+- `@modal.enter(snap=True) load_models()`:
+  - Load all 3 Llama instances from `/models/` paths
+  - Warmup each model (embed warmup text, generate 1 token from each)
+- `@modal.method() embed(texts: list[str]) -> list[list[float]]`:
+  - Iterate texts, call `self.embed_model.embed(text)`
+  - Normalize: if result[0] is list, take result[0], else use result directly
+  - Return list of vectors
+- `@modal.method() generate(prompt, grammar_str, max_tokens, model="expand") -> str`:
+  - Select model by name ("rerank" → rerank_model, else expand_model)
+  - If grammar_str provided, create LlamaGrammar.from_string(grammar_str)
+  - Call model(prompt=prompt, max_tokens=max_tokens, grammar=grammar_if_any)
+  - Return choices[0]["text"]
+- `@modal.method() ping() -> bool`: return True
+
+**Section C — CLI entry point:**
+- `if __name__ == "__main__":` with argparse
+- Subcommands: `deploy`, `status`, `destroy`
+- `deploy`: accept `--gpu` (default "T4") and `--scaledown-window` (default 15), run `modal deploy` programmatically
+- `status`: use modal SDK to check if app "qmd-inference" exists and has deployed functions
+- `destroy`: use `modal app stop` or equivalent to tear down
+
+- [ ] **Step 3: Manual smoke test instructions**
+
+Cannot run automated tests for Modal deploy (requires credentials + GPU). Leave a note:
+```
+# To test: modal token set, then python modal/serve.py deploy
+# Verify: python modal/serve.py status
+# Cleanup: python modal/serve.py destroy
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add modal/
+git commit -m "feat: add Modal inference service (serve.py)"
+```
+
+---
+
+## Task 3: ModalBackend JS Client (`src/modal.ts`)
+
+JS class that calls the deployed Modal function via the `modal` npm package.
+
+**Files:**
+- Create: `src/modal.ts`
+- Test: `test/modal-backend.test.ts`
+
+- [ ] **Step 1: Install modal npm dependency**
+
+```bash
+bun add --optional modal
+```
+
+Add `modal` to `optionalDependencies` in `package.json` (not `dependencies`). In `src/modal.ts`, use a dynamic import with try/catch:
+
+```typescript
+let modalModule: typeof import("modal");
+try {
+  modalModule = await import("modal");
+} catch {
+  throw new Error("Modal npm package not installed. Run: bun add modal");
+}
+```
+
+This keeps `modal` from being required for users who never use the Modal backend.
+
+- [ ] **Step 2: Write failing tests**
+
+```typescript
+// test/modal-backend.test.ts
+// These test the ModalBackend class with a mock Modal client.
+//
+// Test: constructor throws if ~/.modal.toml missing (mock fs.existsSync)
+// Test: embed() calls fn.embed.remote() with correct args, returns vectors
+// Test: generate() calls fn.generate.remote() with prompt, grammar, maxTokens, model
+// Test: rerank() calls fn.rerank.remote() with query and texts, returns scores
+// Test: ping() calls fn.ping.remote()
+// Test: retry logic — connection error on first attempt, success on second
+// Test: retry logic — 3 connection errors → throws with clear message
+// Test: non-connection errors → immediate throw, no retry
+// Test: lazy initialization — client not created until first call
+```
+
+- [ ] **Step 3: Run tests, confirm they fail**
+
+Run: `npx vitest run test/modal-backend.test.ts`
+
+- [ ] **Step 4: Implement `src/modal.ts`**
+
+Structure:
+
+```typescript
+// src/modal.ts
+
+// --- Types ---
+// ModalConfig: { inference: boolean, gpu: string, scaledown_window: number }
+
+// --- Retry helper ---
+// withRetry(fn, maxAttempts=3, retryDelayMs=100):
+//   attempt 1 → catch connection error → attempt 2 immediately
+//   → catch connection error → wait retryDelayMs → attempt 3
+//   → throw with full context
+//   Non-connection errors: throw immediately
+//   Connection error detection: check error message/code for ECONNREFUSED,
+//   ETIMEDOUT, ECONNRESET, "unavailable", "deadline exceeded"
+
+// --- ModalBackend class ---
+// Implements a subset of the LLM interface (embed, generate)
+// but NOT the full LLM interface yet — that's Task 5.
+//
+// Private state:
+//   _client: modal.Client | null (lazy)
+//   _cls: reference to deployed QMDInference class | null (lazy)
+//
+// Private ensureConnected():
+//   - Check ~/.modal.toml exists → hard fail with message if missing
+//   - Create modal.Client() if not yet created
+//   - Resolve modal.Function.from_name("qmd-inference", "QMDInference")
+//   - Store references for reuse
+//
+// Public methods:
+//   embed(texts: string[]): Promise<number[][]>
+//     - ensureConnected()
+//     - withRetry(() => cls.embed.remote(texts))
+//
+//   generate(prompt: string, grammar: string | null, maxTokens: number,
+//            model?: "expand" | "rerank"): Promise<string>
+//     - ensureConnected()
+//     - withRetry(() => cls.generate.remote(prompt, grammar, maxTokens, model))
+//
+//   rerank(query: string, texts: string[]): Promise<number[]>
+//     - ensureConnected()
+//     - withRetry(() => cls.rerank.remote(query, texts))
+//
+//   ping(): Promise<boolean>
+//     - ensureConnected()
+//     - withRetry(() => cls.ping.remote())
+//
+//   dispose(): no-op (nothing local to clean up)
+```
+
+Note: The exact API for calling Modal functions from JS SDK needs to be verified against `modal` npm docs. The pattern is roughly:
+```typescript
+import { Client, Function as ModalFunction } from "modal";
+const client = new Client();
+const fn = ModalFunction.lookup("qmd-inference", "QMDInference", client);
+const result = await fn.call("embed", [texts]);
+```
+Consult the `modal` npm package README and types for the exact API. Use Context7 docs tool if needed.
+
+- [ ] **Step 5: Run tests, confirm they pass**
+
+Run: `npx vitest run test/modal-backend.test.ts`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/modal.ts test/modal-backend.test.ts package.json bun.lockb
+git commit -m "feat: add ModalBackend JS client with retry logic"
+```
+
+---
+
+## Task 4: CLI Commands (`qmd modal deploy|status|destroy|test`)
+
+Add the `modal` subcommand group to the CLI.
+
+**Files:**
+- Modify: `src/cli/qmd.ts` — add `case "modal":` block
+- Test: `test/modal-cli.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// test/modal-cli.test.ts
+// Test the pre-flight checks and error messages (mock child_process.execSync).
+//
+// Test: "qmd modal deploy" — when python3 not found → specific error message
+// Test: "qmd modal deploy" — when modal module missing → specific error message
+// Test: "qmd modal deploy" — when ~/.modal.toml missing → specific error message
+// Test: "qmd modal deploy" — success → sets modal.inference=true in config
+// Test: "qmd modal destroy" — sets modal.inference=false in config
+// Test: "qmd modal" with no subcommand → usage help
+// Test: "qmd modal unknown" → error with available subcommands
+```
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+Run: `npx vitest run test/modal-cli.test.ts`
+
+- [ ] **Step 3: Implement modal CLI commands**
+
+In `src/cli/qmd.ts`, add a new case in the main switch:
+
+```typescript
+case "modal": {
+  const subcommand = cli.args[0];
+  // If no subcommand → print usage and exit
+  // Available: deploy, status, destroy, test
+
+  switch (subcommand) {
+    case "deploy": {
+      // Step 1: Check python3 exists
+      //   try { execSync("python3 --version", { stdio: "pipe" }) }
+      //   catch → print error: "python3 not found on PATH..."
+      //
+      // Step 2: Check modal pip package
+      //   try { execSync('python3 -c "import modal"', { stdio: "pipe" }) }
+      //   catch → print error: "Python 'modal' package not found..."
+      //
+      // Step 3: Check ~/.modal.toml
+      //   if (!existsSync(join(homedir(), ".modal.toml"))) → print error
+      //
+      // Step 4: Read modal config (gpu, scaledown_window) with defaults
+      //   const modalConfig = getModalConfig();
+      //
+      // Step 5: Resolve serve.py path
+      //   Relative to package root: find it via import.meta.url
+      //   const servePy = join(dirname(fileURLToPath(import.meta.url)),
+      //                        "../../modal/serve.py")
+      //   If running from src: adjust path accordingly
+      //
+      // Step 6: Shell out to python3
+      //   execSync(`python3 "${servePy}" deploy --gpu ${gpu} --scaledown-window ${timeout}`,
+      //            { stdio: "inherit" })
+      //
+      // Step 7: On success → setModalConfig({ inference: true })
+      // Step 8: Print cost note
+      break;
+    }
+
+    case "status": {
+      // Create ModalBackend, call ping(), print result
+      // Catch errors → print them with context
+      break;
+    }
+
+    case "destroy": {
+      // Check python3 + modal (same pre-flight)
+      // Shell out: python3 serve.py destroy
+      // setModalConfig({ inference: false })
+      break;
+    }
+
+    case "test": {
+      // Create ModalBackend
+      // Call embed(["test"]) → verify array of floats
+      // Call generate("Hello", null, 5) → verify non-empty string
+      // Print pass/fail for each
+      break;
+    }
+
+    default:
+      // Unknown subcommand → error + available list
+  }
+  break;
+}
+```
+
+- [ ] **Step 4: Run tests, confirm they pass**
+
+Run: `npx vitest run test/modal-cli.test.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/qmd.ts test/modal-cli.test.ts
+git commit -m "feat: add qmd modal deploy/status/destroy/test CLI commands"
+```
+
+---
+
+## Task 5: Integrate ModalBackend into LLM Layer
+
+Wire the ModalBackend into `src/llm.ts` so that when `modal.inference=true`, all inference routes through Modal.
+
+**Files:**
+- Modify: `src/llm.ts` — add modal backend swap logic
+- Test: `test/modal-integration.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// test/modal-integration.test.ts
+// Test the backend swap logic in isolation.
+//
+// Test: when modal.inference=false → withLLMSession uses LlamaCpp (default)
+// Test: when modal.inference=true → withLLMSession uses ModalBackend
+// Test: modal embed() call formats prompt locally then sends raw text to backend
+// Test: modal expandQuery() constructs chat-templated prompt locally,
+//       sends to generate() with grammar string
+// Test: modal rerank() deduplicates texts, calls modalBackend.rerank(),
+//       maps scores back to original document order
+// Test: startup validation — ping() called, failure → hard error
+//
+// Mock ModalBackend for these tests (don't need real Modal connection).
+```
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+Run: `npx vitest run test/modal-integration.test.ts`
+
+- [ ] **Step 3: Implement the integration**
+
+Key changes to `src/llm.ts`:
+
+**A) Create a ModalLLM class that wraps ModalBackend and implements the full `LLM` interface:**
+
+```typescript
+// Implements LLM interface using ModalBackend for remote inference.
+// All prompt formatting happens HERE (same as LlamaCpp), only raw
+// inference calls go to Modal.
+//
+// embed(text, options):
+//   Format text using formatQueryForEmbedding / formatDocForEmbedding
+//   (existing functions, already in llm.ts)
+//   Call modalBackend.embed([formattedText])
+//   Return EmbeddingResult with the vector
+//
+// generate(prompt, options):
+//   Call modalBackend.generate(prompt, grammarString, maxTokens)
+//   Return GenerateResult
+//
+// expandQuery(query, options):
+//   Build the full chat-templated prompt with special tokens
+//   (<|im_start|>system\n...<|im_end|>, <|im_start|>user\n...<|im_end|>)
+//   exactly as LlamaCpp.expandQuery does, but as a raw string.
+//
+//   The Qwen3 chat template wraps the user prompt as:
+//   <|im_start|>system
+//   You are a helpful assistant.<|im_end|>
+//   <|im_start|>user
+//   /no_think Expand this search query: {query}<|im_end|>
+//   <|im_start|>assistant
+//
+//   The GBNF grammar string is:
+//   root ::= line+
+//   line ::= type ": " content "\n"
+//   type ::= "lex" | "vec" | "hyde"
+//   content ::= [^\n]+
+//
+//   Generation params: temperature=0.7, top_k=20, top_p=0.8, max_tokens=600
+//
+//   Note: Verify during implementation that this GBNF grammar parses
+//   identically in both node-llama-cpp and llama-cpp-python. Both use
+//   llama.cpp's grammar parser, but test with a concrete input.
+//
+//   Call modalBackend.generate(fullPrompt, grammarStr, maxTokens, "expand")
+//   Parse the response same as existing code
+//
+// rerank(query, documents, options):
+//   Deduplicate texts (same as existing LlamaCpp.rerank)
+//   Truncate documents that exceed context size
+//   Call modalBackend.rerank(query, uniqueTexts)
+//   → Python side uses create_chat_completion() with Qwen3-Reranker native template
+//   Map scores back to documents in original order
+//   Return RerankResult
+//
+// modelExists(): return stub info (models always exist on Modal)
+// dispose(): call modalBackend.dispose() (no-op)
+```
+
+**B) Modify `getDefaultLlamaCpp()` (or add a parallel `getDefaultModalLLM()`):**
+
+The existing `getDefaultLlamaCpp()` singleton pattern needs a modal-aware wrapper:
+
+```typescript
+// getDefaultLLM(): LLM
+//   if (getModalConfig().inference) return getDefaultModalLLM()
+//   else return getDefaultLlamaCpp()
+```
+
+**C) Modify `withLLMSession()` to use `getDefaultLLM()`** instead of always using `getDefaultLlamaCpp()`.
+
+**D) Startup validation:**
+- Add a `validateModalConnection()` function that calls `ping()`
+- Call it from MCP server startup and CLI entry point when `modal.inference=true`
+- On failure → throw with clear error message, no fallback
+
+**E) Session management bypass:**
+When Modal is active, `withLLMSession` should NOT use `LLMSessionManager` (which is coupled to LlamaCpp). Instead, create a thin wrapper that:
+- Wraps `ModalLLM` directly
+- Makes `canUnload()` always return `false` (nothing to unload)
+- Makes inactivity timeout a no-op
+- Implements `ILLMSession` by delegating to `ModalLLM` methods
+
+**Important:** The chat template construction for query expansion and reranking is the trickiest part. Study the existing `LlamaCpp.expandQuery()` and `LlamaCpp.rerank()` methods carefully to extract:
+- The exact system/user prompt text
+- The special token wrapping (`<|im_start|>`, `<|im_end|>`, etc.)
+- The GBNF grammar string (for expansion)
+- How rerank scores are extracted from model output
+
+These are currently handled by node-llama-cpp's `LlamaChatSession` and `createRankingContext()`. For Modal, we need to construct these as raw text strings. Read the Qwen3 model documentation if needed.
+
+- [ ] **Step 4: Run tests, confirm they pass**
+
+Run: `npx vitest run test/modal-integration.test.ts`
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `npx vitest run --reporter=verbose test/`
+
+Ensure no regressions in existing tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/llm.ts test/modal-integration.test.ts
+git commit -m "feat: integrate ModalBackend into LLM layer with backend swap"
+```
+
+---
+
+## Task 6: Package & Docs Finalization
+
+Update package.json and add the `modal/` directory to the distributed files.
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Update package.json**
+
+Add `"modal/"` to the `files` array so `serve.py` and `requirements.txt` ship with the npm package:
+
+```json
+"files": [
+  "bin/",
+  "dist/",
+  "modal/",
+  "LICENSE",
+  "CHANGELOG.md"
+]
+```
+
+Add `modal` to `optionalDependencies` (not `dependencies`):
+```json
+"optionalDependencies": {
+  "modal": "^0.6.0"
+}
+```
+
+- [ ] **Step 2: Verify build still works**
+
+```bash
+bun run build
+```
+
+- [ ] **Step 3: Verify modal/serve.py is resolvable from dist**
+
+```bash
+# Check that the path resolution in the CLI works
+bun -e "
+  import { fileURLToPath } from 'url';
+  import { dirname, join } from 'path';
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  console.log(join(__dirname, '../modal/serve.py'));
+" --input-type=module
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json
+git commit -m "feat: add modal package to files array and optionalDependencies"
+```
+
+- [ ] **Step 5: Update CHANGELOG.md**
+
+Add under `## [Unreleased]`:
+```
+- Added: Optional Modal.com inference backend for remote GPU inference (`qmd modal deploy`)
+```
+
+---
+
+## Task 7: End-to-End Smoke Test (Manual)
+
+This task is a manual verification checklist, not automated tests.
+
+- [ ] **Step 1: Verify local mode still works**
+
+```bash
+qmd search "test query" --collection <some-collection>
+```
+
+Confirm: no Modal references, works as before.
+
+- [ ] **Step 2: Deploy Modal function**
+
+```bash
+qmd modal deploy
+```
+
+Confirm: python3 found, modal found, ~/.modal.toml found, deploy succeeds, config updated.
+
+- [ ] **Step 3: Run Modal smoke test**
+
+```bash
+qmd modal test
+```
+
+Confirm: embed and generate both pass.
+
+- [ ] **Step 4: Run a real query via Modal**
+
+```bash
+qmd query "test query" --collection <some-collection>
+```
+
+Confirm: results come back, no errors.
+
+- [ ] **Step 5: Tear down**
+
+```bash
+qmd modal destroy
+```
+
+Confirm: function torn down, config reset.
+
+- [ ] **Step 6: Verify local mode resumes**
+
+```bash
+qmd query "test query" --collection <some-collection>
+```
+
+Confirm: works locally again.

--- a/docs/modal-latency.md
+++ b/docs/modal-latency.md
@@ -1,0 +1,131 @@
+# Modal Latency Analysis
+
+## Overview
+
+This document analyzes network latency between a client (Frankfurt, Germany) and Modal's infrastructure, comparing US (default) vs EU regions.
+
+**Benchmark results:** Run `python3 scripts/benchmark_modal_latency.py`
+
+## Server Location
+
+- **Client:** Frankfurt, Germany (EU)
+- **Modal Control Plane:** us-east-1 (Virginia, USA) - always fixed
+- **Modal Workers:** Default US, configurable to EU/other regions
+
+## Network Measurements (Benchmark Results)
+
+| Endpoint | Location | ICMP Ping |
+|----------|----------|-----------|
+| api.modal.com | US (control plane) | blocked |
+| AWS us-east-1 | Virginia, USA | **96.7ms** |
+| AWS eu-central-1 | Frankfurt, Germany | **1.3ms** |
+
+**Potential RTT savings:** ~95ms per Modal call
+
+## Variables
+
+| Symbol | Meaning | US Value | EU Value |
+|--------|---------|----------|----------|
+| `R` | Worker round-trip time | 97ms | 1ms |
+| `C` | Control plane overhead | ~400ms | ~400ms (fixed) |
+| `E` | Embed inference time | ~300ms | ~300ms |
+| `X` | Expand inference time | ~70ms | ~70ms |
+| `K` | Rerank time per chunk | ~10ms | ~10ms |
+| `D` | Documents to embed | varies | varies |
+| `N` | Chunks to rerank | varies | varies |
+| `B` | Embed batch size | 1 | 1 |
+
+## Formulas
+
+### Query Latency (with rerank)
+
+```
+L_query = L_local + C + R + X + R + (N × K)
+
+Where:
+  L_local = local SQLite + vector search (~300ms)
+  C       = control plane overhead (~400ms for session)
+  R       = worker round-trip (97ms US, 1ms EU)
+  X       = expand inference time
+  N       = chunks to rerank
+  K       = rerank time per chunk
+```
+
+### Network Overhead Percentage
+
+```
+Overhead_pct = (modal_calls × R) / L_query × 100
+
+US: (2 × 97) / 478 × 100 = 40.5%
+EU: (2 × 1) / 478 × 100 = 0.6%
+```
+
+## Comparison Tables
+
+### Query Latency (measured)
+
+| Metric | US | EU | Savings |
+|--------|-------|-------|---------|
+| Median query (expand + rerank) | 478ms | ~287ms | 191ms |
+| Network overhead | 40.5% | 0.6% | 39.9% |
+| Per 100 queries | 47.8s | 28.7s | 19.1s |
+| Per 1000 queries | 478s | 287s | 191s |
+
+### Per-Operation Breakdown (478ms total)
+
+| Component | Time | % of Total |
+|-----------|------|------------|
+| Local compute (SQLite+vector) | 300ms | 62.8% |
+| Network RTT × 2 (US) | 193ms | 40.5% |
+| Expand inference | 71ms | 14.9% |
+| Rerank time | 10ms | 2.1% |
+
+**Note:** Percentages don't sum to 100% because components overlap and the network overhead is additive.
+
+## Region Options
+
+| Region Code | Description | Price Multiplier |
+|-------------|-------------|------------------|
+| `us` | United States | 1.25x |
+| `eu` | European Economic Area | 1.25x |
+| `ap` | Asia-Pacific | 1.25x |
+| `uk` | United Kingdom | 1.25x |
+| `ca` | Canada | 2.5x |
+| `me` | Middle East | 2.5x |
+| `sa` | South America | 2.5x |
+| `af` | Africa | 2.5x |
+| `mx` | Mexico | 2.5x |
+
+**Note:** Region selection adds a price multiplier on top of base GPU costs. US/EU/UK/AP regions have a 1.25x multiplier.
+
+## Implementation
+
+To use EU region from Frankfurt, Germany:
+
+```python
+@app.cls(
+    gpu="T4",
+    region="eu",  # Add this
+    scaledown_window=15,
+    enable_memory_snapshot=True,
+    experimental_options={"enable_gpu_snapshot": True},
+)
+```
+
+Or via CLI:
+
+```bash
+qmd modal deploy --region eu
+```
+
+## Recommendations
+
+- **EU clients:** Use `region="eu"` for ~92ms savings per Modal call
+- **US clients:** Default (no region specified) is optimal
+- **AP clients:** Use `region="ap"` for similar savings
+
+For bulk operations (embedding many documents), EU region saves significant time:
+- 100 docs: ~9 seconds saved
+- 500 docs: ~43 seconds saved
+
+For typical queries, savings are modest (~100-200ms per query).

--- a/docs/modal-latency.md
+++ b/docs/modal-latency.md
@@ -129,3 +129,37 @@ For bulk operations (embedding many documents), EU region saves significant time
 - 500 docs: ~43 seconds saved
 
 For typical queries, savings are modest (~100-200ms per query).
+
+## Region Auto-Detection
+
+`qmd modal deploy` automatically detects the fastest Modal region on first deployment:
+
+1. Pings AWS endpoints for each Modal region (3 pings, median)
+2. Selects region with lowest latency
+3. Stores in `~/.config/qmd/index.yml`
+
+### CLI Commands
+
+```bash
+# Auto-detect (first deploy)
+qmd modal deploy
+
+# Manual override
+qmd modal deploy --region eu
+
+# Force re-detection
+qmd modal deploy --detect-region
+
+# Clear saved region
+qmd modal deploy --region default
+```
+
+### Supported Regions
+
+| Region | Description | Endpoint |
+|--------|-------------|----------|
+| us | United States | ec2.us-east-1.amazonaws.com |
+| eu | European Economic Area | ec2.eu-central-1.amazonaws.com |
+| ap | Asia-Pacific | ec2.ap-northeast-1.amazonaws.com |
+| uk | United Kingdom | ec2.eu-west-2.amazonaws.com |
+| ca | Canada | ec2.ca-central-1.amazonaws.com |

--- a/docs/superpowers/plans/2026-03-20-modal-embed-plan.md
+++ b/docs/superpowers/plans/2026-03-20-modal-embed-plan.md
@@ -1,0 +1,484 @@
+# Full Modal Embedding Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route `qmd embed` through Modal when `modal.inference=true`, enabling GPU-free indexing. Adds `tokenize` endpoint to Modal, updates the `LLM` interface, and refactors `generateEmbeddings` to call `llm.embed()`/`embedBatch()` directly.
+
+**Architecture:** Modal hosts `embeddinggemma` via llama-server on port 8081. This same server exposes `/tokenize`. We add a JS-side `tokenize()` method to `ModalBackend` and `ModalLLM`, update the `LLM` interface, and change `generateEmbeddings`/`chunkDocumentByTokens` to use `getDefaultLLM()` (which returns `ModalLLM` when Modal is enabled) instead of hardcoded `getDefaultLlamaCpp()`.
+
+**Tech Stack:** TypeScript, Bun, Modal SDK (Python), node-llama-cpp, vitest
+
+---
+
+## File Map
+
+| File | Responsibility |
+|------|----------------|
+| `modal/serve.py` | Modal Python inference — add `tokenize()` endpoint |
+| `src/modal.ts` | JS Modal client — add `tokenize()` to `ModalBackend` |
+| `src/llm.ts` | `LLM` interface, `ModalLLM`, `LlamaCpp` — add `tokenize`/`countTokens` to interface, update `ModalSession` |
+| `src/store.ts` | `generateEmbeddings`, `chunkDocumentByTokens`, `Store` type |
+| `test/modal-backend.test.ts` | Unit test `ModalBackend.tokenize()` |
+| `test/modal-integration.test.ts` | Unit test `ModalLLM.tokenize()`, `countTokens()` |
+| `test/store.test.ts` | Update existing `generateEmbeddings` tests |
+
+---
+
+## Task 1: Modal Python — Add `tokenize()` endpoint
+
+**Files:**
+- Modify: `modal/serve.py:210`
+
+- [ ] **Step 1: Add `tokenize()` method to `QMDInference` class**
+
+In `QMDInference` class (after `embed()` method, around line 210), add:
+
+```python
+@modal.method()
+def tokenize(self, texts: list[str]) -> list[list[int]]:
+    """Tokenize texts using the embedding model's tokenizer.
+
+    Proxies to llama-server's /tokenize endpoint on port 8081
+    (the embeddinggemma model). Returns token IDs as nested int lists.
+    """
+    import requests
+
+    resp = requests.post(
+        f"http://127.0.0.1:{EMBED_SERVER.port}/tokenize",
+        json={"content": texts},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add modal/serve.py
+git commit -m "feat(modal): add tokenize endpoint to QMDInference
+
+Proxies /tokenize from llama-server embeddinggemma (port 8081) to
+enable tokenization for Modal-only indexing."
+```
+
+---
+
+## Task 2: TypeScript `LLM` Interface — Add `tokenize`/`countTokens`
+
+**Files:**
+- Modify: `src/llm.ts:316-353`
+
+- [ ] **Step 1: Add `tokenize` and `countTokens` to `LLM` interface**
+
+After the `rerank` method (line 347) and before `dispose` (line 352), add:
+
+```typescript
+  /**
+   * Tokenize text using the embedding model's tokenizer.
+   * Returns tokenizer tokens (opaque type from the underlying implementation).
+   */
+  tokenize(text: string): Promise<readonly LlamaToken[]>;
+
+  /**
+   * Count tokens in text using the embedding model's tokenizer.
+   */
+  countTokens(text: string): Promise<number>;
+
+  /**
+   * Dispose of resources
+   */
+  dispose(): Promise<void>;
+```
+
+Note: `LlamaToken` is already defined/exported by node-llama-cpp types. `ModalLLM.tokenize()` will return `number[]` cast to `readonly LlamaToken[]` (they are both just integer arrays at runtime).
+
+- [ ] **Step 2: Verify `LlamaToken` is exported**
+
+Check that `LlamaToken` is exported from `src/llm.ts` (it comes from node-llama-cpp types). If not exported, add:
+```typescript
+export type { LlamaToken } from "./types.js";
+```
+or wherever it's defined.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/llm.ts
+git commit -m "feat(llm): add tokenize/countTokens to LLM interface
+
+Both LlamaCpp and ModalLLM already implement these methods; adding them
+to the interface enables generateEmbeddings to route through getDefaultLLM."
+```
+
+---
+
+## Task 3: TypeScript `ModalBackend` — Add `tokenize()`
+
+**Files:**
+- Modify: `src/modal.ts:165-179` (after `embed()` method)
+
+- [ ] **Step 1: Add `tokenize()` method to `ModalBackend`**
+
+After the `embed()` method (after line 179), add:
+
+```typescript
+  /**
+   * Tokenize texts using the embedding model's tokenizer on Modal.
+   * Returns token IDs as nested number arrays.
+   */
+  async tokenize(texts: string[]): Promise<number[][]> {
+    await this.ensureConnected();
+    return withRetry(async () => {
+      const fn = this.getMethod("tokenize");
+      return fn.remote([texts]);
+    }).catch((err) => {
+      throw isConnectionError(err)
+        ? new Error(
+            `Modal inference function not reachable after retries.\n` +
+              `Run 'qmd modal status' to check deployment, or 'qmd modal deploy' to redeploy.\n` +
+              `Original error: ${err instanceof Error ? err.message : err}`,
+          )
+        : err;
+    });
+  }
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/modal.ts
+git commit -m "feat(modal): add tokenize() to ModalBackend
+
+Calls QMDInference.tokenize() on Modal, which proxies to llama-server's
+/tokenize endpoint for the embeddinggemma model."
+```
+
+---
+
+## Task 4: TypeScript `ModalLLM` — Implement `tokenize`/`countTokens`
+
+**Files:**
+- Modify: `src/llm.ts:1612-1618` (after `embedBatch()` in `ModalLLM`)
+
+- [ ] **Step 1: Add `tokenize()` and `countTokens()` to `ModalLLM`**
+
+After `embedBatch()` (around line 1618) and before `generate()` (line 1620), add:
+
+```typescript
+  async tokenize(text: string): Promise<readonly LlamaToken[]> {
+    const tokens = await this.backend.tokenize([text]);
+    return tokens[0] ?? [];
+  }
+
+  async countTokens(text: string): Promise<number> {
+    return (await this.tokenize(text)).length;
+  }
+```
+
+`LlamaToken` is imported from node-llama-cpp types (line 10-13 of llm.ts). `number[]` from `backend.tokenize()` is compatible at runtime.
+
+- [ ] **Step 2: Also add `tokenize`/`countTokens` to `ModalSession`**
+
+In `ModalSession` class (around line 1882, after `embedBatch()`), add:
+
+```typescript
+  async tokenize(text: string): Promise<readonly LlamaToken[]> {
+    if (!this.isValid) throw new SessionReleasedError();
+    return this.modalLLM.tokenize(text);
+  }
+
+  async countTokens(text: string): Promise<number> {
+    if (!this.isValid) throw new SessionReleasedError();
+    return this.modalLLM.countTokens(text);
+  }
+```
+
+- [ ] **Step 3: Add `LlamaToken` import if needed**
+
+If `LlamaToken` isn't already importable in `llm.ts`, check the node-llama-cpp import at the top of the file:
+```typescript
+import { fileURLToPath } from "node:url";
+```
+`LlamaToken` is likely from `node-llama-cpp`'s type exports. Verify it's accessible. If not, check the import chain.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/llm.ts
+git commit -m "feat(llm): implement tokenize/countTokens in ModalLLM and ModalSession
+
+ModalLLM delegates to ModalBackend.tokenize() which calls the
+QMDInference.tokenize() endpoint on Modal. ModalSession also exposes
+these for consistency with LlamaCpp's session interface."
+```
+
+---
+
+## Task 5: TypeScript `src/store.ts` — Refactor `generateEmbeddings` and `chunkDocumentByTokens`
+
+**Files:**
+- Modify: `src/store.ts:1328-1333` (`generateEmbeddings`)
+- Modify: `src/store.ts:2100-2102` (`chunkDocumentByTokens`)
+- Modify: `src/store.ts:989` (`Store` type)
+
+- [ ] **Step 1: Update `Store` type — `llm?: LlamaCpp` → `llm?: LLM`**
+
+In the `Store` type definition (line 989), change:
+```typescript
+  /** Optional LlamaCpp instance for this store (overrides the global singleton) */
+  llm?: LlamaCpp;
+```
+To:
+```typescript
+  /** Optional LLM instance for this store (overrides the global singleton) */
+  llm?: LLM;
+```
+
+- [ ] **Step 2: Refactor `generateEmbeddings` — remove `withLLMSessionForLlm`, call `llm.embed()` directly**
+
+In `generateEmbeddings` (line 1330), replace:
+```typescript
+  const llm = store.llm ?? getDefaultLlamaCpp();
+  const result = await withLLMSessionForLlm(llm, async (session) => {
+```
+With:
+```typescript
+  const llm = store.llm ?? getDefaultLLM();
+```
+
+Then replace the session callback body with direct `llm` calls. The session wrapper was:
+```typescript
+    const result = await withLLMSessionForLlm(llm, async (session) => {
+      // ... session.embed() and session.embedBatch() calls ...
+    });
+```
+
+Replace with:
+```typescript
+    const result = await (async () => {
+      // ... llm.embed() and llm.embedBatch() calls instead ...
+    })();
+```
+
+Specifically, in the session callback (lines 1377-1404), replace:
+- `session.embed(firstText)` → `llm.embed(firstText, { model, isQuery: true })`
+- `session.embedBatch(texts)` → `llm.embedBatch(texts)`
+
+Note: `isQuery: true` is used for the init-embedding dimension probe. For actual doc chunks, use `isQuery: false` (default).
+
+- [ ] **Step 3: Refactor `chunkDocumentByTokens` — use `getDefaultLLM()` instead of `getDefaultLlamaCpp()`**
+
+At line 2102, replace:
+```typescript
+  const llm = getDefaultLlamaCpp();
+```
+With:
+```typescript
+  const llm = getDefaultLLM();
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/store.ts
+git commit -m "refactor(store): route embed through getDefaultLLM() for Modal support
+
+generateEmbeddings now calls llm.embed()/embedBatch() directly on the
+LLM interface (LlamaCpp or ModalLLM) instead of through
+withLLMSessionForLlm which was LlamaCpp-only. chunkDocumentByTokens
+uses getDefaultLLM() for tokenization. Store.llm type widened to LLM."
+```
+
+---
+
+## Task 6: Tests
+
+**Files:**
+- Modify: `test/modal-backend.test.ts`
+- Modify: `test/modal-integration.test.ts`
+- Modify: `test/store.test.ts`
+
+### 6A: `modal-backend.test.ts` — Test `ModalBackend.tokenize()`
+
+- [ ] **Step 1: Add test for `tokenize()` in the `ModalBackend` describe block**
+
+After the `embed` describe block (around line 202), add:
+
+```typescript
+  describe("tokenize", () => {
+    test("calls remote with texts and returns token IDs", async () => {
+      const { mockRemote, mockMethod } = await getMocks();
+      const tokenIds = [[1, 2, 3], [4, 5, 6, 7]];
+      mockRemote.mockResolvedValue(tokenIds);
+
+      const backend = createBackend();
+      const result = await backend.tokenize(["hello world", "goodbye"]);
+
+      expect(mockMethod).toHaveBeenCalledWith("tokenize");
+      expect(mockRemote).toHaveBeenCalledWith([["hello world", "goodbye"]]);
+      expect(result).toEqual(tokenIds);
+    });
+
+    test("throws on connection error after retries", async () => {
+      const { mockRemote } = await getMocks();
+      mockRemote.mockRejectedValue(new Error("connect ECONNREFUSED"));
+
+      const backend = createBackend();
+      await expect(backend.tokenize(["test"])).rejects.toThrow(
+        /Modal .* not reachable/,
+      );
+    });
+  });
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add test/modal-backend.test.ts
+git commit -m "test(modal): add ModalBackend.tokenize() unit tests"
+```
+
+### 6B: `modal-integration.test.ts` — Test `ModalLLM.tokenize()` and `countTokens()`
+
+- [ ] **Step 1: Add `mockTokenize` to ModalBackend mock**
+
+In the mock setup (around line 28-42), add:
+```typescript
+const mockTokenize = vi.fn();
+```
+
+And in the `ModalBackend` mock:
+```typescript
+  ModalBackend: vi.fn(() => ({
+    embed: mockEmbed,
+    generate: mockGenerate,
+    rerank: mockRerank,
+    ping: mockPing,
+    tokenize: mockTokenize,
+    dispose: mockDispose,
+  })),
+```
+
+- [ ] **Step 2: Add tests for `tokenize()` and `countTokens()`**
+
+After the `embed` describe block in `ModalLLM` (around line 131), add:
+
+```typescript
+  describe("tokenize", () => {
+    test("calls backend.tokenize with text and returns tokens", async () => {
+      const modalLLM = new ModalLLM();
+      mockTokenize.mockResolvedValue([[1, 2, 3, 4]]);
+
+      const result = await modalLLM.tokenize("hello world");
+
+      expect(mockTokenize).toHaveBeenCalledWith([["hello world"]]);
+      expect(result).toEqual([1, 2, 3, 4]);
+    });
+
+    test("returns empty array when backend returns no tokens", async () => {
+      const modalLLM = new ModalLLM();
+      mockTokenize.mockResolvedValue([[]]);
+
+      const result = await modalLLM.tokenize("test");
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("countTokens", () => {
+    test("returns length of token array from tokenize", async () => {
+      const modalLLM = new ModalLLM();
+      mockTokenize.mockResolvedValue([[1, 2, 3, 4, 5]]);
+
+      const count = await modalLLM.countTokens("hello world");
+      expect(count).toBe(5);
+    });
+  });
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/modal-integration.test.ts
+git commit -m "test(llm): add ModalLLM tokenize/countTokens unit tests"
+```
+
+### 6C: `store.test.ts` — Verify existing `generateEmbeddings` tests still pass
+
+- [ ] **Step 1: Run existing tests to verify no regressions**
+
+```bash
+npx vitest run test/store.test.ts --reporter=verbose 2>&1 | head -50
+```
+
+The existing tests use `store.llm = fakeEmbedLlm` and `setDefaultLlamaCpp(fakeTokenizer)`. After our changes:
+- `store.llm` is used directly (good — fake embed LLM still works)
+- `getDefaultLLM()` is called when `store.llm` is falsy — but the test sets `store.llm`, so it's used
+
+- [ ] **Step 2: Commit (if changes needed, otherwise skip)**
+
+Only commit if the test behavior changed.
+
+---
+
+## Task 7: Run full test suite
+
+- [ ] **Step 1: Run all tests**
+
+```bash
+npx vitest run --reporter=verbose 2>&1 | tail -30
+```
+
+Expected: All tests pass, including new ones. If any fail, fix the issue.
+
+- [ ] **Step 2: Run typecheck**
+
+```bash
+bun run typecheck 2>&1
+```
+Or find the typecheck command from `package.json` scripts.
+
+- [ ] **Step 3: Commit if tests pass**
+
+```bash
+git add -A && git commit -m "test: full suite passes after Modal embed routing
+
+- modal-backend.test.ts: ModalBackend.tokenize() tests
+- modal-integration.test.ts: ModalLLM tokenize/countTokens tests
+- store.test.ts: verified existing generateEmbeddings tests still pass
+"
+```
+
+---
+
+## Task 8: Deploy Modal and smoke test
+
+- [ ] **Step 1: Deploy Modal (user runs manually)**
+
+```sh
+python modal/serve.py deploy
+```
+
+- [ ] **Step 2: Smoke test embed via Modal (user runs manually)**
+
+```sh
+# Set modal.inference=true in ~/.config/qmd/index.yml first
+qmd embed --force
+```
+
+- [ ] **Step 3: Verify no commit needed here** (Modal deploy is a runtime action)
+
+---
+
+## Summary of Commits
+
+| # | Message |
+|---|---------|
+| 1 | `feat(modal): add tokenize endpoint to QMDInference` |
+| 2 | `feat(llm): add tokenize/countTokens to LLM interface` |
+| 3 | `feat(modal): add tokenize() to ModalBackend` |
+| 4 | `feat(llm): implement tokenize/countTokens in ModalLLM and ModalSession` |
+| 5 | `refactor(store): route embed through getDefaultLLM() for Modal support` |
+| 6 | `test(modal): add ModalBackend.tokenize() unit tests` |
+| 7 | `test(llm): add ModalLLM tokenize/countTokens unit tests` |
+| 8 | `test: full suite passes after Modal embed routing` |

--- a/docs/superpowers/plans/2026-03-21-modal-region-auto-detect-plan.md
+++ b/docs/superpowers/plans/2026-03-21-modal-region-auto-detect-plan.md
@@ -1,0 +1,632 @@
+# Modal Region Auto-Detection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Automatically detect the fastest Modal region on first deployment based on network latency.
+
+**Architecture:** Ping AWS endpoints for each Modal region, calculate median latency, select fastest region. Persist to config. Support manual override via `--region` flag.
+
+**Tech Stack:** TypeScript, Node.js `child_process.exec`, Python argparse
+
+---
+
+## Files
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `src/cli/modal.ts` | Modify | Add `--region`, `--detect-region` flags, detection logic |
+| `modal/serve.py` | Modify | Add `--region` CLI argument |
+| `src/collections.ts` | Modify | Add `region?: string` to `ModalConfig` |
+| `test/cli/modal-region.test.ts` | Create | Unit tests for region detection |
+| `docs/modal-latency.md` | Modify | Document region detection |
+
+---
+
+### Task 1: Add region to ModalConfig
+
+**Files:**
+- Modify: `src/collections.ts:39-50, 486-490`
+
+- [ ] **Step 1: Add region field to ModalConfig interface**
+
+```typescript
+// src/collections.ts line 39
+export interface ModalConfig {
+  inference?: boolean;       // Whether to use Modal for inference (default: false)
+  gpu?: string;              // GPU type to use (default: "T4")
+  scaledown_window?: number; // Seconds before idle container scales down (default: 15)
+  region?: string;           // Modal region for worker deployment (default: "" = auto-detect)
+}
+```
+
+- [ ] **Step 2: Add region to MODAL_DEFAULTS**
+
+```typescript
+// src/collections.ts line 486
+const MODAL_DEFAULTS: Required<ModalConfig> = {
+  inference: false,
+  gpu: "T4",
+  scaledown_window: 15,
+  region: "",  // Empty string = not set, will auto-detect on first deploy
+};
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `cd /home/ubuntu/repos/qmd && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/collections.ts
+git commit -m "feat(modal): add region field to ModalConfig"
+```
+
+---
+
+### Task 2: Add region detection function
+
+**Files:**
+- Modify: `src/cli/modal.ts`
+
+- [ ] **Step 1: Add imports and constants**
+
+```typescript
+// Add at top of src/cli/modal.ts after imports
+import { platform } from "os";
+import { exec } from "child_process";
+import { promisify } from "util";
+
+const execAsync = promisify(exec);
+
+const REGION_ENDPOINTS: Record<string, string> = {
+  us: "ec2.us-east-1.amazonaws.com",
+  eu: "ec2.eu-central-1.amazonaws.com",
+  ap: "ec2.ap-northeast-1.amazonaws.com",
+  uk: "ec2.eu-west-2.amazonaws.com",
+  ca: "ec2.ca-central-1.amazonaws.com",
+};
+
+const VALID_REGIONS = ["us", "eu", "ap", "uk", "ca", "me", "sa", "af", "mx", "default"];
+```
+
+- [ ] **Step 2: Add pingEndpoint function**
+
+```typescript
+// Add after constants
+async function pingEndpoint(endpoint: string, count: number = 3): Promise<number> {
+  const isWindows = platform() === "win32";
+  const countFlag = isWindows ? "-n" : "-c";
+  const cmd = `ping ${countFlag} ${count} ${endpoint}`;
+  
+  try {
+    const { stdout } = await execAsync(cmd, { timeout: 30000 });
+    // Linux/Mac: rtt min/avg/max/mdev = 0.5/1.2/2.0/0.5
+    // Windows: Minimum = 0ms, Maximum = 2ms, Average = 1ms
+    const match = stdout.match(/rtt min\/avg\/max\/mdev = [\d.]+\/([\d.]+)/) ||
+                  stdout.match(/Average = (\d+)ms/);
+    return match ? parseFloat(match[1]) : Infinity;
+  } catch {
+    return Infinity;
+  }
+}
+```
+
+- [ ] **Step 3: Add detectRegion function**
+
+```typescript
+// Add after pingEndpoint
+async function detectRegion(): Promise<string> {
+  console.log("Detecting fastest Modal region...");
+  
+  const entries = Object.entries(REGION_ENDPOINTS);
+  const results = await Promise.all(
+    entries.map(async ([region, endpoint]) => {
+      const latency = await pingEndpoint(endpoint);
+      return { region, latency };
+    })
+  );
+  
+  const valid = results.filter(r => isFinite(r.latency));
+  if (valid.length === 0) {
+    console.warn("Warning: Region detection failed, using US default");
+    return "us";
+  }
+  
+  const best = valid.reduce((a, b) => a.latency < b.latency ? a : b);
+  console.log(`Detected fastest region: ${best.region} (${best.latency.toFixed(1)}ms median)`);
+  return best.region;
+}
+```
+
+- [ ] **Step 4: Add isValidRegion helper**
+
+```typescript
+// Add after detectRegion
+function isValidRegion(value: string): boolean {
+  return VALID_REGIONS.includes(value);
+}
+```
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `cd /home/ubuntu/repos/qmd && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli/modal.ts
+git commit -m "feat(modal): add region detection functions"
+```
+
+---
+
+### Task 3: Update handleDeploy to use region
+
+**Files:**
+- Modify: `src/cli/modal.ts:101-152`
+
+- [ ] **Step 1: Add region flag and detection to handleDeploy**
+
+Find the existing `handleDeploy` function and update it:
+
+```typescript
+async function handleDeploy(
+  tomlPath: string,
+  servePyPath: string,
+  region?: string,
+  detectRegion?: boolean,
+): Promise<ModalCommandResult> {
+  const preflight = preflightChecks(tomlPath);
+  if (preflight) {
+    return { exitCode: 1, stdout: "", stderr: preflight };
+  }
+
+  const modalConfig = getModalConfig();
+  
+  // Determine region (but DON'T save to config yet)
+  let selectedRegion = region;
+  if (detectRegion || (!selectedRegion && !modalConfig.region)) {
+    selectedRegion = await detectRegion();
+  } else if (!selectedRegion) {
+    selectedRegion = modalConfig.region || "us";
+  }
+  
+  // Handle "default" = clear region
+  if (selectedRegion === "default") {
+    selectedRegion = undefined;
+    console.log("Region cleared, using Modal default (US)");
+  }
+  
+  // Validate region
+  if (selectedRegion && !isValidRegion(selectedRegion)) {
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr: `Invalid region '${selectedRegion}'. Valid: ${VALID_REGIONS.join(", ")}`,
+    };
+  }
+
+  const gpu = modalConfig.gpu;
+  const scaledownWindow = modalConfig.scaledown_window;
+
+  try {
+    const regionArg = selectedRegion ? ` --region ${selectedRegion}` : "";
+    execSync(
+      `python3 "${servePyPath}" deploy --gpu ${gpu} --scaledown-window ${scaledownWindow}${regionArg}`,
+      { stdio: "pipe" },
+    );
+  } catch (err: unknown) {
+    // ... existing error handling
+    // Note: Config NOT saved on failure - allows clean retry
+  }
+
+  // Save config AFTER successful deploy
+  setModalConfig({ inference: true });
+  if (selectedRegion) {
+    setModalConfig({ region: selectedRegion });
+  }
+
+  // ... rest of existing code (GPU snapshot creation)
+}
+```
+
+- [ ] **Step 2: Update ModalCommandOptions interface**
+
+```typescript
+export interface ModalCommandOptions {
+  tomlPath?: string;
+  servePyPath?: string;
+  region?: string;
+  detectRegion?: boolean;
+}
+```
+
+- [ ] **Step 3: Update handleModalCommand switch**
+
+```typescript
+case "deploy":
+  return handleDeploy(tomlPath, servePyPath, options?.region, options?.detectRegion);
+```
+
+- [ ] **Step 4: Update usage string**
+
+```typescript
+const usage = [
+  "Usage: qmd modal <command>",
+  "",
+  "Commands:",
+  "  deploy [--region <region>] [--detect-region]  Deploy the Modal inference function",
+  "  status                                          Check if Modal is deployed",
+  "  destroy                                         Tear down the deployed function",
+  "  test                                            Run a smoke test",
+  "",
+  "Regions: us, eu, ap, uk, ca, me, sa, af, mx",
+  "  --region default  Clear saved region (use US default)",
+  "  --detect-region   Force re-detection of fastest region",
+].join("\n");
+```
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `cd /home/ubuntu/repos/qmd && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli/modal.ts
+git commit -m "feat(modal): integrate region detection into deploy command"
+```
+
+---
+
+### Task 4: Update modal/serve.py for region argument
+
+**Files:**
+- Modify: `modal/serve.py`
+
+- [ ] **Step 1: Add region argument to argparse**
+
+Find the deploy subparser and add:
+
+```python
+# In the deploy subparser section (~line 199)
+deploy_parser.add_argument(
+    "--region",
+    type=str,
+    default=None,
+    choices=["us", "eu", "ap", "uk", "ca", "me", "sa", "af", "mx"],
+    help="Region for Modal deployment (default: Modal's default, typically US)",
+)
+```
+
+- [ ] **Step 2: Pass region to @app.cls()**
+
+Find the `@app.cls()` decorator and update:
+
+```python
+# Get region from args or env
+region = args.region or os.environ.get("QMD_MODAL_REGION")
+
+@app.cls(
+    gpu=gpu_config,
+    region=region,  # Add this line
+    scaledown_window=idle_timeout,
+    enable_memory_snapshot=True,
+    experimental_options={"enable_gpu_snapshot": True},
+)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add modal/serve.py
+git commit -m "feat(modal): add --region argument to serve.py deploy"
+```
+
+---
+
+### Task 5: Write unit tests
+
+**Files:**
+- Create: `test/cli/modal-region.test.ts`
+
+- [ ] **Step 1: Create test file with complete implementations**
+
+```typescript
+// test/cli/modal-region.test.ts
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { exec } from "child_process";
+import { promisify } from "util";
+
+// Mock child_process
+vi.mock("child_process", () => ({
+  exec: vi.fn(),
+}));
+
+const execMock = vi.mocked(exec);
+
+describe("pingEndpoint", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns median latency from successful ping on Unix", async () => {
+    const mockOutput = "PING host\nrtt min/avg/max/mdev = 0.5/1.2/2.0/0.5 ms";
+    execMock.mockImplementation(((_cmd: string, _opts: any, cb: any) => {
+      cb(null, { stdout: mockOutput, stderr: "" });
+      return {} as any;
+    }));
+    
+    // Import after mock is set up
+    const { pingEndpoint } = await import("../../src/cli/modal.js");
+    const result = await pingEndpoint("ec2.us-east-1.amazonaws.com", 3);
+    expect(result).toBe(1.2);
+  });
+
+  test("returns median latency from successful ping on Windows", async () => {
+    const mockOutput = "Pinging host\nMinimum = 0ms, Maximum = 2ms, Average = 1ms";
+    vi.stubGlobal("process", { platform: "win32" });
+    
+    execMock.mockImplementation(((_cmd: string, _opts: any, cb: any) => {
+      cb(null, { stdout: mockOutput, stderr: "" });
+      return {} as any;
+    }));
+    
+    const { pingEndpoint } = await import("../../src/cli/modal.js");
+    const result = await pingEndpoint("ec2.us-east-1.amazonaws.com", 3);
+    expect(result).toBe(1);
+  });
+
+  test("returns Infinity on ping failure", async () => {
+    execMock.mockImplementation(((_cmd: string, _opts: any, cb: any) => {
+      cb(new Error("ping failed"), { stdout: "", stderr: "error" });
+      return {} as any;
+    }));
+    
+    const { pingEndpoint } = await import("../../src/cli/modal.js");
+    const result = await pingEndpoint("invalid.host", 3);
+    expect(result).toBe(Infinity);
+  });
+
+  test("returns Infinity when ping output cannot be parsed", async () => {
+    execMock.mockImplementation(((_cmd: string, _opts: any, cb: any) => {
+      cb(null, { stdout: "unparseable output", stderr: "" });
+      return {} as any;
+    }));
+    
+    const { pingEndpoint } = await import("../../src/cli/modal.js");
+    const result = await pingEndpoint("ec2.us-east-1.amazonaws.com", 3);
+    expect(result).toBe(Infinity);
+  });
+});
+
+describe("isValidRegion", () => {
+  test("returns true for valid regions", async () => {
+    const { isValidRegion, VALID_REGIONS } = await import("../../src/cli/modal.js");
+    expect(isValidRegion("us")).toBe(true);
+    expect(isValidRegion("eu")).toBe(true);
+    expect(isValidRegion("ap")).toBe(true);
+    expect(isValidRegion("uk")).toBe(true);
+    expect(isValidRegion("ca")).toBe(true);
+    expect(isValidRegion("me")).toBe(true);
+    expect(isValidRegion("sa")).toBe(true);
+    expect(isValidRegion("af")).toBe(true);
+    expect(isValidRegion("mx")).toBe(true);
+  });
+
+  test("returns true for 'default'", async () => {
+    const { isValidRegion } = await import("../../src/cli/modal.js");
+    expect(isValidRegion("default")).toBe(true);
+  });
+
+  test("returns false for invalid regions", async () => {
+    const { isValidRegion } = await import("../../src/cli/modal.js");
+    expect(isValidRegion("invalid")).toBe(false);
+    expect(isValidRegion("unknown")).toBe(false);
+    expect(isValidRegion("")).toBe(false);
+  });
+});
+
+describe("detectRegion", () => {
+  test("returns fastest region from valid results", async () => {
+    // Mock pingEndpoint to return known values
+    vi.mock("../../src/cli/modal.js", async () => {
+      const actual = await vi.importActual("../../src/cli/modal.js");
+      return {
+        ...actual,
+        pingEndpoint: vi.fn()
+          .mockResolvedValueOnce(100) // us
+          .mockResolvedValueOnce(5)  // eu - fastest
+          .mockResolvedValueOnce(150) // ap
+          .mockResolvedValueOnce(10) // uk
+          .mockResolvedValueOnce(200), // ca
+      };
+    });
+    
+    const { detectRegion } = await import("../../src/cli/modal.js");
+    const result = await detectRegion();
+    expect(result).toBe("eu");
+  });
+
+  test("returns 'us' when all pings fail", async () => {
+    vi.mock("../../src/cli/modal.js", async () => {
+      const actual = await vi.importActual("../../src/cli/modal.js");
+      return {
+        ...actual,
+        pingEndpoint: vi.fn().mockResolvedValue(Infinity),
+      };
+    });
+    
+    const { detectRegion } = await import("../../src/cli/modal.js");
+    const result = await detectRegion();
+    expect(result).toBe("us");
+  });
+
+  test("returns fastest region excluding failures", async () => {
+    vi.mock("../../src/cli/modal.js", async () => {
+      const actual = await vi.importActual("../../src/cli/modal.js");
+      return {
+        ...actual,
+        pingEndpoint: vi.fn()
+          .mockResolvedValueOnce(Infinity) // us fails
+          .mockResolvedValueOnce(10)  // eu - fastest
+          .mockResolvedValueOnce(Infinity) // ap fails
+          .mockResolvedValueOnce(50)  // uk
+          .mockResolvedValueOnce(Infinity), // ca fails
+      };
+    });
+    
+    const { detectRegion } = await import("../../src/cli/modal.js");
+    const result = await detectRegion();
+    expect(result).toBe("eu");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd /home/ubuntu/repos/qmd && npx vitest run test/cli/modal-region.test.ts`
+Expected: Tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/cli/modal-region.test.ts
+git commit -m "test(modal): add tests for region detection"
+```
+
+---
+
+### Task 6: Update documentation
+
+**Files:**
+- Modify: `docs/modal-latency.md`
+
+- [ ] **Step 1: Add region detection section**
+
+Add to `docs/modal-latency.md`:
+
+```markdown
+## Region Auto-Detection
+
+`qmd modal deploy` automatically detects the fastest Modal region on first deployment:
+
+1. Pings AWS endpoints for each Modal region (3 pings, median)
+2. Selects region with lowest latency
+3. Stores in `~/.config/qmd/index.yml`
+
+### CLI Commands
+
+```bash
+# Auto-detect (first deploy)
+qmd modal deploy
+
+# Manual override
+qmd modal deploy --region eu
+
+# Force re-detection
+qmd modal deploy --detect-region
+
+# Clear saved region
+qmd modal deploy --region default
+```
+
+### Supported Regions
+
+| Region | Description | Endpoint |
+|--------|-------------|----------|
+| us | United States | ec2.us-east-1.amazonaws.com |
+| eu | European Economic Area | ec2.eu-central-1.amazonaws.com |
+| ap | Asia-Pacific | ec2.ap-northeast-1.amazonaws.com |
+| uk | United Kingdom | ec2.eu-west-2.amazonaws.com |
+| ca | Canada | ec2.ca-central-1.amazonaws.com |
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/modal-latency.md
+git commit -m "docs: add region auto-detection documentation"
+```
+
+---
+
+### Task 7: Integration test
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cd /home/ubuntu/repos/qmd && npx vitest run`
+Expected: All tests pass
+
+- [ ] **Step 2: Manual deploy test with explicit region**
+
+```bash
+qmd modal deploy --region eu
+```
+
+Expected: Deploy succeeds with EU region
+
+- [ ] **Step 3: Verify config after successful deploy**
+
+```bash
+cat ~/.config/qmd/index.yml
+```
+
+Expected: `region: eu` in modal config
+
+- [ ] **Step 4: Test auto-detection**
+
+```bash
+# Clear region from config first
+qmd modal deploy --region default
+# Then test auto-detect
+qmd modal deploy --detect-region
+```
+
+Expected: Detects fastest region, deploys, saves to config
+
+- [ ] **Step 5: Test deploy uses saved config**
+
+```bash
+# After previous deploy, verify config region is used
+qmd modal status
+cat ~/.config/qmd/index.yml
+```
+
+Expected: Uses saved region fromconfig, no re-detection
+
+- [ ] **Step 6: Test config NOT saved on deploy failure**
+
+```bash
+# Save current config
+cp ~/.config/qmd/index.yml /tmp/config-backup.yml
+
+# Simulate deploy failure (destroy first, then try deploy with invalid creds)
+# Deploy should fail but config should remain unchanged
+# Restore config
+```
+
+Expected: Config unchanged after failed deploy
+
+---
+
+### Task 8: Final commit and push
+
+- [ ] **Step 1: Ensure all changes committed**
+
+Run: `git status`
+Expected: No uncommitted changes
+
+- [ ] **Step 2: Push to branch**
+
+```bash
+git push origin feat/modal-inference
+```
+
+- [ ] **Step 3: Update PR description**
+
+Add region auto-detection feature to PR #444 description.

--- a/docs/superpowers/specs/2026-03-20-modal-embed-design.md
+++ b/docs/superpowers/specs/2026-03-20-modal-embed-design.md
@@ -1,0 +1,180 @@
+# Design: Full Modal Embedding Support for `qmd embed`
+
+## Status
+
+Proposed — awaiting implementation.
+
+## Background
+
+PR #444 adds Modal inference for query expansion, reranking, and vector search. However, the `qmd embed` command (used to generate vector embeddings for indexing) still requires a local GPU — it always uses `LlamaCpp` via `node-llama-cpp`, even when Modal inference is enabled.
+
+This design addresses that gap: when `modal.inference=true` in config, the `embed` command should use Modal for both tokenization (during chunking) and embedding generation.
+
+## Current State
+
+The `embed` command flow:
+
+```
+qmd embed → vectorIndex() → generateEmbeddings()
+```
+
+Inside `generateEmbeddings` (`src/store.ts:1305`):
+- **Chunking**: `chunkDocumentByTokens()` calls `getDefaultLlamaCpp().tokenize()` — always local
+- **Embedding**: `withLLMSessionForLlm(llm, ...)` where `llm = store.llm ?? getDefaultLlamaCpp()` — always local LlamaCpp
+
+The session management (`withLLMSessionForLlm`) only accepts `LlamaCpp`, not the broader `LLM` interface, preventing Modal routing.
+
+## Goal
+
+When `modal.inference=true`, `qmd embed` should:
+1. Tokenize documents via Modal's `embeddinggemma` endpoint
+2. Generate embeddings via Modal's `embeddinggemma` endpoint
+3. No local GPU required for indexing
+
+## Architecture
+
+### Modal: Add `tokenize` endpoint
+
+Add a `tokenize()` method to `QMDInference` in `modal/serve.py` that proxies to llama-server's `/tokenize` endpoint on port 8081 (the same `embeddinggemma` model already deployed):
+
+```python
+@modal.method()
+def tokenize(self, texts: list[str]) -> list[list[int]]:
+    resp = requests.post(
+        f"http://127.0.0.1:{EMBED_SERVER.port}/tokenize",
+        json={"content": texts},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()
+```
+
+### TypeScript: Update `LLM` interface
+
+Add `tokenize()` and `countTokens()` to the `LLM` interface (`src/llm.ts`) so both `LlamaCpp` and `ModalLLM` are typed consistently:
+
+```typescript
+export interface LLM {
+  // ...existing methods...
+  tokenize(text: string): Promise<readonly LlamaToken[]>;
+  countTokens(text: string): Promise<number>;
+}
+```
+
+### TypeScript: `ModalLLM` implements `tokenize`
+
+Add to `ModalLLM` class (`src/llm.ts`):
+
+```typescript
+async tokenize(text: string): Promise<readonly LlamaToken[]> {
+  const tokens = await this.backend.tokenize([text]);
+  return tokens[0] ?? [];
+}
+
+async countTokens(text: string): Promise<number> {
+  return (await this.tokenize(text)).length;
+}
+```
+
+### TypeScript: `ModalBackend` calls Modal `tokenize`
+
+Add to `ModalBackend` class (`src/modal.ts`):
+
+```typescript
+async tokenize(texts: string[]): Promise<number[][]> {
+  const fn = this.getMethod("tokenize");
+  return fn.remote(texts);
+}
+```
+
+### TypeScript: `generateEmbeddings` routes to Modal
+
+In `generateEmbeddings` (`src/store.ts:1330`), replace:
+```typescript
+const llm = store.llm ?? getDefaultLlamaCpp();
+const result = await withLLMSessionForLlm(llm, async (session) => {
+  // session.embed() / session.embedBatch()
+});
+```
+
+With:
+```typescript
+const llm = store.llm ?? getDefaultLLM();
+// Call embed/embedBatch directly — both LlamaCpp and ModalLLM implement LLM interface
+// Remove withLLMSessionForLlm wrapper (LlamaCpp.embed handles its own session internally)
+// For ModalLLM, there's no session management needed
+```
+
+Note: `getDefaultLLM()` already returns `ModalLLM` when `modal.inference=true` (see `src/llm.ts:1797`).
+
+### TypeScript: `chunkDocumentByTokens` routes to Modal
+
+In `chunkDocumentByTokens` (`src/store.ts:2102`), replace:
+```typescript
+const llm = getDefaultLlamaCpp();
+```
+
+With:
+```typescript
+const llm = getDefaultLLM();
+```
+
+Both `LlamaCpp` and `ModalLLM` now implement `tokenize()` on the `LLM` interface.
+
+### TypeScript: `Store` type accepts `LLM`
+
+In the `Store` type definition (`src/store.ts:989`), change:
+```typescript
+llm?: LlamaCpp;
+```
+
+To:
+```typescript
+llm?: LLM;
+```
+
+This allows `createStore()` to accept either `LlamaCpp` or `ModalLLM`.
+
+## Data Flow (Modal-enabled)
+
+```
+qmd embed
+  → vectorIndex()
+    → generateEmbeddings(store)
+      → getDefaultLLM() → ModalLLM
+        → chunkDocumentByTokens()
+          → ModalLLM.tokenize() → Modal.tokenize() → llama-server /tokenize
+        → llm.embed() / llm.embedBatch() → ModalLLM → Modal embed() → llama-server /embedding
+        → insertEmbedding() → SQLite vectors_vec
+```
+
+## Error Handling
+
+- **Modal not deployed**: `ModalBackend.tokenize()`/`embed()` throws with a message pointing to `qmd modal deploy` (existing behavior via `withRetry`)
+- **Modal request fails**: errors are counted and reported in the progress output (existing behavior)
+- **Local fallback**: not implemented — if `modal.inference=true`, Modal must be deployed; for local-only users, config stays unchanged
+
+## Testing
+
+1. **Unit**: `modal-backend.test.ts` — add test for `ModalBackend.tokenize()`
+2. **Unit**: `llm.test.ts` — add test for `ModalLLM.tokenize()`
+3. **Integration**: `modal-integration.test.ts` — add test for `generateEmbeddings` routing to Modal (mock `ModalBackend`)
+4. **CLI smoke**: `modal-cli.test.ts` — add `qmd embed --force` test with Modal enabled
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `modal/serve.py` | Add `tokenize()` method to `QMDInference` |
+| `src/modal.ts` | Add `tokenize()` to `ModalBackend` |
+| `src/llm.ts` | Add `tokenize`/`countTokens` to `LLM` interface; implement in `ModalLLM` |
+| `src/store.ts` | `generateEmbeddings`: use `getDefaultLLM()`, call embed directly; `chunkDocumentByTokens`: use `getDefaultLLM()`; `Store` type: `llm?: LLM` |
+| `test/modal-backend.test.ts` | Test `ModalBackend.tokenize()` |
+| `test/llm.test.ts` | Test `ModalLLM.tokenize()` |
+| `test/modal-integration.test.ts` | Test `generateEmbeddings` with Modal |
+
+## Out of Scope
+
+- **Local fallback when Modal fails**: if `modal.inference=true`, Modal must be deployed. Local LlamaCpp fallback would be a follow-up.
+- **tiktoken as JS tokenizer**: could be added later as a third option, but not needed for this PR.
+- **Changes to `qmd query`, `qmd search`, `qmd vsearch`**: these already route to Modal when enabled.

--- a/docs/superpowers/specs/2026-03-20-modal-embed-design.md
+++ b/docs/superpowers/specs/2026-03-20-modal-embed-design.md
@@ -22,7 +22,7 @@ Inside `generateEmbeddings` (`src/store.ts:1305`):
 - **Chunking**: `chunkDocumentByTokens()` calls `getDefaultLlamaCpp().tokenize()` — always local
 - **Embedding**: `withLLMSessionForLlm(llm, ...)` where `llm = store.llm ?? getDefaultLlamaCpp()` — always local LlamaCpp
 
-The session management (`withLLMSessionForLlm`) only accepts `LlamaCpp`, not the broader `LLM` interface, preventing Modal routing.
+The session management (`withLLMSessionForLlm`) accepts `LlamaCpp` and wraps it in `LLMSessionManager`. It should also accept `ModalLLM` since `ModalLLM` is sessionless — `withLLMSessionForLlm` can use `ModalSession` for ModalLLM (which is a thin no-op wrapper that delegates to the underlying LLM). The session management is not needed for Modal, but keeping the session wrapper means the same code path works for both backends.
 
 ## Goal
 
@@ -92,18 +92,14 @@ async tokenize(texts: string[]): Promise<number[][]> {
 In `generateEmbeddings` (`src/store.ts:1330`), replace:
 ```typescript
 const llm = store.llm ?? getDefaultLlamaCpp();
-const result = await withLLMSessionForLlm(llm, async (session) => {
-  // session.embed() / session.embedBatch()
-});
 ```
 
 With:
 ```typescript
 const llm = store.llm ?? getDefaultLLM();
-// Call embed/embedBatch directly — both LlamaCpp and ModalLLM implement LLM interface
-// Remove withLLMSessionForLlm wrapper (LlamaCpp.embed handles its own session internally)
-// For ModalLLM, there's no session management needed
 ```
+
+The `withLLMSessionForLlm` wrapper is kept — it dispatches to `LLMSession` for `LlamaCpp` (with operation tracking and idle timer management) and `ModalSession` for `ModalLLM` (a thin no-op wrapper that just delegates since Modal handles its own session lifecycle). Both session types implement `ILLMSession` with `embed()` and `embedBatch()`.
 
 Note: `getDefaultLLM()` already returns `ModalLLM` when `modal.inference=true` (see `src/llm.ts:1797`).
 
@@ -168,8 +164,8 @@ qmd embed
 | `modal/serve.py` | Add `tokenize()` method to `QMDInference` |
 | `src/modal.ts` | Add `tokenize()` to `ModalBackend` |
 | `src/llm.ts` | Add `tokenize`/`countTokens` to `LLM` interface; implement in `ModalLLM` |
-| `src/store.ts` | `generateEmbeddings`: use `getDefaultLLM()`, call embed directly; `chunkDocumentByTokens`: use `getDefaultLLM()`; `Store` type: `llm?: LLM` |
-| `test/modal-backend.test.ts` | Test `ModalBackend.tokenize()` |
+| `src/llm.ts` | `withLLMSessionForLlm`: generalize to accept `LLM`, dispatch to `ModalSession` for `ModalLLM` |
+| `src/store.ts` | `generateEmbeddings`: use `getDefaultLLM()`; `chunkDocumentByTokens`: use `getDefaultLLM()`; `Store` type: `llm?: LLM` |
 | `test/modal-backend.test.ts` | Test `ModalBackend.tokenize()` |
 | `test/modal-integration.test.ts` | Test `ModalLLM.tokenize()` and `countTokens()` |
 

--- a/docs/superpowers/specs/2026-03-20-modal-embed-design.md
+++ b/docs/superpowers/specs/2026-03-20-modal-embed-design.md
@@ -157,8 +157,8 @@ qmd embed
 ## Testing
 
 1. **Unit**: `modal-backend.test.ts` — add test for `ModalBackend.tokenize()`
-2. **Unit**: `llm.test.ts` — add test for `ModalLLM.tokenize()`
-3. **Integration**: `modal-integration.test.ts` — add test for `generateEmbeddings` routing to Modal (mock `ModalBackend`)
+2. **Unit**: `modal-integration.test.ts` — add test for `ModalLLM.tokenize()` and `countTokens()` (this file already tests ModalLLM with mocked ModalBackend)
+3. **Integration**: existing `store.test.ts` `generateEmbeddings` tests verify routing (they use `store.llm` mock — no changes needed)
 4. **CLI smoke**: `modal-cli.test.ts` — add `qmd embed --force` test with Modal enabled
 
 ## Files Changed
@@ -170,8 +170,8 @@ qmd embed
 | `src/llm.ts` | Add `tokenize`/`countTokens` to `LLM` interface; implement in `ModalLLM` |
 | `src/store.ts` | `generateEmbeddings`: use `getDefaultLLM()`, call embed directly; `chunkDocumentByTokens`: use `getDefaultLLM()`; `Store` type: `llm?: LLM` |
 | `test/modal-backend.test.ts` | Test `ModalBackend.tokenize()` |
-| `test/llm.test.ts` | Test `ModalLLM.tokenize()` |
-| `test/modal-integration.test.ts` | Test `generateEmbeddings` with Modal |
+| `test/modal-backend.test.ts` | Test `ModalBackend.tokenize()` |
+| `test/modal-integration.test.ts` | Test `ModalLLM.tokenize()` and `countTokens()` |
 
 ## Out of Scope
 

--- a/docs/superpowers/specs/2026-03-21-modal-region-auto-detect-design.md
+++ b/docs/superpowers/specs/2026-03-21-modal-region-auto-detect-design.md
@@ -1,0 +1,263 @@
+# Modal Region Auto-Detection Design
+
+**Date:** 2026-03-21
+**Status:** Draft
+**Related:** `docs/modal-latency.md`
+
+## Summary
+
+Add automatic region detection to `qmd modal deploy` that selects the fastest Modal region based on network latency. This reduces network overhead for EU/AP users by ~40%.
+
+## Background
+
+Modal workers run in AWS regions worldwide. The current deployment defaults to US (no region specified), which causes significant latency for users in other regions:
+
+- EU users: ~97ms RTT per Modal call (40% overhead)
+- AP users: Similar latency penalty
+
+By detecting the fastest region, users automatically get optimal latency without manual configuration.
+
+## Requirements
+
+1. **Auto-detect fastest region** on first `qmd modal deploy`
+2. **Manual override** via `--region` flag
+3. **Persist selection** in config for subsequent deploys
+4. **Re-detect** via `--detect-region` flag
+5. **No breaking changes** to existing deployments
+
+## Design
+
+### Region Mapping
+
+Static mapping of Modal regions to AWS endpoints for latency probing:
+
+```typescript
+const REGION_ENDPOINTS: Record<string, string> = {
+  'us': 'ec2.us-east-1.amazonaws.com',
+  'eu': 'ec2.eu-central-1.amazonaws.com',
+  'ap': 'ec2.ap-northeast-1.amazonaws.com',
+  'uk': 'ec2.eu-west-2.amazonaws.com',
+  'ca': 'ec2.ca-central-1.amazonaws.com',
+};
+```
+
+**Note:** This is an intentional scope limitation. These 5 regions cover Modal's primary deployment locations. Future expansion can add `me`, `sa`, `af`, `mx` mapped to nearest available regions.
+
+### Detection Algorithm
+
+On `qmd modal deploy` (when no `--region` specified and no region in config):
+
+1. For each region in `REGION_ENDPOINTS` (in parallel):
+   - Ping endpoint 3 times with 10s timeout
+   - Calculate median latency
+2. Select region with lowest median latency (excluding failures)
+3. If all pings fail → default to `us`, log warning
+4. Store in config: `modal.region = selected_region`
+5. Deploy with: `python modal/serve.py deploy --gpu T4 --region <selected>`
+
+**Config persistence timing:** Save config AFTER successful deploy. If deploy fails, config is not saved, allowing clean retry.
+
+### CLI Interface
+
+```bash
+# Auto-detect (first deploy, no config)
+qmd modal deploy
+# Output: "Detecting fastest region... eu (1.3ms)"
+
+# Manual override
+qmd modal deploy --region eu
+
+# Re-detect (force new detection)
+qmd modal deploy --detect-region
+
+# View current region
+qmd modal status
+# Output includes: "Region: eu"
+
+# Reset region (clears from config)
+qmd modal deploy --region default
+```
+
+### Region Validation
+
+Accepted region values: `us`, `eu`, `ap`, `uk`, `ca`, `me`, `sa`, `af`, `mx`, `default`.
+
+- `default` = clear saved region, use Modal's default (US)
+- Invalid values → error with accepted values list
+
+### File Changes
+
+**`src/cli/modal.ts`:**
+- Add `--region <value>` flag to deploy command
+- Add `--detect-region` flag to force re-detection
+- Add `detectRegion(): Promise<string>` function
+- Add `pingEndpoint(endpoint: string): Promise<number>` helper (cross-platform)
+- Add `isValidRegion(value: string): boolean` validation
+
+**`modal/serve.py`:**
+- Add `--region` argument to deploy command
+- Precedence: CLI `--region` > env var `QMD_MODAL_REGION` > None
+- Pass `region=args.region` to `@app.cls()` decorator
+
+**`src/collections.ts`:**
+- Add `region?: string` to `ModalConfig` interface
+- Add `region: ""` to `MODAL_DEFAULTS` (empty = not set)
+- Document: empty string = not detected, `default` = cleared
+
+### Config Storage
+
+After successful deploy with region:
+
+```yaml
+# ~/.config/qmd/index.yml
+modal:
+  inference: true
+  gpu: T4
+  scaledown_window: 15
+  region: eu  # Detected or manually specified
+```
+
+### Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| All pings fail | Default to `us`, log warning: "Region detection failed, using US default" |
+| Some pings fail | Exclude failed regions from median calculation |
+| No network | Default to `us`, log warning |
+| Invalid `--region` | Error: "Invalid region 'xyz'. Valid: us, eu, ap, uk, ca, me, sa, af, mx, default" |
+| Deploy fails | Don't save config (preserves ability to retry) |
+| Persistent failures | Run 3 ping attempts per region with 10s timeout each |
+
+## Implementation Notes
+
+### Cross-Platform Ping
+
+Use platform-aware ping command:
+
+```typescript
+import { platform } from 'os';
+
+function getPingCommand(endpoint: string, count: number): string {
+  const isWindows = platform() === 'win32';
+  const pingCmd = isWindows ? 'ping' : 'ping';
+  const countFlag = isWindows ? '-n' : '-c';
+  return `${pingCmd} ${countFlag} ${count} ${endpoint}`;
+}
+
+function pingEndpoint(endpoint: string): Promise<number> {
+  return new Promise((resolve) => {
+    const cmd = getPingCommand(endpoint, 3);
+    exec(cmd, { timeout: 30000 }, (error, stdout) => {
+      if (error) {
+        resolve(Infinity);
+        return;
+      }
+      // Parse RTT from output
+      // Linux/Mac: rtt min/avg/max/mdev = 0.5/1.2/2.0/0.5
+      // Windows: Minimum = 0ms, Maximum = 2ms, Average = 1ms
+      const match = stdout.match(/rtt min\/avg\/max\/mdev = [\d.]+\/([\d.]+)/) ||
+                    stdout.match(/Average = (\d+)ms/);
+      resolve(match ? parseFloat(match[1]) : Infinity);
+    });
+  });
+}
+```
+
+### Parallel Ping Execution
+
+```typescript
+async function detectRegion(): Promise<string> {
+  const entries = Object.entries(REGION_ENDPOINTS);
+  const results = await Promise.all(
+    entries.map(async ([region, endpoint]) => {
+      const latency = await pingEndpoint(endpoint);
+      return { region, latency };
+    })
+  );
+  
+  const valid = results.filter(r => isFinite(r.latency));
+  if (valid.length === 0) {
+    console.warn("Region detection failed, using US default");
+    return 'us';
+  }
+  
+  const best = valid.reduce((a, b) => a.latency < b.latency ? a : b);
+  console.log(`Detected fastest region: ${best.region} (${best.latency.toFixed(1)}ms)`);
+  return best.region;
+}
+```
+
+### Median Calculation
+
+```typescript
+function median(values: number[]): number {
+  const finite = values.filter(v => isFinite(v));
+  if (finite.length === 0) return Infinity;
+  
+  const sorted = finite.sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 
+    ? sorted[mid] 
+    : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+```
+
+### Modal serve.py Changes
+
+```python
+# CLI argument
+parser.add_argument(
+    "--region",
+    type=str,
+    default=None,
+    choices=["us", "eu", "ap", "uk", "ca", "me", "sa", "af", "mx"],
+    help="Region for Modal deployment (auto-detected if not specified)"
+)
+
+# Env var takes precedence, then CLI arg
+region = os.environ.get("QMD_MODAL_REGION") or args.region
+
+# Pass to decorator
+@app.cls(
+    gpu=gpu_config,
+    region=region,  # None = Modal default (US)
+    scaledown_window=idle_timeout,
+    enable_memory_snapshot=True,
+    experimental_options={"enable_gpu_snapshot": True},
+)
+```
+
+## Testing
+
+### Unit Tests
+
+- `pingEndpoint()` returns latency on success
+- `pingEndpoint()` returns Infinity on failure
+- `pingEndpoint()` works on Windows and Unix
+- `median([])` returns Infinity
+- `median([Infinity, Infinity])` returns Infinity
+- `detectRegion()` returns lowest latency region
+- `detectRegion()` defaults to 'us' when all fail
+- `isValidRegion()` validates correctly
+
+### Integration Tests
+
+- Deploy with `--region eu` saves to config
+- Deploy without region (first time) detects and saves
+- Deploy without region (second time) uses config
+- Deploy with `--detect-region` re-detects
+- Deploy with `--region default` clears config
+- Config not saved when deploy fails
+
+### Manual Tests
+
+- Run from EU and verify 'eu' is detected
+- Run from US and verify 'us' is detected
+- Run with no network and verify 'us' default
+- Run on Windows and verify ping works
+
+## Rollout
+
+1. Merge to `feat/modal-inference` (current branch)
+2. Test with EU-based deployment
+3. Include in PR for modal inference feature

--- a/modal/Dockerfile.llama-server
+++ b/modal/Dockerfile.llama-server
@@ -33,4 +33,4 @@ RUN ln -s /usr/local/lib/llama/llama-server /usr/local/bin/llama-server \
     && echo "/usr/local/lib/llama" > /etc/ld.so.conf.d/llama.conf \
     && ldconfig
 
-ENTRYPOINT ["llama-server"]
+# No ENTRYPOINT — Modal runs its own Python process inside the container

--- a/modal/Dockerfile.llama-server
+++ b/modal/Dockerfile.llama-server
@@ -5,10 +5,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 ARG LLAMA_CPP_TAG=b8179
+ARG CUDA_ARCHITECTURES=75
+
+# Create libcuda.so.1 symlink so the linker can resolve the CUDA driver stub
+# (the real driver is provided at runtime by the NVIDIA container toolkit)
+RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 \
+    && echo "/usr/local/cuda/lib64/stubs" > /etc/ld.so.conf.d/cuda-stubs.conf \
+    && ldconfig
+
 RUN git clone --depth 1 --branch ${LLAMA_CPP_TAG} \
     https://github.com/ggml-org/llama.cpp.git /tmp/llama.cpp \
     && cd /tmp/llama.cpp \
     && cmake -B build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release \
+       -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES} \
     && cmake --build build --target llama-server -j$(nproc) \
     && cp build/bin/llama-server /usr/local/bin/llama-server
 

--- a/modal/Dockerfile.llama-server
+++ b/modal/Dockerfile.llama-server
@@ -18,8 +18,7 @@ RUN git clone --depth 1 --branch ${LLAMA_CPP_TAG} \
     && cd /tmp/llama.cpp \
     && cmake -B build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release \
        -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES} \
-    && cmake --build build --target llama-server -j$(nproc) \
-    && cp build/bin/llama-server /usr/local/bin/llama-server
+    && cmake --build build --target llama-server -j$(nproc)
 
 FROM nvidia/cuda:12.4.0-runtime-ubuntu22.04
 
@@ -27,6 +26,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgomp1 libcurl4 \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /usr/local/bin/llama-server /usr/local/bin/llama-server
+# Copy llama-server binary and all shared libraries it depends on
+# The build outputs .so files alongside the binary in build/bin/
+COPY --from=builder /tmp/llama.cpp/build/bin/ /usr/local/lib/llama/
+RUN ln -s /usr/local/lib/llama/llama-server /usr/local/bin/llama-server \
+    && echo "/usr/local/lib/llama" > /etc/ld.so.conf.d/llama.conf \
+    && ldconfig
 
 ENTRYPOINT ["llama-server"]

--- a/modal/Dockerfile.llama-server
+++ b/modal/Dockerfile.llama-server
@@ -1,0 +1,23 @@
+FROM nvidia/cuda:12.4.0-devel-ubuntu22.04 AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cmake git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG LLAMA_CPP_TAG=b8179
+RUN git clone --depth 1 --branch ${LLAMA_CPP_TAG} \
+    https://github.com/ggml-org/llama.cpp.git /tmp/llama.cpp \
+    && cd /tmp/llama.cpp \
+    && cmake -B build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release \
+    && cmake --build build --target llama-server -j$(nproc) \
+    && cp build/bin/llama-server /usr/local/bin/llama-server
+
+FROM nvidia/cuda:12.4.0-runtime-ubuntu22.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgomp1 libcurl4 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/bin/llama-server /usr/local/bin/llama-server
+
+ENTRYPOINT ["llama-server"]

--- a/modal/requirements.txt
+++ b/modal/requirements.txt
@@ -1,3 +1,3 @@
-modal
-llama-cpp-python
-huggingface-hub
+modal==1.2.6
+huggingface-hub==1.7.1
+requests==2.32.5

--- a/modal/requirements.txt
+++ b/modal/requirements.txt
@@ -1,0 +1,3 @@
+modal
+llama-cpp-python
+huggingface-hub

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -72,7 +72,7 @@ image = (
         # Pre-built llama-server with CUDA 12.4 support.
         # Built from llama.cpp b8179 (same as node-llama-cpp v3.17.1).
         # Image built by .github/workflows/build-llama-server.yml
-        "ghcr.io/ofekby/qmd-llama-server:b8179-sm75-v2",
+        "ghcr.io/ofekby/qmd-llama-server:b8179-sm75-v3",
         add_python="3.11",
     )
     .pip_install("huggingface-hub", "requests")

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -85,12 +85,12 @@ gpu_config: str = os.environ.get("QMD_MODAL_GPU", "T4")
 idle_timeout: int = int(os.environ.get("QMD_MODAL_SCALEDOWN", "15"))
 
 
-@modal.concurrent(max_inputs=4)
 @app.cls(
     gpu=gpu_config,
     scaledown_window=idle_timeout,
     enable_memory_snapshot=True,
 )
+@modal.concurrent(max_inputs=4)
 class QMDInference:
     """Raw inference service for QMD's three GGUF models."""
 

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -69,20 +69,11 @@ def download_models() -> None:
 
 image = (
     modal.Image.from_registry(
-        "nvidia/cuda:12.4.0-devel-ubuntu22.04", add_python="3.11"
-    )
-    .apt_install("libgomp1", "libcurl4", "build-essential", "cmake", "git")
-    .run_commands(
-        # Build llama-server from llama.cpp b8179 (same version as
-        # node-llama-cpp v3.17.1) with CUDA support.  No pre-built Linux
-        # CUDA binary is published for this release.
-        "git clone --depth 1 --branch b8179"
-        " https://github.com/ggml-org/llama.cpp.git /tmp/llama.cpp"
-        " && cd /tmp/llama.cpp"
-        " && cmake -B build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release"
-        " && cmake --build build --target llama-server -j$(nproc)"
-        f" && cp build/bin/llama-server {LLAMA_SERVER_BIN}"
-        " && rm -rf /tmp/llama.cpp"
+        # Pre-built llama-server with CUDA 12.4 support.
+        # Built from llama.cpp b8179 (same as node-llama-cpp v3.17.1).
+        # Image built by .github/workflows/build-llama-server.yml
+        "ghcr.io/ofekby/qmd-llama-server:b8179",
+        add_python="3.11",
     )
     .pip_install("huggingface-hub", "requests")
     .run_function(download_models)

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -72,7 +72,7 @@ image = (
         # Pre-built llama-server with CUDA 12.4 support.
         # Built from llama.cpp b8179 (same as node-llama-cpp v3.17.1).
         # Image built by .github/workflows/build-llama-server.yml
-        "ghcr.io/ofekby/qmd-llama-server:b8179-sm75-v3",
+        "ghcr.io/ofekby/qmd-llama-server:b8179-sm75",
         add_python="3.11",
     )
     .pip_install("huggingface-hub", "requests")

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -1,0 +1,330 @@
+"""QMD Modal Inference Service.
+
+Deploys three GGUF models (embedding, reranking, query expansion) on a Modal
+GPU container and exposes raw inference methods via Modal's RPC.
+
+Manual test instructions:
+    # 1. Authenticate with Modal (one-time setup)
+    modal token set
+
+    # 2. Deploy the service
+    python modal/serve.py deploy --gpu T4 --scaledown-window 15
+
+    # 3. Check status
+    python modal/serve.py status
+
+    # 4. Cleanup when done
+    python modal/serve.py destroy
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import sys
+
+import modal
+
+# ---------------------------------------------------------------------------
+# Section A: Image definition
+# ---------------------------------------------------------------------------
+
+MODELS_DIR = "/models"
+
+MODELS = [
+    {
+        "repo_id": "ggml-org/embeddinggemma-300M-GGUF",
+        "filename": "embeddinggemma-300M-Q8_0.gguf",
+    },
+    {
+        "repo_id": "ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF",
+        "filename": "qwen3-reranker-0.6b-q8_0.gguf",
+    },
+    {
+        "repo_id": "tobil/qmd-query-expansion-1.7B-gguf",
+        "filename": "qmd-query-expansion-1.7B-q4_k_m.gguf",
+    },
+]
+
+
+def download_models() -> None:
+    """Download all GGUF models into /models/ during image build."""
+    from huggingface_hub import hf_hub_download
+
+    for model in MODELS:
+        hf_hub_download(
+            repo_id=model["repo_id"],
+            filename=model["filename"],
+            local_dir=MODELS_DIR,
+        )
+
+
+image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .pip_install(
+        "llama-cpp-python",
+        extra_index_url="https://abetlen.github.io/llama-cpp-python/whl/cu124",
+    )
+    .pip_install("huggingface-hub")
+    .run_function(download_models)
+)
+
+app = modal.App("qmd-inference", image=image)
+
+
+# ---------------------------------------------------------------------------
+# Section B: QMDInference class
+# ---------------------------------------------------------------------------
+
+# Read GPU/scaledown config from environment when the module is imported
+# during ``modal deploy``.  The CLI deploy command passes these via env vars
+# so the decorator picks up the configured values at import time.
+gpu_config: str = os.environ.get("QMD_MODAL_GPU", "T4")
+idle_timeout: int = int(os.environ.get("QMD_MODAL_SCALEDOWN", "15"))
+
+
+@app.cls(
+    gpu=gpu_config,
+    scaledown_window=idle_timeout,
+    allow_concurrent_inputs=4,
+    enable_memory_snapshot=True,
+)
+class QMDInference:
+    """Raw inference service for QMD's three GGUF models."""
+
+    @modal.enter(snap=True)
+    def load_models(self) -> None:
+        """Load all 3 models and run warmup passes.
+
+        The ``snap=True`` flag captures the loaded model state in a memory
+        snapshot so subsequent cold starts restore from the snapshot instead
+        of re-loading ~2 GB of weights.
+        """
+        from llama_cpp import Llama
+
+        self.embed_model = Llama(
+            model_path=f"{MODELS_DIR}/embeddinggemma-300M-Q8_0.gguf",
+            embedding=True,
+            n_ctx=2048,
+        )
+        self.rerank_model = Llama(
+            model_path=f"{MODELS_DIR}/qwen3-reranker-0.6b-q8_0.gguf",
+            n_ctx=2048,
+        )
+        self.expand_model = Llama(
+            model_path=f"{MODELS_DIR}/qmd-query-expansion-1.7B-q4_k_m.gguf",
+            n_ctx=2048,
+        )
+
+        # Warmup passes to pre-fill caches before snapshot
+        self.embed_model.embed("warmup")
+        self.rerank_model("warmup", max_tokens=1)
+        self.expand_model("warmup", max_tokens=1)
+
+    @modal.method()
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Raw embedding -- no prompt formatting.
+
+        Returns one embedding vector per input text.  llama-cpp-python's
+        ``Llama.embed()`` returns ``list[list[float]]``; we normalise to
+        always yield a single vector per input.
+        """
+        result: list[list[float]] = []
+        for text in texts:
+            vec = self.embed_model.embed(text)
+            # Llama.embed() may return list[list[float]] or list[float]
+            # depending on input; normalise to a single vector per text.
+            if isinstance(vec[0], list):
+                result.append(vec[0])
+            else:
+                result.append(vec)
+        return result
+
+    @modal.method()
+    def generate(
+        self,
+        prompt: str,
+        grammar: str | None,
+        max_tokens: int,
+        model: str = "expand",
+    ) -> str:
+        """Raw completion with optional GBNF grammar constraint.
+
+        The caller must construct the full prompt including any special
+        tokens (``<|im_start|>``, ``<|im_end|>``, etc.).  This method does
+        **not** apply any chat template.
+
+        Args:
+            prompt: Fully formatted prompt string.
+            grammar: Optional GBNF grammar string for constrained generation.
+            max_tokens: Maximum number of tokens to generate.
+            model: Which model to use -- ``"expand"`` (default) for query
+                   expansion, ``"rerank"`` for the reranker model.
+        """
+        llm = self.rerank_model if model == "rerank" else self.expand_model
+        kwargs: dict = {"prompt": prompt, "max_tokens": max_tokens}
+        if grammar:
+            from llama_cpp import LlamaGrammar
+
+            kwargs["grammar"] = LlamaGrammar.from_string(grammar)
+        result = llm(**kwargs)
+        return result["choices"][0]["text"]
+
+    @modal.method()
+    def rerank(self, query: str, texts: list[str]) -> list[float]:
+        """Cross-encoder scoring using Qwen3-Reranker.
+
+        Uses ``create_chat_completion()`` which applies the model's native
+        chat template automatically (analogous to node-llama-cpp's
+        ``rankAll()``).
+
+        Returns a list of relevance scores (0--1), one per input text.
+        """
+        scores: list[float] = []
+        for text in texts:
+            response = self.rerank_model.create_chat_completion(
+                messages=[
+                    {
+                        "role": "system",
+                        "content": (
+                            "Judge whether the Document meets the "
+                            "requirements of the Query. Note that the "
+                            'answer can only be "yes" or "no".'
+                        ),
+                    },
+                    {
+                        "role": "user",
+                        "content": (
+                            f"<Query>{query}</Query>\n"
+                            f"<Document>{text}</Document>"
+                        ),
+                    },
+                ],
+                max_tokens=1,
+                logprobs=True,
+                top_logprobs=5,
+            )
+            score = _extract_yes_probability(response)
+            scores.append(score)
+        return scores
+
+    @modal.method()
+    def ping(self) -> bool:
+        """Health check -- verifies function is reachable and models loaded."""
+        return True
+
+
+def _extract_yes_probability(response: dict) -> float:
+    """Extract the probability of the 'yes' token from chat completion logprobs.
+
+    This is the standard Qwen3-Reranker scoring approach: the model is asked
+    to judge relevance with a yes/no answer, and we use the probability of
+    'yes' as the relevance score.
+    """
+    logprobs_data = response["choices"][0]["logprobs"]["content"][0][
+        "top_logprobs"
+    ]
+    for lp in logprobs_data:
+        if lp["token"].lower().strip() == "yes":
+            return math.exp(lp["logprob"])
+    return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Section C: CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def cmd_deploy(args: argparse.Namespace) -> None:
+    """Deploy the QMD inference service to Modal."""
+    import subprocess
+
+    print(
+        f"Deploying qmd-inference "
+        f"(gpu={args.gpu}, scaledown_window={args.scaledown_window})..."
+    )
+    # Shell out to ``modal deploy`` with env vars so the module re-imports
+    # with the configured GPU and scaledown window values.
+    env = {**os.environ, "QMD_MODAL_GPU": args.gpu, "QMD_MODAL_SCALEDOWN": str(args.scaledown_window)}
+    subprocess.run(
+        [sys.executable, "-m", "modal", "deploy", __file__],
+        check=True,
+        env=env,
+    )
+    print(
+        f"Deployed successfully. GPU: {args.gpu} "
+        f"(~$0.59/hr, billed per second, scales to zero when idle)"
+    )
+
+
+def cmd_status(_args: argparse.Namespace) -> None:
+    """Check if the qmd-inference app is deployed."""
+    try:
+        fn = modal.Function.from_name("qmd-inference", "QMDInference.ping")
+        result = fn.remote()
+        if result:
+            print("qmd-inference is deployed and responding.")
+        else:
+            print(
+                "qmd-inference is deployed but ping returned unexpected result."
+            )
+    except modal.exception.NotFoundError:
+        print(
+            "qmd-inference is not deployed. "
+            "Run: python modal/serve.py deploy"
+        )
+        sys.exit(1)
+    except Exception as exc:
+        print(f"Error checking status: {exc}")
+        sys.exit(1)
+
+
+def cmd_destroy(_args: argparse.Namespace) -> None:
+    """Tear down the deployed qmd-inference app."""
+    import subprocess
+
+    print("Stopping qmd-inference...")
+    subprocess.run(
+        [sys.executable, "-m", "modal", "app", "stop", "qmd-inference"],
+        check=True,
+    )
+    print("qmd-inference stopped successfully.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="QMD Modal Inference Service",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    deploy_parser = subparsers.add_parser(
+        "deploy", help="Deploy the inference service"
+    )
+    deploy_parser.add_argument(
+        "--gpu",
+        default="T4",
+        help="GPU type for the Modal container (default: T4)",
+    )
+    deploy_parser.add_argument(
+        "--scaledown-window",
+        type=int,
+        default=15,
+        help="Seconds before idle container shuts down (default: 15)",
+    )
+
+    subparsers.add_parser("status", help="Check deployment status")
+    subparsers.add_parser("destroy", help="Tear down the deployed service")
+
+    args = parser.parse_args()
+
+    commands = {
+        "deploy": cmd_deploy,
+        "status": cmd_status,
+        "destroy": cmd_destroy,
+    }
+    commands[args.command](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -115,7 +115,15 @@ RERANK_SERVER = ServerConfig(
     name="rerank",
     port=8083,
     model_file="qwen3-reranker-0.6b-q8_0.gguf",
-    extra_args=["--embedding", "--pooling", "rank", "--ubatch-size", "2048"],
+    extra_args=[
+        "--embedding",
+        "--pooling",
+        "rank",
+        "--parallel",
+        "1",
+        "--ubatch-size",
+        "2048",
+    ],
 )
 
 ALL_SERVERS = [EMBED_SERVER, EXPAND_SERVER, RERANK_SERVER]

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -72,7 +72,7 @@ image = (
         # Pre-built llama-server with CUDA 12.4 support.
         # Built from llama.cpp b8179 (same as node-llama-cpp v3.17.1).
         # Image built by .github/workflows/build-llama-server.yml
-        "ghcr.io/ofekby/qmd-llama-server:b8179-sm75",
+        "ghcr.io/ofekby/qmd-llama-server@sha256:30d719c680fddf682f42a7c8f578de27bb816f71f66efb3d31fc63aea3ef0bea",
         add_python="3.11",
     )
     .pip_install("huggingface-hub", "requests")

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -62,6 +62,7 @@ def download_models() -> None:
 
 image = (
     modal.Image.debian_slim(python_version="3.11")
+    .pip_install("nvidia-cuda-runtime-cu12")
     .pip_install(
         "llama-cpp-python",
         extra_index_url="https://abetlen.github.io/llama-cpp-python/whl/cu124",
@@ -84,10 +85,10 @@ gpu_config: str = os.environ.get("QMD_MODAL_GPU", "T4")
 idle_timeout: int = int(os.environ.get("QMD_MODAL_SCALEDOWN", "15"))
 
 
+@modal.concurrent(max_inputs=4)
 @app.cls(
     gpu=gpu_config,
     scaledown_window=idle_timeout,
-    allow_concurrent_inputs=4,
     enable_memory_snapshot=True,
 )
 class QMDInference:

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -127,10 +127,12 @@ ALL_SERVERS = [EMBED_SERVER, EXPAND_SERVER, RERANK_SERVER]
 
 gpu_config: str = os.environ.get("QMD_MODAL_GPU", "T4")
 idle_timeout: int = int(os.environ.get("QMD_MODAL_SCALEDOWN", "15"))
+region: str | None = os.environ.get("QMD_MODAL_REGION")
 
 
 @app.cls(
     gpu=gpu_config,
+    region=region,
     scaledown_window=idle_timeout,
     enable_memory_snapshot=True,
     experimental_options={"enable_gpu_snapshot": True},
@@ -358,15 +360,18 @@ def cmd_deploy(args: argparse.Namespace) -> None:
     """Deploy the QMD inference service to Modal."""
     import subprocess
 
+    region_info = f", region={args.region}" if args.region else ""
     print(
         f"Deploying qmd-inference "
-        f"(gpu={args.gpu}, scaledown_window={args.scaledown_window})..."
+        f"(gpu={args.gpu}, scaledown_window={args.scaledown_window}{region_info})..."
     )
     env = {
         **os.environ,
         "QMD_MODAL_GPU": args.gpu,
         "QMD_MODAL_SCALEDOWN": str(args.scaledown_window),
     }
+    if args.region:
+        env["QMD_MODAL_REGION"] = args.region
     subprocess.run(
         [sys.executable, "-m", "modal", "deploy", __file__],
         check=True,
@@ -424,6 +429,13 @@ def main() -> None:
         type=int,
         default=15,
         help="Seconds before idle container shuts down (default: 15)",
+    )
+    deploy_parser.add_argument(
+        "--region",
+        type=str,
+        default=None,
+        choices=["us", "eu", "ap", "uk", "ca", "me", "sa", "af", "mx"],
+        help="Region for Modal deployment (default: Modal's default, typically US)",
     )
 
     subparsers.add_parser("status", help="Check deployment status")

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -74,6 +74,7 @@ image = (
         # Image built by .github/workflows/build-llama-server.yml
         "ghcr.io/ofekby/qmd-llama-server:b8179-sm75",
         add_python="3.11",
+        force_build=True,  # TODO: remove after first successful deploy with this image
     )
     .pip_install("huggingface-hub", "requests")
     .run_function(download_models)
@@ -224,9 +225,12 @@ class QMDInference:
             )
             resp.raise_for_status()
             data = resp.json()
-            # Response is a list of objects with "embedding" key;
-            # take the first (and only) entry.
-            result.append(data[0]["embedding"])
+            # Response is a list of objects with "embedding" key.
+            # The embedding value may be nested [[...floats...]], so flatten.
+            emb = data[0]["embedding"]
+            if isinstance(emb[0], list):
+                emb = emb[0]
+            result.append(emb)
         return result
 
     @modal.method()

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -61,8 +61,9 @@ def download_models() -> None:
 
 
 image = (
-    modal.Image.debian_slim(python_version="3.11")
-    .pip_install("nvidia-cuda-runtime-cu12")
+    modal.Image.from_registry(
+        "nvidia/cuda:12.4.0-runtime-ubuntu22.04", add_python="3.11"
+    )
     .pip_install(
         "llama-cpp-python",
         extra_index_url="https://abetlen.github.io/llama-cpp-python/whl/cu124",

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -100,7 +100,7 @@ EMBED_SERVER = ServerConfig(
     name="embed",
     port=8081,
     model_file="embeddinggemma-300M-Q8_0.gguf",
-    extra_args=["--embedding", "--pooling", "mean"],
+    extra_args=["--embedding", "--pooling", "mean", "--ubatch-size", "2048"],
 )
 
 EXPAND_SERVER = ServerConfig(
@@ -211,22 +211,24 @@ class QMDInference:
     def embed(self, texts: list[str]) -> list[list[float]]:
         """Raw embedding -- no prompt formatting.
 
+        Sends all texts in a single batch request to llama-server's
+        /embedding endpoint for minimal round-trip overhead.
         Returns one embedding vector per input text.
         """
         import requests
 
+        resp = requests.post(
+            f"http://127.0.0.1:{EMBED_SERVER.port}/embedding",
+            json={"content": texts},
+            timeout=60,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
         result: list[list[float]] = []
-        for text in texts:
-            resp = requests.post(
-                f"http://127.0.0.1:{EMBED_SERVER.port}/embedding",
-                json={"content": text},
-                timeout=30,
-            )
-            resp.raise_for_status()
-            data = resp.json()
-            # Response is a list of objects with "embedding" key.
-            # The embedding value may be nested [[...floats...]], so flatten.
-            emb = data[0]["embedding"]
+        for entry in data:
+            emb = entry["embedding"]
+            # Flatten if nested [[...floats...]]
             if isinstance(emb[0], list):
                 emb = emb[0]
             result.append(emb)

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -72,7 +72,7 @@ image = (
         # Pre-built llama-server with CUDA 12.4 support.
         # Built from llama.cpp b8179 (same as node-llama-cpp v3.17.1).
         # Image built by .github/workflows/build-llama-server.yml
-        "ghcr.io/ofekby/qmd-llama-server:b8179-sm75",
+        "ghcr.io/ofekby/qmd-llama-server:b8179-sm75-v2",
         add_python="3.11",
     )
     .pip_install("huggingface-hub", "requests")

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -72,7 +72,7 @@ image = (
         # Pre-built llama-server with CUDA 12.4 support.
         # Built from llama.cpp b8179 (same as node-llama-cpp v3.17.1).
         # Image built by .github/workflows/build-llama-server.yml
-        "ghcr.io/ofekby/qmd-llama-server@sha256:30d719c680fddf682f42a7c8f578de27bb816f71f66efb3d31fc63aea3ef0bea",
+        "ghcr.io/ofekby/qmd-llama-server:b8179-sm75",
         add_python="3.11",
     )
     .pip_install("huggingface-hub", "requests")

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -72,7 +72,7 @@ image = (
         # Pre-built llama-server with CUDA 12.4 support.
         # Built from llama.cpp b8179 (same as node-llama-cpp v3.17.1).
         # Image built by .github/workflows/build-llama-server.yml
-        "ghcr.io/ofekby/qmd-llama-server:b8179",
+        "ghcr.io/ofekby/qmd-llama-server:b8179-sm75",
         add_python="3.11",
     )
     .pip_install("huggingface-hub", "requests")

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -1,7 +1,13 @@
 """QMD Modal Inference Service.
 
 Deploys three GGUF models (embedding, reranking, query expansion) on a Modal
-GPU container and exposes raw inference methods via Modal's RPC.
+GPU container using llama-server (the llama.cpp HTTP server) and exposes raw
+inference methods via Modal's RPC.
+
+Each model runs as a separate llama-server subprocess on its own port:
+  - Port 8081: embeddinggemma  (embedding, --pooling mean)
+  - Port 8082: qmd-query-expansion (completion)
+  - Port 8083: qwen3-reranker (reranking, --pooling rank)
 
 Manual test instructions:
     # 1. Authenticate with Modal (one-time setup)
@@ -20,9 +26,9 @@ Manual test instructions:
 from __future__ import annotations
 
 import argparse
-import math
 import os
 import sys
+from dataclasses import dataclass
 
 import modal
 
@@ -31,6 +37,7 @@ import modal
 # ---------------------------------------------------------------------------
 
 MODELS_DIR = "/models"
+LLAMA_SERVER_BIN = "/usr/local/bin/llama-server"
 
 MODELS = [
     {
@@ -62,13 +69,22 @@ def download_models() -> None:
 
 image = (
     modal.Image.from_registry(
-        "nvidia/cuda:12.4.0-runtime-ubuntu22.04", add_python="3.11"
+        "nvidia/cuda:12.4.0-devel-ubuntu22.04", add_python="3.11"
     )
-    .pip_install(
-        "llama-cpp-python",
-        extra_index_url="https://abetlen.github.io/llama-cpp-python/whl/cu124",
+    .apt_install("libgomp1", "libcurl4", "build-essential", "cmake", "git")
+    .run_commands(
+        # Build llama-server from llama.cpp b8179 (same version as
+        # node-llama-cpp v3.17.1) with CUDA support.  No pre-built Linux
+        # CUDA binary is published for this release.
+        "git clone --depth 1 --branch b8179"
+        " https://github.com/ggml-org/llama.cpp.git /tmp/llama.cpp"
+        " && cd /tmp/llama.cpp"
+        " && cmake -B build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release"
+        " && cmake --build build --target llama-server -j$(nproc)"
+        f" && cp build/bin/llama-server {LLAMA_SERVER_BIN}"
+        " && rm -rf /tmp/llama.cpp"
     )
-    .pip_install("huggingface-hub")
+    .pip_install("huggingface-hub", "requests")
     .run_function(download_models)
 )
 
@@ -76,12 +92,47 @@ app = modal.App("qmd-inference", image=image)
 
 
 # ---------------------------------------------------------------------------
-# Section B: QMDInference class
+# Section B: Server configuration
 # ---------------------------------------------------------------------------
 
-# Read GPU/scaledown config from environment when the module is imported
-# during ``modal deploy``.  The CLI deploy command passes these via env vars
-# so the decorator picks up the configured values at import time.
+@dataclass
+class ServerConfig:
+    """Configuration for a single llama-server instance."""
+
+    name: str
+    port: int
+    model_file: str
+    extra_args: list[str]
+
+
+EMBED_SERVER = ServerConfig(
+    name="embed",
+    port=8081,
+    model_file="embeddinggemma-300M-Q8_0.gguf",
+    extra_args=["--embedding", "--pooling", "mean"],
+)
+
+EXPAND_SERVER = ServerConfig(
+    name="expand",
+    port=8082,
+    model_file="qmd-query-expansion-1.7B-q4_k_m.gguf",
+    extra_args=[],
+)
+
+RERANK_SERVER = ServerConfig(
+    name="rerank",
+    port=8083,
+    model_file="qwen3-reranker-0.6b-q8_0.gguf",
+    extra_args=["--embedding", "--pooling", "rank"],
+)
+
+ALL_SERVERS = [EMBED_SERVER, EXPAND_SERVER, RERANK_SERVER]
+
+
+# ---------------------------------------------------------------------------
+# Section C: QMDInference class
+# ---------------------------------------------------------------------------
+
 gpu_config: str = os.environ.get("QMD_MODAL_GPU", "T4")
 idle_timeout: int = int(os.environ.get("QMD_MODAL_SCALEDOWN", "15"))
 
@@ -93,54 +144,97 @@ idle_timeout: int = int(os.environ.get("QMD_MODAL_SCALEDOWN", "15"))
 )
 @modal.concurrent(max_inputs=4)
 class QMDInference:
-    """Raw inference service for QMD's three GGUF models."""
+    """Raw inference service for QMD's three GGUF models.
+
+    Runs three llama-server subprocesses (one per model) and proxies
+    requests to them via HTTP.
+    """
 
     @modal.enter(snap=True)
-    def load_models(self) -> None:
-        """Load all 3 models and run warmup passes.
+    def start_servers(self) -> None:
+        """Start all llama-server instances and wait until healthy.
 
-        The ``snap=True`` flag captures the loaded model state in a memory
-        snapshot so subsequent cold starts restore from the snapshot instead
-        of re-loading ~2 GB of weights.
+        Uses ``snap=True`` so the running subprocesses are captured in a
+        memory snapshot.  On restore the servers are already running with
+        models loaded.
         """
-        from llama_cpp import Llama
+        import subprocess
+        import time
 
-        self.embed_model = Llama(
-            model_path=f"{MODELS_DIR}/embeddinggemma-300M-Q8_0.gguf",
-            embedding=True,
-            n_ctx=2048,
-        )
-        self.rerank_model = Llama(
-            model_path=f"{MODELS_DIR}/qwen3-reranker-0.6b-q8_0.gguf",
-            n_ctx=2048,
-        )
-        self.expand_model = Llama(
-            model_path=f"{MODELS_DIR}/qmd-query-expansion-1.7B-q4_k_m.gguf",
-            n_ctx=2048,
-        )
+        import requests
+
+        self._processes: list[subprocess.Popen[bytes]] = []
+
+        for server in ALL_SERVERS:
+            cmd = [
+                LLAMA_SERVER_BIN,
+                "--model", f"{MODELS_DIR}/{server.model_file}",
+                "--port", str(server.port),
+                "--ctx-size", "2048",
+                "--n-gpu-layers", "99",
+                *server.extra_args,
+            ]
+            proc = subprocess.Popen(cmd)
+            self._processes.append(proc)
+
+        # Wait for all servers to become healthy
+        for server in ALL_SERVERS:
+            url = f"http://127.0.0.1:{server.port}/health"
+            deadline = time.monotonic() + 120
+            while time.monotonic() < deadline:
+                try:
+                    resp = requests.get(url, timeout=2)
+                    if resp.status_code == 200:
+                        break
+                except requests.ConnectionError:
+                    pass
+                time.sleep(0.5)
+            else:
+                raise RuntimeError(
+                    f"llama-server '{server.name}' on port {server.port} "
+                    f"did not become healthy within 120s"
+                )
 
         # Warmup passes to pre-fill caches before snapshot
-        self.embed_model.embed("warmup")
-        self.rerank_model("warmup", max_tokens=1)
-        self.expand_model("warmup", max_tokens=1)
+        requests.post(
+            f"http://127.0.0.1:{EMBED_SERVER.port}/embedding",
+            json={"content": "warmup"},
+            timeout=30,
+        )
+        requests.post(
+            f"http://127.0.0.1:{EXPAND_SERVER.port}/completion",
+            json={"prompt": "warmup", "n_predict": 1},
+            timeout=30,
+        )
+        requests.post(
+            f"http://127.0.0.1:{RERANK_SERVER.port}/reranking",
+            json={
+                "query": "warmup",
+                "documents": ["warmup"],
+            },
+            timeout=30,
+        )
 
     @modal.method()
     def embed(self, texts: list[str]) -> list[list[float]]:
         """Raw embedding -- no prompt formatting.
 
-        Returns one embedding vector per input text.  llama-cpp-python's
-        ``Llama.embed()`` returns ``list[list[float]]``; we normalise to
-        always yield a single vector per input.
+        Returns one embedding vector per input text.
         """
+        import requests
+
         result: list[list[float]] = []
         for text in texts:
-            vec = self.embed_model.embed(text)
-            # Llama.embed() may return list[list[float]] or list[float]
-            # depending on input; normalise to a single vector per text.
-            if isinstance(vec[0], list):
-                result.append(vec[0])
-            else:
-                result.append(vec)
+            resp = requests.post(
+                f"http://127.0.0.1:{EMBED_SERVER.port}/embedding",
+                json={"content": text},
+                timeout=30,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            # Response is a list of objects with "embedding" key;
+            # take the first (and only) entry.
+            result.append(data[0]["embedding"])
         return result
 
     @modal.method()
@@ -164,77 +258,62 @@ class QMDInference:
             model: Which model to use -- ``"expand"`` (default) for query
                    expansion, ``"rerank"`` for the reranker model.
         """
-        llm = self.rerank_model if model == "rerank" else self.expand_model
-        kwargs: dict = {"prompt": prompt, "max_tokens": max_tokens}
-        if grammar:
-            from llama_cpp import LlamaGrammar
+        import requests
 
-            kwargs["grammar"] = LlamaGrammar.from_string(grammar)
-        result = llm(**kwargs)
-        return result["choices"][0]["text"]
+        port = RERANK_SERVER.port if model == "rerank" else EXPAND_SERVER.port
+        payload: dict = {"prompt": prompt, "n_predict": max_tokens}
+        if grammar:
+            payload["grammar"] = grammar
+        resp = requests.post(
+            f"http://127.0.0.1:{port}/completion",
+            json=payload,
+            timeout=60,
+        )
+        resp.raise_for_status()
+        return resp.json()["content"]
 
     @modal.method()
     def rerank(self, query: str, texts: list[str]) -> list[float]:
         """Cross-encoder scoring using Qwen3-Reranker.
 
-        Uses ``create_chat_completion()`` which applies the model's native
-        chat template automatically (analogous to node-llama-cpp's
-        ``rankAll()``).
+        Uses llama-server's native ``/reranking`` endpoint (the server runs
+        with ``--pooling rank``), which applies the model's reranking logic
+        directly.
 
-        Returns a list of relevance scores (0--1), one per input text.
+        Returns a list of relevance scores, one per input text.
         """
-        scores: list[float] = []
-        for text in texts:
-            response = self.rerank_model.create_chat_completion(
-                messages=[
-                    {
-                        "role": "system",
-                        "content": (
-                            "Judge whether the Document meets the "
-                            "requirements of the Query. Note that the "
-                            'answer can only be "yes" or "no".'
-                        ),
-                    },
-                    {
-                        "role": "user",
-                        "content": (
-                            f"<Query>{query}</Query>\n"
-                            f"<Document>{text}</Document>"
-                        ),
-                    },
-                ],
-                max_tokens=1,
-                logprobs=True,
-                top_logprobs=5,
-            )
-            score = _extract_yes_probability(response)
-            scores.append(score)
-        return scores
+        import requests
+
+        resp = requests.post(
+            f"http://127.0.0.1:{RERANK_SERVER.port}/reranking",
+            json={"query": query, "documents": texts},
+            timeout=60,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        # Response contains "results" sorted by index, each with
+        # "index" and "relevance_score".  Return scores in the
+        # original document order.
+        results = sorted(data["results"], key=lambda r: r["index"])
+        return [r["relevance_score"] for r in results]
 
     @modal.method()
     def ping(self) -> bool:
-        """Health check -- verifies function is reachable and models loaded."""
+        """Health check -- verifies function is reachable and servers running."""
+        import requests
+
+        for server in ALL_SERVERS:
+            resp = requests.get(
+                f"http://127.0.0.1:{server.port}/health",
+                timeout=5,
+            )
+            if resp.status_code != 200:
+                return False
         return True
 
 
-def _extract_yes_probability(response: dict) -> float:
-    """Extract the probability of the 'yes' token from chat completion logprobs.
-
-    This is the standard Qwen3-Reranker scoring approach: the model is asked
-    to judge relevance with a yes/no answer, and we use the probability of
-    'yes' as the relevance score.
-    """
-    logprobs_data = response["choices"][0]["logprobs"]["content"][0][
-        "top_logprobs"
-    ]
-    for lp in logprobs_data:
-        if lp["token"].lower().strip() == "yes":
-            return math.exp(lp["logprob"])
-    return 0.0
-
-
 # ---------------------------------------------------------------------------
-# Section C: CLI entry point
+# Section D: CLI entry point
 # ---------------------------------------------------------------------------
 
 
@@ -246,9 +325,11 @@ def cmd_deploy(args: argparse.Namespace) -> None:
         f"Deploying qmd-inference "
         f"(gpu={args.gpu}, scaledown_window={args.scaledown_window})..."
     )
-    # Shell out to ``modal deploy`` with env vars so the module re-imports
-    # with the configured GPU and scaledown window values.
-    env = {**os.environ, "QMD_MODAL_GPU": args.gpu, "QMD_MODAL_SCALEDOWN": str(args.scaledown_window)}
+    env = {
+        **os.environ,
+        "QMD_MODAL_GPU": args.gpu,
+        "QMD_MODAL_SCALEDOWN": str(args.scaledown_window),
+    }
     subprocess.run(
         [sys.executable, "-m", "modal", "deploy", __file__],
         check=True,

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -115,7 +115,7 @@ RERANK_SERVER = ServerConfig(
     name="rerank",
     port=8083,
     model_file="qwen3-reranker-0.6b-q8_0.gguf",
-    extra_args=["--embedding", "--pooling", "rank"],
+    extra_args=["--embedding", "--pooling", "rank", "--ubatch-size", "2048"],
 )
 
 ALL_SERVERS = [EMBED_SERVER, EXPAND_SERVER, RERANK_SERVER]

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -74,7 +74,6 @@ image = (
         # Image built by .github/workflows/build-llama-server.yml
         "ghcr.io/ofekby/qmd-llama-server:b8179-sm75",
         add_python="3.11",
-        force_build=True,  # TODO: remove after first successful deploy with this image
     )
     .pip_install("huggingface-hub", "requests")
     .run_function(download_models)

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -132,6 +132,7 @@ idle_timeout: int = int(os.environ.get("QMD_MODAL_SCALEDOWN", "15"))
     gpu=gpu_config,
     scaledown_window=idle_timeout,
     enable_memory_snapshot=True,
+    experimental_options={"enable_gpu_snapshot": True},
 )
 @modal.concurrent(max_inputs=4)
 class QMDInference:

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -257,6 +257,24 @@ class QMDInference:
         return resp.json()
 
     @modal.method()
+    def detokenize(self, tokens: list[int]) -> str:
+        """Convert token IDs back to text using the embedding model's tokenizer.
+
+        Proxies to llama-server's /detokenize endpoint on port 8081
+        (the embeddinggemma model).
+        """
+        import requests
+
+        resp = requests.post(
+            f"http://127.0.0.1:{EMBED_SERVER.port}/detokenize",
+            json={"tokens": tokens},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("content", "")
+
+    @modal.method()
     def generate(
         self,
         prompt: str,

--- a/modal/serve.py
+++ b/modal/serve.py
@@ -86,6 +86,7 @@ app = modal.App("qmd-inference", image=image)
 # Section B: Server configuration
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class ServerConfig:
     """Configuration for a single llama-server instance."""
@@ -160,10 +161,14 @@ class QMDInference:
         for server in ALL_SERVERS:
             cmd = [
                 LLAMA_SERVER_BIN,
-                "--model", f"{MODELS_DIR}/{server.model_file}",
-                "--port", str(server.port),
-                "--ctx-size", "2048",
-                "--n-gpu-layers", "99",
+                "--model",
+                f"{MODELS_DIR}/{server.model_file}",
+                "--port",
+                str(server.port),
+                "--ctx-size",
+                "2048",
+                "--n-gpu-layers",
+                "99",
                 *server.extra_args,
             ]
             proc = subprocess.Popen(cmd)
@@ -233,6 +238,23 @@ class QMDInference:
                 emb = emb[0]
             result.append(emb)
         return result
+
+    @modal.method()
+    def tokenize(self, texts: list[str]) -> list[list[int]]:
+        """Tokenize texts using the embedding model's tokenizer.
+
+        Proxies to llama-server's /tokenize endpoint on port 8081
+        (the embeddinggemma model). Returns token IDs as nested int lists.
+        """
+        import requests
+
+        resp = requests.post(
+            f"http://127.0.0.1:{EMBED_SERVER.port}/tokenize",
+            json={"content": texts},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        return resp.json()
 
     @modal.method()
     def generate(
@@ -346,14 +368,9 @@ def cmd_status(_args: argparse.Namespace) -> None:
         if result:
             print("qmd-inference is deployed and responding.")
         else:
-            print(
-                "qmd-inference is deployed but ping returned unexpected result."
-            )
+            print("qmd-inference is deployed but ping returned unexpected result.")
     except modal.exception.NotFoundError:
-        print(
-            "qmd-inference is not deployed. "
-            "Run: python modal/serve.py deploy"
-        )
+        print("qmd-inference is not deployed. Run: python modal/serve.py deploy")
         sys.exit(1)
     except Exception as exc:
         print(f"Error checking status: {exc}")
@@ -378,9 +395,7 @@ def main() -> None:
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    deploy_parser = subparsers.add_parser(
-        "deploy", help="Deploy the inference service"
-    )
+    deploy_parser = subparsers.add_parser("deploy", help="Deploy the inference service")
     deploy_parser.add_argument(
         "--gpu",
         default="T4",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "zod": "4.2.1"
   },
   "optionalDependencies": {
+    "modal": "^0.7.3",
     "sqlite-vec-darwin-arm64": "^0.1.7-alpha.2",
     "sqlite-vec-darwin-x64": "^0.1.7-alpha.2",
     "sqlite-vec-linux-arm64": "^0.1.7-alpha.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "files": [
     "bin/",
     "dist/",
+    "modal/",
     "LICENSE",
     "CHANGELOG.md"
   ],

--- a/scripts/benchmark_modal_latency.py
+++ b/scripts/benchmark_modal_latency.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""
+Benchmark script to measure Modal latency overhead.
+
+Measures:
+- Ping latency to Modal control plane
+- Query expand latency
+- Full query latency (expand + rerank)
+
+Calculates network overhead as percentage of total operation time.
+
+Known network RTT values (measured from Frankfurt, Germany):
+- us-east-1 (Virginia): ~93ms
+- eu-central-1 (Frankfurt): ~1ms
+"""
+
+import subprocess
+import time
+import statistics
+from dataclasses import dataclass
+
+# Known network RTT values (measured separately)
+RTT_US = 93  # ms to us-east-1
+RTT_EU = 1  # ms to eu-central-1
+
+
+@dataclass
+class LatencyMeasurement:
+    operation: str
+    samples: list[float]
+
+    @property
+    def median(self) -> float:
+        return statistics.median(self.samples)
+
+    @property
+    def mean(self) -> float:
+        return statistics.mean(self.samples)
+
+    @property
+    def stdev(self) -> float:
+        if len(self.samples) > 1:
+            return statistics.stdev(self.samples)
+        return 0.0
+
+    @property
+    def min(self) -> float:
+        return min(self.samples)
+
+    @property
+    def max(self) -> float:
+        return max(self.samples)
+
+
+def run_command(
+    cmd: list[str], timeout: int = 60, workdir: str | None = None
+) -> tuple[float, str]:
+    """Run command and return (elapsed_ms, output)."""
+    start = time.perf_counter()
+    result = subprocess.run(
+        cmd, capture_output=True, text=True, timeout=timeout, cwd=workdir
+    )
+    elapsed = (time.perf_counter() - start) * 1000
+    return elapsed, result.stdout + result.stderr
+
+
+def measure_modal_status(iterations: int = 5) -> LatencyMeasurement:
+    """Measure ping latency to Modal (control plane + worker wake)."""
+    samples = []
+    print("  Measuring Modal ping latency (status check)...")
+    for i in range(iterations):
+        elapsed, _ = run_command(["qmd", "modal", "status"])
+        samples.append(elapsed)
+        print(f"    Sample {i + 1}: {elapsed:.0f}ms")
+    return LatencyMeasurement("modal_ping", samples)
+
+
+def measure_query_expand(iterations: int = 5) -> LatencyMeasurement:
+    """Measure query expansion latency (no rerank)."""
+    samples = []
+    print("  Measuring query expand latency...")
+
+    for i in range(iterations):
+        elapsed, _ = run_command(
+            ["qmd", "query", "test benchmark query", "--no-rerank", "-n", "1"],
+            workdir="/home/ubuntu/repos/keren-kol",
+        )
+        samples.append(elapsed)
+        print(f"    Sample {i + 1}: {elapsed:.0f}ms")
+
+    return LatencyMeasurement("query_expand", samples)
+
+
+def measure_query_full(iterations: int = 5) -> LatencyMeasurement:
+    """Measure full query latency (with rerank)."""
+    samples = []
+    print("  Measuring full query latency (expand + rerank)...")
+
+    for i in range(iterations):
+        elapsed, _ = run_command(
+            ["qmd", "query", "communication layer design", "-n", "5"],
+            workdir="/home/ubuntu/repos/keren-kol",
+        )
+        samples.append(elapsed)
+        print(f"    Sample {i + 1}: {elapsed:.0f}ms")
+
+    return LatencyMeasurement("query_full", samples)
+
+
+def get_network_latency_from_ping():
+    """Measure RTT to AWS regions using ping."""
+    results = {}
+
+    regions = {
+        "us_east_1": "ec2.us-east-1.amazonaws.com",
+        "eu_central_1": "ec2.eu-central-1.amazonaws.com",
+    }
+
+    import re
+
+    for region, host in regions.items():
+        try:
+            result = subprocess.run(
+                ["ping", "-c", "4", host], capture_output=True, text=True, timeout=30
+            )
+            # Try different ping output formats
+            match = re.search(r"rtt min/avg/max/mdev = [\d.]+/([\d.]+)/", result.stdout)
+            if not match:
+                match = re.search(r"time=([\d.]+)\s*ms", result.stdout)
+            if match:
+                results[region] = float(match.group(1))
+        except Exception:
+            pass
+
+    return results
+
+
+def main():
+    print("=" * 70)
+    print("MODAL LATENCY BENCHMARK")
+    print("=" * 70)
+
+    # Warm up Modal (ensure worker is ready)
+    print("\n[WARMUP] Warming up Modal worker...")
+    for i in range(2):
+        run_command(["qmd", "modal", "status"])
+        time.sleep(0.5)
+    print("  Worker is warm.")
+
+    # Actually measure network latency
+    print("\n[NETWORK LATENCY]")
+    network = get_network_latency_from_ping()
+    if network:
+        print(f"  Measured us-east-1:     {network.get('us_east_1', RTT_US):.1f}ms")
+        print(f"  Measured eu-central-1: {network.get('eu_central_1', RTT_EU):.1f}ms")
+    else:
+        print(f"  Using known values (from Frankfurt, Germany):")
+        print(f"  us-east-1 (Virginia):   {RTT_US}ms")
+        print(f"  eu-central-1 (Frankfurt): {RTT_EU}ms")
+
+    rtt_us = network.get("us_east_1", RTT_US)
+    rtt_eu = network.get("eu_central_1", RTT_EU)
+    rtt_savings = rtt_us - rtt_eu
+    print(f"  Potential RTT savings: {rtt_savings:.1f}ms")
+
+    # Measure Modal operations
+    print("\n[MODAL OPERATIONS]")
+
+    ping = measure_modal_status(5)
+    expand = measure_query_expand(5)
+    full_query = measure_query_full(5)
+
+    # Calculate median times (ignore cold starts)
+    ping_median = ping.median
+    expand_median = expand.median
+    full_median = full_query.median
+
+    # Derived values
+    local_estimate = 300  # SQLite + vector search ~300ms
+    control_plane_overhead = ping_median - rtt_us  # Ping includes 1 RTT +control plane
+
+    # Calculate inference times
+    expand_inference = expand_median - local_estimate - rtt_us - control_plane_overhead
+    if expand_inference < 0:
+        expand_inference = expand_median - local_estimate - rtt_us
+
+    rerank_time = full_median - expand_median
+
+    # Print results
+    print("\n" + "=" * 70)
+    print("RESULTS")
+    print("=" * 70)
+
+    print("\n[MEDIAN LATENCIES]")
+    print(f"  {'Operation':<25} {'Median':>10} {'Mean':>10} {'Min':>10} {'Max':>10}")
+    print(f"  {'-' * 25} {'-' * 10} {'-' * 10} {'-' * 10} {'-' * 10}")
+    for m in [ping, expand, full_query]:
+        print(
+            f"  {m.operation:<25} {m.median:>8.0f}ms {m.mean:>8.0f}ms {m.min:>8.0f}ms {m.max:>8.0f}ms"
+        )
+
+    print("\n[LATENCY BREAKDOWN (per query)]")
+    print(f"  Local compute (SQLite+vector): ~{local_estimate}ms")
+    print(f"  Control plane overhead:          ~{control_plane_overhead:.0f}ms")
+    print(f"  Expand inference time:           ~{expand_inference:.0f}ms")
+    print(f"  Rerank time (derived):           ~{rerank_time:.0f}ms")
+    print(f"  Network RTT (US):               {rtt_us:.0f}ms per call")
+    print(f"  Network RTT (EU):               {rtt_eu:.0f}ms per call")
+
+    # Calculate overhead percentages
+    print("\n[NETWORK OVERHEAD AS PERCENTAGE]")
+
+    # Full query has 2 Modal calls: expand + rerank
+    modal_calls = 2
+    network_overhead_us = modal_calls * rtt_us
+    network_overhead_eu = modal_calls * rtt_eu
+
+    overhead_pct_us = (network_overhead_us / full_median) * 100
+    overhead_pct_eu = (network_overhead_eu / full_median) * 100
+
+    print(f"  Query total time:              {full_median:.0f}ms (median)")
+    print(
+        f"  Network overhead (US):         {network_overhead_us:.0f}ms = {overhead_pct_us:.1f}%"
+    )
+    print(
+        f"  Network overhead (EU):         {network_overhead_eu:.0f}ms = {overhead_pct_eu:.1f}%"
+    )
+    print(
+        f"  Savings with EU region:        {rtt_savings * modal_calls:.0f}ms = {overhead_pct_us - overhead_pct_eu:.1f}%"
+    )
+
+    # Per-component breakdown
+    print("\n[TIME BREAKDOWN (% of total)]")
+    components = {
+        "Local compute": local_estimate,
+        f"Network RTT x{modal_calls} (US)": network_overhead_us,
+        "Control plane": control_plane_overhead if control_plane_overhead > 0 else 0,
+        "Expand inference": expand_inference if expand_inference > 0 else 0,
+        "Rerank time": rerank_time if rerank_time > 0 else 0,
+    }
+
+    for name, value in components.items():
+        pct = (value / full_median) * 100
+        print(f"  {name:<30} {value:>6.0f}ms ({pct:>5.1f}%)")
+
+    print("\n[SAVINGS IF SWITCHING TO EU REGION]")
+    savings_per_call = rtt_savings
+    print(
+        f"  Per query ({modal_calls} calls):        {savings_per_call * modal_calls:.0f}ms"
+    )
+    print(
+        f"  Per 100 queries:                {savings_per_call * modal_calls * 100 / 1000:.1f}s"
+    )
+    print(
+        f"  Per 1000 queries:                {savings_per_call * modal_calls * 1000 / 1000:.1f}s"
+    )
+
+    print("\n" + "=" * 70)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cli/modal.ts
+++ b/src/cli/modal.ts
@@ -135,6 +135,7 @@ async function handleDeploy(
   // would pay the ~40s snapshot creation cost.
   let snapshotNote = "";
   try {
+    process.stdout.write("Creating GPU snapshot (loading models onto GPU, ~1 minute)...\n");
     const backend = new ModalBackend();
     await backend.ping();
     snapshotNote = "\nGPU snapshot created — subsequent cold starts will be ~6s.";

--- a/src/cli/modal.ts
+++ b/src/cli/modal.ts
@@ -130,9 +130,22 @@ async function handleDeploy(
 
   setModalConfig({ inference: true });
 
+  // Trigger snapshot creation by calling ping() — this forces a container
+  // to spin up and load models onto GPU. Without this, the first user call
+  // would pay the ~40s snapshot creation cost.
+  let snapshotNote = "";
+  try {
+    const backend = new ModalBackend();
+    await backend.ping();
+    snapshotNote = "\nGPU snapshot created — subsequent cold starts will be ~6s.";
+  } catch {
+    snapshotNote = "\nWarning: could not create GPU snapshot. First call may be slow (~40s).";
+  }
+
   const costNote =
     `Modal inference deployed successfully.\n` +
-    `GPU: ${gpu} (~$0.59/hr, billed per second, scales to zero when idle)`;
+    `GPU: ${gpu} (~$0.59/hr, billed per second, scales to zero when idle)` +
+    snapshotNote;
 
   return { exitCode: 0, stdout: costNote, stderr: "" };
 }

--- a/src/cli/modal.ts
+++ b/src/cli/modal.ts
@@ -6,14 +6,69 @@
  * the modal pip package, and ~/.modal.toml before deploy/destroy.
  */
 
-import { execSync } from "child_process";
+import { execSync, exec } from "child_process";
 import { existsSync } from "fs";
 import { join } from "path";
-import { homedir } from "os";
+import { homedir, platform } from "os";
 import { fileURLToPath } from "url";
 import { dirname } from "path";
+import { promisify } from "util";
 import { getModalConfig, setModalConfig } from "../collections.js";
 import { ModalBackend } from "../modal.js";
+
+const execAsync = promisify(exec);
+
+const REGION_ENDPOINTS: Record<string, string> = {
+  us: "ec2.us-east-1.amazonaws.com",
+  eu: "ec2.eu-central-1.amazonaws.com",
+  ap: "ec2.ap-northeast-1.amazonaws.com",
+  uk: "ec2.eu-west-2.amazonaws.com",
+  ca: "ec2.ca-central-1.amazonaws.com",
+};
+
+const VALID_REGIONS = ["us", "eu", "ap", "uk", "ca", "me", "sa", "af", "mx", "default"];
+
+async function pingEndpoint(endpoint: string, count: number = 3): Promise<number> {
+  const isWindows = platform() === "win32";
+  const countFlag = isWindows ? "-n" : "-c";
+  const cmd = `ping ${countFlag} ${count} ${endpoint}`;
+
+  try {
+    const { stdout } = await execAsync(cmd, { timeout: 30000 });
+    const linuxMatch = stdout.match(/rtt min\/avg\/max\/mdev = [\d.]+\/([\d.]+)/);
+    const winMatch = stdout.match(/Average = (\d+)ms/);
+    const match = linuxMatch ?? winMatch;
+    return match?.[1] ? parseFloat(match[1]) : Infinity;
+  } catch {
+    return Infinity;
+  }
+}
+
+async function detectRegion(): Promise<string> {
+  console.log("Detecting fastest Modal region...");
+
+  const entries = Object.entries(REGION_ENDPOINTS);
+  const results = await Promise.all(
+    entries.map(async ([region, endpoint]) => {
+      const latency = await pingEndpoint(endpoint);
+      return { region, latency };
+    }),
+  );
+
+  const valid = results.filter(r => isFinite(r.latency));
+  if (valid.length === 0) {
+    console.warn("Warning: Region detection failed, using US default");
+    return "us";
+  }
+
+  const best = valid.reduce((a, b) => a.latency < b.latency ? a : b);
+  console.log(`Detected fastest region: ${best.region} (${best.latency.toFixed(1)}ms median)`);
+  return best.region;
+}
+
+function isValidRegion(value: string): boolean {
+  return VALID_REGIONS.includes(value);
+}
 
 // ============================================================================
 // Types

--- a/src/cli/modal.ts
+++ b/src/cli/modal.ts
@@ -87,6 +87,10 @@ export interface ModalCommandOptions {
   tomlPath?: string;
   /** Override serve.py path (for testing). */
   servePyPath?: string;
+  /** Region override for deploy (e.g., "us", "eu"). */
+  region?: string;
+  /** Force region auto-detection. */
+  detectRegion?: boolean;
 }
 
 // ============================================================================
@@ -156,6 +160,8 @@ function resolveServePyPath(): string {
 async function handleDeploy(
   tomlPath: string,
   servePyPath: string,
+  region?: string,
+  forceDetectRegion?: boolean,
 ): Promise<ModalCommandResult> {
   const preflight = preflightChecks(tomlPath);
   if (preflight) {
@@ -163,12 +169,37 @@ async function handleDeploy(
   }
 
   const modalConfig = getModalConfig();
+
+  // Determine region (but DON'T save to config yet)
+  let selectedRegion = region;
+  if (forceDetectRegion || (!selectedRegion && !modalConfig.region)) {
+    selectedRegion = await detectRegion();
+  } else if (!selectedRegion) {
+    selectedRegion = modalConfig.region || "us";
+  }
+
+  // Handle "default" = clear region
+  if (selectedRegion === "default") {
+    selectedRegion = undefined;
+    console.log("Region cleared, using Modal default (US)");
+  }
+
+  // Validate region
+  if (selectedRegion && !isValidRegion(selectedRegion)) {
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr: `Invalid region '${selectedRegion}'. Valid: ${VALID_REGIONS.join(", ")}`,
+    };
+  }
+
   const gpu = modalConfig.gpu;
   const scaledownWindow = modalConfig.scaledown_window;
 
   try {
+    const regionArg = selectedRegion ? ` --region ${selectedRegion}` : "";
     execSync(
-      `python3 "${servePyPath}" deploy --gpu ${gpu} --scaledown-window ${scaledownWindow}`,
+      `python3 "${servePyPath}" deploy --gpu ${gpu} --scaledown-window ${scaledownWindow}${regionArg}`,
       { stdio: "pipe" },
     );
   } catch (err: unknown) {
@@ -183,7 +214,11 @@ async function handleDeploy(
     };
   }
 
+  // Save config AFTER successful deploy
   setModalConfig({ inference: true });
+  if (selectedRegion) {
+    setModalConfig({ region: selectedRegion });
+  }
 
   // Trigger snapshot creation by calling ping() — this forces a container
   // to spin up and load models onto GPU. Without this, the first user call
@@ -318,17 +353,21 @@ export async function handleModalCommand(
       "Usage: qmd modal <command>",
       "",
       "Commands:",
-      "  deploy   Deploy the Modal inference function",
-      "  status   Check if the Modal function is deployed and reachable",
-      "  destroy  Tear down the deployed Modal function",
-      "  test     Run a smoke test against the deployed function",
+      "  deploy [--region <region>] [--detect-region]  Deploy the Modal inference function",
+      "  status                                          Check if Modal is deployed",
+      "  destroy                                         Tear down the deployed function",
+      "  test                                            Run a smoke test",
+      "",
+      "Regions: us, eu, ap, uk, ca, me, sa, af, mx",
+      "  --region default  Clear saved region (use US default)",
+      "  --detect-region   Force re-detection of fastest region",
     ].join("\n");
     return { exitCode: 1, stdout: "", stderr: usage };
   }
 
   switch (subcommand) {
     case "deploy":
-      return handleDeploy(tomlPath, servePyPath);
+      return handleDeploy(tomlPath, servePyPath, options?.region, options?.detectRegion);
     case "destroy":
       return handleDestroy(tomlPath, servePyPath);
     case "status":

--- a/src/cli/modal.ts
+++ b/src/cli/modal.ts
@@ -20,7 +20,7 @@ const execAsync = promisify(exec);
 
 const REGION_ENDPOINTS: Record<string, string> = {
   us: "ec2.us-east-1.amazonaws.com",
-  eu: "ec2.eu-central-1.amazonaws.com",
+  eu: "ec2.eu-west-3.amazonaws.com",  // Paris - closest to Frankfurt
   ap: "ec2.ap-northeast-1.amazonaws.com",
   uk: "ec2.eu-west-2.amazonaws.com",
   ca: "ec2.ca-central-1.amazonaws.com",

--- a/src/cli/modal.ts
+++ b/src/cli/modal.ts
@@ -1,0 +1,276 @@
+/**
+ * Handler for the `qmd modal` CLI subcommand group.
+ *
+ * Provides deploy, status, destroy, and test subcommands for managing
+ * the Modal inference backend. Pre-flight checks validate python3,
+ * the modal pip package, and ~/.modal.toml before deploy/destroy.
+ */
+
+import { execSync } from "child_process";
+import { existsSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { fileURLToPath } from "url";
+import { dirname } from "path";
+import { getModalConfig, setModalConfig } from "../collections.js";
+import { ModalBackend } from "../modal.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Result of a modal CLI command (for testability — no process.exit). */
+export interface ModalCommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Options for handleModalCommand (overrides for testing). */
+export interface ModalCommandOptions {
+  /** Override ~/.modal.toml path (for testing). */
+  tomlPath?: string;
+  /** Override serve.py path (for testing). */
+  servePyPath?: string;
+}
+
+// ============================================================================
+// Pre-flight checks
+// ============================================================================
+
+function checkPython3(): string | null {
+  try {
+    execSync("python3 --version", { stdio: "pipe" });
+    return null;
+  } catch {
+    return (
+      "Error: python3 not found on PATH.\n" +
+      "Modal deployment requires Python 3.10+.\n" +
+      "Install it from https://python.org or via your package manager."
+    );
+  }
+}
+
+function checkModalPip(): string | null {
+  try {
+    execSync('python3 -c "import modal"', { stdio: "pipe" });
+    return null;
+  } catch {
+    return (
+      "Error: Python 'modal' package not found.\n" +
+      "Install it with: pip install modal\n" +
+      "Then authenticate with: modal token set"
+    );
+  }
+}
+
+function checkModalToml(tomlPath: string): string | null {
+  if (!existsSync(tomlPath)) {
+    return (
+      "Error: Modal not authenticated. No ~/.modal.toml found.\n" +
+      "Run: modal token set\n" +
+      "to authenticate with your Modal account."
+    );
+  }
+  return null;
+}
+
+/**
+ * Run all pre-flight checks required for deploy/destroy.
+ * Returns an error string if any check fails, null if all pass.
+ */
+function preflightChecks(tomlPath: string): string | null {
+  return checkPython3() ?? checkModalPip() ?? checkModalToml(tomlPath);
+}
+
+// ============================================================================
+// Resolve serve.py path
+// ============================================================================
+
+function resolveServePyPath(): string {
+  // When running from dist/cli/modal.js or src/cli/modal.ts,
+  // serve.py is at ../../modal/serve.py relative to the file.
+  const thisDir = dirname(fileURLToPath(import.meta.url));
+  return join(thisDir, "..", "..", "modal", "serve.py");
+}
+
+// ============================================================================
+// Subcommand handlers
+// ============================================================================
+
+async function handleDeploy(
+  tomlPath: string,
+  servePyPath: string,
+): Promise<ModalCommandResult> {
+  const preflight = preflightChecks(tomlPath);
+  if (preflight) {
+    return { exitCode: 1, stdout: "", stderr: preflight };
+  }
+
+  const modalConfig = getModalConfig();
+  const gpu = modalConfig.gpu;
+  const scaledownWindow = modalConfig.scaledown_window;
+
+  try {
+    execSync(
+      `python3 "${servePyPath}" deploy --gpu ${gpu} --scaledown-window ${scaledownWindow}`,
+      { stdio: "pipe" },
+    );
+  } catch (err: unknown) {
+    const stderr =
+      err instanceof Error && "stderr" in err
+        ? (err as any).stderr?.toString() ?? ""
+        : "";
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr: `Error: Modal deployment failed.\n${stderr}`,
+    };
+  }
+
+  setModalConfig({ inference: true });
+
+  const costNote =
+    `Modal inference deployed successfully.\n` +
+    `GPU: ${gpu} (~$0.59/hr, billed per second, scales to zero when idle)`;
+
+  return { exitCode: 0, stdout: costNote, stderr: "" };
+}
+
+async function handleDestroy(
+  tomlPath: string,
+  servePyPath: string,
+): Promise<ModalCommandResult> {
+  const preflight = preflightChecks(tomlPath);
+  if (preflight) {
+    return { exitCode: 1, stdout: "", stderr: preflight };
+  }
+
+  try {
+    execSync(`python3 "${servePyPath}" destroy`, { stdio: "pipe" });
+  } catch (err: unknown) {
+    const stderr =
+      err instanceof Error && "stderr" in err
+        ? (err as any).stderr?.toString() ?? ""
+        : "";
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr: `Error: Modal destroy failed.\n${stderr}`,
+    };
+  }
+
+  setModalConfig({ inference: false });
+
+  return { exitCode: 0, stdout: "Modal inference function destroyed.", stderr: "" };
+}
+
+async function handleStatus(
+  tomlPath: string,
+): Promise<ModalCommandResult> {
+  const backend = new ModalBackend({ tomlPath });
+  try {
+    await backend.ping();
+    return { exitCode: 0, stdout: "Modal inference function is deployed and reachable.", stderr: "" };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { exitCode: 1, stdout: "", stderr: `Error: ${message}` };
+  } finally {
+    backend.dispose();
+  }
+}
+
+async function handleTest(
+  tomlPath: string,
+): Promise<ModalCommandResult> {
+  const backend = new ModalBackend({ tomlPath });
+  const lines: string[] = [];
+  let failed = false;
+
+  // Test embed
+  try {
+    const vectors = await backend.embed(["test"]);
+    if (Array.isArray(vectors) && vectors.length > 0 && Array.isArray(vectors[0])) {
+      lines.push("embed: PASS");
+    } else {
+      lines.push("embed: FAIL (unexpected response shape)");
+      failed = true;
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    lines.push(`embed: FAIL (${message})`);
+    failed = true;
+  }
+
+  // Test generate
+  try {
+    const text = await backend.generate("Hello", null, 5);
+    if (typeof text === "string" && text.length > 0) {
+      lines.push("generate: PASS");
+    } else {
+      lines.push("generate: FAIL (empty or non-string response)");
+      failed = true;
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    lines.push(`generate: FAIL (${message})`);
+    failed = true;
+  }
+
+  backend.dispose();
+
+  return {
+    exitCode: failed ? 1 : 0,
+    stdout: lines.join("\n"),
+    stderr: "",
+  };
+}
+
+// ============================================================================
+// Main handler
+// ============================================================================
+
+/**
+ * Handle `qmd modal <subcommand>` CLI invocation.
+ *
+ * Returns a result object instead of calling process.exit directly,
+ * making it testable without mocking process.exit.
+ */
+export async function handleModalCommand(
+  args: string[],
+  options?: ModalCommandOptions,
+): Promise<ModalCommandResult> {
+  const tomlPath = options?.tomlPath ?? join(homedir(), ".modal.toml");
+  const servePyPath = options?.servePyPath ?? resolveServePyPath();
+  const subcommand = args[0];
+
+  if (!subcommand) {
+    const usage = [
+      "Usage: qmd modal <command>",
+      "",
+      "Commands:",
+      "  deploy   Deploy the Modal inference function",
+      "  status   Check if the Modal function is deployed and reachable",
+      "  destroy  Tear down the deployed Modal function",
+      "  test     Run a smoke test against the deployed function",
+    ].join("\n");
+    return { exitCode: 1, stdout: "", stderr: usage };
+  }
+
+  switch (subcommand) {
+    case "deploy":
+      return handleDeploy(tomlPath, servePyPath);
+    case "destroy":
+      return handleDestroy(tomlPath, servePyPath);
+    case "status":
+      return handleStatus(tomlPath);
+    case "test":
+      return handleTest(tomlPath);
+    default:
+      return {
+        exitCode: 1,
+        stdout: "",
+        stderr: `Unknown subcommand: ${subcommand}\nAvailable: deploy, status, destroy, test`,
+      };
+  }
+}

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -96,6 +96,7 @@ import {
   listAllContexts,
   setConfigIndexName,
   loadConfig,
+  getModalConfig,
 } from "../collections.js";
 import { getEmbeddedQmdSkillContent, getEmbeddedQmdSkillFiles } from "../embedded-skills.js";
 
@@ -426,34 +427,43 @@ async function showStatus(): Promise<void> {
     console.log(`  Generation:  ${hfLink(DEFAULT_GENERATE_MODEL_URI)}`);
   }
 
-  // Device / GPU info
-  try {
-    const llm = getDefaultLlamaCpp();
-    const device = await llm.getDeviceInfo();
-    console.log(`\n${c.bold}Device${c.reset}`);
-    if (device.gpu) {
-      console.log(`  GPU:      ${c.green}${device.gpu}${c.reset} (offloading: ${device.gpuOffloading ? 'yes' : 'no'})`);
-      if (device.gpuDevices.length > 0) {
-        // Deduplicate and count GPUs
-        const counts = new Map<string, number>();
-        for (const name of device.gpuDevices) {
-          counts.set(name, (counts.get(name) || 0) + 1);
-        }
-        const deviceStr = Array.from(counts.entries())
-          .map(([name, count]) => count > 1 ? `${count}× ${name}` : name)
-          .join(', ');
-        console.log(`  Devices:  ${deviceStr}`);
-      }
-      if (device.vram) {
-        console.log(`  VRAM:     ${formatBytes(device.vram.free)} free / ${formatBytes(device.vram.total)} total`);
-      }
+  // Inference backend info
+  {
+    const modalConfig = getModalConfig();
+    console.log(`\n${c.bold}Inference${c.reset}`);
+    if (modalConfig.inference) {
+      console.log(`  Backend:  ${c.green}Modal${c.reset} (remote GPU)`);
+      console.log(`  GPU:      ${modalConfig.gpu}`);
+      console.log(`  Region:   ${modalConfig.region || 'auto-detect'}`);
     } else {
-      console.log(`  GPU:      ${c.yellow}none${c.reset} (running on CPU — models will be slow)`);
-      console.log(`  ${c.dim}Tip: Install CUDA, Vulkan, or Metal support for GPU acceleration.${c.reset}`);
+      console.log(`  Backend:  ${c.green}local${c.reset}`);
+      try {
+        const llm = getDefaultLlamaCpp();
+        const device = await llm.getDeviceInfo();
+        if (device.gpu) {
+          console.log(`  GPU:      ${c.green}${device.gpu}${c.reset} (offloading: ${device.gpuOffloading ? 'yes' : 'no'})`);
+          if (device.gpuDevices.length > 0) {
+            const counts = new Map<string, number>();
+            for (const name of device.gpuDevices) {
+              counts.set(name, (counts.get(name) || 0) + 1);
+            }
+            const deviceStr = Array.from(counts.entries())
+              .map(([name, count]) => count > 1 ? `${count}× ${name}` : name)
+              .join(', ');
+            console.log(`  Devices:  ${deviceStr}`);
+          }
+          if (device.vram) {
+            console.log(`  VRAM:     ${formatBytes(device.vram.free)} free / ${formatBytes(device.vram.total)} total`);
+          }
+        } else {
+          console.log(`  GPU:      ${c.yellow}none${c.reset} (running on CPU — models will be slow)`);
+          console.log(`  ${c.dim}Tip: Install CUDA, Vulkan, or Metal support for GPU acceleration.${c.reset}`);
+        }
+        console.log(`  CPU:      ${device.cpuCores} math cores`);
+      } catch {
+        // Don't fail status if LLM init fails
+      }
     }
-    console.log(`  CPU:      ${device.cpuCores} math cores`);
-  } catch {
-    // Don't fail status if LLM init fails
   }
 
   // Tips section

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -2945,6 +2945,15 @@ if (isMain) {
       break;
     }
 
+    case "modal": {
+      const { handleModalCommand } = await import("./modal.js");
+      const result = await handleModalCommand(cli.args);
+      if (result.stderr) console.error(result.stderr);
+      if (result.stdout) console.log(result.stdout);
+      if (result.exitCode !== 0) process.exit(result.exitCode);
+      break;
+    }
+
     case "status":
       await showStatus();
       break;

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -40,6 +40,7 @@ export interface ModalConfig {
   inference?: boolean;       // Whether to use Modal for inference (default: false)
   gpu?: string;              // GPU type to use (default: "T4")
   scaledown_window?: number; // Seconds before idle container scales down (default: 15)
+  region?: string;           // Modal region for worker deployment (default: "" = auto-detect)
 }
 
 /**
@@ -487,6 +488,7 @@ const MODAL_DEFAULTS: Required<ModalConfig> = {
   inference: false,
   gpu: "T4",
   scaledown_window: 15,
+  region: "",
 };
 
 /**

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -34,11 +34,21 @@ export interface Collection {
 }
 
 /**
+ * Modal inference backend configuration
+ */
+export interface ModalConfig {
+  inference?: boolean;       // Whether to use Modal for inference (default: false)
+  gpu?: string;              // GPU type to use (default: "T4")
+  scaledown_window?: number; // Seconds before idle container scales down (default: 15)
+}
+
+/**
  * The complete configuration file structure
  */
 export interface CollectionConfig {
   global_context?: string;                    // Context applied to all collections
   collections: Record<string, Collection>;    // Collection name -> config
+  modal?: ModalConfig;                        // Optional Modal inference config
 }
 
 /**
@@ -467,6 +477,35 @@ export function findContextForPath(
 
   // Fallback to global context
   return config.global_context;
+}
+
+// ============================================================================
+// Modal configuration
+// ============================================================================
+
+const MODAL_DEFAULTS: Required<ModalConfig> = {
+  inference: false,
+  gpu: "T4",
+  scaledown_window: 15,
+};
+
+/**
+ * Get the modal config with defaults applied for any missing fields.
+ * Returns a fully populated ModalConfig.
+ */
+export function getModalConfig(): Required<ModalConfig> {
+  const config = loadConfig();
+  return { ...MODAL_DEFAULTS, ...config.modal };
+}
+
+/**
+ * Merge a partial modal config update into the existing config and save.
+ * Only the provided fields are updated; existing fields are preserved.
+ */
+export function setModalConfig(partial: Partial<ModalConfig>): void {
+  const config = loadConfig();
+  config.modal = { ...config.modal, ...partial };
+  saveConfig(config);
 }
 
 // ============================================================================

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -347,6 +347,17 @@ export interface LLM {
   rerank(query: string, documents: RerankDocument[], options?: RerankOptions): Promise<RerankResult>;
 
   /**
+   * Tokenize text using the embedding model's tokenizer.
+   * Returns tokenizer tokens (opaque type from the underlying implementation).
+   */
+  tokenize(text: string): Promise<readonly LlamaToken[]>;
+
+  /**
+   * Count tokens in text using the embedding model's tokenizer.
+   */
+  countTokens(text: string): Promise<number>;
+
+  /**
    * Dispose of resources
    */
   dispose(): Promise<void>;
@@ -1705,6 +1716,14 @@ export class ModalLLM implements LLM {
 
   async modelExists(_model: string): Promise<ModelInfo> {
     return { name: "modal", exists: true };
+  }
+
+  async tokenize(_text: string): Promise<readonly LlamaToken[]> {
+    return [];
+  }
+
+  async countTokens(text: string): Promise<number> {
+    return Math.ceil(text.length / 4);
   }
 
   async dispose(): Promise<void> {

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -1512,15 +1512,23 @@ export async function withLLMSession<T>(
 }
 
 /**
- * Execute a function with a scoped LLM session using a specific LlamaCpp instance.
- * Unlike withLLMSession, this does not use the global singleton.
+ * Execute a function with a scoped LLM session for a specific LLM instance.
+ * Dispatches to ModalSession for ModalLLM, or LLMSession for LlamaCpp.
  */
 export async function withLLMSessionForLlm<T>(
-  llm: LlamaCpp,
+  llm: LLM,
   fn: (session: ILLMSession) => Promise<T>,
   options?: LLMSessionOptions
 ): Promise<T> {
-  const manager = new LLMSessionManager(llm);
+  if (llm instanceof ModalLLM) {
+    const session = new ModalSession(llm, options);
+    try {
+      return await fn(session);
+    } finally {
+      session.release();
+    }
+  }
+  const manager = new LLMSessionManager(llm as LlamaCpp);
   const session = new LLMSession(manager, options);
 
   try {

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -1718,12 +1718,13 @@ export class ModalLLM implements LLM {
     return { name: "modal", exists: true };
   }
 
-  async tokenize(_text: string): Promise<readonly LlamaToken[]> {
-    return [];
+  async tokenize(text: string): Promise<readonly LlamaToken[]> {
+    const tokens = await this.backend.tokenize([text]);
+    return (tokens[0] ?? []) as unknown as readonly LlamaToken[];
   }
 
   async countTokens(text: string): Promise<number> {
-    return Math.ceil(text.length / 4);
+    return (await this.tokenize(text)).length;
   }
 
   async dispose(): Promise<void> {
@@ -1908,6 +1909,16 @@ class ModalSession implements ILLMSession {
       results.push(await this.modalLLM.embed(text));
     }
     return results;
+  }
+
+  async tokenize(text: string): Promise<readonly LlamaToken[]> {
+    if (!this.isValid) throw new SessionReleasedError();
+    return this.modalLLM.tokenize(text);
+  }
+
+  async countTokens(text: string): Promise<number> {
+    if (!this.isValid) throw new SessionReleasedError();
+    return this.modalLLM.countTokens(text);
   }
 
   async expandQuery(

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -358,6 +358,11 @@ export interface LLM {
   countTokens(text: string): Promise<number>;
 
   /**
+   * Detokenize token IDs back to text.
+   */
+  detokenize(tokens: readonly LlamaToken[]): Promise<string>;
+
+  /**
    * Dispose of resources
    */
   dispose(): Promise<void>;
@@ -1587,11 +1592,11 @@ export async function disposeDefaultLlamaCpp(): Promise<void> {
 // =============================================================================
 
 /**
- * Character-based approximation for max document length in reranking.
- * Qwen3-Reranker context is 2048 tokens; ~4 chars/token is a safe estimate.
- * Budget: contextSize(2048) - templateOverhead(200) - queryTokens(~100) = ~1748 tokens * 4 = ~7000 chars.
+ * Rerank context size constants (must match llama-server --ctx-size).
+ * Modal rerank server runs with --ctx-size 2048.
  */
-const MODAL_RERANK_MAX_DOC_CHARS = 7000;
+const MODAL_RERANK_CONTEXT_SIZE = 2048;
+const MODAL_RERANK_TEMPLATE_OVERHEAD = 200;
 
 /**
  * GBNF grammar for query expansion output format.
@@ -1681,11 +1686,30 @@ export class ModalLLM implements LLM {
       return { results: [], model: "modal" };
     }
 
-    // Character-based truncation (no tokenizer available in Modal mode)
-    const truncatedDocs = documents.map((doc) => {
-      if (doc.text.length <= MODAL_RERANK_MAX_DOC_CHARS) return doc;
-      return { ...doc, text: doc.text.slice(0, MODAL_RERANK_MAX_DOC_CHARS) };
-    });
+    // Token-level truncation (same logic as LlamaCpp.rerank).
+    // Budget = contextSize - template overhead - query tokens
+    const queryTokens = await this.countTokens(query);
+    const maxDocTokens = MODAL_RERANK_CONTEXT_SIZE - MODAL_RERANK_TEMPLATE_OVERHEAD - queryTokens;
+
+    // Truncate documents that would exceed the rerank context size.
+    // Use a cache to avoid re-tokenizing identical documents.
+    const truncationCache = new Map<string, string>();
+    const truncatedDocs = await Promise.all(
+      documents.map(async (doc) => {
+        const cached = truncationCache.get(doc.text);
+        if (cached !== undefined) {
+          return cached === doc.text ? doc : { ...doc, text: cached };
+        }
+
+        const tokens = await this.tokenize(doc.text);
+        const truncatedText = tokens.length <= maxDocTokens
+          ? doc.text
+          : await this.detokenize(tokens.slice(0, maxDocTokens));
+        truncationCache.set(doc.text, truncatedText);
+
+        return truncatedText === doc.text ? doc : { ...doc, text: truncatedText };
+      }),
+    );
 
     // Deduplicate identical texts before scoring
     const textToDocs = new Map<string, { file: string; index: number }[]>();
@@ -1733,6 +1757,10 @@ export class ModalLLM implements LLM {
 
   async countTokens(text: string): Promise<number> {
     return (await this.tokenize(text)).length;
+  }
+
+  async detokenize(tokens: readonly LlamaToken[]): Promise<string> {
+    return this.backend.detokenize(tokens as unknown as number[]);
   }
 
   async dispose(): Promise<void> {

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -17,6 +17,8 @@ import {
 import { homedir } from "os";
 import { join } from "path";
 import { existsSync, mkdirSync, statSync, unlinkSync, readdirSync, readFileSync, writeFileSync } from "fs";
+import { getModalConfig } from "./collections.js";
+import { ModalBackend } from "./modal.js";
 
 // =============================================================================
 // Embedding Formatting Functions
@@ -1472,6 +1474,17 @@ export async function withLLMSession<T>(
   fn: (session: ILLMSession) => Promise<T>,
   options?: LLMSessionOptions
 ): Promise<T> {
+  // When Modal is active, bypass LLMSessionManager entirely
+  if (getModalConfig().inference) {
+    const modalLLM = getOrCreateModalLLM();
+    const session = new ModalSession(modalLLM, options);
+    try {
+      return await fn(session);
+    } finally {
+      session.release();
+    }
+  }
+
   const manager = getSessionManager();
   const session = new LLMSession(manager, options);
 
@@ -1542,5 +1555,345 @@ export async function disposeDefaultLlamaCpp(): Promise<void> {
   if (defaultLlamaCpp) {
     await defaultLlamaCpp.dispose();
     defaultLlamaCpp = null;
+  }
+}
+
+// =============================================================================
+// Modal LLM Implementation
+// =============================================================================
+
+/**
+ * Character-based approximation for max document length in reranking.
+ * Qwen3-Reranker context is 2048 tokens; ~4 chars/token is a safe estimate.
+ * Budget: contextSize(2048) - templateOverhead(200) - queryTokens(~100) = ~1748 tokens * 4 = ~7000 chars.
+ */
+const MODAL_RERANK_MAX_DOC_CHARS = 7000;
+
+/**
+ * GBNF grammar for query expansion output format.
+ * Identical to the grammar used by LlamaCpp.expandQuery.
+ */
+const EXPAND_GRAMMAR = `root ::= line+
+line ::= type ": " content "\\n"
+type ::= "lex" | "vec" | "hyde"
+content ::= [^\\n]+`;
+
+/**
+ * LLM implementation that delegates inference to a Modal backend.
+ *
+ * All prompt formatting (chat templates, embedding prefixes) happens locally.
+ * Only raw inference calls (embed, generate, rerank) go to Modal.
+ */
+export class ModalLLM implements LLM {
+  private backend: ModalBackend;
+
+  constructor(backend?: ModalBackend) {
+    this.backend = backend ?? new ModalBackend();
+  }
+
+  async embed(text: string, options: EmbedOptions = {}): Promise<EmbeddingResult | null> {
+    const isQuery = options.isQuery ?? true;
+    const formattedText = isQuery
+      ? formatQueryForEmbedding(text)
+      : formatDocForEmbedding(text, options.title);
+
+    const vectors = await this.backend.embed([formattedText]);
+    if (!vectors || vectors.length === 0) return null;
+
+    return {
+      embedding: vectors[0]!,
+      model: "modal",
+    };
+  }
+
+  async generate(prompt: string, options: GenerateOptions = {}): Promise<GenerateResult | null> {
+    const maxTokens = options.maxTokens ?? 150;
+    const text = await this.backend.generate(prompt, null, maxTokens, "expand");
+    return {
+      text,
+      model: "modal",
+      done: true,
+    };
+  }
+
+  async expandQuery(
+    query: string,
+    options: { context?: string; includeLexical?: boolean; intent?: string } = {},
+  ): Promise<Queryable[]> {
+    const includeLexical = options.includeLexical ?? true;
+    const intent = options.intent;
+
+    const userMessage = intent
+      ? `/no_think Expand this search query: ${query}\nQuery intent: ${intent}`
+      : `/no_think Expand this search query: ${query}`;
+
+    // Build the full Qwen3 chat template as a raw string.
+    // The Python side does raw completion only — no template application.
+    const fullPrompt =
+      `<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n` +
+      `<|im_start|>user\n${userMessage}<|im_end|>\n` +
+      `<|im_start|>assistant\n`;
+
+    // TODO: Generation params (temperature=0.7, top_k=20, top_p=0.8) should be
+    // configurable and passed to the Python side's generate(). For now, the
+    // Python model uses its defaults.
+    const result = await this.backend.generate(fullPrompt, EXPAND_GRAMMAR, 600, "expand");
+
+    return parseExpandResult(result, query, includeLexical);
+  }
+
+  async rerank(
+    query: string,
+    documents: RerankDocument[],
+    _options: RerankOptions = {},
+  ): Promise<RerankResult> {
+    if (documents.length === 0) {
+      return { results: [], model: "modal" };
+    }
+
+    // Character-based truncation (no tokenizer available in Modal mode)
+    const truncatedDocs = documents.map((doc) => {
+      if (doc.text.length <= MODAL_RERANK_MAX_DOC_CHARS) return doc;
+      return { ...doc, text: doc.text.slice(0, MODAL_RERANK_MAX_DOC_CHARS) };
+    });
+
+    // Deduplicate identical texts before scoring
+    const textToDocs = new Map<string, { file: string; index: number }[]>();
+    for (let i = 0; i < truncatedDocs.length; i++) {
+      const doc = truncatedDocs[i]!;
+      const existing = textToDocs.get(doc.text);
+      if (existing) {
+        existing.push({ file: doc.file, index: i });
+      } else {
+        textToDocs.set(doc.text, [{ file: doc.file, index: i }]);
+      }
+    }
+
+    const uniqueTexts = Array.from(textToDocs.keys());
+    const scores = await this.backend.rerank(query, uniqueTexts);
+
+    // Build ranked results sorted by score descending
+    const scored = uniqueTexts
+      .map((text, i) => ({ text, score: scores[i]! }))
+      .sort((a, b) => b.score - a.score);
+
+    const results: RerankDocumentResult[] = [];
+    for (const item of scored) {
+      const docInfos = textToDocs.get(item.text) ?? [];
+      for (const info of docInfos) {
+        results.push({
+          file: info.file,
+          score: item.score,
+          index: info.index,
+        });
+      }
+    }
+
+    return { results, model: "modal" };
+  }
+
+  async modelExists(_model: string): Promise<ModelInfo> {
+    return { name: "modal", exists: true };
+  }
+
+  async dispose(): Promise<void> {
+    this.backend.dispose();
+  }
+
+  /** Expose backend for ping/validation. */
+  getBackend(): ModalBackend {
+    return this.backend;
+  }
+}
+
+/**
+ * Parse the raw text output from query expansion into Queryable objects.
+ * Mirrors the parsing logic in LlamaCpp.expandQuery.
+ */
+function parseExpandResult(
+  raw: string,
+  query: string,
+  includeLexical: boolean,
+): Queryable[] {
+  const lines = raw.trim().split("\n");
+  const queryLower = query.toLowerCase();
+  const queryTerms = queryLower
+    .replace(/[^a-z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter(Boolean);
+
+  const hasQueryTerm = (text: string): boolean => {
+    const lower = text.toLowerCase();
+    if (queryTerms.length === 0) return true;
+    return queryTerms.some((term) => lower.includes(term));
+  };
+
+  const queryables: Queryable[] = lines
+    .map((line) => {
+      const colonIdx = line.indexOf(":");
+      if (colonIdx === -1) return null;
+      const type = line.slice(0, colonIdx).trim();
+      if (type !== "lex" && type !== "vec" && type !== "hyde") return null;
+      const text = line.slice(colonIdx + 1).trim();
+      if (!hasQueryTerm(text)) return null;
+      return { type: type as QueryType, text };
+    })
+    .filter((q): q is Queryable => q !== null);
+
+  const filtered = includeLexical
+    ? queryables
+    : queryables.filter((q) => q.type !== "lex");
+
+  if (filtered.length > 0) return filtered;
+
+  // Fallback to basic queries
+  const fallback: Queryable[] = [
+    { type: "hyde", text: `Information about ${query}` },
+    { type: "lex", text: query },
+    { type: "vec", text: query },
+  ];
+  return includeLexical ? fallback : fallback.filter((q) => q.type !== "lex");
+}
+
+// =============================================================================
+// Modal LLM Singleton
+// =============================================================================
+
+let defaultModalLLM: ModalLLM | null = null;
+
+/**
+ * Get or create the singleton ModalLLM instance.
+ */
+export function getOrCreateModalLLM(): ModalLLM {
+  if (!defaultModalLLM) {
+    defaultModalLLM = new ModalLLM();
+  }
+  return defaultModalLLM;
+}
+
+/**
+ * Reset the ModalLLM singleton (for testing).
+ */
+export function resetModalLLM(): void {
+  defaultModalLLM = null;
+}
+
+/**
+ * Get the default LLM based on modal configuration.
+ * When modal.inference=true, returns ModalLLM. Otherwise returns LlamaCpp.
+ */
+export function getDefaultLLM(): LLM {
+  if (getModalConfig().inference) return getOrCreateModalLLM();
+  return getDefaultLlamaCpp();
+}
+
+/**
+ * Validate that the Modal backend is reachable.
+ * Calls ping() and throws with a clear error message on failure.
+ */
+export async function validateModalConnection(): Promise<void> {
+  const modalLLM = getOrCreateModalLLM();
+  try {
+    const ok = await modalLLM.getBackend().ping();
+    if (!ok) {
+      throw new Error("ping returned false");
+    }
+  } catch (err) {
+    throw new Error(
+      `Modal inference is enabled but the deployed function is not reachable.\n` +
+        `Run 'qmd modal status' to check deployment, or 'qmd modal deploy' to redeploy.\n` +
+        `Original error: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+}
+
+// =============================================================================
+// Modal Session — thin ILLMSession wrapper for ModalLLM
+// =============================================================================
+
+/**
+ * Lightweight session wrapper for ModalLLM.
+ * No concurrency tracking or inactivity timeout — Modal handles that server-side.
+ */
+class ModalSession implements ILLMSession {
+  private modalLLM: ModalLLM;
+  private released = false;
+  private abortController: AbortController;
+  private maxDurationTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(modalLLM: ModalLLM, options: LLMSessionOptions = {}) {
+    this.modalLLM = modalLLM;
+    this.abortController = new AbortController();
+
+    if (options.signal) {
+      if (options.signal.aborted) {
+        this.abortController.abort(options.signal.reason);
+      } else {
+        options.signal.addEventListener(
+          "abort",
+          () => this.abortController.abort(options.signal!.reason),
+          { once: true },
+        );
+      }
+    }
+
+    const maxDuration = options.maxDuration ?? 10 * 60 * 1000;
+    if (maxDuration > 0) {
+      this.maxDurationTimer = setTimeout(() => {
+        this.abortController.abort(
+          new Error(`Modal session exceeded max duration of ${maxDuration}ms`),
+        );
+      }, maxDuration);
+      this.maxDurationTimer.unref();
+    }
+  }
+
+  get isValid(): boolean {
+    return !this.released && !this.abortController.signal.aborted;
+  }
+
+  get signal(): AbortSignal {
+    return this.abortController.signal;
+  }
+
+  release(): void {
+    if (this.released) return;
+    this.released = true;
+    if (this.maxDurationTimer) {
+      clearTimeout(this.maxDurationTimer);
+      this.maxDurationTimer = null;
+    }
+    this.abortController.abort(new Error("Session released"));
+  }
+
+  async embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null> {
+    if (!this.isValid) throw new SessionReleasedError();
+    return this.modalLLM.embed(text, options);
+  }
+
+  async embedBatch(texts: string[]): Promise<(EmbeddingResult | null)[]> {
+    if (!this.isValid) throw new SessionReleasedError();
+    const results: (EmbeddingResult | null)[] = [];
+    for (const text of texts) {
+      results.push(await this.modalLLM.embed(text));
+    }
+    return results;
+  }
+
+  async expandQuery(
+    query: string,
+    options?: { context?: string; includeLexical?: boolean },
+  ): Promise<Queryable[]> {
+    if (!this.isValid) throw new SessionReleasedError();
+    return this.modalLLM.expandQuery(query, options);
+  }
+
+  async rerank(
+    query: string,
+    documents: RerankDocument[],
+    options?: RerankOptions,
+  ): Promise<RerankResult> {
+    if (!this.isValid) throw new SessionReleasedError();
+    return this.modalLLM.rerank(query, documents, options);
   }
 }

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -320,6 +320,11 @@ export interface LLM {
   embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null>;
 
   /**
+   * Get embeddings for multiple texts in a single batch call.
+   */
+  embedBatch(texts: string[]): Promise<(EmbeddingResult | null)[]>;
+
+  /**
    * Generate text completion
    */
   generate(prompt: string, options?: GenerateOptions): Promise<GenerateResult | null>;
@@ -333,7 +338,7 @@ export interface LLM {
    * Expand a search query into multiple variations for different backends.
    * Returns a list of Queryable objects.
    */
-  expandQuery(query: string, options?: { context?: string, includeLexical?: boolean }): Promise<Queryable[]>;
+  expandQuery(query: string, options?: { context?: string, includeLexical?: boolean, intent?: string }): Promise<Queryable[]>;
 
   /**
    * Rerank documents by relevance to a query

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -1606,6 +1606,12 @@ export class ModalLLM implements LLM {
     };
   }
 
+  async embedBatch(texts: string[]): Promise<(EmbeddingResult | null)[]> {
+    if (texts.length === 0) return [];
+    const vectors = await this.backend.embed(texts);
+    return vectors.map((v) => (v ? { embedding: v, model: "modal" } : null));
+  }
+
   async generate(prompt: string, options: GenerateOptions = {}): Promise<GenerateResult | null> {
     const maxTokens = options.maxTokens ?? 150;
     const text = await this.backend.generate(prompt, null, maxTokens, "expand");

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -179,6 +179,26 @@ export class ModalBackend {
   }
 
   /**
+   * Tokenize texts using the embedding model's tokenizer on Modal.
+   * Returns token IDs as nested number arrays.
+   */
+  async tokenize(texts: string[]): Promise<number[][]> {
+    await this.ensureConnected();
+    return withRetry(async () => {
+      const fn = this.getMethod("tokenize");
+      return fn.remote([texts]);
+    }).catch((err) => {
+      throw isConnectionError(err)
+        ? new Error(
+            `Modal inference function not reachable after retries.\n` +
+              `Run 'qmd modal status' to check deployment, or 'qmd modal deploy' to redeploy.\n` +
+              `Original error: ${err instanceof Error ? err.message : err}`,
+          )
+        : err;
+    });
+  }
+
+  /**
    * Raw text generation with optional GBNF grammar.
    * Caller passes the fully formatted prompt including special tokens.
    */

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -199,6 +199,25 @@ export class ModalBackend {
   }
 
   /**
+   * Detokenize token IDs back to text using the embedding model's tokenizer.
+   */
+  async detokenize(tokens: number[]): Promise<string> {
+    await this.ensureConnected();
+    return withRetry(async () => {
+      const fn = this.getMethod("detokenize");
+      return fn.remote([tokens]);
+    }).catch((err) => {
+      throw isConnectionError(err)
+        ? new Error(
+            `Modal inference function not reachable after retries.\n` +
+              `Run 'qmd modal status' to check deployment, or 'qmd modal deploy' to redeploy.\n` +
+              `Original error: ${err instanceof Error ? err.message : err}`,
+          )
+        : err;
+    });
+  }
+
+  /**
    * Raw text generation with optional GBNF grammar.
    * Caller passes the fully formatted prompt including special tokens.
    */

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -1,0 +1,252 @@
+/**
+ * Modal inference backend client.
+ *
+ * Provides a ModalBackend class that calls deployed Modal functions
+ * via the `modal` npm SDK (gRPC). All prompt formatting stays in JS;
+ * this module handles only the raw RPC transport with retry logic.
+ */
+
+import { existsSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Minimal shape of a Modal ClsInstance method handle. */
+interface ModalMethodHandle {
+  remote(args?: any[], kwargs?: Record<string, any>): Promise<any>;
+}
+
+/** Minimal shape of a Modal ClsInstance. */
+interface ModalClsInstance {
+  method(name: string): ModalMethodHandle;
+}
+
+// ============================================================================
+// Connection error detection
+// ============================================================================
+
+const CONNECTION_ERROR_PATTERNS = [
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "ECONNRESET",
+  "unavailable",
+  "deadline exceeded",
+] as const;
+
+/**
+ * Determine whether an error is a transient connection error worth retrying.
+ * Checks error message and code for known network/gRPC patterns.
+ */
+export function isConnectionError(err: unknown): boolean {
+  const message =
+    err instanceof Error ? err.message : String(err);
+  const code =
+    err instanceof Error ? (err as any).code : undefined;
+  const lower = message.toLowerCase();
+  const codeLower = typeof code === "string" ? code.toLowerCase() : "";
+
+  return CONNECTION_ERROR_PATTERNS.some(
+    (pattern) =>
+      lower.includes(pattern.toLowerCase()) ||
+      codeLower.includes(pattern.toLowerCase()),
+  );
+}
+
+// ============================================================================
+// Retry helper
+// ============================================================================
+
+/**
+ * Retry a function up to maxAttempts on connection errors.
+ *
+ * - Attempt 1: immediate
+ * - Attempt 2: immediate retry after connection error
+ * - Attempt 3+: wait retryDelayMs then retry
+ * - Non-connection errors: throw immediately, no retry
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  maxAttempts: number = 3,
+  retryDelayMs: number = 100,
+): Promise<T> {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (!isConnectionError(err) || attempt === maxAttempts) {
+        throw err;
+      }
+      // Wait before retry (skip delay on first retry for responsiveness)
+      if (attempt > 1 && retryDelayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+      }
+    }
+  }
+  // Unreachable, but TypeScript needs it
+  throw new Error("withRetry: unreachable");
+}
+
+// ============================================================================
+// ModalBackend
+// ============================================================================
+
+/**
+ * Client for calling Modal-deployed QMDInference methods.
+ *
+ * Lazily initializes the Modal client and class reference on first use.
+ * Requires ~/.modal.toml for authentication.
+ */
+/** Options for constructing a ModalBackend (primarily for testing). */
+export interface ModalBackendOptions {
+  /** Override the path to the Modal auth token file. */
+  tomlPath?: string;
+}
+
+export class ModalBackend {
+  private instance: ModalClsInstance | null = null;
+  private initPromise: Promise<void> | null = null;
+  private readonly tomlPath: string;
+
+  constructor(options?: ModalBackendOptions) {
+    this.tomlPath = options?.tomlPath ?? join(homedir(), ".modal.toml");
+  }
+
+  /**
+   * Ensure the Modal client and cls instance are initialized.
+   * Uses a cached promise to prevent concurrent initialization races.
+   */
+  private async ensureConnected(): Promise<void> {
+    if (this.instance) return;
+    if (this.initPromise) return this.initPromise;
+    this.initPromise = this.connect();
+    return this.initPromise;
+  }
+
+  private async connect(): Promise<void> {
+    // Check auth file exists before attempting connection
+    if (!existsSync(this.tomlPath)) {
+      throw new Error(
+        `Modal not authenticated. No ~/.modal.toml found.\n` +
+          `Run: modal token set`,
+      );
+    }
+
+    // Dynamic import — modal is an optional dependency
+    let modalModule: typeof import("modal");
+    try {
+      modalModule = await import("modal");
+    } catch {
+      throw new Error(
+        "Modal npm package not installed. Run: bun add modal",
+      );
+    }
+
+    const client = new modalModule.ModalClient();
+    const cls = await client.cls.fromName("qmd-inference", "QMDInference");
+    this.instance = await cls.instance();
+  }
+
+  /**
+   * Get a method handle from the cls instance.
+   */
+  private getMethod(name: string): ModalMethodHandle {
+    if (!this.instance) {
+      throw new Error("ModalBackend not connected");
+    }
+    return this.instance.method(name);
+  }
+
+  /**
+   * Raw embedding. Caller is responsible for prompt formatting.
+   */
+  async embed(texts: string[]): Promise<number[][]> {
+    await this.ensureConnected();
+    return withRetry(async () => {
+      const fn = this.getMethod("embed");
+      return fn.remote([texts]);
+    }).catch((err) => {
+      throw isConnectionError(err)
+        ? new Error(
+            `Modal inference function not reachable after retries.\n` +
+              `Run 'qmd modal status' to check deployment, or 'qmd modal deploy' to redeploy.\n` +
+              `Original error: ${err instanceof Error ? err.message : err}`,
+          )
+        : err;
+    });
+  }
+
+  /**
+   * Raw text generation with optional GBNF grammar.
+   * Caller passes the fully formatted prompt including special tokens.
+   */
+  async generate(
+    prompt: string,
+    grammar: string | null,
+    maxTokens: number,
+    model: "expand" | "rerank" = "expand",
+  ): Promise<string> {
+    await this.ensureConnected();
+    return withRetry(async () => {
+      const fn = this.getMethod("generate");
+      return fn.remote([prompt, grammar, maxTokens, model]);
+    }).catch((err) => {
+      throw isConnectionError(err)
+        ? new Error(
+            `Modal inference function not reachable after retries.\n` +
+              `Run 'qmd modal status' to check deployment, or 'qmd modal deploy' to redeploy.\n` +
+              `Original error: ${err instanceof Error ? err.message : err}`,
+          )
+        : err;
+    });
+  }
+
+  /**
+   * Cross-encoder reranking using Qwen3-Reranker.
+   * Python side handles the chat template via create_chat_completion().
+   */
+  async rerank(query: string, texts: string[]): Promise<number[]> {
+    await this.ensureConnected();
+    return withRetry(async () => {
+      const fn = this.getMethod("rerank");
+      return fn.remote([query, texts]);
+    }).catch((err) => {
+      throw isConnectionError(err)
+        ? new Error(
+            `Modal inference function not reachable after retries.\n` +
+              `Run 'qmd modal status' to check deployment, or 'qmd modal deploy' to redeploy.\n` +
+              `Original error: ${err instanceof Error ? err.message : err}`,
+          )
+        : err;
+    });
+  }
+
+  /**
+   * Health check. Verifies the deployed function is reachable.
+   */
+  async ping(): Promise<boolean> {
+    await this.ensureConnected();
+    return withRetry(async () => {
+      const fn = this.getMethod("ping");
+      return fn.remote();
+    }).catch((err) => {
+      throw isConnectionError(err)
+        ? new Error(
+            `Modal inference function not reachable after retries.\n` +
+              `Run 'qmd modal status' to check deployment, or 'qmd modal deploy' to redeploy.\n` +
+              `Original error: ${err instanceof Error ? err.message : err}`,
+          )
+        : err;
+    });
+  }
+
+  /**
+   * No-op. Nothing local to clean up — Modal handles container lifecycle.
+   */
+  dispose(): void {
+    this.instance = null;
+    this.initPromise = null;
+  }
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -22,7 +22,7 @@ import {
   LlamaCpp,
   getDefaultLlamaCpp,
   getDefaultLLM,
-  ModalLLM,
+  type LLM,
   formatQueryForEmbedding,
   formatDocForEmbedding,
   withLLMSessionForLlm,
@@ -64,8 +64,8 @@ export const CHUNK_WINDOW_CHARS = CHUNK_WINDOW_TOKENS * 4;  // 800 chars
  * Get the LlamaCpp instance for a store — prefers the store's own instance,
  * falls back to the global singleton.
  */
-function getLlm(store: Store): LlamaCpp | ModalLLM {
-  return store.llm ?? (getDefaultLLM() as LlamaCpp | ModalLLM);
+function getLlm(store: Store): LLM {
+  return store.llm ?? getDefaultLLM();
 }
 
 // =============================================================================
@@ -1325,8 +1325,9 @@ export async function generateEmbeddings(
   const totalDocs = docsToEmbed.length;
   const startTime = Date.now();
 
-  // Use store's LlamaCpp or global singleton, wrapped in a session
-  const llm = getLlm(store);
+  // Embedding generation requires local LlamaCpp for tokenization during chunking.
+  // Even with Modal inference enabled, indexing uses the local model.
+  const llm = store.llm ?? getDefaultLlamaCpp();
 
   // Create a session manager for this llm instance
   const result = await withLLMSessionForLlm(llm, async (session) => {
@@ -2096,7 +2097,9 @@ export async function chunkDocumentByTokens(
   overlapTokens: number = CHUNK_OVERLAP_TOKENS,
   windowTokens: number = CHUNK_WINDOW_TOKENS
 ): Promise<{ text: string; pos: number; tokens: number }[]> {
-  const llm = getDefaultLLM();
+  // Tokenization requires LlamaCpp (local) — not available via Modal.
+  // This is only called during indexing (generateEmbeddings), not search.
+  const llm = getDefaultLlamaCpp();
 
   // Use moderate chars/token estimate (prose ~4, code ~2, mixed ~3)
   // If chunks exceed limit, they'll be re-split with actual ratio

--- a/src/store.ts
+++ b/src/store.ts
@@ -21,6 +21,8 @@ import fastGlob from "fast-glob";
 import {
   LlamaCpp,
   getDefaultLlamaCpp,
+  getDefaultLLM,
+  ModalLLM,
   formatQueryForEmbedding,
   formatDocForEmbedding,
   withLLMSessionForLlm,
@@ -62,8 +64,8 @@ export const CHUNK_WINDOW_CHARS = CHUNK_WINDOW_TOKENS * 4;  // 800 chars
  * Get the LlamaCpp instance for a store — prefers the store's own instance,
  * falls back to the global singleton.
  */
-function getLlm(store: Store): LlamaCpp {
-  return store.llm ?? getDefaultLlamaCpp();
+function getLlm(store: Store): LlamaCpp | ModalLLM {
+  return store.llm ?? (getDefaultLLM() as LlamaCpp | ModalLLM);
 }
 
 // =============================================================================
@@ -2094,7 +2096,7 @@ export async function chunkDocumentByTokens(
   overlapTokens: number = CHUNK_OVERLAP_TOKENS,
   windowTokens: number = CHUNK_WINDOW_TOKENS
 ): Promise<{ text: string; pos: number; tokens: number }[]> {
-  const llm = getDefaultLlamaCpp();
+  const llm = getDefaultLLM();
 
   // Use moderate chars/token estimate (prose ~4, code ~2, mixed ~3)
   // If chunks exceed limit, they'll be re-split with actual ratio
@@ -2912,7 +2914,7 @@ async function getEmbedding(text: string, model: string, isQuery: boolean, sessi
   const formattedText = isQuery ? formatQueryForEmbedding(text, model) : formatDocForEmbedding(text, undefined, model);
   const result = session
     ? await session.embed(formattedText, { model, isQuery })
-    : await (llmOverride ?? getDefaultLlamaCpp()).embed(formattedText, { model, isQuery });
+    : await (llmOverride ?? getDefaultLLM()).embed(formattedText, { model, isQuery });
   return result?.embedding || null;
 }
 
@@ -2983,7 +2985,7 @@ export async function expandQuery(query: string, model: string = DEFAULT_QUERY_M
     }
   }
 
-  const llm = llmOverride ?? getDefaultLlamaCpp();
+  const llm = llmOverride ?? getDefaultLLM();
   // Note: LlamaCpp uses hardcoded model, model parameter is ignored
   const results = await llm.expandQuery(query, { intent });
 
@@ -3029,7 +3031,7 @@ export async function rerank(query: string, documents: { file: string; text: str
 
   // Rerank uncached documents using LlamaCpp
   if (uncachedDocsByChunk.size > 0) {
-    const llm = llmOverride ?? getDefaultLlamaCpp();
+    const llm = llmOverride ?? getDefaultLLM();
     const uncachedDocs = [...uncachedDocsByChunk.values()];
     const rerankResult = await llm.rerank(rerankQuery, uncachedDocs, { model });
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -985,8 +985,8 @@ function ensureVecTableInternal(db: Database, dimensions: number): void {
 export type Store = {
   db: Database;
   dbPath: string;
-  /** Optional LlamaCpp instance for this store (overrides the global singleton) */
-  llm?: LlamaCpp;
+  /** Optional LLM instance for this store (overrides the global singleton) */
+  llm?: LLM;
   close: () => void;
   ensureVecTable: (dimensions: number) => void;
 
@@ -1325,9 +1325,7 @@ export async function generateEmbeddings(
   const totalDocs = docsToEmbed.length;
   const startTime = Date.now();
 
-  // Embedding generation requires local LlamaCpp for tokenization during chunking.
-  // Even with Modal inference enabled, indexing uses the local model.
-  const llm = store.llm ?? getDefaultLlamaCpp();
+  const llm = store.llm ?? getDefaultLLM();
 
   // Create a session manager for this llm instance
   const result = await withLLMSessionForLlm(llm, async (session) => {
@@ -2097,9 +2095,7 @@ export async function chunkDocumentByTokens(
   overlapTokens: number = CHUNK_OVERLAP_TOKENS,
   windowTokens: number = CHUNK_WINDOW_TOKENS
 ): Promise<{ text: string; pos: number; tokens: number }[]> {
-  // Tokenization requires LlamaCpp (local) — not available via Modal.
-  // This is only called during indexing (generateEmbeddings), not search.
-  const llm = getDefaultLlamaCpp();
+  const llm = getDefaultLLM();
 
   // Use moderate chars/token estimate (prose ~4, code ~2, mixed ~3)
   // If chunks exceed limit, they'll be re-split with actual ratio
@@ -2970,7 +2966,7 @@ export function insertEmbedding(
 // Query expansion
 // =============================================================================
 
-export async function expandQuery(query: string, model: string = DEFAULT_QUERY_MODEL, db: Database, intent?: string, llmOverride?: LlamaCpp): Promise<ExpandedQuery[]> {
+export async function expandQuery(query: string, model: string = DEFAULT_QUERY_MODEL, db: Database, intent?: string, llmOverride?: LLM): Promise<ExpandedQuery[]> {
   // Check cache first — stored as JSON preserving types
   const cacheKey = getCacheKey("expandQuery", { query, model, ...(intent && { intent }) });
   const cached = getCachedResult(db, cacheKey);
@@ -3009,7 +3005,7 @@ export async function expandQuery(query: string, model: string = DEFAULT_QUERY_M
 // Reranking
 // =============================================================================
 
-export async function rerank(query: string, documents: { file: string; text: string }[], model: string = DEFAULT_RERANK_MODEL, db: Database, intent?: string, llmOverride?: LlamaCpp): Promise<{ file: string; score: number }[]> {
+export async function rerank(query: string, documents: { file: string; text: string }[], model: string = DEFAULT_RERANK_MODEL, db: Database, intent?: string, llmOverride?: LLM): Promise<{ file: string; score: number }[]> {
   // Prepend intent to rerank query so the reranker scores with domain context
   const rerankQuery = intent ? `${intent}\n\n${query}` : query;
 

--- a/test/cli/modal-region.test.ts
+++ b/test/cli/modal-region.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Unit tests for Modal region detection functions.
+ *
+ * Tests pingEndpoint(), isValidRegion(), and detectRegion()
+ * with mocked child_process.exec to avoid actual network calls.
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockExec = vi.fn();
+vi.mock("child_process", () => ({
+  exec: (...args: any[]) => mockExec(...args),
+  execSync: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+const mockPlatform = vi.fn();
+vi.mock("os", () => ({
+  platform: () => mockPlatform(),
+  homedir: vi.fn(() => "/home/test"),
+}));
+
+// Mock getModalConfig - not used by region functions but required for module import
+vi.mock("../src/collections.js", () => ({
+  getModalConfig: vi.fn(() => ({ inference: false, gpu: "T4", scaledown_window: 15 })),
+  setModalConfig: vi.fn(),
+}));
+
+// Mock ModalBackend - not used by region functions but required for module import
+vi.mock("../src/modal.js", () => ({
+  ModalBackend: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks are set up
+// ---------------------------------------------------------------------------
+
+import { exec } from "child_process";
+import { promisify } from "util";
+import { platform } from "os";
+
+// ---------------------------------------------------------------------------
+// The functions are not exported from the module, so we create testable
+// versions that mirror the implementation and test against those.
+// ---------------------------------------------------------------------------
+
+const REGION_ENDPOINTS: Record<string, string> = {
+  us: "ec2.us-east-1.amazonaws.com",
+  eu: "ec2.eu-central-1.amazonaws.com",
+  ap: "ec2.ap-northeast-1.amazonaws.com",
+  uk: "ec2.eu-west-2.amazonaws.com",
+  ca: "ec2.ca-central-1.amazonaws.com",
+};
+
+const execAsync = promisify(exec);
+
+async function pingEndpoint(endpoint: string, count: number = 3): Promise<number> {
+  const isWindows = platform() === "win32";
+  const countFlag = isWindows ? "-n" : "-c";
+  const cmd = `ping ${countFlag} ${count} ${endpoint}`;
+
+  try {
+    const { stdout } = await execAsync(cmd, { timeout: 30000 });
+    const linuxMatch = stdout.match(/rtt min\/avg\/max\/mdev = [\d.]+\/([\d.]+)/);
+    const winMatch = stdout.match(/Average = (\d+)ms/);
+    const match = linuxMatch ?? winMatch;
+    return match?.[1] ? parseFloat(match[1]) : Infinity;
+  } catch {
+    return Infinity;
+  }
+}
+
+const VALID_REGIONS = ["us", "eu", "ap", "uk", "ca", "me", "sa", "af", "mx", "default"];
+
+function isValidRegion(value: string): boolean {
+  return VALID_REGIONS.includes(value);
+}
+
+async function detectRegion(): Promise<string> {
+  const entries = Object.entries(REGION_ENDPOINTS);
+  const results = await Promise.all(
+    entries.map(async ([region, endpoint]) => {
+      const latency = await pingEndpoint(endpoint);
+      return { region, latency };
+    }),
+  );
+
+  const valid = results.filter(r => isFinite(r.latency));
+  if (valid.length === 0) {
+    return "us";
+  }
+
+  const best = valid.reduce((a, b) => a.latency < b.latency ? a : b);
+  return best.region;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("pingEndpoint", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("returns median latency from successful ping on Unix", async () => {
+    mockPlatform.mockReturnValue("linux");
+
+    // Linux ping output with rtt min/avg/max/mdev format
+    // Note: Linux uses "rtt min/avg/max/mdev", BSD/macOS uses "round-trip min/avg/max/mdev"
+    const unixPingOutput = `PING ec2.us-east-1.amazonaws.com (1.2.3.4): 56 data bytes
+64 bytes from 1.2.3.4: icmp_seq=0 ttl=247 time=12.345 ms
+64 bytes from 1.2.3.4: icmp_seq=1 ttl=247 time=11.234 ms
+64 bytes from 1.2.3.4: icmp_seq=2 ttl=247 time=13.456 ms
+--- ec2.us-east-1.amazonaws.com ping statistics ---
+3 packets transmitted, 3 received, 0% packet loss, time 2003ms
+rtt min/avg/max/mdev = 11.234/12.012/13.456/0.912 ms`;
+
+    mockExec.mockImplementation((cmd: string, options: any, callback: any) => {
+      if (typeof options === "function") {
+        callback = options;
+      }
+      callback(null, { stdout: unixPingOutput, stderr: "" });
+    });
+
+    const result = await pingEndpoint("ec2.us-east-1.amazonaws.com");
+    expect(result).toBeCloseTo(12.012, 3);
+  });
+
+  test("returns median latency from successful ping on Windows", async () => {
+    mockPlatform.mockReturnValue("win32");
+
+    // Windows ping output with Average format
+    const winPingOutput = `
+Pinging ec2.us-east-1.amazonaws.com [1.2.3.4] with 32 bytes of data:
+Reply from 1.2.3.4: bytes=32 time=15ms TTL=247
+Reply from 1.2.3.4: bytes=32 time=14ms TTL=247
+Reply from 1.2.3.4: bytes=32 time=16ms TTL=247
+
+Ping statistics for 1.2.3.4:
+    Packets: Sent = 3, Received = 3, Lost = 0 (0% loss),
+Approximate round trip times in milli-seconds:
+    Minimum = 14ms, Maximum = 16ms, Average = 15ms`;
+
+    mockExec.mockImplementation((cmd: string, options: any, callback: any) => {
+      if (typeof options === "function") {
+        callback = options;
+      }
+      callback(null, { stdout: winPingOutput, stderr: "" });
+    });
+
+    const result = await pingEndpoint("ec2.us-east-1.amazonaws.com");
+    expect(result).toBe(15);
+  });
+
+  test("returns Infinity on ping failure", async () => {
+    mockPlatform.mockReturnValue("linux");
+
+    mockExec.mockImplementation((cmd: string, options: any, callback: any) => {
+      if (typeof options === "function") {
+        callback = options;
+      }
+      callback(new Error("ping: unknown host"), { stdout: "", stderr: "" });
+    });
+
+    const result = await pingEndpoint("invalid-endpoint.test");
+    expect(result).toBe(Infinity);
+  });
+
+  test("returns Infinity when ping output cannot be parsed", async () => {
+    mockPlatform.mockReturnValue("linux");
+
+    // Unparseable output (no matching patterns)
+    const unparseableOutput = `Some random output that doesn't match expected patterns`;
+
+    mockExec.mockImplementation((cmd: string, options: any, callback: any) => {
+      if (typeof options === "function") {
+        callback = options;
+      }
+      callback(null, { stdout: unparseableOutput, stderr: "" });
+    });
+
+    const result = await pingEndpoint("ec2.us-east-1.amazonaws.com");
+    expect(result).toBe(Infinity);
+  });
+});
+
+describe("isValidRegion", () => {
+  test("returns true for all valid regions", () => {
+    const validRegions = ["us", "eu", "ap", "uk", "ca", "me", "sa", "af", "mx"];
+    for (const region of validRegions) {
+      expect(isValidRegion(region)).toBe(true);
+    }
+  });
+
+  test("returns true for 'default'", () => {
+    expect(isValidRegion("default")).toBe(true);
+  });
+
+  test("returns false for invalid regions", () => {
+    const invalidRegions = ["invalid", "", "US", "EU", "asia", "north-america", "123", "xy"];
+    for (const region of invalidRegions) {
+      expect(isValidRegion(region)).toBe(false);
+    }
+  });
+});
+
+describe("detectRegion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("returns fastest region from valid results", async () => {
+    mockPlatform.mockReturnValue("linux");
+
+    // Mock ping results - EU will be fastest (Linux format uses "rtt min/avg/max/mdev")
+    const pingResults: Record<string, string> = {
+      "ping -c 3 ec2.us-east-1.amazonaws.com": `PING us (1.2.3.4): 56 data bytes
+rtt min/avg/max/mdev = 10.0/50.0/100.0/30.0 ms`,
+      "ping -c 3 ec2.eu-central-1.amazonaws.com": `PING eu (1.2.3.4): 56 data bytes
+rtt min/avg/max/mdev = 10.0/15.0/20.0/5.0 ms`,
+      "ping -c 3 ec2.ap-northeast-1.amazonaws.com": `PING ap (1.2.3.4): 56 data bytes
+rtt min/avg/max/mdev = 10.0/150.0/300.0/100.0 ms`,
+      "ping -c 3 ec2.eu-west-2.amazonaws.com": `PING uk (1.2.3.4): 56 data bytes
+rtt min/avg/max/mdev = 10.0/80.0/150.0/40.0 ms`,
+      "ping -c 3 ec2.ca-central-1.amazonaws.com": `PING ca (1.2.3.4): 56 data bytes
+rtt min/avg/max/mdev = 10.0/120.0/200.0/60.0 ms`,
+    };
+
+    mockExec.mockImplementation((cmd: string, options: any, callback: any) => {
+      if (typeof options === "function") {
+        callback = options;
+      }
+      const output = pingResults[cmd] || "";
+      callback(null, { stdout: output, stderr: "" });
+    });
+
+    const result = await detectRegion();
+    expect(result).toBe("eu");
+  });
+
+  test("returns 'us' when all pings fail", async () => {
+    mockPlatform.mockReturnValue("linux");
+
+    // All pings fail
+    mockExec.mockImplementation((cmd: string, options: any, callback: any) => {
+      if (typeof options === "function") {
+        callback = options;
+      }
+      callback(new Error("network unreachable"), { stdout: "", stderr: "" });
+    });
+
+    const result = await detectRegion();
+    expect(result).toBe("us");
+  });
+
+  test("returns fastest region excluding failures", async () => {
+    mockPlatform.mockReturnValue("linux");
+
+    // US fails, EU succeeds with 20ms, AP succeeds with 150ms (Linux format)
+    const pingResults: Record<string, { success: boolean; output?: string }> = {
+      "ping -c 3 ec2.us-east-1.amazonaws.com": { success: false },
+      "ping -c 3 ec2.eu-central-1.amazonaws.com": { success: true, output: `PING eu (1.2.3.4): 56 data bytes
+rtt min/avg/max/mdev = 10.0/20.0/30.0/5.0 ms` },
+      "ping -c 3 ec2.ap-northeast-1.amazonaws.com": { success: true, output: `PING ap (1.2.3.4): 56 data bytes
+rtt min/avg/max/mdev = 10.0/150.0/300.0/100.0 ms` },
+      "ping -c 3 ec2.eu-west-2.amazonaws.com": { success: true, output: `PING uk (1.2.3.4): 56 data bytes
+rtt min/avg/max/mdev = 10.0/80.0/150.0/40.0 ms` },
+      "ping -c 3 ec2.ca-central-1.amazonaws.com": { success: true, output: `PING ca (1.2.3.4): 56 data bytes
+rtt min/avg/max/mdev = 10.0/120.0/200.0/60.0 ms` },
+    };
+
+    mockExec.mockImplementation((cmd: string, options: any, callback: any) => {
+      if (typeof options === "function") {
+        callback = options;
+      }
+      const result = pingResults[cmd];
+      if (result && result.success) {
+        callback(null, { stdout: result.output || "", stderr: "" });
+      } else {
+        callback(new Error("ping failed"), { stdout: "", stderr: "" });
+      }
+    });
+
+    const result = await detectRegion();
+    expect(result).toBe("eu");
+  });
+});

--- a/test/modal-backend.test.ts
+++ b/test/modal-backend.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Unit tests for ModalBackend JS client.
+ *
+ * Tests the ModalBackend class with mocked Modal SDK, covering:
+ * - embed(), generate(), rerank(), ping() method calls
+ * - Retry logic for connection errors
+ * - Immediate throw for non-connection errors
+ * - Lazy initialization
+ */
+
+import { describe, test, expect, vi, beforeEach, afterAll } from "vitest";
+import { writeFileSync, unlinkSync, mkdtempSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// Create a temp directory with a fake .modal.toml for tests that need auth
+const tempDir = mkdtempSync(join(tmpdir(), "modal-test-"));
+const fakeTomlPath = join(tempDir, ".modal.toml");
+writeFileSync(fakeTomlPath, "[default]\ntoken_id = fake\ntoken_secret = fake\n");
+
+// Path that does not exist (for missing-toml test)
+const missingTomlPath = join(tempDir, "nonexistent", ".modal.toml");
+
+afterAll(() => {
+  try { unlinkSync(fakeTomlPath); } catch { /* ignore */ }
+});
+
+// Mock the "modal" package
+vi.mock("modal", () => {
+  const mockRemote = vi.fn();
+  const mockMethod = vi.fn(() => ({ remote: mockRemote }));
+  const mockInstance = vi.fn(() => Promise.resolve({ method: mockMethod }));
+  const mockFromName = vi.fn(() =>
+    Promise.resolve({ instance: mockInstance }),
+  );
+  const MockModalClient = vi.fn(() => ({
+    cls: { fromName: mockFromName },
+  }));
+
+  return {
+    ModalClient: MockModalClient,
+    _mockRemote: mockRemote,
+    _mockMethod: mockMethod,
+    _mockInstance: mockInstance,
+    _mockFromName: mockFromName,
+    _MockModalClient: MockModalClient,
+  };
+});
+
+// Import after mocks are set up
+import {
+  ModalBackend,
+  withRetry,
+  isConnectionError,
+} from "../src/modal.js";
+
+// Access mock internals
+async function getMocks() {
+  const modal = await import("modal");
+  return {
+    ModalClient: (modal as any)._MockModalClient as ReturnType<typeof vi.fn>,
+    mockFromName: (modal as any)._mockFromName as ReturnType<typeof vi.fn>,
+    mockInstance: (modal as any)._mockInstance as ReturnType<typeof vi.fn>,
+    mockMethod: (modal as any)._mockMethod as ReturnType<typeof vi.fn>,
+    mockRemote: (modal as any)._mockRemote as ReturnType<typeof vi.fn>,
+  };
+}
+
+/** Create a ModalBackend pointed at the fake toml file. */
+function createBackend(): ModalBackend {
+  return new ModalBackend({ tomlPath: fakeTomlPath });
+}
+
+beforeEach(async () => {
+  const { ModalClient, mockFromName, mockInstance, mockMethod, mockRemote } =
+    await getMocks();
+  ModalClient.mockClear();
+  mockFromName.mockClear();
+  mockInstance.mockClear();
+  mockMethod.mockClear();
+  mockRemote.mockClear();
+
+  // Re-setup default return values after clear
+  mockMethod.mockReturnValue({ remote: mockRemote });
+  mockInstance.mockReturnValue(Promise.resolve({ method: mockMethod }));
+  mockFromName.mockReturnValue(Promise.resolve({ instance: mockInstance }));
+});
+
+// ============================================================================
+// isConnectionError
+// ============================================================================
+
+describe("isConnectionError", () => {
+  test("detects ECONNREFUSED", () => {
+    const err = new Error("connect ECONNREFUSED 127.0.0.1:443");
+    expect(isConnectionError(err)).toBe(true);
+  });
+
+  test("detects ETIMEDOUT", () => {
+    const err = new Error("connect ETIMEDOUT 10.0.0.1:443");
+    expect(isConnectionError(err)).toBe(true);
+  });
+
+  test("detects ECONNRESET", () => {
+    const err = new Error("read ECONNRESET");
+    expect(isConnectionError(err)).toBe(true);
+  });
+
+  test("detects 'unavailable' (gRPC status)", () => {
+    const err = new Error("14 UNAVAILABLE: Connection dropped");
+    expect(isConnectionError(err)).toBe(true);
+  });
+
+  test("detects 'deadline exceeded' (gRPC status)", () => {
+    const err = new Error("4 DEADLINE_EXCEEDED: Deadline exceeded");
+    expect(isConnectionError(err)).toBe(true);
+  });
+
+  test("returns false for auth errors", () => {
+    const err = new Error("Authentication failed: invalid token");
+    expect(isConnectionError(err)).toBe(false);
+  });
+
+  test("returns false for not-found errors", () => {
+    const err = new Error("Function not found: qmd-inference");
+    expect(isConnectionError(err)).toBe(false);
+  });
+});
+
+// ============================================================================
+// withRetry
+// ============================================================================
+
+describe("withRetry", () => {
+  test("returns result on first success", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    const result = await withRetry(fn, 3, 0);
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries on connection error and succeeds on second attempt", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("connect ECONNREFUSED"))
+      .mockResolvedValueOnce("ok");
+    const result = await withRetry(fn, 3, 0);
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test("throws after maxAttempts connection errors", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValue(new Error("connect ECONNREFUSED 127.0.0.1:443"));
+    await expect(withRetry(fn, 3, 0)).rejects.toThrow(
+      /ECONNREFUSED/,
+    );
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  test("throws immediately on non-connection error without retrying", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValue(new Error("Authentication failed"));
+    await expect(withRetry(fn, 3, 0)).rejects.toThrow("Authentication failed");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ============================================================================
+// ModalBackend
+// ============================================================================
+
+describe("ModalBackend", () => {
+  test("lazy initialization: client not created until first call", async () => {
+    const { ModalClient } = await getMocks();
+    const _backend = createBackend();
+    expect(ModalClient).not.toHaveBeenCalled();
+  });
+
+  test("throws if ~/.modal.toml is missing", async () => {
+    const backend = new ModalBackend({ tomlPath: missingTomlPath });
+    await expect(backend.ping()).rejects.toThrow(/\.modal\.toml/);
+  });
+
+  describe("embed", () => {
+    test("calls remote with correct args and returns vectors", async () => {
+      const { mockRemote, mockMethod } = await getMocks();
+      const vectors = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]];
+      mockRemote.mockResolvedValue(vectors);
+
+      const backend = createBackend();
+      const result = await backend.embed(["hello", "world"]);
+
+      expect(mockMethod).toHaveBeenCalledWith("embed");
+      expect(mockRemote).toHaveBeenCalledWith(
+        [["hello", "world"]],
+      );
+      expect(result).toEqual(vectors);
+    });
+  });
+
+  describe("generate", () => {
+    test("calls remote with prompt, grammar, maxTokens, model", async () => {
+      const { mockRemote, mockMethod } = await getMocks();
+      mockRemote.mockResolvedValue("generated text");
+
+      const backend = createBackend();
+      const result = await backend.generate(
+        "test prompt",
+        "root ::= [a-z]+",
+        100,
+        "expand",
+      );
+
+      expect(mockMethod).toHaveBeenCalledWith("generate");
+      expect(mockRemote).toHaveBeenCalledWith(
+        ["test prompt", "root ::= [a-z]+", 100, "expand"],
+      );
+      expect(result).toBe("generated text");
+    });
+
+    test("passes null grammar correctly", async () => {
+      const { mockRemote } = await getMocks();
+      mockRemote.mockResolvedValue("text");
+
+      const backend = createBackend();
+      await backend.generate("prompt", null, 50);
+
+      expect(mockRemote).toHaveBeenCalledWith(
+        ["prompt", null, 50, "expand"],
+      );
+    });
+  });
+
+  describe("rerank", () => {
+    test("calls remote with query and texts, returns scores", async () => {
+      const { mockRemote, mockMethod } = await getMocks();
+      const scores = [0.9, 0.3, 0.7];
+      mockRemote.mockResolvedValue(scores);
+
+      const backend = createBackend();
+      const result = await backend.rerank("search query", [
+        "doc1",
+        "doc2",
+        "doc3",
+      ]);
+
+      expect(mockMethod).toHaveBeenCalledWith("rerank");
+      expect(mockRemote).toHaveBeenCalledWith(
+        ["search query", ["doc1", "doc2", "doc3"]],
+      );
+      expect(result).toEqual(scores);
+    });
+  });
+
+  describe("ping", () => {
+    test("calls remote and returns true", async () => {
+      const { mockRemote, mockMethod } = await getMocks();
+      mockRemote.mockResolvedValue(true);
+
+      const backend = createBackend();
+      const result = await backend.ping();
+
+      expect(mockMethod).toHaveBeenCalledWith("ping");
+      expect(mockRemote).toHaveBeenCalledWith();
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("retry logic", () => {
+    test("retries on connection error, succeeds on second attempt", async () => {
+      const { mockRemote } = await getMocks();
+      mockRemote
+        .mockRejectedValueOnce(new Error("connect ECONNREFUSED"))
+        .mockResolvedValueOnce(true);
+
+      const backend = createBackend();
+      const result = await backend.ping();
+
+      expect(result).toBe(true);
+      expect(mockRemote).toHaveBeenCalledTimes(2);
+    });
+
+    test("throws after 3 connection errors with clear message", async () => {
+      const { mockRemote } = await getMocks();
+      mockRemote.mockRejectedValue(
+        new Error("connect ECONNREFUSED 127.0.0.1:443"),
+      );
+
+      const backend = createBackend();
+      await expect(backend.ping()).rejects.toThrow(
+        /Modal .* not reachable/,
+      );
+    });
+
+    test("non-connection errors throw immediately without retry", async () => {
+      const { mockRemote } = await getMocks();
+      mockRemote.mockRejectedValue(new Error("Not found: qmd-inference"));
+
+      const backend = createBackend();
+      await expect(backend.ping()).rejects.toThrow("Not found: qmd-inference");
+      expect(mockRemote).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("dispose", () => {
+    test("is a no-op and does not throw", () => {
+      const backend = createBackend();
+      expect(() => backend.dispose()).not.toThrow();
+    });
+  });
+
+  describe("connection reuse", () => {
+    test("reuses client and cls instance across calls", async () => {
+      const { ModalClient, mockRemote } = await getMocks();
+      mockRemote.mockResolvedValue(true);
+
+      const backend = createBackend();
+      await backend.ping();
+      await backend.ping();
+
+      // ModalClient constructor called only once
+      expect(ModalClient).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/test/modal-backend.test.ts
+++ b/test/modal-backend.test.ts
@@ -226,6 +226,30 @@ describe("ModalBackend", () => {
     });
   });
 
+  describe("detokenize", () => {
+    test("calls remote with tokens and returns text", async () => {
+      const { mockRemote, mockMethod } = await getMocks();
+      mockRemote.mockResolvedValue("hello world");
+
+      const backend = createBackend();
+      const result = await backend.detokenize([1, 2, 3, 4]);
+
+      expect(mockMethod).toHaveBeenCalledWith("detokenize");
+      expect(mockRemote).toHaveBeenCalledWith([[1, 2, 3, 4]]);
+      expect(result).toBe("hello world");
+    });
+
+    test("throws on connection error after retries", async () => {
+      const { mockRemote } = await getMocks();
+      mockRemote.mockRejectedValue(new Error("connect ECONNREFUSED"));
+
+      const backend = createBackend();
+      await expect(backend.detokenize([1, 2, 3])).rejects.toThrow(
+        /Modal .* not reachable/,
+      );
+    });
+  });
+
   describe("generate", () => {
     test("calls remote with prompt, grammar, maxTokens, model", async () => {
       const { mockRemote, mockMethod } = await getMocks();

--- a/test/modal-backend.test.ts
+++ b/test/modal-backend.test.ts
@@ -201,6 +201,31 @@ describe("ModalBackend", () => {
     });
   });
 
+  describe("tokenize", () => {
+    test("calls remote with texts and returns token IDs", async () => {
+      const { mockRemote, mockMethod } = await getMocks();
+      const tokenIds = [[1, 2, 3], [4, 5, 6, 7]];
+      mockRemote.mockResolvedValue(tokenIds);
+
+      const backend = createBackend();
+      const result = await backend.tokenize(["hello world", "goodbye"]);
+
+      expect(mockMethod).toHaveBeenCalledWith("tokenize");
+      expect(mockRemote).toHaveBeenCalledWith([["hello world", "goodbye"]]);
+      expect(result).toEqual(tokenIds);
+    });
+
+    test("throws on connection error after retries", async () => {
+      const { mockRemote } = await getMocks();
+      mockRemote.mockRejectedValue(new Error("connect ECONNREFUSED"));
+
+      const backend = createBackend();
+      await expect(backend.tokenize(["test"])).rejects.toThrow(
+        /Modal .* not reachable/,
+      );
+    });
+  });
+
   describe("generate", () => {
     test("calls remote with prompt, grammar, maxTokens, model", async () => {
       const { mockRemote, mockMethod } = await getMocks();

--- a/test/modal-cli.test.ts
+++ b/test/modal-cli.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Unit tests for the `qmd modal` CLI subcommand group.
+ *
+ * Tests pre-flight checks (python3, modal pip package, ~/.modal.toml),
+ * deploy/destroy config toggling, usage help, and unknown subcommand errors.
+ *
+ * Mocks: child_process.execSync, ModalBackend, getModalConfig/setModalConfig,
+ * and process.exit/console.error/console.log for output capture.
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, unlinkSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// ---------------------------------------------------------------------------
+// Shared mocks
+// ---------------------------------------------------------------------------
+
+// Mock child_process.execSync
+const mockExecSync = vi.fn();
+vi.mock("child_process", () => ({
+  execSync: (...args: any[]) => mockExecSync(...args),
+  // Preserve other exports the module might need
+  spawn: vi.fn(),
+}));
+
+// Mock ModalBackend
+const mockPing = vi.fn();
+const mockEmbed = vi.fn();
+const mockGenerate = vi.fn();
+const mockDispose = vi.fn();
+vi.mock("../src/modal.js", () => ({
+  ModalBackend: vi.fn(() => ({
+    ping: mockPing,
+    embed: mockEmbed,
+    generate: mockGenerate,
+    dispose: mockDispose,
+  })),
+}));
+
+// Mock getModalConfig / setModalConfig
+const mockGetModalConfig = vi.fn(() => ({
+  inference: false,
+  gpu: "T4",
+  scaledown_window: 15,
+}));
+const mockSetModalConfig = vi.fn();
+vi.mock("../src/collections.js", () => ({
+  getModalConfig: (...args: any[]) => mockGetModalConfig(...args),
+  setModalConfig: (...args: any[]) => mockSetModalConfig(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Import the handler under test
+// ---------------------------------------------------------------------------
+
+// We need to extract and test the modal CLI logic. Since the CLI is a giant
+// switch statement in the main module, we'll import the module's handleModal
+// function. But since it's not exported, we need to test via a helper that
+// mimics what the CLI switch does.
+//
+// Strategy: Extract the modal handler into a separate function we can import.
+// For now, we'll create and import a focused handler module.
+import { handleModalCommand } from "../src/cli/modal.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Temp dir for fake ~/.modal.toml
+const tempDir = mkdtempSync(join(tmpdir(), "modal-cli-test-"));
+const fakeTomlPath = join(tempDir, ".modal.toml");
+const missingTomlPath = join(tempDir, "nonexistent", ".modal.toml");
+
+function setupFakeToml(): void {
+  writeFileSync(fakeTomlPath, "[default]\ntoken_id = fake\ntoken_secret = fake\n");
+}
+
+afterEach(() => {
+  try { unlinkSync(fakeTomlPath); } catch { /* ignore */ }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("qmd modal CLI", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetModalConfig.mockReturnValue({
+      inference: false,
+      gpu: "T4",
+      scaledown_window: 15,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // No subcommand → usage help
+  // -------------------------------------------------------------------------
+
+  test("no subcommand prints usage and exits with code 1", async () => {
+    const result = await handleModalCommand([], { tomlPath: fakeTomlPath });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/Usage: qmd modal/);
+    expect(result.stderr).toMatch(/deploy/);
+    expect(result.stderr).toMatch(/status/);
+    expect(result.stderr).toMatch(/destroy/);
+    expect(result.stderr).toMatch(/test/);
+  });
+
+  // -------------------------------------------------------------------------
+  // Unknown subcommand → error
+  // -------------------------------------------------------------------------
+
+  test("unknown subcommand prints error with available subcommands", async () => {
+    const result = await handleModalCommand(["unknown"], { tomlPath: fakeTomlPath });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/Unknown subcommand: unknown/);
+    expect(result.stderr).toMatch(/deploy, status, destroy, test/);
+  });
+
+  // -------------------------------------------------------------------------
+  // deploy: pre-flight checks
+  // -------------------------------------------------------------------------
+
+  describe("deploy", () => {
+    test("python3 not found → specific error message", async () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === "python3 --version") {
+          throw new Error("command not found");
+        }
+      });
+
+      const result = await handleModalCommand(["deploy"], { tomlPath: fakeTomlPath });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("python3 not found on PATH");
+      expect(result.stderr).toContain("Python 3.10+");
+      expect(result.stderr).toContain("https://python.org");
+    });
+
+    test("modal pip package missing → specific error message", async () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === "python3 --version") return "Python 3.11.0";
+        if (cmd.includes("import modal")) {
+          throw new Error("ModuleNotFoundError");
+        }
+      });
+
+      const result = await handleModalCommand(["deploy"], { tomlPath: fakeTomlPath });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("Python 'modal' package not found");
+      expect(result.stderr).toContain("pip install modal");
+    });
+
+    test("~/.modal.toml missing → specific error message", async () => {
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === "python3 --version") return "Python 3.11.0";
+        if (cmd.includes("import modal")) return "";
+      });
+
+      const result = await handleModalCommand(["deploy"], { tomlPath: missingTomlPath });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("Modal not authenticated");
+      expect(result.stderr).toContain("modal token set");
+    });
+
+    test("success → sets modal.inference=true in config", async () => {
+      setupFakeToml();
+
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === "python3 --version") return "Python 3.11.0";
+        if (cmd.includes("import modal")) return "";
+        // python3 serve.py deploy — succeed silently
+        return "";
+      });
+
+      const result = await handleModalCommand(["deploy"], {
+        tomlPath: fakeTomlPath,
+        servePyPath: "/fake/modal/serve.py",
+      });
+      expect(result.exitCode).toBe(0);
+      expect(mockSetModalConfig).toHaveBeenCalledWith({ inference: true });
+      expect(result.stdout).toContain("T4");
+      expect(result.stdout).toContain("$0.59/hr");
+    });
+
+    test("deploy failure → shows error", async () => {
+      setupFakeToml();
+
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === "python3 --version") return "Python 3.11.0";
+        if (cmd.includes("import modal")) return "";
+        if (cmd.includes("serve.py")) {
+          throw Object.assign(new Error("deploy failed"), {
+            stderr: Buffer.from("Modal deploy error details"),
+          });
+        }
+      });
+
+      const result = await handleModalCommand(["deploy"], {
+        tomlPath: fakeTomlPath,
+        servePyPath: "/fake/modal/serve.py",
+      });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("Modal deployment failed");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // destroy
+  // -------------------------------------------------------------------------
+
+  describe("destroy", () => {
+    test("success → sets modal.inference=false in config", async () => {
+      setupFakeToml();
+
+      mockExecSync.mockImplementation((cmd: string) => {
+        if (cmd === "python3 --version") return "Python 3.11.0";
+        if (cmd.includes("import modal")) return "";
+        return "";
+      });
+
+      const result = await handleModalCommand(["destroy"], {
+        tomlPath: fakeTomlPath,
+        servePyPath: "/fake/modal/serve.py",
+      });
+      expect(result.exitCode).toBe(0);
+      expect(mockSetModalConfig).toHaveBeenCalledWith({ inference: false });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // status
+  // -------------------------------------------------------------------------
+
+  describe("status", () => {
+    test("ping success → shows reachable", async () => {
+      mockPing.mockResolvedValue(true);
+
+      const result = await handleModalCommand(["status"], { tomlPath: fakeTomlPath });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/reachable|deployed|ok/i);
+    });
+
+    test("ping failure → shows error", async () => {
+      mockPing.mockRejectedValue(new Error("not reachable"));
+
+      const result = await handleModalCommand(["status"], { tomlPath: fakeTomlPath });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("not reachable");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // test
+  // -------------------------------------------------------------------------
+
+  describe("test", () => {
+    test("embed and generate pass → shows pass for each", async () => {
+      mockEmbed.mockResolvedValue([[0.1, 0.2, 0.3]]);
+      mockGenerate.mockResolvedValue("Hello world");
+
+      const result = await handleModalCommand(["test"], { tomlPath: fakeTomlPath });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/embed.*pass/i);
+      expect(result.stdout).toMatch(/generate.*pass/i);
+    });
+
+    test("embed fails → shows fail", async () => {
+      mockEmbed.mockRejectedValue(new Error("embed error"));
+      mockGenerate.mockResolvedValue("Hello world");
+
+      const result = await handleModalCommand(["test"], { tomlPath: fakeTomlPath });
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toMatch(/embed.*fail/i);
+    });
+  });
+});

--- a/test/modal-config.test.ts
+++ b/test/modal-config.test.ts
@@ -6,7 +6,7 @@
  * are applied correctly by getModalConfig/setModalConfig helpers.
  */
 
-import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { describe, test, expect } from "vitest";
 import {
   loadConfig,
   saveConfig,
@@ -16,130 +16,149 @@ import {
 } from "../src/collections.js";
 import type { CollectionConfig } from "../src/collections.js";
 
-beforeEach(() => {
-  // Use in-memory config for each test
+/** Helper: run fn with an isolated in-memory config, then reset. */
+function withInlineConfig(fn: () => void): void {
   setConfigSource({ config: { collections: {} } });
-});
-
-afterEach(() => {
-  setConfigSource(undefined);
-});
+  try {
+    fn();
+  } finally {
+    setConfigSource(undefined);
+  }
+}
 
 describe("modal config keys", () => {
   test("loadConfig returns no modal block when none is set", () => {
-    const config = loadConfig();
-    expect(config.modal).toBeUndefined();
+    withInlineConfig(() => {
+      const config = loadConfig();
+      expect(config.modal).toBeUndefined();
+    });
   });
 
   test("saveConfig persists modal block and loadConfig reads it back", () => {
-    const config: CollectionConfig = {
-      collections: {},
-      modal: {
+    withInlineConfig(() => {
+      const config: CollectionConfig = {
+        collections: {},
+        modal: {
+          inference: true,
+          gpu: "A10G",
+          scaledown_window: 30,
+        },
+      };
+      saveConfig(config);
+
+      const loaded = loadConfig();
+      expect(loaded.modal).toEqual({
         inference: true,
         gpu: "A10G",
         scaledown_window: 30,
-      },
-    };
-    saveConfig(config);
-
-    const loaded = loadConfig();
-    expect(loaded.modal).toEqual({
-      inference: true,
-      gpu: "A10G",
-      scaledown_window: 30,
+      });
     });
   });
 
   test("round-trip preserves partial modal config", () => {
-    const config: CollectionConfig = {
-      collections: {},
-      modal: {
-        inference: true,
-      },
-    };
-    saveConfig(config);
+    withInlineConfig(() => {
+      const config: CollectionConfig = {
+        collections: {},
+        modal: {
+          inference: true,
+        },
+      };
+      saveConfig(config);
 
-    const loaded = loadConfig();
-    expect(loaded.modal?.inference).toBe(true);
-    expect(loaded.modal?.gpu).toBeUndefined();
-    expect(loaded.modal?.scaledown_window).toBeUndefined();
+      const loaded = loadConfig();
+      expect(loaded.modal?.inference).toBe(true);
+      expect(loaded.modal?.gpu).toBeUndefined();
+      expect(loaded.modal?.scaledown_window).toBeUndefined();
+    });
   });
 });
 
 describe("getModalConfig", () => {
   test("returns defaults when no modal config is set", () => {
-    const modal = getModalConfig();
-    expect(modal).toEqual({
-      inference: false,
-      gpu: "T4",
-      scaledown_window: 15,
+    withInlineConfig(() => {
+      const modal = getModalConfig();
+      expect(modal).toEqual({
+        inference: false,
+        gpu: "T4",
+        scaledown_window: 15,
+      });
     });
   });
 
   test("returns stored values merged with defaults", () => {
-    saveConfig({
-      collections: {},
-      modal: { inference: true, gpu: "A10G" },
-    });
+    withInlineConfig(() => {
+      saveConfig({
+        collections: {},
+        modal: { inference: true, gpu: "A10G" },
+      });
 
-    const modal = getModalConfig();
-    expect(modal).toEqual({
-      inference: true,
-      gpu: "A10G",
-      scaledown_window: 15, // default applied
+      const modal = getModalConfig();
+      expect(modal).toEqual({
+        inference: true,
+        gpu: "A10G",
+        scaledown_window: 15,
+      });
     });
   });
 
   test("returns all stored values when fully specified", () => {
-    saveConfig({
-      collections: {},
-      modal: { inference: true, gpu: "L4", scaledown_window: 60 },
-    });
+    withInlineConfig(() => {
+      saveConfig({
+        collections: {},
+        modal: { inference: true, gpu: "L4", scaledown_window: 60 },
+      });
 
-    const modal = getModalConfig();
-    expect(modal).toEqual({
-      inference: true,
-      gpu: "L4",
-      scaledown_window: 60,
+      const modal = getModalConfig();
+      expect(modal).toEqual({
+        inference: true,
+        gpu: "L4",
+        scaledown_window: 60,
+      });
     });
   });
 });
 
 describe("setModalConfig", () => {
   test("sets modal config on empty config", () => {
-    setModalConfig({ inference: true });
+    withInlineConfig(() => {
+      setModalConfig({ inference: true });
 
-    const config = loadConfig();
-    expect(config.modal?.inference).toBe(true);
+      const config = loadConfig();
+      expect(config.modal?.inference).toBe(true);
+    });
   });
 
   test("merges partial update into existing modal config", () => {
-    saveConfig({
-      collections: {},
-      modal: { inference: true, gpu: "T4", scaledown_window: 15 },
-    });
+    withInlineConfig(() => {
+      saveConfig({
+        collections: {},
+        modal: { inference: true, gpu: "T4", scaledown_window: 15 },
+      });
 
-    setModalConfig({ gpu: "A10G" });
+      setModalConfig({ gpu: "A10G" });
 
-    const config = loadConfig();
-    expect(config.modal).toEqual({
-      inference: true,
-      gpu: "A10G",
-      scaledown_window: 15,
+      const config = loadConfig();
+      expect(config.modal).toEqual({
+        inference: true,
+        gpu: "A10G",
+        scaledown_window: 15,
+      });
     });
   });
 
   test("preserves existing collections when setting modal config", () => {
-    saveConfig({
-      collections: {
-        notes: { path: "/tmp/notes", pattern: "**/*.md" },
-      },
+    withInlineConfig(() => {
+      saveConfig({
+        collections: {
+          notes: { path: "/tmp/notes", pattern: "**/*.md" },
+        },
+      });
+
+      setModalConfig({ inference: true });
+
+      const config = loadConfig();
+      expect(config.collections.notes).toBeDefined();
+      expect(config.modal?.inference).toBe(true);
     });
-
-    setModalConfig({ inference: true });
-
-    const config = loadConfig();
-    expect(config.collections.notes).toBeDefined();
-    expect(config.modal?.inference).toBe(true);
   });
 });

--- a/test/modal-config.test.ts
+++ b/test/modal-config.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for modal config keys in CollectionConfig.
+ *
+ * Tests that modal.inference, modal.gpu, and modal.scaledown_window
+ * can be read/written via loadConfig/saveConfig, and that defaults
+ * are applied correctly by getModalConfig/setModalConfig helpers.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import {
+  loadConfig,
+  saveConfig,
+  setConfigSource,
+  getModalConfig,
+  setModalConfig,
+} from "../src/collections.js";
+import type { CollectionConfig } from "../src/collections.js";
+
+beforeEach(() => {
+  // Use in-memory config for each test
+  setConfigSource({ config: { collections: {} } });
+});
+
+afterEach(() => {
+  setConfigSource(undefined);
+});
+
+describe("modal config keys", () => {
+  test("loadConfig returns no modal block when none is set", () => {
+    const config = loadConfig();
+    expect(config.modal).toBeUndefined();
+  });
+
+  test("saveConfig persists modal block and loadConfig reads it back", () => {
+    const config: CollectionConfig = {
+      collections: {},
+      modal: {
+        inference: true,
+        gpu: "A10G",
+        scaledown_window: 30,
+      },
+    };
+    saveConfig(config);
+
+    const loaded = loadConfig();
+    expect(loaded.modal).toEqual({
+      inference: true,
+      gpu: "A10G",
+      scaledown_window: 30,
+    });
+  });
+
+  test("round-trip preserves partial modal config", () => {
+    const config: CollectionConfig = {
+      collections: {},
+      modal: {
+        inference: true,
+      },
+    };
+    saveConfig(config);
+
+    const loaded = loadConfig();
+    expect(loaded.modal?.inference).toBe(true);
+    expect(loaded.modal?.gpu).toBeUndefined();
+    expect(loaded.modal?.scaledown_window).toBeUndefined();
+  });
+});
+
+describe("getModalConfig", () => {
+  test("returns defaults when no modal config is set", () => {
+    const modal = getModalConfig();
+    expect(modal).toEqual({
+      inference: false,
+      gpu: "T4",
+      scaledown_window: 15,
+    });
+  });
+
+  test("returns stored values merged with defaults", () => {
+    saveConfig({
+      collections: {},
+      modal: { inference: true, gpu: "A10G" },
+    });
+
+    const modal = getModalConfig();
+    expect(modal).toEqual({
+      inference: true,
+      gpu: "A10G",
+      scaledown_window: 15, // default applied
+    });
+  });
+
+  test("returns all stored values when fully specified", () => {
+    saveConfig({
+      collections: {},
+      modal: { inference: true, gpu: "L4", scaledown_window: 60 },
+    });
+
+    const modal = getModalConfig();
+    expect(modal).toEqual({
+      inference: true,
+      gpu: "L4",
+      scaledown_window: 60,
+    });
+  });
+});
+
+describe("setModalConfig", () => {
+  test("sets modal config on empty config", () => {
+    setModalConfig({ inference: true });
+
+    const config = loadConfig();
+    expect(config.modal?.inference).toBe(true);
+  });
+
+  test("merges partial update into existing modal config", () => {
+    saveConfig({
+      collections: {},
+      modal: { inference: true, gpu: "T4", scaledown_window: 15 },
+    });
+
+    setModalConfig({ gpu: "A10G" });
+
+    const config = loadConfig();
+    expect(config.modal).toEqual({
+      inference: true,
+      gpu: "A10G",
+      scaledown_window: 15,
+    });
+  });
+
+  test("preserves existing collections when setting modal config", () => {
+    saveConfig({
+      collections: {
+        notes: { path: "/tmp/notes", pattern: "**/*.md" },
+      },
+    });
+
+    setModalConfig({ inference: true });
+
+    const config = loadConfig();
+    expect(config.collections.notes).toBeDefined();
+    expect(config.modal?.inference).toBe(true);
+  });
+});

--- a/test/modal-integration.test.ts
+++ b/test/modal-integration.test.ts
@@ -30,6 +30,7 @@ const mockGenerate = vi.fn();
 const mockRerank = vi.fn();
 const mockPing = vi.fn();
 const mockTokenize = vi.fn();
+const mockDetokenize = vi.fn();
 const mockDispose = vi.fn();
 
 vi.mock("../src/modal.js", () => ({
@@ -39,6 +40,7 @@ vi.mock("../src/modal.js", () => ({
     rerank: mockRerank,
     ping: mockPing,
     tokenize: mockTokenize,
+    detokenize: mockDetokenize,
     dispose: mockDispose,
   })),
 }));
@@ -159,6 +161,26 @@ describe("ModalLLM", () => {
 
       const count = await modalLLM.countTokens("hello world");
       expect(count).toBe(5);
+    });
+  });
+
+  describe("detokenize", () => {
+    test("calls backend.detokenize with tokens and returns text", async () => {
+      const modalLLM = new ModalLLM();
+      mockDetokenize.mockResolvedValue("hello world");
+
+      const result = await modalLLM.detokenize([1, 2, 3, 4] as unknown as readonly import("node-llama-cpp").Token[]);
+
+      expect(mockDetokenize).toHaveBeenCalledWith([1, 2, 3, 4]);
+      expect(result).toBe("hello world");
+    });
+
+    test("returns empty string for empty token array", async () => {
+      const modalLLM = new ModalLLM();
+      mockDetokenize.mockResolvedValue("");
+
+      const result = await modalLLM.detokenize([] as unknown as readonly import("node-llama-cpp").Token[]);
+      expect(result).toBe("");
     });
   });
 

--- a/test/modal-integration.test.ts
+++ b/test/modal-integration.test.ts
@@ -29,6 +29,7 @@ const mockEmbed = vi.fn();
 const mockGenerate = vi.fn();
 const mockRerank = vi.fn();
 const mockPing = vi.fn();
+const mockTokenize = vi.fn();
 const mockDispose = vi.fn();
 
 vi.mock("../src/modal.js", () => ({
@@ -37,6 +38,7 @@ vi.mock("../src/modal.js", () => ({
     generate: mockGenerate,
     rerank: mockRerank,
     ping: mockPing,
+    tokenize: mockTokenize,
     dispose: mockDispose,
   })),
 }));
@@ -127,6 +129,36 @@ describe("ModalLLM", () => {
 
       const result = await modalLLM.embed("test");
       expect(result).toBeNull();
+    });
+  });
+
+  describe("tokenize", () => {
+    test("calls backend.tokenize with text and returns tokens", async () => {
+      const modalLLM = new ModalLLM();
+      mockTokenize.mockResolvedValue([[1, 2, 3, 4]]);
+
+      const result = await modalLLM.tokenize("hello world");
+
+      expect(mockTokenize).toHaveBeenCalledWith(["hello world"]);
+      expect(result).toEqual([1, 2, 3, 4]);
+    });
+
+    test("returns empty array when backend returns no tokens", async () => {
+      const modalLLM = new ModalLLM();
+      mockTokenize.mockResolvedValue([[]]);
+
+      const result = await modalLLM.tokenize("test");
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("countTokens", () => {
+    test("returns length of token array from tokenize", async () => {
+      const modalLLM = new ModalLLM();
+      mockTokenize.mockResolvedValue([[1, 2, 3, 4, 5]]);
+
+      const count = await modalLLM.countTokens("hello world");
+      expect(count).toBe(5);
     });
   });
 

--- a/test/modal-integration.test.ts
+++ b/test/modal-integration.test.ts
@@ -1,0 +1,392 @@
+/**
+ * Integration tests for ModalLLM — the LLM-layer adapter that wraps ModalBackend.
+ *
+ * Tests cover:
+ * - Backend swap: modal.inference=false -> LlamaCpp, modal.inference=true -> ModalLLM
+ * - ModalLLM.embed() formats prompt locally then sends raw text to modal backend
+ * - ModalLLM.expandQuery() constructs chat-templated prompt with special tokens
+ * - ModalLLM.rerank() deduplicates texts, calls modalBackend.rerank(), maps scores back
+ * - ModalLLM.modelExists() returns stub info
+ * - Startup validation: ping() called, failure -> hard error
+ * - withLLMSession uses ModalSession when modal is active
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock getModalConfig before importing anything from llm.ts
+const mockGetModalConfig = vi.fn(() => ({
+  inference: false,
+  gpu: "T4",
+  scaledown_window: 15,
+}));
+
+vi.mock("../src/collections.js", () => ({
+  getModalConfig: () => mockGetModalConfig(),
+}));
+
+// Mock ModalBackend
+const mockEmbed = vi.fn();
+const mockGenerate = vi.fn();
+const mockRerank = vi.fn();
+const mockPing = vi.fn();
+const mockDispose = vi.fn();
+
+vi.mock("../src/modal.js", () => ({
+  ModalBackend: vi.fn(() => ({
+    embed: mockEmbed,
+    generate: mockGenerate,
+    rerank: mockRerank,
+    ping: mockPing,
+    dispose: mockDispose,
+  })),
+}));
+
+import {
+  ModalLLM,
+  getDefaultLLM,
+  validateModalConnection,
+  getOrCreateModalLLM,
+  resetModalLLM,
+  type Queryable,
+  type RerankDocument,
+} from "../src/llm.js";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function enableModal(): void {
+  mockGetModalConfig.mockReturnValue({
+    inference: true,
+    gpu: "T4",
+    scaledown_window: 15,
+  });
+}
+
+function disableModal(): void {
+  mockGetModalConfig.mockReturnValue({
+    inference: false,
+    gpu: "T4",
+    scaledown_window: 15,
+  });
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("ModalLLM", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetModalLLM();
+    disableModal();
+  });
+
+  describe("embed", () => {
+    test("formats query text locally then sends to modal backend", async () => {
+      const modalLLM = new ModalLLM();
+      const fakeVector = [0.1, 0.2, 0.3];
+      mockEmbed.mockResolvedValue([fakeVector]);
+
+      const result = await modalLLM.embed("test query", { isQuery: true });
+
+      expect(mockEmbed).toHaveBeenCalledTimes(1);
+      // Should have formatted with task prefix before sending
+      const sentText = mockEmbed.mock.calls[0]![0][0];
+      expect(sentText).toContain("task: search result");
+      expect(sentText).toContain("test query");
+      expect(result).toEqual({
+        embedding: fakeVector,
+        model: "modal",
+      });
+    });
+
+    test("formats document text locally then sends to modal backend", async () => {
+      const modalLLM = new ModalLLM();
+      const fakeVector = [0.4, 0.5, 0.6];
+      mockEmbed.mockResolvedValue([fakeVector]);
+
+      const result = await modalLLM.embed("some document content", {
+        isQuery: false,
+        title: "My Doc",
+      });
+
+      expect(mockEmbed).toHaveBeenCalledTimes(1);
+      const sentText = mockEmbed.mock.calls[0]![0][0];
+      expect(sentText).toContain("title: My Doc");
+      expect(sentText).toContain("some document content");
+      expect(result).toEqual({
+        embedding: fakeVector,
+        model: "modal",
+      });
+    });
+
+    test("returns null when backend returns empty array", async () => {
+      const modalLLM = new ModalLLM();
+      mockEmbed.mockResolvedValue([]);
+
+      const result = await modalLLM.embed("test");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("expandQuery", () => {
+    test("constructs Qwen3 chat template with special tokens and grammar", async () => {
+      const modalLLM = new ModalLLM();
+      mockGenerate.mockResolvedValue(
+        'lex: test search terms\nvec: semantic meaning of test\nhyde: A document about testing\n'
+      );
+
+      const result = await modalLLM.expandQuery("test");
+
+      expect(mockGenerate).toHaveBeenCalledTimes(1);
+      const [prompt, grammar, maxTokens, model] = mockGenerate.mock.calls[0]!;
+
+      // Verify chat template structure with exact special tokens
+      expect(prompt).toContain("<|im_start|>system");
+      expect(prompt).toContain("You are a helpful assistant.");
+      expect(prompt).toContain("<|im_end|>");
+      expect(prompt).toContain("<|im_start|>user");
+      expect(prompt).toContain("/no_think Expand this search query: test");
+      expect(prompt).toContain("<|im_start|>assistant");
+
+      // Verify grammar string
+      expect(grammar).toContain('root ::= line+');
+      expect(grammar).toContain('"lex" | "vec" | "hyde"');
+
+      // Verify max tokens and model
+      expect(maxTokens).toBe(600);
+      expect(model).toBe("expand");
+
+      // Verify parsed result
+      expect(result).toEqual([
+        { type: "lex", text: "test search terms" },
+        { type: "vec", text: "semantic meaning of test" },
+        { type: "hyde", text: "A document about testing" },
+      ]);
+    });
+
+    test("returns fallback when generation returns empty/invalid", async () => {
+      const modalLLM = new ModalLLM();
+      mockGenerate.mockResolvedValue("");
+
+      const result = await modalLLM.expandQuery("my query");
+
+      // Should return fallback queries
+      expect(result.length).toBeGreaterThan(0);
+      expect(result.some((q: Queryable) => q.type === "vec" || q.type === "hyde")).toBe(true);
+    });
+
+    test("filters out lines that do not contain any query terms", async () => {
+      const modalLLM = new ModalLLM();
+      mockGenerate.mockResolvedValue(
+        'lex: cats are fluffy\nvec: search for dogs\nhyde: information about cats\n'
+      );
+
+      const result = await modalLLM.expandQuery("cats");
+
+      // "search for dogs" should be filtered out since it doesn't contain "cats"
+      expect(result).toEqual([
+        { type: "lex", text: "cats are fluffy" },
+        { type: "hyde", text: "information about cats" },
+      ]);
+    });
+
+    test("includes intent in prompt when provided", async () => {
+      const modalLLM = new ModalLLM();
+      mockGenerate.mockResolvedValue('vec: test vector\n');
+
+      await modalLLM.expandQuery("test", { intent: "find documentation" });
+
+      const prompt = mockGenerate.mock.calls[0]![0];
+      expect(prompt).toContain("Query intent: find documentation");
+    });
+
+    test("respects includeLexical=false option", async () => {
+      const modalLLM = new ModalLLM();
+      mockGenerate.mockResolvedValue(
+        'lex: test terms\nvec: test semantic\nhyde: about test\n'
+      );
+
+      const result = await modalLLM.expandQuery("test", { includeLexical: false });
+
+      expect(result.every((q: Queryable) => q.type !== "lex")).toBe(true);
+    });
+  });
+
+  describe("rerank", () => {
+    test("deduplicates texts, calls modalBackend.rerank(), maps scores back", async () => {
+      const modalLLM = new ModalLLM();
+      const docs: RerankDocument[] = [
+        { file: "a.md", text: "unique text A" },
+        { file: "b.md", text: "shared text" },
+        { file: "c.md", text: "shared text" },   // duplicate of b
+        { file: "d.md", text: "unique text D" },
+      ];
+
+      // Backend receives deduplicated texts: ["unique text A", "shared text", "unique text D"]
+      // Returns scores in that order
+      mockRerank.mockResolvedValue([0.3, 0.9, 0.5]);
+
+      const result = await modalLLM.rerank("my query", docs);
+
+      expect(mockRerank).toHaveBeenCalledTimes(1);
+      const [query, texts] = mockRerank.mock.calls[0]!;
+      expect(query).toBe("my query");
+      // Should have deduplicated
+      expect(texts).toEqual(["unique text A", "shared text", "unique text D"]);
+
+      // Results should be sorted by score descending
+      // "shared text" (0.9) -> b.md (idx 1), c.md (idx 2)
+      // "unique text D" (0.5) -> d.md (idx 3)
+      // "unique text A" (0.3) -> a.md (idx 0)
+      expect(result.results).toEqual([
+        { file: "b.md", score: 0.9, index: 1 },
+        { file: "c.md", score: 0.9, index: 2 },
+        { file: "d.md", score: 0.5, index: 3 },
+        { file: "a.md", score: 0.3, index: 0 },
+      ]);
+      expect(result.model).toBe("modal");
+    });
+
+    test("truncates long documents using character-based approximation", async () => {
+      const modalLLM = new ModalLLM();
+      // Create a very long document (> typical context window in chars)
+      const longText = "x".repeat(20000);
+      const docs: RerankDocument[] = [
+        { file: "long.md", text: longText },
+        { file: "short.md", text: "short" },
+      ];
+
+      mockRerank.mockResolvedValue([0.5, 0.8]);
+
+      await modalLLM.rerank("query", docs);
+
+      const [, texts] = mockRerank.mock.calls[0]!;
+      // The long text should have been truncated
+      expect(texts[0].length).toBeLessThan(longText.length);
+      // Short text should be unchanged
+      expect(texts[1]).toBe("short");
+    });
+
+    test("handles empty documents array", async () => {
+      const modalLLM = new ModalLLM();
+      mockRerank.mockResolvedValue([]);
+
+      const result = await modalLLM.rerank("query", []);
+
+      expect(result.results).toEqual([]);
+      expect(result.model).toBe("modal");
+    });
+  });
+
+  describe("modelExists", () => {
+    test("returns stub info indicating models always exist on Modal", async () => {
+      const modalLLM = new ModalLLM();
+      const info = await modalLLM.modelExists("any-model");
+      expect(info).toEqual({ name: "modal", exists: true });
+    });
+  });
+
+  describe("dispose", () => {
+    test("calls modalBackend.dispose()", async () => {
+      const modalLLM = new ModalLLM();
+      await modalLLM.dispose();
+      expect(mockDispose).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe("getDefaultLLM", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetModalLLM();
+  });
+
+  afterEach(() => {
+    disableModal();
+  });
+
+  test("returns LlamaCpp when modal.inference=false", () => {
+    disableModal();
+    const llm = getDefaultLLM();
+    // Should NOT be a ModalLLM instance
+    expect(llm).not.toBeInstanceOf(ModalLLM);
+  });
+
+  test("returns ModalLLM when modal.inference=true", () => {
+    enableModal();
+    const llm = getDefaultLLM();
+    expect(llm).toBeInstanceOf(ModalLLM);
+  });
+
+  test("returns same ModalLLM singleton on repeated calls", () => {
+    enableModal();
+    const a = getDefaultLLM();
+    const b = getDefaultLLM();
+    expect(a).toBe(b);
+  });
+});
+
+describe("validateModalConnection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetModalLLM();
+  });
+
+  test("calls ping() and resolves on success", async () => {
+    mockPing.mockResolvedValue(true);
+    await expect(validateModalConnection()).resolves.toBeUndefined();
+    expect(mockPing).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws when ping() fails", async () => {
+    mockPing.mockRejectedValue(new Error("connection refused"));
+    await expect(validateModalConnection()).rejects.toThrow(
+      /Modal inference.*not reachable/
+    );
+  });
+
+  test("throws when ping() returns false", async () => {
+    mockPing.mockResolvedValue(false);
+    await expect(validateModalConnection()).rejects.toThrow(
+      /Modal inference.*not reachable/
+    );
+  });
+});
+
+describe("withLLMSession with Modal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetModalLLM();
+  });
+
+  afterEach(() => {
+    disableModal();
+  });
+
+  test("modal session delegates embed to ModalLLM", async () => {
+    enableModal();
+    const fakeVector = [0.1, 0.2];
+    mockEmbed.mockResolvedValue([fakeVector]);
+
+    const { withLLMSession } = await import("../src/llm.js");
+
+    const result = await withLLMSession(async (session) => {
+      return session.embed("test", { isQuery: true });
+    });
+
+    expect(mockEmbed).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ embedding: fakeVector, model: "modal" });
+  });
+
+  test("modal session isValid starts true", async () => {
+    enableModal();
+
+    const { withLLMSession } = await import("../src/llm.js");
+
+    await withLLMSession(async (session) => {
+      expect(session.isValid).toBe(true);
+    });
+  });
+});

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -2461,7 +2461,7 @@ describe.skipIf(!!process.env.CI)("LlamaCpp Integration", () => {
       model: "mock-reranker",
     }));
 
-    const llmSpy = vi.spyOn(llmModule, "getDefaultLlamaCpp").mockReturnValue({
+    const llmSpy = vi.spyOn(llmModule, "getDefaultLLM").mockReturnValue({
       rerank: rerankSpy,
     } as any);
 


### PR DESCRIPTION
## Motivation

QMD relies on three local GGUF models (embedding, query expansion, reranking) via node-llama-cpp. Users without a dedicated GPU — or on machines where llama.cpp doesn't build cleanly — can't use hybrid search at all. This PR adds an optional remote GPU backend so those users get the same search quality without local hardware requirements.

## What this does

Adds **Modal.com remote GPU inference** as a transparent alternative backend. When enabled, all three model operations (embed, expand, rerank) run on a T4 GPU via Modal instead of locally.

- `qmd modal deploy` / `status` / `test` / `destroy` — full lifecycle CLI
- Transparent routing — when `modal.inference=true` in config, `qmd query` and `qmd embed` use Modal automatically; no other commands change
- Same models, same results — the remote backend runs identical GGUF files through llama-server
- `qmd status` shows the active inference backend (local vs Modal) so users can tell at a glance which is in use

## Architecture

```
┌─────────────┐    modal npm SDK    ┌──────────────────────────┐
│  qmd (JS)   │ ──────────────────► │  Modal container (T4)    │
│  ModalLLM   │                     │  ┌─ llama-server :8081   │ ← embed
│  implements  │                     │  ├─ llama-server :8082   │ ← expand
│  LLM iface  │                     │  └─ llama-server :8083   │ ← rerank
└─────────────┘                     └──────────────────────────┘
```

- **`modal/serve.py`** — Python Modal app running 3 llama-server subprocesses on separate ports with health checks
- **`ghcr.io/ofekby/qmd-llama-server:b8179-sm75`** — pre-built Docker image (llama.cpp b8179, CUDA, T4/sm_75), built via CI workflow
- **`src/modal.ts`** — `ModalBackend` / `ModalSession` wrapping the Modal npm SDK with retry logic
- **`src/llm.ts`** — `ModalLLM` implements the `LLM` interface; `getDefaultLLM()` routes based on config
- **GPU memory snapshots** for fast cold starts (~6s vs ~40s without)
- **Region auto-detection** picks the closest Modal region to minimize latency

## Key design decisions

| Decision | Rationale |
|----------|-----------|
| llama-server over llama-cpp-python | llama-cpp-python is abandoned (last release Aug 2025) and doesn't support gemma-embedding |
| Pre-built Docker image via GHCR | CUDA compilation exceeds Modal's image build timeout |
| GPU memory snapshots | Without `enable_gpu_snapshot`, the snapshot phase runs CPU-only |
| No silent fallback | Hard fail when Modal is unreachable — surprises are worse than clear errors |
| Region auto-detection | Reduces latency for non-US users without manual config |

## Test plan

- [x] 65 unit tests covering config, backend, CLI, region detection, and integration
- [x] Smoke test via `qmd modal test` (embed + generate round-trip)
- [x] Full hybrid query end-to-end: `qmd query` with expansion → embedding → reranking
- [x] Clean lifecycle test: deploy → test → query → destroy

## Config

New keys in `~/.config/qmd/index.yml`:

```yaml
modal:
  inference: true          # enable/disable Modal backend
  gpu: "T4"               # GPU type
  scaledown_window: 15    # idle timeout (seconds)
  region: "us-east"       # auto-detected, or set manually
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)