### PR TITLE
fix(store): error on embedding dimension mismatch instead of silent rebuild

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -1053,7 +1053,12 @@ function ensureVecTableInternal(db: Database, dimensions: number): void {
     const hasCosine = tableInfo.sql.includes('distance_metric=cosine');
     const existingDims = match?.[1] ? parseInt(match[1], 10) : null;
     if (existingDims === dimensions && hasHashSeq && hasCosine) return;
-    // Table exists but wrong schema - need to rebuild
+    if (existingDims !== null && existingDims !== dimensions) {
+      throw new Error(
+        `Embedding dimension mismatch: existing vectors are ${existingDims}d but the current model produces ${dimensions}d. ` +
+        `Run 'qmd embed -f' to re-embed with the new model.`
+      );
+    }
     db.exec("DROP TABLE IF EXISTS vectors_vec");
   }
   db.exec(`CREATE VIRTUAL TABLE vectors_vec USING vec0(hash_seq TEXT PRIMARY KEY, embedding float[${dimensions}] distance_metric=cosine)`);


### PR DESCRIPTION
## Problem

When switching to an embedding model with different dimensions (e.g., embeddinggemma at 768 → Qwen3-Embedding at 1024), `ensureVecTableInternal()` silently drops the vector table. All existing embeddings are lost without any indication — users only discover this when semantic search returns empty results.

## Fix

Throw an error on dimension mismatch instead of silently rebuilding:

```
Error: Embedding dimension mismatch: existing vectors are 768d but the current model produces 1024d.
Run 'qmd embed -f' to re-embed with the new model.
```

This is safe because `qmd embed -f` calls `clearAllEmbeddings()` which drops the table before `ensureVecTable` is reached — so the explicit re-embed path still works.

## Changes

Single file: `src/store.ts` (+6 lines, -1 line)

Related to #497