### PR TITLE
feat(http): REST search endpoints + --warm flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Changes
+
+- Add REST search endpoints to MCP HTTP server: `POST /search/bm25`,
+  `/search/vector`, `/search/hybrid` for direct access to individual
+  search backends without MCP protocol overhead.
+- Pass `rerank` parameter through existing `POST /query` REST endpoint,
+  enabling `"rerank": false` to skip LLM reranking via HTTP.
+- Add `--warm` flag to `qmd mcp --http` to pre-load the embedding model
+  on startup. First vector search drops from ~700ms to ~24ms.
+
 ### Fixes
 
 - Sync stale `bun.lock` (`better-sqlite3` 11.x → 12.x). CI and release

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -2376,6 +2376,7 @@ function parseCLI() {
       http: { type: "boolean" },
       daemon: { type: "boolean" },
       port: { type: "string" },
+      warm: { type: "boolean" },
     },
     allowPositionals: true,
     strict: false, // Allow unknown options to pass through
@@ -2619,6 +2620,8 @@ function showHelp(): void {
   console.log("  - Use `qmd skill install --global` for ~/.agents/skills/qmd.");
   console.log("  - `qmd --skill` is kept as an alias for `qmd skill show`.");
   console.log("  - Advanced: `qmd mcp --http ...` and `qmd mcp --http --daemon` are optional for custom transports.");
+  console.log("  - `qmd mcp --http --warm` pre-loads the embedding model for fast vector searches (~24ms vs ~700ms cold).");
+  console.log("  - REST endpoints: POST /search/bm25, /search/vector, /search/hybrid, /query");
   console.log("");
   console.log("Global options:");
   console.log("  --index <name>             - Use a named index (default: index)");
@@ -3065,9 +3068,11 @@ if (isMain) {
           const logPath = resolve(cacheDir, "mcp.log");
           const logFd = openSync(logPath, "w"); // truncate — fresh log per daemon run
           const selfPath = fileURLToPath(import.meta.url);
+          const mcpArgs = ["mcp", "--http", "--port", String(port)];
+          if (cli.values.warm) mcpArgs.push("--warm");
           const spawnArgs = selfPath.endsWith(".ts")
-            ? ["--import", pathJoin(dirname(selfPath), "..", "..", "node_modules", "tsx", "dist", "esm", "index.mjs"), selfPath, "mcp", "--http", "--port", String(port)]
-            : [selfPath, "mcp", "--http", "--port", String(port)];
+            ? ["--import", pathJoin(dirname(selfPath), "..", "..", "node_modules", "tsx", "dist", "esm", "index.mjs"), selfPath, ...mcpArgs]
+            : [selfPath, ...mcpArgs];
           const child = nodeSpawn(process.execPath, spawnArgs, {
             stdio: ["ignore", logFd, logFd],
             detached: true,
@@ -3087,7 +3092,7 @@ if (isMain) {
         process.removeAllListeners("SIGINT");
         const { startMcpHttpServer } = await import("../mcp/server.js");
         try {
-          await startMcpHttpServer(port);
+          await startMcpHttpServer(port, { warm: !!cli.values.warm });
         } catch (e: any) {
           if (e?.code === "EADDRINUSE") {
             console.error(`Port ${port} already in use. Try a different port with --port.`);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -540,11 +540,22 @@ export type HttpServerHandle = {
  * Start MCP server over Streamable HTTP (JSON responses, no SSE).
  * Binds to localhost only. Returns a handle for shutdown and port discovery.
  */
-export async function startMcpHttpServer(port: number, options?: { quiet?: boolean }): Promise<HttpServerHandle> {
+export async function startMcpHttpServer(port: number, options?: { quiet?: boolean; warm?: boolean }): Promise<HttpServerHandle> {
   const store = await createStore({ dbPath: getDefaultDbPath() });
 
   // Pre-fetch default collection names for REST endpoint
   const defaultCollectionNames = await store.getDefaultCollectionNames();
+
+  // Optionally warm the embedding model so first vector search is fast (~24ms vs ~700ms cold)
+  if (options?.warm) {
+    const warmStart = Date.now();
+    try {
+      await store.searchVector("warmup", { limit: 1 });
+    } catch { /* embedding may not be available — that's fine */ }
+    if (!options?.quiet) {
+      console.error(`Embedding model warmed in ${Date.now() - warmStart}ms`);
+    }
+  }
 
   // Session map: each client gets its own McpServer + Transport pair (MCP spec requirement).
   // The store is shared — it's stateless SQLite, safe for concurrent access.
@@ -649,6 +660,7 @@ export async function startMcpHttpServer(port: number, options?: { quiet?: boole
           limit: params.limit ?? 10,
           minScore: params.minScore ?? 0,
           intent: params.intent,
+          rerank: params.rerank,
         });
 
         // Use first lex or vec query for snippet extraction
@@ -672,6 +684,68 @@ export async function startMcpHttpServer(port: number, options?: { quiet?: boole
         nodeRes.end(JSON.stringify({ results: formatted }));
         log(`${ts()} POST /query ${params.searches.length} queries (${Date.now() - reqStart}ms)`);
         return;
+      }
+
+      // REST endpoint: POST /search/bm25 — BM25 keyword search (no LLM)
+      // REST endpoint: POST /search/vector — vector similarity search (embedding model only)
+      // REST endpoint: POST /search/hybrid — BM25 + vector RRF fusion (no LLM reranking)
+      if (pathname?.startsWith("/search/") && nodeReq.method === "POST") {
+        const mode = pathname.slice("/search/".length);
+        if (mode !== "bm25" && mode !== "vector" && mode !== "hybrid") {
+          nodeRes.writeHead(404, { "Content-Type": "application/json" });
+          nodeRes.end(JSON.stringify({ error: `Unknown search mode: ${mode}. Use bm25, vector, or hybrid.` }));
+          return;
+        }
+
+        const rawBody = await collectBody(nodeReq);
+        const params = JSON.parse(rawBody);
+
+        if (!params.query || typeof params.query !== "string") {
+          nodeRes.writeHead(400, { "Content-Type": "application/json" });
+          nodeRes.end(JSON.stringify({ error: "Missing required field: query (string)" }));
+          return;
+        }
+
+        const limit = params.limit ?? 10;
+        const collection = params.collection;
+
+        if (mode === "bm25") {
+          const results = await store.searchLex(params.query, { limit, collection });
+          nodeRes.writeHead(200, { "Content-Type": "application/json" });
+          nodeRes.end(JSON.stringify({ results, mode, latency_ms: Date.now() - reqStart }));
+          log(`${ts()} POST /search/bm25 "${params.query.slice(0, 60)}" (${Date.now() - reqStart}ms)`);
+          return;
+        }
+
+        if (mode === "vector") {
+          const results = await store.searchVector(params.query, { limit, collection });
+          nodeRes.writeHead(200, { "Content-Type": "application/json" });
+          nodeRes.end(JSON.stringify({ results, mode, latency_ms: Date.now() - reqStart }));
+          log(`${ts()} POST /search/vector "${params.query.slice(0, 60)}" (${Date.now() - reqStart}ms)`);
+          return;
+        }
+
+        if (mode === "hybrid") {
+          const results = await store.search({
+            query: params.query,
+            collection,
+            limit,
+            minScore: params.minScore ?? 0,
+            intent: params.intent,
+            rerank: false,
+          });
+          const formatted = results.map(r => ({
+            docid: `#${r.docid}`,
+            file: r.displayPath,
+            title: r.title,
+            score: Math.round(r.score * 100) / 100,
+            context: r.context,
+          }));
+          nodeRes.writeHead(200, { "Content-Type": "application/json" });
+          nodeRes.end(JSON.stringify({ results: formatted, mode, latency_ms: Date.now() - reqStart }));
+          log(`${ts()} POST /search/hybrid "${params.query.slice(0, 60)}" (${Date.now() - reqStart}ms)`);
+          return;
+        }
       }
 
       if (pathname === "/mcp" && nodeReq.method === "POST") {

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1074,4 +1074,85 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
     expect(json.result).toBeDefined();
     expect(json.result.content.length).toBeGreaterThan(0);
   });
+
+  // ---------------------------------------------------------------------------
+  // REST search endpoints
+  // ---------------------------------------------------------------------------
+
+  test("POST /search/bm25 returns BM25 results", async () => {
+    const res = await fetch(`${baseUrl}/search/bm25`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "API", limit: 5 }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.mode).toBe("bm25");
+    expect(body.results).toBeDefined();
+    expect(Array.isArray(body.results)).toBe(true);
+    expect(typeof body.latency_ms).toBe("number");
+  });
+
+  test("POST /search/vector returns vector results", async () => {
+    const res = await fetch(`${baseUrl}/search/vector`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "API documentation", limit: 5 }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.mode).toBe("vector");
+    expect(body.results).toBeDefined();
+    expect(Array.isArray(body.results)).toBe(true);
+  });
+
+  test("POST /search/hybrid returns hybrid results without reranking", async () => {
+    const res = await fetch(`${baseUrl}/search/hybrid`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "API endpoints", limit: 5 }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.mode).toBe("hybrid");
+    expect(body.results).toBeDefined();
+    expect(Array.isArray(body.results)).toBe(true);
+  });
+
+  test("POST /search/bm25 returns 400 when query is missing", async () => {
+    const res = await fetch(`${baseUrl}/search/bm25`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ limit: 5 }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("query");
+  });
+
+  test("POST /search/unknown returns 404", async () => {
+    const res = await fetch(`${baseUrl}/search/unknown`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "test" }),
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toContain("unknown");
+  });
+
+  test("POST /query passes rerank:false through", async () => {
+    const res = await fetch(`${baseUrl}/query`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        searches: [{ type: "lex", query: "API" }],
+        rerank: false,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.results).toBeDefined();
+    expect(Array.isArray(body.results)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

The MCP HTTP server (`qmd mcp --http`) already has `POST /query` and `/search` endpoints, but they require the full structured search format and always use the hybrid pipeline. This PR adds:

- **`POST /search/bm25`** — direct BM25 keyword search, no LLM needed (~3ms)
- **`POST /search/vector`** — direct vector similarity search (~24ms warm)
- **`POST /search/hybrid`** — BM25 + vector RRF fusion without LLM reranking (~26ms)
- **`rerank` passthrough** on existing `POST /query` — callers can now send `"rerank": false`
- **`--warm` flag** — `qmd mcp --http --warm` pre-loads the embedding model on startup. Opt-in to avoid ~300MB memory cost on constrained machines.

### Motivation

I built a custom HTTP wrapper around QMD's SDK for my personal vault search and found that keeping the embedding model warm and having direct access to individual backends (without MCP protocol overhead) made a massive difference for agent integrations. Tobi suggested I contribute this upstream.

The individual endpoints are useful for:
- Debugging which signal (BM25 vs vector) is helping for a given query
- Agent tools that need fast, targeted search without the full hybrid pipeline
- Latency-sensitive integrations where reranking isn't needed

### API

All new endpoints accept JSON POST:

```bash
# BM25 keyword search
curl -X POST localhost:8181/search/bm25 \
  -d '{"query": "authentication", "limit": 10}'

# Vector similarity search
curl -X POST localhost:8181/search/vector \
  -d '{"query": "how does auth work?", "limit": 10}'

# Hybrid (BM25 + vector, no reranking)
curl -X POST localhost:8181/search/hybrid \
  -d '{"query": "auth flow", "limit": 10, "intent": "user login"}'

# Existing endpoint now supports rerank: false
curl -X POST localhost:8181/query \
  -d '{"searches": [{"type": "lex", "query": "auth"}], "rerank": false}'
```

Response format: `{ results: [...], mode: "bm25"|"vector"|"hybrid", latency_ms: number }`

## Test plan

- [ ] `npx vitest run test/mcp.test.ts` — new tests for all REST endpoints (bm25, vector, hybrid, error cases, rerank passthrough)
- [ ] Manual: `qmd mcp --http --warm` starts server with embedding model pre-loaded
- [ ] Manual: `qmd mcp --http --daemon --warm` passes --warm through to daemon child process
- [ ] Verify existing `POST /query` and `POST /mcp` still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)