### PR TITLE
fix(llm): set explicit embed context size (default 2048), configurable via env var

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -665,6 +665,7 @@ export class LlamaCpp implements LLM {
       for (let i = 0; i < n; i++) {
         try {
           this.embedContexts.push(await model.createEmbeddingContext({
+            contextSize: LlamaCpp.EMBED_CONTEXT_SIZE,
             ...(threads > 0 ? { threads } : {}),
           }));
         } catch {
@@ -768,6 +769,11 @@ export class LlamaCpp implements LLM {
   private static readonly RERANK_CONTEXT_SIZE: number = (() => {
     const v = parseInt(process.env.QMD_RERANK_CONTEXT_SIZE ?? "", 10);
     return Number.isFinite(v) && v > 0 ? v : 4096;
+  })();
+
+  private static readonly EMBED_CONTEXT_SIZE: number = (() => {
+    const v = parseInt(process.env.QMD_EMBED_CONTEXT_SIZE ?? "", 10);
+    return Number.isFinite(v) && v > 0 ? v : 2048;
   })();
   private async ensureRerankContexts(): Promise<Awaited<ReturnType<LlamaModel["createRankingContext"]>>[]> {
     if (this.rerankContexts.length === 0) {


### PR DESCRIPTION
## Problem

`createEmbeddingContext()` does not pass a `contextSize`, so node-llama-cpp defaults to `"auto"` — allocating the model's full training context window. For models like Qwen3-Embedding-0.6B (32k context) or harrier-oss-v1-0.6b (32k), this pre-allocates ~3.5 GB of KV cache per embedding context, even though indexed chunks are typically ~900 tokens.

On machines with large unified memory (e.g., Apple Silicon with 64+ GB), `contextSize: "auto"` scales up aggressively, causing the QMD daemon to consume 15-30 GB for embedding contexts alone.

## Fix

- Add `EMBED_CONTEXT_SIZE` static field (default 2048), following the same pattern as `RERANK_CONTEXT_SIZE`
- Pass it to `createEmbeddingContext()` 
- Overridable via `QMD_EMBED_CONTEXT_SIZE` env var

2048 tokens is more than sufficient — QMD chunks at ~900 tokens, and the KV cache for a 2048-context embedding model is ~110 MB vs ~3.5 GB at 32k.

## Changes

Single file: `src/llm.ts` (+6 lines)

Addresses #329, related to #297