### PR TITLE
feat: add --follow-symlinks option for collection indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,9 @@ qmd collection add . --name myproject
 # Create a collection with explicit path and custom glob mask
 qmd collection add ~/Documents/notes --name notes --mask "**/*.md"
 
+# Follow symbolic links when indexing (e.g. for vaults with symlinked folders)
+qmd collection add ~/vault --name vault --follow-symlinks
+
 # List all collections
 qmd collection list
 

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -2909,6 +2909,9 @@ if (isMain) {
           console.log(`  Path:     ${col.path}`);
           console.log(`  Pattern:  ${col.pattern}`);
           console.log(`  Include:  ${col.includeByDefault !== false ? 'yes (default)' : 'no'}`);
+          if (col.follow_symlinks) {
+            console.log(`  Symlinks: follow`);
+          }
           if (col.update) {
             console.log(`  Update:   ${col.update}`);
           }

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -559,6 +559,7 @@ async function updateCollections(): Promise<void> {
 
     const result = await reindexCollection(storeInstance, col.pwd, col.glob_pattern, col.name, {
       ignorePatterns: yamlCol?.ignore,
+      followSymlinks: yamlCol?.follow_symlinks,
       onProgress: (info) => {
         progress.set((info.current / info.total) * 100);
         const elapsed = (Date.now() - startTime) / 1000;
@@ -1374,7 +1375,7 @@ function collectionList(): void {
   closeDb();
 }
 
-async function collectionAdd(pwd: string, globPattern: string, name?: string): Promise<void> {
+async function collectionAdd(pwd: string, globPattern: string, name?: string, followSymlinks?: boolean): Promise<void> {
   // If name not provided, generate from pwd basename
   let collName = name;
   if (!collName) {
@@ -1404,13 +1405,13 @@ async function collectionAdd(pwd: string, globPattern: string, name?: string): P
 
   // Add to YAML config + sync to SQLite
   const { addCollection } = await import("../collections.js");
-  addCollection(collName, pwd, globPattern);
+  addCollection(collName, pwd, globPattern, { follow_symlinks: followSymlinks });
   resyncConfig();
 
   // Create the collection and index files
   console.log(`Creating collection '${collName}'...`);
   const newColl = getCollectionFromYaml(collName);
-  await indexFiles(pwd, globPattern, collName, false, newColl?.ignore);
+  await indexFiles(pwd, globPattern, collName, false, newColl?.ignore, followSymlinks);
   console.log(`${c.green}✓${c.reset} Collection '${collName}' created successfully`);
 }
 
@@ -1463,7 +1464,7 @@ function collectionRename(oldName: string, newName: string): void {
   console.log(`  Virtual paths updated: ${c.cyan}qmd://${oldName}/${c.reset} → ${c.cyan}qmd://${newName}/${c.reset}`);
 }
 
-async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, collectionName?: string, suppressEmbedNotice: boolean = false, ignorePatterns?: string[]): Promise<void> {
+async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, collectionName?: string, suppressEmbedNotice: boolean = false, ignorePatterns?: string[], followSymlinks?: boolean): Promise<void> {
   const db = getDb();
   const resolvedPwd = pwd || getPwd();
   const now = new Date().toISOString();
@@ -1487,7 +1488,7 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
   const allFiles: string[] = await fastGlob(globPattern, {
     cwd: resolvedPwd,
     onlyFiles: true,
-    followSymbolicLinks: false,
+    followSymbolicLinks: followSymlinks ?? false,
     dot: false,
     ignore: allIgnore,
   });
@@ -2356,6 +2357,7 @@ function parseCLI() {
       // Collection options
       name: { type: "string" },  // collection name
       mask: { type: "string" },  // glob pattern
+      "follow-symlinks": { type: "boolean" },  // follow symbolic links when scanning
       // Embed options
       force: { type: "boolean", short: "f" },
       "max-docs-per-batch": { type: "string" },
@@ -2817,8 +2819,9 @@ if (isMain) {
           const resolvedPwd = pwd === '.' ? getPwd() : getRealPath(resolve(pwd));
           const globPattern = cli.values.mask as string || DEFAULT_GLOB;
           const name = cli.values.name as string | undefined;
+          const followSymlinks = cli.values["follow-symlinks"] as boolean | undefined;
 
-          await collectionAdd(resolvedPwd, globPattern, name);
+          await collectionAdd(resolvedPwd, globPattern, name, followSymlinks);
           break;
         }
 
@@ -2922,7 +2925,7 @@ if (isMain) {
           console.log("");
           console.log("Commands:");
           console.log("  list                      List all collections");
-          console.log("  add <path> [--name NAME]  Add a collection");
+          console.log("  add <path> [--name NAME] [--follow-symlinks]  Add a collection");
           console.log("  remove <name>             Remove a collection");
           console.log("  rename <old> <new>        Rename a collection");
           console.log("  show <name>               Show collection details");
@@ -2932,6 +2935,7 @@ if (isMain) {
           console.log("");
           console.log("Examples:");
           console.log("  qmd collection add ~/notes --name notes");
+          console.log("  qmd collection add ~/notes --follow-symlinks");
           console.log("  qmd collection update-cmd brain 'git pull'");
           console.log("  qmd collection exclude archive");
           process.exit(0);

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -31,6 +31,7 @@ export interface Collection {
   context?: ContextMap;      // Optional context definitions
   update?: string;           // Optional bash command to run during qmd update
   includeByDefault?: boolean; // Include in queries by default (default: true)
+  follow_symlinks?: boolean; // Follow symbolic links when scanning (default: false)
 }
 
 /**
@@ -236,7 +237,7 @@ export function getDefaultCollectionNames(): string[] {
  */
 export function updateCollectionSettings(
   name: string,
-  settings: { update?: string | null; includeByDefault?: boolean }
+  settings: { update?: string | null; includeByDefault?: boolean; follow_symlinks?: boolean }
 ): boolean {
   const config = loadConfig();
   const collection = config.collections[name];
@@ -259,6 +260,15 @@ export function updateCollectionSettings(
     }
   }
 
+  if (settings.follow_symlinks !== undefined) {
+    if (settings.follow_symlinks === false) {
+      // false is default, remove the field
+      delete collection.follow_symlinks;
+    } else {
+      collection.follow_symlinks = settings.follow_symlinks;
+    }
+  }
+
   saveConfig(config);
   return true;
 }
@@ -269,7 +279,8 @@ export function updateCollectionSettings(
 export function addCollection(
   name: string,
   path: string,
-  pattern: string = "**/*.md"
+  pattern: string = "**/*.md",
+  options?: { follow_symlinks?: boolean }
 ): void {
   const config = loadConfig();
 
@@ -277,6 +288,7 @@ export function addCollection(
     path,
     pattern,
     context: config.collections[name]?.context, // Preserve existing context
+    ...(options?.follow_symlinks ? { follow_symlinks: true } : {}),
   };
 
   saveConfig(config);

--- a/src/store.ts
+++ b/src/store.ts
@@ -1082,6 +1082,7 @@ export async function reindexCollection(
   collectionName: string,
   options?: {
     ignorePatterns?: string[];
+    followSymlinks?: boolean;
     onProgress?: (info: ReindexProgress) => void;
   }
 ): Promise<ReindexResult> {
@@ -1096,7 +1097,7 @@ export async function reindexCollection(
   const allFiles: string[] = await fastGlob(globPattern, {
     cwd: collectionPath,
     onlyFiles: true,
-    followSymbolicLinks: false,
+    followSymbolicLinks: options?.followSymlinks ?? false,
     dot: false,
     ignore: allIgnore,
   });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -368,6 +368,57 @@ describe("CLI Add Command", () => {
   });
 });
 
+describe("CLI Follow Symlinks", () => {
+  let symlinkTarget: string;
+
+  beforeEach(async () => {
+    // Create a directory outside the fixtures tree with a markdown file
+    symlinkTarget = join(testDir, "symlink-target");
+    await mkdir(symlinkTarget, { recursive: true });
+    await writeFile(join(symlinkTarget, "linked.md"), "# Symlinked Document\n\nThis file lives behind a symlink.\n");
+
+    // Create a symlink inside fixtures pointing to the external directory
+    const symlinkPath = join(fixturesDir, "linked-dir");
+    try { unlinkSync(symlinkPath); } catch {}
+    symlinkSync(symlinkTarget, symlinkPath, "dir");
+  });
+
+  test("skips symlinked directories by default", async () => {
+    const { stdout, exitCode } = await runQmd(["collection", "add", "."]);
+    expect(exitCode).toBe(0);
+
+    const { stdout: lsOut } = await runQmd(["ls", "fixtures"]);
+    expect(lsOut).not.toContain("linked-dir/linked.md");
+  });
+
+  test("follows symlinked directories with --follow-symlinks", async () => {
+    const { stdout, exitCode } = await runQmd(["collection", "add", ".", "--follow-symlinks"]);
+    expect(exitCode).toBe(0);
+
+    const { stdout: lsOut } = await runQmd(["ls", "fixtures"]);
+    expect(lsOut).toContain("linked-dir/linked.md");
+  });
+
+  test("persists follow_symlinks in config and respects it on update", async () => {
+    // Add with --follow-symlinks
+    await runQmd(["collection", "add", ".", "--follow-symlinks"]);
+
+    // Verify config was persisted
+    const configContent = readFileSync(join(testConfigDir, "index.yml"), "utf-8");
+    expect(configContent).toContain("follow_symlinks: true");
+
+    // Add a new file behind the symlink
+    writeFileSync(join(symlinkTarget, "new-linked.md"), "# New Linked\n\nAdded after initial index.\n");
+
+    // Run update — should pick up the new file through the symlink
+    const { stdout: updateOut } = await runQmd(["update"]);
+    expect(updateOut).toContain("1 new");
+
+    const { stdout: lsOut } = await runQmd(["ls", "fixtures"]);
+    expect(lsOut).toContain("new-linked.md");
+  });
+});
+
 describe("CLI Status Command", () => {
   beforeEach(async () => {
     // Ensure we have indexed files


### PR DESCRIPTION
## Problem

`qmd collection add` and `qmd update` do not traverse symbolic links when scanning for files. Collections whose root directory contains symlinked subdirectories silently skip all files behind those symlinks.

Fixes #423.

## Solution

Add a per-collection `follow_symlinks` option that controls `fast-glob`'s `followSymbolicLinks` behavior. The setting is:

- Set via CLI: `qmd collection add ~/vault --follow-symlinks`
- Persisted in `index.yml` per collection:
  ```yaml
  collections:
    vault:
      path: ~/vault
      follow_symlinks: true
  ```
- Respected by both `collection add` (initial index) and `qmd update` (re-index)
- Defaults to `false` (backward compatible)

## Changes

| File | Change |
|------|--------|
| `src/collections.ts` | Added `follow_symlinks` to `Collection` interface, `addCollection()`, and `updateCollectionSettings()` |
| `src/store.ts` | Added `followSymlinks` option to `reindexCollection()`, passes to `fast-glob` |
| `src/cli/qmd.ts` | Added `--follow-symlinks` CLI flag, threaded through `collectionAdd()` → `indexFiles()`, updated help text |

## Testing

Verified manually:
- Without `--follow-symlinks`: symlinked directory skipped (3 files indexed)
- With `--follow-symlinks`: symlinked directory traversed (4 files indexed)
- `qmd update` respects the persisted `follow_symlinks: true` config
- All existing tests pass