### PR TITLE
fix: preserve dots and original case in handelize()

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -1595,7 +1595,6 @@ export function handelize(path: string): string {
 
   const result = path
     .replace(/___/g, '/')       // Triple underscore becomes folder separator
-    .toLowerCase()
     .split('/')
     .map((segment, idx, arr) => {
       const isLastSegment = idx === arr.length - 1;


### PR DESCRIPTION
## Summary

Two small fixes to `handelize()` in `src/store.ts`:

- **Preserve dots in filenames**: The regex replaced all non-letter/non-number chars with dashes, including dots in the filename stem. This mangled filenames like `topic-1773595309.753009.md` → `topic-1773595309-753009.md`, breaking path resolution when the original file has dots.
- **Preserve original filename case**: The blanket `.toLowerCase()` call converted `MEMORY.md` → `memory.md`, causing file-not-found errors on case-sensitive filesystems when the actual file retains uppercase.

## Changes

```diff
- .replace(/[^\p{L}\p{N}$]+/gu, '-')
+ .replace(/[^\p{L}\p{N}.$]+/gu, '-')
```

```diff
  const result = path
    .replace(/___/g, '/')
-   .toLowerCase()
    .split('/')
```

## Test plan

- [ ] Index a collection containing files with dots in names (e.g. `topic-1773595309.753009.md`) — verify paths resolve correctly
- [ ] Index a collection with uppercase filenames (e.g. `MEMORY.md`, `README.md`) — verify case is preserved in the index