### PR TITLE
fix(embed): handle vec0 OR REPLACE limitation in insertEmbedding

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -2943,6 +2943,12 @@ export function clearAllEmbeddings(db: Database): void {
 /**
  * Insert a single embedding into both content_vectors and vectors_vec tables.
  * The hash_seq key is formatted as "hash_seq" for the vectors_vec table.
+ *
+ * content_vectors is inserted first so that getHashesForEmbedding (which checks
+ * only content_vectors) won't re-select the hash on a crash between the two inserts.
+ *
+ * vectors_vec uses DELETE + INSERT instead of INSERT OR REPLACE because sqlite-vec's
+ * vec0 virtual tables silently ignore the OR REPLACE conflict clause.
  */
 export function insertEmbedding(
   db: Database,
@@ -2954,11 +2960,16 @@ export function insertEmbedding(
   embeddedAt: string
 ): void {
   const hashSeq = `${hash}_${seq}`;
-  const insertVecStmt = db.prepare(`INSERT OR REPLACE INTO vectors_vec (hash_seq, embedding) VALUES (?, ?)`);
-  const insertContentVectorStmt = db.prepare(`INSERT OR REPLACE INTO content_vectors (hash, seq, pos, model, embedded_at) VALUES (?, ?, ?, ?, ?)`);
 
-  insertVecStmt.run(hashSeq, embedding);
+  // Insert content_vectors first — crash-safe ordering (see getHashesForEmbedding)
+  const insertContentVectorStmt = db.prepare(`INSERT OR REPLACE INTO content_vectors (hash, seq, pos, model, embedded_at) VALUES (?, ?, ?, ?, ?)`);
   insertContentVectorStmt.run(hash, seq, pos, model, embeddedAt);
+
+  // vec0 virtual tables don't support OR REPLACE — use DELETE + INSERT
+  const deleteVecStmt = db.prepare(`DELETE FROM vectors_vec WHERE hash_seq = ?`);
+  const insertVecStmt = db.prepare(`INSERT INTO vectors_vec (hash_seq, embedding) VALUES (?, ?)`);
+  deleteVecStmt.run(hashSeq);
+  insertVecStmt.run(hashSeq, embedding);
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Fixes #445 — `insertEmbedding` uses `INSERT OR REPLACE` for the `vectors_vec` table, but sqlite-vec's `vec0` virtual tables silently ignore the `OR REPLACE` clause. A crash mid-embed leaves orphan rows in `vectors_vec` without corresponding `content_vectors` entries, causing `UNIQUE constraint failed` errors on re-embed.

## Changes

- **Insert `content_vectors` first** so `getHashesForEmbedding` (which checks only `content_vectors`) won't re-select the hash if a crash occurs between the two inserts.
- **Use `DELETE` + `INSERT` for `vectors_vec`** instead of `INSERT OR REPLACE`, since vec0 doesn't honor the conflict clause.

## Test plan

- All 706 existing tests pass (vitest, Node.js + macOS).
- The fix is a minimal reorder + statement change in a single function — no new APIs or schema changes.

Built with Claude Code.