### PR TITLE
feat: add --keep-models flag and QMD_KEEP_MODELS env var for MCP server

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -2376,6 +2376,7 @@ function parseCLI() {
       http: { type: "boolean" },
       daemon: { type: "boolean" },
       port: { type: "string" },
+      "keep-models": { type: "boolean" },
     },
     allowPositionals: true,
     strict: false, // Allow unknown options to pass through
@@ -2565,6 +2566,7 @@ function showHelp(): void {
   console.log("  qmd multi-get <pattern>       - Batch fetch via glob or comma-separated list");
   console.log("  qmd skill show/install        - Show or install the packaged QMD skill");
   console.log("  qmd mcp                       - Start the MCP server (stdio transport for AI agents)");
+  console.log("    --keep-models               - Keep model weights in RAM between queries (good for servers)");
   console.log("");
   console.log("Collections & context:");
   console.log("  qmd collection add/list/remove/rename/show   - Manage indexed folders");
@@ -2619,6 +2621,8 @@ function showHelp(): void {
   console.log("  - Use `qmd skill install --global` for ~/.agents/skills/qmd.");
   console.log("  - `qmd --skill` is kept as an alias for `qmd skill show`.");
   console.log("  - Advanced: `qmd mcp --http ...` and `qmd mcp --http --daemon` are optional for custom transports.");
+  console.log("  - Use `qmd mcp --keep-models` (or QMD_KEEP_MODELS=1) to keep model weights warm between queries.");
+  console.log("    This avoids reload latency for long-running servers. For one-off CLI use the default is fine.");
   console.log("");
   console.log("Global options:");
   console.log("  --index <name>             - Use a named index (default: index)");
@@ -3045,6 +3049,12 @@ if (isMain) {
         process.exit(0);
       }
 
+      // Resolve keep-models: flag > env var
+      const keepModels =
+        Boolean(cli.values["keep-models"]) ||
+        process.env.QMD_KEEP_MODELS === "1" ||
+        process.env.QMD_KEEP_MODELS === "true";
+
       if (cli.values.http) {
         const port = Number(cli.values.port) || 8181;
 
@@ -3065,9 +3075,10 @@ if (isMain) {
           const logPath = resolve(cacheDir, "mcp.log");
           const logFd = openSync(logPath, "w"); // truncate — fresh log per daemon run
           const selfPath = fileURLToPath(import.meta.url);
+          const keepModelsArgs = keepModels ? ["--keep-models"] : [];
           const spawnArgs = selfPath.endsWith(".ts")
-            ? ["--import", pathJoin(dirname(selfPath), "..", "..", "node_modules", "tsx", "dist", "esm", "index.mjs"), selfPath, "mcp", "--http", "--port", String(port)]
-            : [selfPath, "mcp", "--http", "--port", String(port)];
+            ? ["--import", pathJoin(dirname(selfPath), "..", "..", "node_modules", "tsx", "dist", "esm", "index.mjs"), selfPath, "mcp", "--http", "--port", String(port), ...keepModelsArgs]
+            : [selfPath, "mcp", "--http", "--port", String(port), ...keepModelsArgs];
           const child = nodeSpawn(process.execPath, spawnArgs, {
             stdio: ["ignore", logFd, logFd],
             detached: true,
@@ -3087,7 +3098,7 @@ if (isMain) {
         process.removeAllListeners("SIGINT");
         const { startMcpHttpServer } = await import("../mcp/server.js");
         try {
-          await startMcpHttpServer(port);
+          await startMcpHttpServer(port, { keepModels });
         } catch (e: any) {
           if (e?.code === "EADDRINUSE") {
             console.error(`Port ${port} already in use. Try a different port with --port.`);
@@ -3098,7 +3109,7 @@ if (isMain) {
       } else {
         // Default: stdio transport
         const { startMcpServer } = await import("../mcp/server.js");
-        await startMcpServer();
+        await startMcpServer({ keepModels });
       }
       break;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,6 +200,21 @@ export interface StoreOptions {
   configPath?: string;
   /** Inline collection config (mutually exclusive with `configPath`) */
   config?: CollectionConfig;
+  /**
+   * Keep model weights in memory between queries (default: false).
+   *
+   * When true, only LLM contexts (the per-session VRAM objects) are released
+   * on inactivity — the model weights themselves stay loaded so the next query
+   * starts instantly without a reload.  Ideal for long-running servers such as
+   * `qmd mcp --http`.
+   *
+   * When false (the default), both contexts *and* model weights are disposed
+   * after the inactivity timeout, freeing VRAM — good for one-off CLI use
+   * where you don't want to keep memory pinned after a single query.
+   *
+   * Can also be set via the `QMD_KEEP_MODELS=1` environment variable.
+   */
+  keepModels?: boolean;
 }
 
 /**
@@ -358,11 +373,20 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
   }
   // else: DB-only mode — no external config, use existing store_collections
 
-  // Create a per-store LlamaCpp instance — lazy-loads models on first use,
-  // auto-unloads after 5 min inactivity to free VRAM.
+  // Resolve keepModels: explicit option takes priority, then env var.
+  const keepModels =
+    options.keepModels !== undefined
+      ? options.keepModels
+      : process.env.QMD_KEEP_MODELS === "1" || process.env.QMD_KEEP_MODELS === "true";
+
+  // Create a per-store LlamaCpp instance — lazy-loads models on first use.
+  // By default both contexts and model weights are released after 5 min of
+  // inactivity (good for CLI one-off queries).  When keepModels is true only
+  // contexts are released — weights stay warm for fast subsequent queries,
+  // which is ideal for long-running servers like `qmd mcp --http`.
   const llm = new LlamaCpp({
     inactivityTimeoutMs: 5 * 60 * 1000,
-    disposeModelsOnInactivity: true,
+    disposeModelsOnInactivity: !keepModels,
   });
   internal.llm = llm;
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -519,8 +519,8 @@ Intent-aware lex (C++ performance, not sports):
 // Transport: stdio (default)
 // =============================================================================
 
-export async function startMcpServer(): Promise<void> {
-  const store = await createStore({ dbPath: getDefaultDbPath() });
+export async function startMcpServer(options?: { keepModels?: boolean }): Promise<void> {
+  const store = await createStore({ dbPath: getDefaultDbPath(), keepModels: options?.keepModels });
   const server = await createMcpServer(store);
   const transport = new StdioServerTransport();
   await server.connect(transport);
@@ -540,8 +540,8 @@ export type HttpServerHandle = {
  * Start MCP server over Streamable HTTP (JSON responses, no SSE).
  * Binds to localhost only. Returns a handle for shutdown and port discovery.
  */
-export async function startMcpHttpServer(port: number, options?: { quiet?: boolean }): Promise<HttpServerHandle> {
-  const store = await createStore({ dbPath: getDefaultDbPath() });
+export async function startMcpHttpServer(port: number, options?: { quiet?: boolean; keepModels?: boolean }): Promise<HttpServerHandle> {
+  const store = await createStore({ dbPath: getDefaultDbPath(), keepModels: options?.keepModels });
 
   // Pre-fetch default collection names for REST endpoint
   const defaultCollectionNames = await store.getDefaultCollectionNames();


### PR DESCRIPTION
## Problem

When running `qmd mcp` or `qmd mcp --http` as a long-lived daemon, the current behaviour disposes **model weights** after 5 minutes of inactivity (`disposeModelsOnInactivity: true` hard-coded in `createStore`). This means the first query after an idle period has to reload the GGUF file from disk — which can take several seconds and causes a brief VRAM spike.

That trade-off makes sense for one-off CLI usage (you don't want to keep VRAM pinned after a single query), but not for a persistent MCP server where the whole point is low-latency responses.

The `LlamaCppConfig` already has `disposeModelsOnInactivity: false` as its default for exactly this reason (see the comment in `llm.ts`: *"Keeping models loaded avoids repeated VRAM thrash"*). We just had no way to opt into it from the outside.

## Solution

Add a `--keep-models` flag (and `QMD_KEEP_MODELS=1` env var) that keeps model **weights** in memory between queries while still releasing **contexts** (the lighter per-session VRAM objects) on inactivity.

### Changes

| File | Change |
|------|--------|
| `src/index.ts` | `StoreOptions` gains `keepModels?: boolean`; `createStore` reads `QMD_KEEP_MODELS` env var and passes the flag through to `LlamaCpp` |
| `src/mcp/server.ts` | `startMcpServer` and `startMcpHttpServer` accept `{ keepModels }` and forward it to `createStore` |
| `src/cli/qmd.ts` | `qmd mcp` gains `--keep-models` flag; it is also forwarded through the daemon spawn args; help text updated |

### Usage

```bash
# stdio transport (e.g. Claude Desktop, Cursor)
qmd mcp --keep-models

# HTTP foreground
qmd mcp --http --keep-models

# HTTP daemon (flag is forwarded to the child process)
qmd mcp --http --daemon --keep-models

# Via environment variable (handy for systemd units or Docker)
QMD_KEEP_MODELS=1 qmd mcp
```

### Why not flip the default?

The 5-minute timeout + `disposeModelsOnInactivity: true` is the right default for CLI use — most people run `qmd query` once and move on, and holding VRAM indefinitely would surprise them. The flag is an explicit opt-in for operators who know they are running a server.

## Testing

Verified by reading the logic path end-to-end:
- `--keep-models` → `keepModels = true` → `createStore({ keepModels: true })` → `disposeModelsOnInactivity: false` → model weights stay loaded, contexts are still released on inactivity timer
- `QMD_KEEP_MODELS=1` works the same way when the flag is absent
- Daemon spawn correctly appends `--keep-models` to child args so the flag survives `qmd mcp --http --daemon --keep-models`