### PR TITLE
feat: support remote embedding and reranking via OpenAI-compatible endpoints

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -76,7 +76,9 @@ import {
   syncConfigToDb,
   type ReindexResult,
 } from "../store.js";
-import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, withLLMSession, pullModels, DEFAULT_EMBED_MODEL_URI, DEFAULT_GENERATE_MODEL_URI, DEFAULT_RERANK_MODEL_URI, DEFAULT_MODEL_CACHE_DIR } from "../llm.js";
+import { LlamaCpp, disposeDefaultLlamaCpp, getDefaultLLM, getDefaultLlamaCpp, setDefaultLLM, withLLMSession, pullModels, DEFAULT_EMBED_MODEL_URI, DEFAULT_GENERATE_MODEL_URI, DEFAULT_RERANK_MODEL_URI, DEFAULT_MODEL_CACHE_DIR } from "../llm.js";
+import { HybridLLM } from "../hybrid-llm.js";
+import { RemoteLLM } from "../remote-llm.js";
 import {
   formatSearchResults,
   formatDocuments,
@@ -102,6 +104,23 @@ import { getEmbeddedQmdSkillContent, getEmbeddedQmdSkillFiles } from "../embedde
 // Enable production mode - allows using default database path
 // Tests must set INDEX_PATH or use createStore() with explicit path
 enableProductionMode();
+
+const remoteEmbedUrl = process.env.QMD_REMOTE_EMBED_URL;
+const remoteRerankUrl = process.env.QMD_REMOTE_RERANK_URL;
+
+if (remoteEmbedUrl || remoteRerankUrl) {
+  if (!remoteEmbedUrl || !remoteRerankUrl) {
+    throw new Error("QMD_REMOTE_EMBED_URL and QMD_REMOTE_RERANK_URL must both be set to enable remote embedding/reranking");
+  }
+
+  const remote = new RemoteLLM({
+    embedUrl: remoteEmbedUrl,
+    rerankUrl: remoteRerankUrl,
+    apiKey: process.env.QMD_REMOTE_API_KEY,
+  });
+  const local = new LlamaCpp({});
+  setDefaultLLM(new HybridLLM(local, remote));
+}
 
 // =============================================================================
 // Store/DB lifecycle (no legacy singletons in store.ts)
@@ -428,30 +447,31 @@ async function showStatus(): Promise<void> {
 
   // Device / GPU info
   try {
-    const llm = getDefaultLlamaCpp();
-    const device = await llm.getDeviceInfo();
-    console.log(`\n${c.bold}Device${c.reset}`);
-    if (device.gpu) {
-      console.log(`  GPU:      ${c.green}${device.gpu}${c.reset} (offloading: ${device.gpuOffloading ? 'yes' : 'no'})`);
-      if (device.gpuDevices.length > 0) {
-        // Deduplicate and count GPUs
-        const counts = new Map<string, number>();
-        for (const name of device.gpuDevices) {
-          counts.set(name, (counts.get(name) || 0) + 1);
+    const llm = getDefaultLLM() as Partial<LlamaCpp>;
+    if (typeof llm.getDeviceInfo === "function") {
+      const device = await llm.getDeviceInfo();
+      console.log(`\n${c.bold}Device${c.reset}`);
+      if (device.gpu) {
+        console.log(`  GPU:      ${c.green}${device.gpu}${c.reset} (offloading: ${device.gpuOffloading ? 'yes' : 'no'})`);
+        if (device.gpuDevices.length > 0) {
+          const counts = new Map<string, number>();
+          for (const name of device.gpuDevices) {
+            counts.set(name, (counts.get(name) || 0) + 1);
+          }
+          const deviceStr = Array.from(counts.entries())
+            .map(([name, count]) => count > 1 ? `${count}× ${name}` : name)
+            .join(', ');
+          console.log(`  Devices:  ${deviceStr}`);
         }
-        const deviceStr = Array.from(counts.entries())
-          .map(([name, count]) => count > 1 ? `${count}× ${name}` : name)
-          .join(', ');
-        console.log(`  Devices:  ${deviceStr}`);
+        if (device.vram) {
+          console.log(`  VRAM:     ${formatBytes(device.vram.free)} free / ${formatBytes(device.vram.total)} total`);
+        }
+      } else {
+        console.log(`  GPU:      ${c.yellow}none${c.reset} (running on CPU — models will be slow)`);
+        console.log(`  ${c.dim}Tip: Install CUDA, Vulkan, or Metal support for GPU acceleration.${c.reset}`);
       }
-      if (device.vram) {
-        console.log(`  VRAM:     ${formatBytes(device.vram.free)} free / ${formatBytes(device.vram.total)} total`);
-      }
-    } else {
-      console.log(`  GPU:      ${c.yellow}none${c.reset} (running on CPU — models will be slow)`);
-      console.log(`  ${c.dim}Tip: Install CUDA, Vulkan, or Metal support for GPU acceleration.${c.reset}`);
+      console.log(`  CPU:      ${device.cpuCores} math cores`);
     }
-    console.log(`  CPU:      ${device.cpuCores} math cores`);
   } catch {
     // Don't fail status if LLM init fails
   }

--- a/src/hybrid-llm.ts
+++ b/src/hybrid-llm.ts
@@ -1,0 +1,54 @@
+import type {
+  EmbedOptions,
+  EmbeddingResult,
+  GenerateOptions,
+  GenerateResult,
+  LLM,
+  ModelInfo,
+  Queryable,
+  RerankDocument,
+  RerankOptions,
+  RerankResult,
+} from "./llm.js";
+
+export class HybridLLM implements LLM {
+  readonly isRemote = true;
+
+  constructor(
+    private readonly local: LLM,
+    private readonly remote: LLM,
+  ) {}
+
+  async embed(text: string, options: EmbedOptions = {}): Promise<EmbeddingResult | null> {
+    return this.remote.embed(text, options);
+  }
+
+  async embedBatch(texts: string[], options: EmbedOptions = {}): Promise<(EmbeddingResult | null)[]> {
+    return this.remote.embedBatch(texts, options);
+  }
+
+  async rerank(query: string, documents: RerankDocument[], options: RerankOptions = {}): Promise<RerankResult> {
+    return this.remote.rerank(query, documents, options);
+  }
+
+  async generate(prompt: string, options: GenerateOptions = {}): Promise<GenerateResult | null> {
+    return this.local.generate(prompt, options);
+  }
+
+  async expandQuery(query: string, options?: { context?: string; includeLexical?: boolean; intent?: string }): Promise<Queryable[]> {
+    return this.local.expandQuery(query, options);
+  }
+
+  async modelExists(model: string): Promise<ModelInfo> {
+    const [remoteResult, localResult] = await Promise.all([
+      this.remote.modelExists(model).catch(() => ({ name: model, exists: false })),
+      this.local.modelExists(model).catch(() => ({ name: model, exists: false })),
+    ]);
+
+    return remoteResult.exists ? remoteResult : localResult;
+  }
+
+  async dispose(): Promise<void> {
+    await Promise.allSettled([this.local.dispose(), this.remote.dispose()]);
+  }
+}

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -156,7 +156,7 @@ export type LLMSessionOptions = {
 export interface ILLMSession {
   embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null>;
   embedBatch(texts: string[]): Promise<(EmbeddingResult | null)[]>;
-  expandQuery(query: string, options?: { context?: string; includeLexical?: boolean }): Promise<Queryable[]>;
+  expandQuery(query: string, options?: { context?: string; includeLexical?: boolean; intent?: string }): Promise<Queryable[]>;
   rerank(query: string, documents: RerankDocument[], options?: RerankOptions): Promise<RerankResult>;
   /** Whether this session is still valid (not released or aborted) */
   readonly isValid: boolean;
@@ -318,6 +318,11 @@ export interface LLM {
   embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null>;
 
   /**
+   * Batch embed multiple texts efficiently
+   */
+  embedBatch(texts: string[], options?: EmbedOptions): Promise<(EmbeddingResult | null)[]>;
+
+  /**
    * Generate text completion
    */
   generate(prompt: string, options?: GenerateOptions): Promise<GenerateResult | null>;
@@ -331,13 +336,19 @@ export interface LLM {
    * Expand a search query into multiple variations for different backends.
    * Returns a list of Queryable objects.
    */
-  expandQuery(query: string, options?: { context?: string, includeLexical?: boolean }): Promise<Queryable[]>;
+  expandQuery(query: string, options?: { context?: string, includeLexical?: boolean, intent?: string }): Promise<Queryable[]>;
 
   /**
    * Rerank documents by relevance to a query
    * Returns list of documents with relevance scores (higher = more relevant)
    */
   rerank(query: string, documents: RerankDocument[], options?: RerankOptions): Promise<RerankResult>;
+
+  /**
+   * Whether this LLM delegates embedding/reranking to a remote provider.
+   * Remote backends may need different text formatting than local GGUF models.
+   */
+  readonly isRemote?: boolean;
 
   /**
    * Dispose of resources
@@ -1274,11 +1285,11 @@ export class LlamaCpp implements LLM {
  * Coordinates with LlamaCpp idle timeout to prevent disposal during active sessions.
  */
 class LLMSessionManager {
-  private llm: LlamaCpp;
+  private llm: LLM;
   private _activeSessionCount = 0;
   private _inFlightOperations = 0;
 
-  constructor(llm: LlamaCpp) {
+  constructor(llm: LLM) {
     this.llm = llm;
   }
 
@@ -1314,7 +1325,7 @@ class LLMSessionManager {
     this._inFlightOperations = Math.max(0, this._inFlightOperations - 1);
   }
 
-  getLlamaCpp(): LlamaCpp {
+  getLLM(): LLM {
     return this.llm;
   }
 }
@@ -1417,18 +1428,18 @@ class LLMSession implements ILLMSession {
   }
 
   async embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null> {
-    return this.withOperation(() => this.manager.getLlamaCpp().embed(text, options));
+    return this.withOperation(() => this.manager.getLLM().embed(text, options));
   }
 
   async embedBatch(texts: string[]): Promise<(EmbeddingResult | null)[]> {
-    return this.withOperation(() => this.manager.getLlamaCpp().embedBatch(texts));
+    return this.withOperation(() => this.manager.getLLM().embedBatch(texts));
   }
 
   async expandQuery(
     query: string,
-    options?: { context?: string; includeLexical?: boolean }
+    options?: { context?: string; includeLexical?: boolean; intent?: string }
   ): Promise<Queryable[]> {
-    return this.withOperation(() => this.manager.getLlamaCpp().expandQuery(query, options));
+    return this.withOperation(() => this.manager.getLLM().expandQuery(query, options));
   }
 
   async rerank(
@@ -1436,7 +1447,7 @@ class LLMSession implements ILLMSession {
     documents: RerankDocument[],
     options?: RerankOptions
   ): Promise<RerankResult> {
-    return this.withOperation(() => this.manager.getLlamaCpp().rerank(query, documents, options));
+    return this.withOperation(() => this.manager.getLLM().rerank(query, documents, options));
   }
 }
 
@@ -1447,8 +1458,8 @@ let defaultSessionManager: LLMSessionManager | null = null;
  * Get the session manager for the default LlamaCpp instance.
  */
 function getSessionManager(): LLMSessionManager {
-  const llm = getDefaultLlamaCpp();
-  if (!defaultSessionManager || defaultSessionManager.getLlamaCpp() !== llm) {
+  const llm = getDefaultLLM();
+  if (!defaultSessionManager || defaultSessionManager.getLLM() !== llm) {
     defaultSessionManager = new LLMSessionManager(llm);
   }
   return defaultSessionManager;
@@ -1483,11 +1494,11 @@ export async function withLLMSession<T>(
 }
 
 /**
- * Execute a function with a scoped LLM session using a specific LlamaCpp instance.
+ * Execute a function with a scoped LLM session using a specific LLM instance.
  * Unlike withLLMSession, this does not use the global singleton.
  */
 export async function withLLMSessionForLlm<T>(
-  llm: LlamaCpp,
+  llm: LLM,
   fn: (session: ILLMSession) => Promise<T>,
   options?: LLMSessionOptions
 ): Promise<T> {
@@ -1514,24 +1525,50 @@ export function canUnloadLLM(): boolean {
 // Singleton for default LlamaCpp instance
 // =============================================================================
 
-let defaultLlamaCpp: LlamaCpp | null = null;
+let defaultLLMInstance: LLM | null = null;
 
 /**
- * Get the default LlamaCpp instance (creates one if needed)
+ * Get the default LLM instance (creates one if needed).
+ */
+export function getDefaultLLM(): LLM {
+  if (!defaultLLMInstance) {
+    const embedModel = process.env.QMD_EMBED_MODEL;
+    defaultLLMInstance = new LlamaCpp(embedModel ? { embedModel } : {});
+  }
+  return defaultLLMInstance;
+}
+
+/**
+ * Get the default LlamaCpp instance.
+ * Use getDefaultLLM() when the default backend may be remote/hybrid.
  */
 export function getDefaultLlamaCpp(): LlamaCpp {
-  if (!defaultLlamaCpp) {
-    const embedModel = process.env.QMD_EMBED_MODEL;
-    defaultLlamaCpp = new LlamaCpp(embedModel ? { embedModel } : {});
-  }
-  return defaultLlamaCpp;
+  return getDefaultLLM() as LlamaCpp;
+}
+
+/**
+ * Set a custom default LLM instance (useful for testing or remote/hybrid backends).
+ */
+export function setDefaultLLM(llm: LLM | null): void {
+  defaultLLMInstance = llm;
 }
 
 /**
  * Set a custom default LlamaCpp instance (useful for testing)
  */
 export function setDefaultLlamaCpp(llm: LlamaCpp | null): void {
-  defaultLlamaCpp = llm;
+  setDefaultLLM(llm);
+}
+
+/**
+ * Dispose the default LLM instance if it exists.
+ * Call this before process exit to prevent NAPI crashes.
+ */
+export async function disposeDefaultLLM(): Promise<void> {
+  if (defaultLLMInstance) {
+    await defaultLLMInstance.dispose();
+    defaultLLMInstance = null;
+  }
 }
 
 /**
@@ -1539,8 +1576,5 @@ export function setDefaultLlamaCpp(llm: LlamaCpp | null): void {
  * Call this before process exit to prevent NAPI crashes.
  */
 export async function disposeDefaultLlamaCpp(): Promise<void> {
-  if (defaultLlamaCpp) {
-    await defaultLlamaCpp.dispose();
-    defaultLlamaCpp = null;
-  }
+  await disposeDefaultLLM();
 }

--- a/src/remote-llm.ts
+++ b/src/remote-llm.ts
@@ -1,0 +1,501 @@
+import {
+  isQwen3EmbeddingModel,
+  type EmbedOptions,
+  type EmbeddingResult,
+  type GenerateOptions,
+  type GenerateResult,
+  type LLM,
+  type ModelInfo,
+  type Queryable,
+  type RerankDocument,
+  type RerankOptions,
+  type RerankResult,
+} from "./llm.js";
+
+const DEFAULT_CONNECT_TIMEOUT_MS = 500;
+const DEFAULT_READ_TIMEOUT_MS = 10_000;
+const DEFAULT_BREAKER_THRESHOLD = 2;
+const DEFAULT_BREAKER_COOLDOWN_MS = 10 * 60 * 1000;
+const QWEN_QUERY_PREFIX = "Instruct: Retrieve relevant documents for the given query\nQuery: ";
+const LEGACY_QUERY_PREFIX = "task: search result | query: ";
+const LEGACY_DOC_PREFIX = /^title:\s*(.*?)\s*\|\s*text:\s*([\s\S]*)$/;
+const COUNTED_FAILURE = Symbol("remoteFailureCounted");
+
+type EndpointName = "embed" | "rerank";
+type BreakerStatus = "closed" | "open" | "half-open";
+
+type BreakerState = {
+  failures: number;
+  openUntil: number;
+  state: BreakerStatus;
+};
+
+export type RemoteLLMConfig = {
+  embedUrl?: string;
+  rerankUrl?: string;
+  embedModel?: string;
+  rerankModel?: string;
+  apiKey?: string;
+  connectTimeoutMs?: number;
+  readTimeoutMs?: number;
+  breakerThreshold?: number;
+  breakerCooldownMs?: number;
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function logStderr(message: string): void {
+  process.stderr.write(`[${nowIso()}] ${message}\n`);
+}
+
+function parseTimeout(value: number | string | undefined, fallback: number, label: string): number {
+  if (value === undefined || value === "") {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+  return parsed;
+}
+
+function parsePositiveInt(value: number | undefined, fallback: number, label: string): number {
+  if (value === undefined) return fallback;
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+  return value;
+}
+
+function joinEndpoint(baseUrl: string, path: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}${path}`;
+}
+
+function clipForLog(value: string, max = 300): string {
+  return value.length <= max ? value : `${value.slice(0, max)}...`;
+}
+
+function markFailureCounted(error: unknown): unknown {
+  if (error && typeof error === "object") {
+    Reflect.set(error, COUNTED_FAILURE, true);
+  }
+  return error;
+}
+
+function wasFailureCounted(error: unknown): boolean {
+  return !!(error && typeof error === "object" && Reflect.get(error, COUNTED_FAILURE));
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: NodeJS.Timeout | null = null;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(`${label} timeout after ${timeoutMs}ms`));
+        }, timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function extractOriginalEmbeddingText(text: string): { kind: "query" | "document" | "unknown"; text: string } {
+  if (text.startsWith(QWEN_QUERY_PREFIX)) {
+    return { kind: "query", text: text.slice(QWEN_QUERY_PREFIX.length) };
+  }
+  if (text.startsWith(LEGACY_QUERY_PREFIX)) {
+    return { kind: "query", text: text.slice(LEGACY_QUERY_PREFIX.length) };
+  }
+
+  const docMatch = LEGACY_DOC_PREFIX.exec(text);
+  if (docMatch) {
+    const [, title, body] = docMatch;
+    return { kind: "document", text: title ? `${title}\n${body ?? ""}` : (body ?? "") };
+  }
+
+  return { kind: "unknown", text };
+}
+
+export class RemoteLLM implements LLM {
+  readonly isRemote = true;
+  private readonly embedUrl: string;
+  private readonly rerankUrl: string;
+  private readonly embedModel: string;
+  private readonly rerankModel: string;
+  private readonly apiKey: string;
+  private readonly connectTimeoutMs: number;
+  private readonly readTimeoutMs: number;
+  private readonly breakerThreshold: number;
+  private readonly breakerCooldownMs: number;
+  private readonly breakerState: Record<EndpointName, BreakerState>;
+  private expectedEmbedDim: number | null = null;
+
+  constructor(config: RemoteLLMConfig = {}) {
+    const embedUrl = config.embedUrl ?? process.env.QMD_REMOTE_EMBED_URL;
+    const rerankUrl = config.rerankUrl ?? process.env.QMD_REMOTE_RERANK_URL;
+
+    if (!embedUrl) throw new Error("QMD_REMOTE_EMBED_URL is required for RemoteLLM");
+    if (!rerankUrl) throw new Error("QMD_REMOTE_RERANK_URL is required for RemoteLLM");
+
+    this.embedUrl = String(embedUrl).replace(/\/+$/, "");
+    this.rerankUrl = String(rerankUrl).replace(/\/+$/, "");
+    this.embedModel =
+      config.embedModel ??
+      process.env.QMD_REMOTE_EMBED_MODEL ??
+      process.env.QMD_EMBED_MODEL ??
+      "remote-embedding";
+    this.rerankModel =
+      config.rerankModel ??
+      process.env.QMD_REMOTE_RERANK_MODEL ??
+      process.env.QMD_RERANK_MODEL ??
+      "remote-reranker";
+    this.apiKey = config.apiKey ?? process.env.QMD_REMOTE_API_KEY ?? "";
+    this.connectTimeoutMs = parseTimeout(
+      config.connectTimeoutMs ?? process.env.QMD_REMOTE_CONNECT_TIMEOUT,
+      DEFAULT_CONNECT_TIMEOUT_MS,
+      "QMD_REMOTE_CONNECT_TIMEOUT",
+    );
+    this.readTimeoutMs = parseTimeout(
+      config.readTimeoutMs ?? process.env.QMD_REMOTE_READ_TIMEOUT,
+      DEFAULT_READ_TIMEOUT_MS,
+      "QMD_REMOTE_READ_TIMEOUT",
+    );
+    this.breakerThreshold = parsePositiveInt(
+      config.breakerThreshold,
+      DEFAULT_BREAKER_THRESHOLD,
+      "breakerThreshold",
+    );
+    this.breakerCooldownMs = parsePositiveInt(
+      config.breakerCooldownMs,
+      DEFAULT_BREAKER_COOLDOWN_MS,
+      "breakerCooldownMs",
+    );
+    this.breakerState = {
+      embed: { failures: 0, openUntil: 0, state: "closed" },
+      rerank: { failures: 0, openUntil: 0, state: "closed" },
+    };
+  }
+
+  private normalizeEmbeddingInput(text: string, options: EmbedOptions = {}): string {
+    const extracted = extractOriginalEmbeddingText(text);
+    const kind = options.isQuery ? "query" : extracted.kind;
+    const plainText = extracted.text;
+    const embedModelHint = options.model ?? this.embedModel;
+
+    if (kind === "query" && isQwen3EmbeddingModel(embedModelHint)) {
+      return `${QWEN_QUERY_PREFIX}${plainText}`;
+    }
+
+    return plainText;
+  }
+
+  private buildHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      accept: "application/json",
+    };
+    if (this.apiKey) {
+      headers.authorization = `Bearer ${this.apiKey}`;
+    }
+    return headers;
+  }
+
+  private beforeRequest(endpoint: EndpointName): void {
+    const state = this.breakerState[endpoint];
+    const now = Date.now();
+
+    if (state.openUntil > now) {
+      const retryAt = new Date(state.openUntil).toISOString();
+      logStderr(`RemoteLLM ${endpoint} circuit open until ${retryAt}; skipping request`);
+      throw markFailureCounted(new Error(`Remote ${endpoint} endpoint is in circuit-breaker cooldown until ${retryAt}`));
+    }
+
+    if (state.state === "open" && state.openUntil !== 0 && state.openUntil <= now) {
+      state.state = "half-open";
+      state.openUntil = 0;
+      logStderr(`RemoteLLM ${endpoint} circuit cooldown elapsed; retrying endpoint`);
+    }
+  }
+
+  private onSuccess(endpoint: EndpointName): void {
+    const state = this.breakerState[endpoint];
+    const previousState = state.state;
+    const hadFailures = state.failures > 0;
+    state.failures = 0;
+    state.openUntil = 0;
+    state.state = "closed";
+
+    if (previousState !== "closed" || hadFailures) {
+      logStderr(`RemoteLLM ${endpoint} circuit closed after successful request`);
+    }
+  }
+
+  private onFailure(endpoint: EndpointName, error: unknown): void {
+    const state = this.breakerState[endpoint];
+    state.failures += 1;
+
+    if (state.failures >= this.breakerThreshold) {
+      state.state = "open";
+      state.openUntil = Date.now() + this.breakerCooldownMs;
+      logStderr(
+        `RemoteLLM ${endpoint} circuit opened after ${state.failures} consecutive failures; cooldown ${Math.round(this.breakerCooldownMs / 60000)}m`,
+      );
+    } else {
+      state.state = "closed";
+    }
+
+    logStderr(`RemoteLLM ${endpoint} error: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  private async postJson(endpoint: EndpointName, url: string, payload: unknown): Promise<any> {
+    this.beforeRequest(endpoint);
+
+    const connectController = new AbortController();
+    const connectTimer = setTimeout(() => {
+      connectController.abort(new Error(`connect timeout after ${this.connectTimeoutMs}ms`));
+    }, this.connectTimeoutMs);
+    connectTimer.unref?.();
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "POST",
+        headers: this.buildHeaders(),
+        body: JSON.stringify(payload),
+        signal: connectController.signal,
+      });
+    } catch (error) {
+      clearTimeout(connectTimer);
+      this.onFailure(endpoint, error);
+      throw markFailureCounted(error);
+    }
+    clearTimeout(connectTimer);
+
+    let responseText: string;
+    try {
+      responseText = await withTimeout(response.text(), this.readTimeoutMs, "read");
+    } catch (error) {
+      this.onFailure(endpoint, error);
+      throw markFailureCounted(error);
+    }
+
+    if (!response.ok) {
+      const error = new Error(`HTTP ${response.status} from ${url}: ${clipForLog(responseText)}`);
+      this.onFailure(endpoint, error);
+      throw markFailureCounted(error);
+    }
+
+    try {
+      return responseText ? JSON.parse(responseText) : {};
+    } catch {
+      const error = new Error(`Invalid JSON from ${url}: ${clipForLog(responseText)}`);
+      this.onFailure(endpoint, error);
+      throw markFailureCounted(error);
+    }
+  }
+
+  private async fetchModels(endpoint: EndpointName, baseUrl: string): Promise<string[]> {
+    this.beforeRequest(endpoint);
+
+    const connectController = new AbortController();
+    const connectTimer = setTimeout(() => {
+      connectController.abort(new Error(`connect timeout after ${this.connectTimeoutMs}ms`));
+    }, this.connectTimeoutMs);
+    connectTimer.unref?.();
+
+    let response: Response;
+    try {
+      response = await fetch(joinEndpoint(baseUrl, "/v1/models"), {
+        method: "GET",
+        headers: this.buildHeaders(),
+        signal: connectController.signal,
+      });
+    } catch (error) {
+      clearTimeout(connectTimer);
+      this.onFailure(endpoint, error);
+      throw markFailureCounted(error);
+    }
+    clearTimeout(connectTimer);
+
+    let body: string;
+    try {
+      body = await withTimeout(response.text(), this.readTimeoutMs, "read");
+    } catch (error) {
+      this.onFailure(endpoint, error);
+      throw markFailureCounted(error);
+    }
+
+    if (!response.ok) {
+      const error = new Error(`HTTP ${response.status} from ${baseUrl}/v1/models: ${clipForLog(body)}`);
+      this.onFailure(endpoint, error);
+      throw markFailureCounted(error);
+    }
+
+    try {
+      const parsed = body ? JSON.parse(body) : {};
+      const models = Array.isArray(parsed?.data) ? parsed.data : [];
+      this.onSuccess(endpoint);
+      return models
+        .map((model) => (typeof model?.id === "string" ? model.id : null))
+        .filter((value): value is string => value !== null);
+    } catch {
+      const error = new Error(`Invalid JSON from ${baseUrl}/v1/models: ${clipForLog(body)}`);
+      this.onFailure(endpoint, error);
+      throw markFailureCounted(error);
+    }
+  }
+
+  async embed(text: string, options: EmbedOptions = {}): Promise<EmbeddingResult | null> {
+    const [result] = await this.embedBatch([text], options);
+    return result ?? null;
+  }
+
+  async embedBatch(texts: string[], options: EmbedOptions = {}): Promise<(EmbeddingResult | null)[]> {
+    if (texts.length === 0) return [];
+
+    const input = texts.map((text) => this.normalizeEmbeddingInput(text, options));
+    const url = joinEndpoint(this.embedUrl, "/v1/embeddings");
+
+    try {
+      const data = await this.postJson("embed", url, {
+        input,
+        model: options.model ?? this.embedModel,
+      });
+
+      if (!Array.isArray(data?.data)) {
+        throw new Error(`Invalid embedding response from ${url}: missing data array`);
+      }
+
+      const sorted = [...data.data].sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
+      if (sorted.length !== texts.length) {
+        throw new Error(`Invalid embedding response from ${url}: expected ${texts.length} vectors, got ${sorted.length}`);
+      }
+
+      const results = sorted.map((item) => {
+        if (!Array.isArray(item?.embedding)) {
+          throw new Error(`Invalid embedding response item from ${url}: missing embedding array`);
+        }
+
+        const dim = item.embedding.length;
+        if (this.expectedEmbedDim === null) {
+          this.expectedEmbedDim = dim;
+          logStderr(`RemoteLLM embed dimension locked: ${dim}`);
+        } else if (dim !== this.expectedEmbedDim) {
+          throw new Error(
+            `Embedding dimension mismatch: expected ${this.expectedEmbedDim}, got ${dim}. Model or server config may have changed.`,
+          );
+        }
+
+        return {
+          embedding: item.embedding,
+          model: data.model ?? options.model ?? this.embedModel,
+        } satisfies EmbeddingResult;
+      });
+
+      this.onSuccess("embed");
+      return results;
+    } catch (error) {
+      if (!wasFailureCounted(error)) {
+        this.onFailure("embed", error);
+      }
+      throw error;
+    }
+  }
+
+  async generate(_prompt: string, _options: GenerateOptions = {}): Promise<GenerateResult | null> {
+    throw new Error("RemoteLLM does not implement generate(); use HybridLLM with a local LlamaCpp");
+  }
+
+  async expandQuery(_query: string, _options?: { context?: string; includeLexical?: boolean; intent?: string }): Promise<Queryable[]> {
+    throw new Error("RemoteLLM does not implement expandQuery(); use HybridLLM with a local LlamaCpp");
+  }
+
+  async rerank(query: string, documents: RerankDocument[], options: RerankOptions = {}): Promise<RerankResult> {
+    if (documents.length === 0) {
+      return { results: [], model: options.model ?? this.rerankModel };
+    }
+
+    const url = joinEndpoint(this.rerankUrl, "/v1/rerank");
+    try {
+      const data = await this.postJson("rerank", url, {
+        query,
+        documents: documents.map((document) => document.text),
+        model: options.model ?? this.rerankModel,
+        return_documents: false,
+      });
+
+      const results = Array.isArray(data?.results) ? data.results : Array.isArray(data?.data) ? data.data : null;
+      if (!results) {
+        throw new Error(`Invalid rerank response from ${url}: missing results array`);
+      }
+
+      const normalized = results.map((item) => {
+        const index = item.index ?? item.document_index;
+        const score = item.relevance_score ?? item.score;
+        if (!Number.isInteger(index) || index < 0 || index >= documents.length) {
+          throw new Error(`Invalid rerank response item from ${url}: bad index ${String(index)}`);
+        }
+        if (typeof score !== "number" || Number.isNaN(score)) {
+          throw new Error(`Invalid rerank response item from ${url}: bad score ${String(score)}`);
+        }
+        const document = documents[index];
+        if (!document) {
+          throw new Error(`Invalid rerank response item from ${url}: missing document for index ${String(index)}`);
+        }
+        return {
+          file: document.file,
+          index,
+          score,
+        };
+      });
+
+      normalized.sort((a, b) => b.score - a.score);
+      this.onSuccess("rerank");
+      return {
+        results: normalized,
+        model: data.model ?? options.model ?? this.rerankModel,
+      };
+    } catch (error) {
+      if (!wasFailureCounted(error)) {
+        this.onFailure("rerank", error);
+      }
+      throw error;
+    }
+  }
+
+  async modelExists(model: string): Promise<ModelInfo> {
+    try {
+      const [embedModels, rerankModels] = await Promise.allSettled([
+        this.fetchModels("embed", this.embedUrl),
+        this.fetchModels("rerank", this.rerankUrl),
+      ]);
+
+      const available = new Set<string>();
+      if (embedModels.status === "fulfilled") {
+        for (const name of embedModels.value) available.add(name);
+      }
+      if (rerankModels.status === "fulfilled") {
+        for (const name of rerankModels.value) available.add(name);
+      }
+
+      if (available.size > 0) {
+        return { name: model, exists: available.has(model) };
+      }
+    } catch {
+      // Fall through to optimistic default below.
+    }
+
+    return { name: model, exists: true };
+  }
+
+  async dispose(): Promise<void> {
+    // No local resources to release.
+  }
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -20,6 +20,8 @@ import { readFileSync, realpathSync, statSync, mkdirSync } from "node:fs";
 import fastGlob from "fast-glob";
 import {
   LlamaCpp,
+  type LLM,
+  getDefaultLLM,
   getDefaultLlamaCpp,
   formatQueryForEmbedding,
   formatDocForEmbedding,
@@ -62,8 +64,8 @@ export const CHUNK_WINDOW_CHARS = CHUNK_WINDOW_TOKENS * 4;  // 800 chars
  * Get the LlamaCpp instance for a store — prefers the store's own instance,
  * falls back to the global singleton.
  */
-function getLlm(store: Store): LlamaCpp {
-  return store.llm ?? getDefaultLlamaCpp();
+function getLlm(store: Store): LLM {
+  return store.llm ?? getDefaultLLM();
 }
 
 // =============================================================================
@@ -983,8 +985,8 @@ function ensureVecTableInternal(db: Database, dimensions: number): void {
 export type Store = {
   db: Database;
   dbPath: string;
-  /** Optional LlamaCpp instance for this store (overrides the global singleton) */
-  llm?: LlamaCpp;
+  /** Optional LLM instance for this store (overrides the global singleton) */
+  llm?: LLM;
   close: () => void;
   ensureVecTable: (dimensions: number) => void;
 
@@ -1323,8 +1325,11 @@ export async function generateEmbeddings(
   const totalDocs = docsToEmbed.length;
   const startTime = Date.now();
 
-  // Use store's LlamaCpp or global singleton, wrapped in a session
+  // Use store's configured LLM or the global singleton, wrapped in a session
   const llm = getLlm(store);
+  const formatDoc = llm.isRemote
+    ? (text: string, title?: string) => title ? `${title}\n${text}` : text
+    : formatDocForEmbedding;
 
   // Create a session manager for this llm instance
   const result = await withLLMSessionForLlm(llm, async (session) => {
@@ -1370,7 +1375,7 @@ export async function generateEmbeddings(
 
       if (!vectorTableInitialized) {
         const firstChunk = batchChunks[0]!;
-        const firstText = formatDocForEmbedding(firstChunk.text, firstChunk.title);
+        const firstText = formatDoc(firstChunk.text, firstChunk.title);
         const firstResult = await session.embed(firstText);
         if (!firstResult) {
           throw new Error("Failed to get embedding dimensions from first chunk");
@@ -1385,7 +1390,7 @@ export async function generateEmbeddings(
       for (let batchStart = 0; batchStart < batchChunks.length; batchStart += BATCH_SIZE) {
         const batchEnd = Math.min(batchStart + BATCH_SIZE, batchChunks.length);
         const chunkBatch = batchChunks.slice(batchStart, batchEnd);
-        const texts = chunkBatch.map(chunk => formatDocForEmbedding(chunk.text, chunk.title));
+        const texts = chunkBatch.map(chunk => formatDoc(chunk.text, chunk.title));
 
         try {
           const embeddings = await session.embedBatch(texts);
@@ -1404,7 +1409,7 @@ export async function generateEmbeddings(
           // Batch failed — try individual embeddings as fallback
           for (const chunk of chunkBatch) {
             try {
-              const text = formatDocForEmbedding(chunk.text, chunk.title);
+              const text = formatDoc(chunk.text, chunk.title);
               const result = await session.embed(text);
               if (result) {
                 insertEmbedding(db, chunk.hash, chunk.seq, chunk.pos, new Float32Array(result.embedding), model, now);
@@ -2907,12 +2912,14 @@ export async function searchVec(db: Database, query: string, model: string, limi
 // Embeddings
 // =============================================================================
 
-async function getEmbedding(text: string, model: string, isQuery: boolean, session?: ILLMSession, llmOverride?: LlamaCpp): Promise<number[] | null> {
-  // Format text using the appropriate prompt template
-  const formattedText = isQuery ? formatQueryForEmbedding(text, model) : formatDocForEmbedding(text, undefined, model);
+async function getEmbedding(text: string, model: string, isQuery: boolean, session?: ILLMSession, llmOverride?: LLM): Promise<number[] | null> {
+  const llm = llmOverride ?? getDefaultLLM();
+  const formattedText = llm.isRemote
+    ? text
+    : isQuery ? formatQueryForEmbedding(text, model) : formatDocForEmbedding(text, undefined, model);
   const result = session
     ? await session.embed(formattedText, { model, isQuery })
-    : await (llmOverride ?? getDefaultLlamaCpp()).embed(formattedText, { model, isQuery });
+    : await llm.embed(formattedText, { model, isQuery });
   return result?.embedding || null;
 }
 
@@ -2965,7 +2972,7 @@ export function insertEmbedding(
 // Query expansion
 // =============================================================================
 
-export async function expandQuery(query: string, model: string = DEFAULT_QUERY_MODEL, db: Database, intent?: string, llmOverride?: LlamaCpp): Promise<ExpandedQuery[]> {
+export async function expandQuery(query: string, model: string = DEFAULT_QUERY_MODEL, db: Database, intent?: string, llmOverride?: LLM): Promise<ExpandedQuery[]> {
   // Check cache first — stored as JSON preserving types
   const cacheKey = getCacheKey("expandQuery", { query, model, ...(intent && { intent }) });
   const cached = getCachedResult(db, cacheKey);
@@ -2983,7 +2990,7 @@ export async function expandQuery(query: string, model: string = DEFAULT_QUERY_M
     }
   }
 
-  const llm = llmOverride ?? getDefaultLlamaCpp();
+  const llm = llmOverride ?? getDefaultLLM();
   // Note: LlamaCpp uses hardcoded model, model parameter is ignored
   const results = await llm.expandQuery(query, { intent });
 
@@ -3004,7 +3011,7 @@ export async function expandQuery(query: string, model: string = DEFAULT_QUERY_M
 // Reranking
 // =============================================================================
 
-export async function rerank(query: string, documents: { file: string; text: string }[], model: string = DEFAULT_RERANK_MODEL, db: Database, intent?: string, llmOverride?: LlamaCpp): Promise<{ file: string; score: number }[]> {
+export async function rerank(query: string, documents: { file: string; text: string }[], model: string = DEFAULT_RERANK_MODEL, db: Database, intent?: string, llmOverride?: LLM): Promise<{ file: string; score: number }[]> {
   // Prepend intent to rerank query so the reranker scores with domain context
   const rerankQuery = intent ? `${intent}\n\n${query}` : query;
 
@@ -3029,7 +3036,7 @@ export async function rerank(query: string, documents: { file: string; text: str
 
   // Rerank uncached documents using LlamaCpp
   if (uncachedDocsByChunk.size > 0) {
-    const llm = llmOverride ?? getDefaultLlamaCpp();
+    const llm = llmOverride ?? getDefaultLLM();
     const uncachedDocs = [...uncachedDocsByChunk.values()];
     const rerankResult = await llm.rerank(rerankQuery, uncachedDocs, { model });
 
@@ -3797,7 +3804,9 @@ export async function hybridQuery(
 
     // Batch embed all vector queries in a single call
     const llm = getLlm(store);
-    const textsToEmbed = vecQueries.map(q => formatQueryForEmbedding(q.text));
+    const textsToEmbed = llm.isRemote
+      ? vecQueries.map(q => q.text)
+      : vecQueries.map(q => formatQueryForEmbedding(q.text));
     hooks?.onEmbedStart?.(textsToEmbed.length);
     const embedStart = Date.now();
     const embeddings = await llm.embedBatch(textsToEmbed);
@@ -4178,7 +4187,9 @@ export async function structuredSearch(
     );
     if (vecSearches.length > 0) {
       const llm = getLlm(store);
-      const textsToEmbed = vecSearches.map(s => formatQueryForEmbedding(s.query));
+      const textsToEmbed = llm.isRemote
+        ? vecSearches.map(s => s.query)
+        : vecSearches.map(s => formatQueryForEmbedding(s.query));
       hooks?.onEmbedStart?.(textsToEmbed.length);
       const embedStart = Date.now();
       const embeddings = await llm.embedBatch(textsToEmbed);

--- a/test/remote-llm.test.ts
+++ b/test/remote-llm.test.ts
@@ -1,0 +1,351 @@
+import http from "node:http";
+import { afterAll, afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { LLM } from "../src/llm.js";
+import { HybridLLM } from "../src/hybrid-llm.js";
+import { RemoteLLM } from "../src/remote-llm.js";
+
+type RecordedRequest = {
+  path: string;
+  method: string;
+  headers: http.IncomingHttpHeaders;
+  body: any;
+};
+
+async function createServer(
+  handler: (req: http.IncomingMessage, res: http.ServerResponse, body: any, requests: RecordedRequest[]) => void,
+): Promise<{ server: http.Server; baseUrl: string; requests: RecordedRequest[] }> {
+  const requests: RecordedRequest[] = [];
+  const server = http.createServer((req, res) => {
+    let raw = "";
+    req.on("data", (chunk) => {
+      raw += chunk;
+    });
+    req.on("end", () => {
+      const body = raw ? JSON.parse(raw) : {};
+      requests.push({
+        path: req.url ?? "",
+        method: req.method ?? "GET",
+        headers: req.headers,
+        body,
+      });
+      handler(req, res, body, requests);
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address !== "object") {
+    throw new Error("Failed to get server address");
+  }
+
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    requests,
+  };
+}
+
+function createLocalLLM(overrides: Partial<LLM> = {}): LLM {
+  return {
+    embed: async () => ({ embedding: [0.1], model: "local" }),
+    embedBatch: async (texts) => texts.map(() => ({ embedding: [0.1], model: "local" })),
+    generate: async () => ({ text: "local-generated", model: "local", done: true }),
+    modelExists: async (model) => ({ name: model, exists: true }),
+    expandQuery: async () => [{ type: "vec", text: "expanded-local" }],
+    rerank: async (_query, documents) => ({
+      results: documents.map((document, index) => ({ file: document.file, score: 1 - index * 0.1, index })),
+      model: "local",
+    }),
+    dispose: async () => {},
+    ...overrides,
+  };
+}
+
+const serversToClose: http.Server[] = [];
+
+afterAll(async () => {
+  await Promise.all(serversToClose.map((server) => new Promise<void>((resolve) => server.close(() => resolve()))));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("RemoteLLM", () => {
+  beforeEach(() => {
+    delete process.env.QMD_REMOTE_EMBED_URL;
+    delete process.env.QMD_REMOTE_RERANK_URL;
+    delete process.env.QMD_REMOTE_API_KEY;
+    delete process.env.QMD_REMOTE_CONNECT_TIMEOUT;
+    delete process.env.QMD_REMOTE_READ_TIMEOUT;
+  });
+
+  test("uses separate embed and rerank URLs", async () => {
+    const embedServer = await createServer((_req, res, body) => {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({
+        data: (body.input as string[]).map((_: string, index: number) => ({ index, embedding: [0.1, 0.2, 0.3] })),
+        model: body.model,
+      }));
+    });
+    const rerankServer = await createServer((_req, res, body) => {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({
+        results: (body.documents as string[]).map((_: string, index: number) => ({ index, relevance_score: 1 - index * 0.1 })),
+        model: body.model,
+      }));
+    });
+    serversToClose.push(embedServer.server, rerankServer.server);
+
+    const remote = new RemoteLLM({
+      embedUrl: embedServer.baseUrl,
+      rerankUrl: rerankServer.baseUrl,
+      embedModel: "embed-model",
+      rerankModel: "rerank-model",
+    });
+
+    await remote.embed("hello");
+    await remote.rerank("query", [{ file: "a.md", text: "doc-a" }]);
+
+    expect(embedServer.requests).toHaveLength(1);
+    expect(embedServer.requests[0]?.path).toBe("/v1/embeddings");
+    expect(rerankServer.requests).toHaveLength(1);
+    expect(rerankServer.requests[0]?.path).toBe("/v1/rerank");
+  });
+
+  test("adds Qwen instruct prefix for query embeddings and strips legacy prefixes", async () => {
+    let lastInput: string[] = [];
+    const embedServer = await createServer((_req, res, body) => {
+      lastInput = body.input;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({
+        data: [{ index: 0, embedding: [0.1, 0.2, 0.3] }],
+        model: body.model,
+      }));
+    });
+    const rerankServer = await createServer((_req, res) => {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ results: [] }));
+    });
+    serversToClose.push(embedServer.server, rerankServer.server);
+
+    const remote = new RemoteLLM({
+      embedUrl: embedServer.baseUrl,
+      rerankUrl: rerankServer.baseUrl,
+      embedModel: "Qwen3-Embedding-8B",
+    });
+
+    await remote.embed("task: search result | query: cats", { isQuery: true });
+    expect(lastInput).toEqual(["Instruct: Retrieve relevant documents for the given query\nQuery: cats"]);
+  });
+
+  test("locks embedding dimension and throws on mismatch", async () => {
+    let callCount = 0;
+    const embedServer = await createServer((_req, res) => {
+      callCount += 1;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({
+        data: [{ index: 0, embedding: callCount === 1 ? [1, 2, 3] : [1, 2, 3, 4] }],
+      }));
+    });
+    const rerankServer = await createServer((_req, res) => {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ results: [] }));
+    });
+    serversToClose.push(embedServer.server, rerankServer.server);
+
+    const remote = new RemoteLLM({
+      embedUrl: embedServer.baseUrl,
+      rerankUrl: rerankServer.baseUrl,
+    });
+
+    await remote.embed("first");
+    await expect(remote.embed("second")).rejects.toThrow("Embedding dimension mismatch");
+  });
+
+  test("opens the embed circuit after two failures and keeps rerank circuit independent", async () => {
+    let embedHits = 0;
+    const embedServer = await createServer((_req, res) => {
+      embedHits += 1;
+      res.statusCode = 500;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ error: "embed failed" }));
+    });
+    const rerankServer = await createServer((_req, res, body) => {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({
+        results: (body.documents as string[]).map((_: string, index: number) => ({ index, relevance_score: 0.9 - index * 0.1 })),
+      }));
+    });
+    serversToClose.push(embedServer.server, rerankServer.server);
+
+    const remote = new RemoteLLM({
+      embedUrl: embedServer.baseUrl,
+      rerankUrl: rerankServer.baseUrl,
+      breakerCooldownMs: 50,
+    });
+
+    await expect(remote.embed("first")).rejects.toThrow("HTTP 500");
+    await expect(remote.embed("second")).rejects.toThrow("HTTP 500");
+    await expect(remote.embed("third")).rejects.toThrow("circuit-breaker cooldown");
+    expect(embedHits).toBe(2);
+
+    const rerank = await remote.rerank("query", [{ file: "a.md", text: "doc-a" }]);
+    expect(rerank.results[0]?.file).toBe("a.md");
+  });
+
+  test("retries after cooldown in half-open state", async () => {
+    let callCount = 0;
+    const embedServer = await createServer((_req, res) => {
+      callCount += 1;
+      res.setHeader("content-type", "application/json");
+      if (callCount <= 2) {
+        res.statusCode = 500;
+        res.end(JSON.stringify({ error: "boom" }));
+        return;
+      }
+      res.end(JSON.stringify({
+        data: [{ index: 0, embedding: [0.1, 0.2, 0.3] }],
+      }));
+    });
+    const rerankServer = await createServer((_req, res) => {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ results: [] }));
+    });
+    serversToClose.push(embedServer.server, rerankServer.server);
+
+    const remote = new RemoteLLM({
+      embedUrl: embedServer.baseUrl,
+      rerankUrl: rerankServer.baseUrl,
+      breakerCooldownMs: 20,
+    });
+
+    await expect(remote.embed("first")).rejects.toThrow();
+    await expect(remote.embed("second")).rejects.toThrow();
+    await expect(remote.embed("third")).rejects.toThrow("circuit-breaker cooldown");
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    const result = await remote.embed("fourth");
+    expect(result?.embedding).toHaveLength(3);
+    expect(callCount).toBe(3);
+  });
+
+  test("uses Authorization header when api key is configured", async () => {
+    const embedServer = await createServer((_req, res, body) => {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({
+        data: (body.input as string[]).map((_: string, index: number) => ({ index, embedding: [0.1, 0.2, 0.3] })),
+      }));
+    });
+    const rerankServer = await createServer((_req, res) => {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ results: [] }));
+    });
+    serversToClose.push(embedServer.server, rerankServer.server);
+
+    const remote = new RemoteLLM({
+      embedUrl: embedServer.baseUrl,
+      rerankUrl: rerankServer.baseUrl,
+      apiKey: "secret-token",
+    });
+
+    await remote.embed("hello");
+    expect(embedServer.requests[0]?.headers.authorization).toBe("Bearer secret-token");
+  });
+
+  test("enforces connect timeout", async () => {
+    const fetchStub = vi.fn(async (_url: string, init?: RequestInit) => {
+      const signal = init?.signal as AbortSignal | undefined;
+      return await new Promise<Response>((resolve, reject) => {
+        signal?.addEventListener("abort", () => reject(signal.reason));
+        void resolve;
+      });
+    });
+    vi.stubGlobal("fetch", fetchStub);
+
+    const remote = new RemoteLLM({
+      embedUrl: "http://example.com",
+      rerankUrl: "http://example.com",
+      connectTimeoutMs: 20,
+      readTimeoutMs: 100,
+    });
+
+    await expect(remote.embed("hello")).rejects.toThrow("connect timeout after 20ms");
+  });
+
+  test("enforces read timeout", async () => {
+    const fetchStub = vi.fn(async () => new Response(null, {
+      status: 200,
+    }));
+
+    const responseTextSpy = vi.spyOn(Response.prototype, "text").mockImplementation(async () => {
+      return await new Promise<string>(() => {});
+    });
+
+    vi.stubGlobal("fetch", fetchStub);
+
+    const remote = new RemoteLLM({
+      embedUrl: "http://example.com",
+      rerankUrl: "http://example.com",
+      connectTimeoutMs: 50,
+      readTimeoutMs: 20,
+    });
+
+    await expect(remote.embed("hello")).rejects.toThrow("read timeout after 20ms");
+    responseTextSpy.mockRestore();
+  });
+});
+
+describe("HybridLLM", () => {
+  test("routes embed and rerank to remote, generate and expansion to local", async () => {
+    const calls = {
+      localGenerate: 0,
+      localExpand: 0,
+      remoteEmbed: 0,
+      remoteRerank: 0,
+    };
+
+    const local = createLocalLLM({
+      generate: async () => {
+        calls.localGenerate += 1;
+        return { text: "local-generated", model: "local", done: true };
+      },
+      expandQuery: async () => {
+        calls.localExpand += 1;
+        return [{ type: "vec", text: "expanded-local" }];
+      },
+    });
+
+    const remote = createLocalLLM({
+      isRemote: true,
+      embed: async () => {
+        calls.remoteEmbed += 1;
+        return { embedding: [1, 2, 3], model: "remote-embed" };
+      },
+      embedBatch: async (texts) => {
+        calls.remoteEmbed += texts.length;
+        return texts.map(() => ({ embedding: [1, 2, 3], model: "remote-embed" }));
+      },
+      rerank: async (_query, documents) => {
+        calls.remoteRerank += 1;
+        return {
+          results: documents.map((document, index) => ({ file: document.file, score: 1 - index * 0.1, index })),
+          model: "remote-rerank",
+        };
+      },
+    });
+
+    const hybrid = new HybridLLM(local, remote);
+
+    expect((await hybrid.embed("hello"))?.model).toBe("remote-embed");
+    expect((await hybrid.generate("prompt"))?.text).toBe("local-generated");
+    expect((await hybrid.expandQuery("query"))[0]?.text).toBe("expanded-local");
+    expect((await hybrid.rerank("query", [{ file: "a.md", text: "doc-a" }])).model).toBe("remote-rerank");
+
+    expect(calls.remoteEmbed).toBe(1);
+    expect(calls.remoteRerank).toBe(1);
+    expect(calls.localGenerate).toBe(1);
+    expect(calls.localExpand).toBe(1);
+  });
+});


### PR DESCRIPTION
## Motivation

On machines with limited VRAM (e.g. 16GB unified memory MacBooks), loading embedding + reranking models locally via node-llama-cpp is slow with long cold-start times. Meanwhile, a separate GPU machine (e.g. a PC with RTX 5090) can serve these models via `llama-server` with near-instant response over a local network.

This PR adds native support for offloading embedding and reranking to remote OpenAI-compatible API servers, while keeping query expansion running locally (since it uses a QMD fine-tuned model).

## Relation to #415

PR #415 by @shyuan introduced a similar concept. This PR builds on the same direction but addresses several limitations:

| Feature | #415 | This PR |
|---------|------|---------|
| URL configuration | Single `QMD_REMOTE_URL` | Separate `QMD_REMOTE_EMBED_URL` + `QMD_REMOTE_RERANK_URL` |
| Multi-host deployment | ❌ | ✅ (embed and rerank on different servers/ports) |
| Circuit breaker | ❌ | ✅ Per-endpoint (2 failures → 10min cooldown → half-open retry) |
| Dimension validation | ❌ | ✅ First response locks expected dimensions |
| Connect timeout | ❌ | ✅ `QMD_REMOTE_CONNECT_TIMEOUT` (default 500ms) |
| Read timeout | ❌ | ✅ `QMD_REMOTE_READ_TIMEOUT` (default 10000ms) |
| Error handling | Returns score=0 on failure | Throws immediately (no silent degradation) |
| Qwen3 instruct format | ❌ | ✅ Auto-detects and injects instruct prefix |

## Summary of changes

- **`src/remote-llm.ts`** — `RemoteLLM` class: HTTP calls to OpenAI-compatible `/v1/embeddings` and `/v1/rerank` endpoints, with per-endpoint circuit breaker, dimension locking, configurable timeouts, and Qwen3 instruct formatting
- **`src/hybrid-llm.ts`** — `HybridLLM` class: routes embed/rerank → remote, generate/expandQuery → local LlamaCpp
- **`src/llm.ts`** — Extended `LLM` interface to support generic default instances (not just `LlamaCpp`)
- **`src/store.ts`** — Decoupled from `LlamaCpp` concrete type
- **`src/cli/qmd.ts`** — Env var detection + HybridLLM initialization
- **`test/remote-llm.test.ts`** — Tests covering remote calls, circuit breaker, dimension validation, Qwen3 formatting, timeouts

## Environment variables

```bash
QMD_REMOTE_EMBED_URL=http://host:8080     # Remote embedding server
QMD_REMOTE_RERANK_URL=http://host:8081     # Remote reranker (can differ from embed)
QMD_REMOTE_API_KEY=optional                # Bearer token auth
QMD_REMOTE_CONNECT_TIMEOUT=500             # Connect timeout ms (default 500)
QMD_REMOTE_READ_TIMEOUT=10000              # Read timeout ms (default 10000)
```

No env vars set = behavior completely unchanged (pure local).

## Tested with

- Two `llama-server` instances on PC (RTX 5090) serving Qwen3-Embedding-8B (Q8_0) and Qwen3-Reranker-4B (Q8_0) over 10GbE
- `qmd query` end-to-end: local query expansion → remote embedding (189ms) → remote reranking (837ms)
- Circuit breaker: service down → 2 failures → open state → 10min cooldown → half-open recovery
- `npm run build` passes
- `npx vitest run test/remote-llm.test.ts` passes
- No regressions in existing tests