### PR TITLE
Add rerank parameter to MCP query tool

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -296,9 +296,12 @@ Intent-aware lex (C++ performance, not sports):
         intent: z.string().optional().describe(
           "Background context to disambiguate the query. Example: query='performance', intent='web page load times and Core Web Vitals'. Does not search on its own."
         ),
+        rerank: z.boolean().optional().default(true).describe(
+          "Rerank results using LLM (default: true). Set to false for faster results on CPU-only machines."
+        ),
       },
     },
-    async ({ searches, limit, minScore, candidateLimit, collections, intent }) => {
+    async ({ searches, limit, minScore, candidateLimit, collections, intent, rerank }) => {
       // Map to internal format
       const queries: ExpandedQuery[] = searches.map(s => ({
         type: s.type,
@@ -313,6 +316,7 @@ Intent-aware lex (C++ performance, not sports):
         collections: effectiveCollections.length > 0 ? effectiveCollections : undefined,
         limit,
         minScore,
+        rerank,
         intent,
       });
 


### PR DESCRIPTION
## Summary

- Adds a `rerank` boolean parameter to the MCP `query` tool's input schema (default: `true`)
- Forwards it to `store.search()` which already handles `rerank: false` via `skipRerank`

## Motivation

On CPU-only infrastructure (e.g. Railway Hobby plan), the reranker model (qwen3-reranker-0.6b, ~640MB) adds 60-120s per query. The SDK already exposes `rerank: false` in `SearchOptions`, and the CLI has `--no-rerank`, but the MCP server had no way to skip reranking.

## Benchmarks (Railway Hobby, 8 vCPU, CPU-only, 1056 docs)

| Command | Time |
|---------|------|
| `qmd search` (BM25 CLI) | ~400ms |
| MCP `query` with lex-only (rerank: true) | ~65s |
| MCP `query` with lex-only (rerank: false) | expected ~400ms |

## Changes

Single file: `src/mcp/server.ts` (+5 lines, -1 line)

1. Added `rerank` to the query tool's zod input schema
2. Added `rerank` to the handler's destructured parameters
3. Forward `rerank` to `store.search()` call

Fixes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)