### PR TITLE
fix: respect XDG_CACHE_HOME for model cache directory

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -209,7 +209,9 @@ export const DEFAULT_RERANK_MODEL_URI = DEFAULT_RERANK_MODEL;
 export const DEFAULT_GENERATE_MODEL_URI = DEFAULT_GENERATE_MODEL;
 
 // Local model cache directory
-const MODEL_CACHE_DIR = join(homedir(), ".cache", "qmd", "models");
+const MODEL_CACHE_DIR = process.env.XDG_CACHE_HOME
+  ? join(process.env.XDG_CACHE_HOME, "qmd", "models")
+  : join(homedir(), ".cache", "qmd", "models");
 export const DEFAULT_MODEL_CACHE_DIR = MODEL_CACHE_DIR;
 
 export type PullResult = {


### PR DESCRIPTION
## Summary

`MODEL_CACHE_DIR` in `src/llm.ts` was hardcoded to `~/.cache/qmd/models/`, ignoring `XDG_CACHE_HOME`. The rest of the codebase (`store.ts`, `cli/qmd.ts`) already respects this environment variable. This one-line fix aligns model cache with the existing XDG pattern.

Fixes #425

## Changes

- `src/llm.ts`: Use `process.env.XDG_CACHE_HOME` when set, falling back to `~/.cache/qmd/models/` — same ternary pattern used in `cli/qmd.ts:333` and `cli/qmd.ts:3024`.

## Test plan

- [x] All 706 tests pass locally (vitest, Node.js)
- [x] Verified the fix follows the exact same pattern as existing XDG usage in `cli/qmd.ts`
- [x] Default behavior unchanged when `XDG_CACHE_HOME` is unset

Built with Claude Code (claude-opus-4-6).