### PR TITLE
feat(update): add --exclude flag and resilient file reads

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -494,10 +494,17 @@ async function showStatus(): Promise<void> {
   closeDb();
 }
 
-async function updateCollections(collectionFilter?: string[]): Promise<void> {
+async function updateCollections(collectionFilter?: string[], excludeFilter?: string[]): Promise<void> {
   const db = getDb();
   const storeInstance = getStore();
   // Collections are defined in YAML; no duplicate cleanup needed.
+
+  // Validate mutual exclusivity of -c and --exclude
+  if (collectionFilter && collectionFilter.length > 0 && excludeFilter && excludeFilter.length > 0) {
+    console.error(`${c.yellow}Error: -c/--collection and --exclude are mutually exclusive.${c.reset}`);
+    closeDb();
+    process.exit(1);
+  }
 
   // Clear Ollama cache on update
   clearCache(db);
@@ -506,12 +513,24 @@ async function updateCollections(collectionFilter?: string[]): Promise<void> {
 
   // Filter by collection names if specified
   if (collectionFilter && collectionFilter.length > 0) {
-    collections = collections.filter(c => collectionFilter.includes(c.name));
+    collections = collections.filter(col => collectionFilter.includes(col.name));
     if (collections.length === 0) {
-      console.log(`${c.dim}No matching collections found. Available: ${listCollections(db).map(c => c.name).join(', ')}${c.reset}`);
+      console.log(`${c.dim}No matching collections found. Available: ${listCollections(db).map(col => col.name).join(', ')}${c.reset}`);
       closeDb();
       return;
     }
+  }
+
+  // Exclude collections by name if specified
+  if (excludeFilter && excludeFilter.length > 0) {
+    const before = collections.length;
+    collections = collections.filter(col => !excludeFilter.includes(col.name));
+    if (collections.length === 0) {
+      console.log(`${c.dim}All collections were excluded. Available: ${listCollections(db).map(col => col.name).join(', ')}${c.reset}`);
+      closeDb();
+      return;
+    }
+    console.log(`${c.dim}Excluded ${before - collections.length} collection(s): ${excludeFilter.join(', ')}${c.reset}\n`);
   }
 
   if (collections.length === 0) {
@@ -583,6 +602,12 @@ async function updateCollections(collectionFilter?: string[]): Promise<void> {
     console.log(`\nIndexed: ${result.indexed} new, ${result.updated} updated, ${result.unchanged} unchanged, ${result.removed} removed`);
     if (result.orphanedCleaned > 0) {
       console.log(`Cleaned up ${result.orphanedCleaned} orphaned content hash(es)`);
+    }
+    if (result.skippedFiles && result.skippedFiles.length > 0) {
+      console.log(`${c.yellow}Skipped ${result.skippedFiles.length} file(s) due to read errors:${c.reset}`);
+      for (const skipped of result.skippedFiles) {
+        console.log(`  ${c.dim}- ${skipped}${c.reset}`);
+      }
     }
     console.log("");
   }
@@ -1517,6 +1542,7 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
 
   let indexed = 0, updated = 0, unchanged = 0, processed = 0;
   const seenPaths = new Set<string>();
+  const skippedFiles: string[] = [];
   const startTime = Date.now();
 
   for (const relativeFile of files) {
@@ -1528,7 +1554,10 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
     try {
       content = readFileSync(filepath, "utf-8");
     } catch (err: any) {
-      // Skip files that can't be read (e.g. iCloud evicted files returning EAGAIN)
+      // Skip files that can't be read (e.g. iCloud evicted, ETIMEDOUT, ENOENT)
+      const code = err?.code || "UNKNOWN";
+      process.stderr.write(`\n  warning: Skipped ${relativeFile}: ${code}\n`);
+      skippedFiles.push(relativeFile);
       processed++;
       progress.set((processed / total) * 100);
       continue;
@@ -1602,6 +1631,12 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
   console.log(`\nIndexed: ${indexed} new, ${updated} updated, ${unchanged} unchanged, ${removed} removed`);
   if (orphanedContent > 0) {
     console.log(`Cleaned up ${orphanedContent} orphaned content hash(es)`);
+  }
+  if (skippedFiles.length > 0) {
+    console.log(`${c.yellow}Skipped ${skippedFiles.length} file(s) due to read errors:${c.reset}`);
+    for (const skipped of skippedFiles) {
+      console.log(`  ${c.dim}- ${skipped}${c.reset}`);
+    }
   }
 
   if (needsEmbedding > 0 && !suppressEmbedNotice) {
@@ -2372,6 +2407,7 @@ function parseCLI() {
       "max-batch-mb": { type: "string" },
       // Update options
       pull: { type: "boolean" },  // git pull before update
+      exclude: { type: "string", multiple: true },  // Exclude collection(s) from update
       refresh: { type: "boolean" },
       // Get options
       l: { type: "string" },  // max lines
@@ -2584,6 +2620,8 @@ function showHelp(): void {
   console.log("Maintenance:");
   console.log("  qmd status                    - View index + collection health");
   console.log("  qmd update [--pull]           - Re-index collections (optionally git pull first)");
+  console.log("    -c, --collection <name>     - Update only named collection(s) (repeatable)");
+  console.log("    --exclude <name>            - Update all EXCEPT named collection(s) (repeatable)");
   console.log("  qmd embed [-f]                - Generate/refresh vector embeddings");
   console.log("    --max-docs-per-batch <n>    - Cap docs loaded into memory per embedding batch");
   console.log("    --max-batch-mb <n>          - Cap UTF-8 MB loaded into memory per embedding batch");
@@ -2960,7 +2998,10 @@ if (isMain) {
       break;
 
     case "update":
-      await updateCollections(cli.opts.collection);
+      await updateCollections(
+        cli.opts.collection ? (Array.isArray(cli.opts.collection) ? cli.opts.collection : [cli.opts.collection]) : undefined,
+        cli.values.exclude as string[] | undefined,
+      );
       break;
 
     case "embed":

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -494,7 +494,7 @@ async function showStatus(): Promise<void> {
   closeDb();
 }
 
-async function updateCollections(): Promise<void> {
+async function updateCollections(collectionFilter?: string[]): Promise<void> {
   const db = getDb();
   const storeInstance = getStore();
   // Collections are defined in YAML; no duplicate cleanup needed.
@@ -502,7 +502,17 @@ async function updateCollections(): Promise<void> {
   // Clear Ollama cache on update
   clearCache(db);
 
-  const collections = listCollections(db);
+  let collections = listCollections(db);
+
+  // Filter by collection names if specified
+  if (collectionFilter && collectionFilter.length > 0) {
+    collections = collections.filter(c => collectionFilter.includes(c.name));
+    if (collections.length === 0) {
+      console.log(`${c.dim}No matching collections found. Available: ${listCollections(db).map(c => c.name).join(', ')}${c.reset}`);
+      closeDb();
+      return;
+    }
+  }
 
   if (collections.length === 0) {
     console.log(`${c.dim}No collections found. Run 'qmd collection add .' to index markdown files.${c.reset}`);
@@ -2950,7 +2960,7 @@ if (isMain) {
       break;
 
     case "update":
-      await updateCollections();
+      await updateCollections(cli.opts.collection);
       break;
 
     case "embed":

--- a/src/store.ts
+++ b/src/store.ts
@@ -1069,6 +1069,7 @@ export type ReindexResult = {
   unchanged: number;
   removed: number;
   orphanedCleaned: number;
+  skippedFiles: string[];
 };
 
 /**
@@ -1109,6 +1110,7 @@ export async function reindexCollection(
   const total = files.length;
   let indexed = 0, updated = 0, unchanged = 0, processed = 0;
   const seenPaths = new Set<string>();
+  const skippedFiles: string[] = [];
 
   for (const relativeFile of files) {
     const filepath = getRealPath(resolve(collectionPath, relativeFile));
@@ -1118,7 +1120,16 @@ export async function reindexCollection(
     let content: string;
     try {
       content = readFileSync(filepath, "utf-8");
-    } catch {
+    } catch (err: any) {
+      const code = err?.code || "UNKNOWN";
+      const msg = `Skipped ${relativeFile}: ${code} (${err?.message || "unknown error"})`;
+      if (code === "ETIMEDOUT" || code === "ENOENT" || code === "EAGAIN" || code === "EPERM") {
+        // Expected transient/access errors — warn and continue
+        process.stderr.write(`\n  warning: ${msg}\n`);
+      } else {
+        process.stderr.write(`\n  warning: ${msg}\n`);
+      }
+      skippedFiles.push(relativeFile);
       processed++;
       options?.onProgress?.({ file: relativeFile, current: processed, total });
       continue;
@@ -1174,7 +1185,7 @@ export async function reindexCollection(
 
   const orphanedCleaned = cleanupOrphanedContent(db);
 
-  return { indexed, updated, unchanged, removed, orphanedCleaned };
+  return { indexed, updated, unchanged, removed, orphanedCleaned, skippedFiles };
 }
 
 export type EmbedProgress = {


### PR DESCRIPTION
## Summary

Two small improvements to `qmd update`:

### 1. `--exclude` flag (fixes #459)
Inverse of `-c` — update all collections except named ones:
```bash
qmd update --exclude openclaw-docs
qmd update --exclude openclaw-docs --exclude pwm-reading
```
Mutually exclusive with `-c` (errors if both provided).

### 2. Resilient file reads (fixes #460)
Wraps `readFileSync` in try/catch during indexing. On ETIMEDOUT/ENOENT/EAGAIN:
- Logs warning with filename and error code
- Skips the file and continues indexing
- Reports skipped files at end of collection update

Applies to both `reindexCollection()` (update path) and `indexFiles()` (collection add path).

## Changes
- `src/cli/qmd.ts` — CLI option parsing, `updateCollections`, `indexFiles`, help text
- `src/store.ts` — `ReindexResult` type, `reindexCollection` error handling

## Test plan
- `qmd update --exclude <collection>` updates all except named
- `qmd update -c foo --exclude bar` errors with mutual exclusivity message
- File with ETIMEDOUT is skipped, remaining files indexed, summary reported
- `qmd update` with no flags still updates all (backward compatible)