### PR TITLE
Add `qmd collection sync` for mtime-first incremental re-indexing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ qmd collection add . --name <n>   # Create/index collection
 qmd collection list               # List all collections with details
 qmd collection remove <name>      # Remove a collection by name
 qmd collection rename <old> <new> # Rename a collection
+qmd collection sync <name>        # Incremental sync (mtime-first diffing)
 qmd ls [collection[/path]]        # List collections or files in a collection
 qmd context add [path] "text"     # Add context for path (defaults to current dir)
 qmd context list                  # List all contexts

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -73,8 +73,10 @@ import {
   getDefaultDbPath,
   reindexCollection,
   generateEmbeddings,
+  syncCollection,
   syncConfigToDb,
   type ReindexResult,
+  type SyncResult,
   type ChunkStrategy,
 } from "../store.js";
 import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, withLLMSession, pullModels, DEFAULT_EMBED_MODEL_URI, DEFAULT_GENERATE_MODEL_URI, DEFAULT_RERANK_MODEL_URI, DEFAULT_MODEL_CACHE_DIR } from "../llm.js";
@@ -1488,6 +1490,59 @@ function collectionRename(oldName: string, newName: string): void {
 
   console.log(`${c.green}✓${c.reset} Renamed collection '${oldName}' to '${newName}'`);
   console.log(`  Virtual paths updated: ${c.cyan}qmd://${oldName}/${c.reset} → ${c.cyan}qmd://${newName}/${c.reset}`);
+}
+
+async function collectionSync(name: string): Promise<void> {
+  const coll = getCollectionFromYaml(name);
+  if (!coll) {
+    console.error(`${c.yellow}Collection not found: ${name}${c.reset}`);
+    console.error(`Run 'qmd collection list' to see available collections.`);
+    process.exit(1);
+  }
+
+  const storeInstance = getStore();
+  const startTime = Date.now();
+
+  console.log(`${c.bold}Syncing collection '${name}'...${c.reset}`);
+  console.log(`  ${c.dim}Path: ${coll.path}${c.reset}`);
+  console.log(`  ${c.dim}Pattern: ${coll.pattern}${c.reset}\n`);
+
+  const result = await syncCollection(storeInstance, coll.path, coll.pattern, name, {
+    ignorePatterns: coll.ignore,
+    onProgress: (info) => {
+      if (info.phase === 'scanning') {
+        process.stderr.write(`\r${c.dim}Scanning filesystem...${c.reset}`);
+      } else if (info.phase === 'processing' && info.file) {
+        process.stderr.write(`\r${c.dim}[${info.current}/${info.total}] ${info.file}${c.reset}\x1b[K`);
+      } else if (info.phase === 'cleanup') {
+        process.stderr.write(`\r${c.dim}Cleaning up...${c.reset}\x1b[K`);
+      }
+    },
+  });
+
+  process.stderr.write('\r\x1b[K'); // Clear progress line
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+
+  console.log(`${c.green}✓${c.reset} Sync complete in ${elapsed}s\n`);
+  console.log(`  ${c.cyan}${result.filesScanned}${c.reset} files scanned`);
+  console.log(`  ${c.green}${result.added}${c.reset} added`);
+  console.log(`  ${c.yellow}${result.updated}${c.reset} updated`);
+  if (result.renamed > 0) {
+    console.log(`  ${c.magenta}${result.renamed}${c.reset} renamed (embeddings reused)`);
+  }
+  console.log(`  ${result.removed > 0 ? c.yellow : c.dim}${result.removed}${c.reset} removed`);
+  console.log(`  ${c.dim}${result.unchanged}${c.reset} unchanged ${c.dim}(${result.skippedMtime} skipped by mtime, ${result.skippedHash} by hash)${c.reset}`);
+
+  if (result.orphanedCleaned > 0) {
+    console.log(`  ${c.dim}${result.orphanedCleaned} orphaned content entries cleaned${c.reset}`);
+  }
+
+  const needsEmbedding = storeInstance.getHashesNeedingEmbedding();
+  if (needsEmbedding > 0) {
+    console.log(`\n${c.dim}${needsEmbedding} document(s) need embedding. Run 'qmd embed' to generate vectors.${c.reset}`);
+  }
+
+  closeDb();
 }
 
 async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, collectionName?: string, suppressEmbedNotice: boolean = false, ignorePatterns?: string[]): Promise<void> {
@@ -2933,6 +2988,18 @@ if (isMain) {
           break;
         }
 
+        case "sync": {
+          const name = cli.args[1];
+          if (!name) {
+            console.error("Usage: qmd collection sync <name>");
+            console.error("  Incrementally sync a collection using mtime-first diffing");
+            console.error("  Use 'qmd collection list' to see available collections");
+            process.exit(1);
+          }
+          await collectionSync(name);
+          break;
+        }
+
         case "show":
         case "info": {
           const name = cli.args[1];
@@ -2969,6 +3036,7 @@ if (isMain) {
           console.log("  add <path> [--name NAME]  Add a collection");
           console.log("  remove <name>             Remove a collection");
           console.log("  rename <old> <new>        Rename a collection");
+          console.log("  sync <name>               Incremental sync (mtime-first diffing)");
           console.log("  show <name>               Show collection details");
           console.log("  update-cmd <name> [cmd]   Set pre-update command (e.g., 'git pull')");
           console.log("  include <name>            Include in default queries");
@@ -2976,6 +3044,7 @@ if (isMain) {
           console.log("");
           console.log("Examples:");
           console.log("  qmd collection add ~/notes --name notes");
+          console.log("  qmd collection sync notes");
           console.log("  qmd collection update-cmd brain 'git pull'");
           console.log("  qmd collection exclude archive");
           process.exit(0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import {
   DEFAULT_EMBED_MODEL,
   DEFAULT_MULTI_GET_MAX_BYTES,
   reindexCollection,
+  syncCollection,
   generateEmbeddings,
   listCollections as storeListCollections,
   syncConfigToDb,
@@ -60,6 +61,8 @@ import {
   type SearchHooks,
   type ReindexProgress,
   type ReindexResult,
+  type SyncProgress,
+  type SyncResult,
   type EmbedProgress,
   type EmbedResult,
   type ChunkStrategy,
@@ -98,6 +101,8 @@ export type {
   SearchHooks,
   ReindexProgress,
   ReindexResult,
+  SyncProgress,
+  SyncResult,
   EmbedProgress,
   EmbedResult,
   Collection,
@@ -285,6 +290,11 @@ export interface QMDStore {
     collections?: string[];
     onProgress?: (info: UpdateProgress) => void;
   }): Promise<UpdateResult>;
+
+  /** Incremental sync using mtime-first diffing (faster than full update) */
+  sync(collectionName: string, options?: {
+    onProgress?: (info: SyncProgress) => void;
+  }): Promise<SyncResult>;
 
   /** Generate vector embeddings for documents that need them */
   embed(options?: {
@@ -505,6 +515,15 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
         removed: totalRemoved,
         needsEmbedding: internal.getHashesNeedingEmbedding(),
       };
+    },
+
+    sync: async (collectionName, syncOpts) => {
+      const col = getStoreCollection(db, collectionName);
+      if (!col) throw new Error(`Collection not found: ${collectionName}`);
+      return syncCollection(internal, col.path, col.pattern || "**/*.md", col.name, {
+        ignorePatterns: col.ignore,
+        onProgress: syncOpts?.onProgress,
+      });
     },
 
     embed: async (embedOpts) => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -768,6 +768,12 @@ function initializeDatabase(db: Database): void {
   db.exec(`CREATE INDEX IF NOT EXISTS idx_documents_hash ON documents(hash)`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_documents_path ON documents(path, active)`);
 
+  // Migration: add disk_mtime column for sync optimization (mtime-first diffing)
+  const docColumns = db.prepare(`PRAGMA table_info(documents)`).all() as { name: string }[];
+  if (!docColumns.some(col => col.name === 'disk_mtime')) {
+    db.exec(`ALTER TABLE documents ADD COLUMN disk_mtime TEXT`);
+  }
+
   // Cache table for LLM API calls
   db.exec(`
     CREATE TABLE IF NOT EXISTS llm_cache (
@@ -1123,10 +1129,10 @@ export type Store = {
 
   // Document indexing operations
   insertContent: (hash: string, content: string, createdAt: string) => void;
-  insertDocument: (collectionName: string, path: string, title: string, hash: string, createdAt: string, modifiedAt: string) => void;
+  insertDocument: (collectionName: string, path: string, title: string, hash: string, createdAt: string, modifiedAt: string, diskMtime?: string) => void;
   findActiveDocument: (collectionName: string, path: string) => { id: number; hash: string; title: string } | null;
   updateDocumentTitle: (documentId: number, title: string, modifiedAt: string) => void;
-  updateDocument: (documentId: number, title: string, hash: string, modifiedAt: string) => void;
+  updateDocument: (documentId: number, title: string, hash: string, modifiedAt: string, diskMtime?: string) => void;
   deactivateDocument: (collectionName: string, path: string) => void;
   getActiveDocumentPaths: (collectionName: string) => string[];
 
@@ -1228,17 +1234,18 @@ export async function reindexCollection(
       } else {
         insertContent(db, hash, content, now);
         const stat = statSync(filepath);
-        updateDocument(db, existing.id, title, hash,
-          stat ? new Date(stat.mtime).toISOString() : now);
+        const mtime = stat ? new Date(stat.mtime).toISOString() : now;
+        updateDocument(db, existing.id, title, hash, mtime, mtime);
         updated++;
       }
     } else {
       indexed++;
       insertContent(db, hash, content, now);
       const stat = statSync(filepath);
+      const mtime = stat ? new Date(stat.mtime).toISOString() : now;
       insertDocument(db, collectionName, path, title, hash,
         stat ? new Date(stat.birthtime).toISOString() : now,
-        stat ? new Date(stat.mtime).toISOString() : now);
+        mtime, mtime);
     }
 
     processed++;
@@ -1258,6 +1265,237 @@ export async function reindexCollection(
   const orphanedCleaned = cleanupOrphanedContent(db);
 
   return { indexed, updated, unchanged, removed, orphanedCleaned };
+}
+
+// =============================================================================
+// Sync — mtime-first differential re-indexing
+// =============================================================================
+
+export type SyncProgress = {
+  phase: 'scanning' | 'diffing' | 'processing' | 'cleanup';
+  file?: string;
+  current: number;
+  total: number;
+};
+
+export type SyncResult = {
+  added: number;
+  updated: number;
+  unchanged: number;
+  removed: number;
+  renamed: number;
+  skippedMtime: number;
+  skippedHash: number;
+  orphanedCleaned: number;
+  filesScanned: number;
+};
+
+/**
+ * Get all active documents for a collection with their disk_mtime and hash.
+ * Returns a map of path → { id, hash, disk_mtime, title } for efficient lookup.
+ */
+function getActiveDocumentsWithMtime(
+  db: Database,
+  collectionName: string
+): Map<string, { id: number; hash: string; disk_mtime: string | null; title: string }> {
+  const rows = db.prepare(`
+    SELECT id, path, hash, disk_mtime, title
+    FROM documents
+    WHERE collection = ? AND active = 1
+  `).all(collectionName) as { id: number; path: string; hash: string; disk_mtime: string | null; title: string }[];
+
+  const map = new Map<string, { id: number; hash: string; disk_mtime: string | null; title: string }>();
+  for (const row of rows) {
+    map.set(row.path, { id: row.id, hash: row.hash, disk_mtime: row.disk_mtime, title: row.title });
+  }
+  return map;
+}
+
+/**
+ * Sync a collection using mtime-first differential strategy.
+ *
+ * Instead of reading every file to compute hashes (O(N) disk reads),
+ * this checks filesystem mtime first (nearly free OS metadata lookup).
+ * Only files whose mtime changed get read and hashed.
+ *
+ * For renamed files (same content hash, different path), the embedding
+ * is reused since embeddings are keyed by content hash.
+ */
+export async function syncCollection(
+  store: Store,
+  collectionPath: string,
+  globPattern: string,
+  collectionName: string,
+  options?: {
+    ignorePatterns?: string[];
+    onProgress?: (info: SyncProgress) => void;
+  }
+): Promise<SyncResult> {
+  const db = store.db;
+  const now = new Date().toISOString();
+  const excludeDirs = ["node_modules", ".git", ".cache", "vendor", "dist", "build"];
+
+  // Phase 1: Scan filesystem
+  options?.onProgress?.({ phase: 'scanning', current: 0, total: 0 });
+
+  const allIgnore = [
+    ...excludeDirs.map(d => `**/${d}/**`),
+    ...(options?.ignorePatterns || []),
+  ];
+  const allFiles: string[] = await fastGlob(globPattern, {
+    cwd: collectionPath,
+    onlyFiles: true,
+    followSymbolicLinks: false,
+    dot: false,
+    ignore: allIgnore,
+  });
+  const files = allFiles.filter(file => {
+    const parts = file.split("/");
+    return !parts.some(part => part.startsWith("."));
+  });
+
+  // Phase 2: Load stored index and build diff
+  options?.onProgress?.({ phase: 'diffing', current: 0, total: files.length });
+
+  const storedDocs = getActiveDocumentsWithMtime(db, collectionName);
+  // Build reverse map: hash → paths (for rename detection)
+  const hashToPaths = new Map<string, string[]>();
+  for (const [path, doc] of storedDocs) {
+    const paths = hashToPaths.get(doc.hash) || [];
+    paths.push(path);
+    hashToPaths.set(doc.hash, paths);
+  }
+
+  const seenPaths = new Set<string>();
+  let added = 0, updated = 0, unchanged = 0, renamed = 0;
+  let skippedMtime = 0, skippedHash = 0;
+  let processed = 0;
+
+  // Phase 3: Process files
+  for (const relativeFile of files) {
+    const filepath = getRealPath(resolve(collectionPath, relativeFile));
+    const path = handelize(relativeFile);
+    seenPaths.add(path);
+
+    let stat: ReturnType<typeof statSync> | null = null;
+    try {
+      stat = statSync(filepath);
+    } catch {
+      processed++;
+      options?.onProgress?.({ phase: 'processing', file: relativeFile, current: ++processed, total: files.length });
+      continue;
+    }
+
+    const diskMtime = new Date(stat.mtime).toISOString();
+    const stored = storedDocs.get(path);
+
+    if (stored) {
+      // File exists in index — check mtime first
+      if (stored.disk_mtime && stored.disk_mtime === diskMtime) {
+        // mtime unchanged → SKIP (don't even read the file)
+        skippedMtime++;
+        unchanged++;
+      } else {
+        // mtime changed → read file, compute hash
+        let content: string;
+        try {
+          content = readFileSync(filepath, "utf-8");
+        } catch {
+          processed++;
+          options?.onProgress?.({ phase: 'processing', file: relativeFile, current: processed, total: files.length });
+          continue;
+        }
+
+        if (!content.trim()) {
+          processed++;
+          continue;
+        }
+
+        const hash = await hashContent(content);
+        const title = extractTitle(content, relativeFile);
+
+        if (hash === stored.hash) {
+          // Hash unchanged → update mtime only, skip embedding
+          db.prepare(`UPDATE documents SET disk_mtime = ? WHERE id = ?`)
+            .run(diskMtime, stored.id);
+          if (title !== stored.title) {
+            updateDocumentTitle(db, stored.id, title, now);
+          }
+          skippedHash++;
+          unchanged++;
+        } else {
+          // Hash changed → UPDATED → re-index (embedding auto-triggered via missing content_vectors)
+          insertContent(db, hash, content, now);
+          updateDocument(db, stored.id, title, hash, now, diskMtime);
+          updated++;
+        }
+      }
+    } else {
+      // File on disk but NOT in index → check if it's a rename (same hash, different path)
+      let content: string;
+      try {
+        content = readFileSync(filepath, "utf-8");
+      } catch {
+        processed++;
+        options?.onProgress?.({ phase: 'processing', file: relativeFile, current: processed, total: files.length });
+        continue;
+      }
+
+      if (!content.trim()) {
+        processed++;
+        continue;
+      }
+
+      const hash = await hashContent(content);
+      const title = extractTitle(content, relativeFile);
+
+      // Check for rename: same hash exists in stored docs at a path not on disk
+      const existingPaths = hashToPaths.get(hash) || [];
+      const renamedFrom = existingPaths.find(p => !seenPaths.has(p) && storedDocs.has(p));
+
+      if (renamedFrom) {
+        // Rename detected: update path reference, reuse embedding
+        const oldDoc = storedDocs.get(renamedFrom)!;
+        db.prepare(`
+          UPDATE documents SET path = ?, title = ?, modified_at = ?, disk_mtime = ?
+          WHERE id = ?
+        `).run(path, title, now, diskMtime, oldDoc.id);
+        // Mark old path as processed so it won't be deleted
+        seenPaths.add(renamedFrom);
+        // Remove old path from storedDocs so it's not found again
+        storedDocs.delete(renamedFrom);
+        renamed++;
+      } else {
+        // Genuinely new file
+        insertContent(db, hash, content, now);
+        insertDocument(db, collectionName, path, title, hash,
+          stat ? new Date(stat.birthtime).toISOString() : now,
+          now, diskMtime);
+        added++;
+      }
+    }
+
+    processed++;
+    options?.onProgress?.({ phase: 'processing', file: relativeFile, current: processed, total: files.length });
+  }
+
+  // Phase 4: Handle deletions — files in index but not on disk
+  options?.onProgress?.({ phase: 'cleanup', current: 0, total: storedDocs.size });
+  let removed = 0;
+  for (const [path] of storedDocs) {
+    if (!seenPaths.has(path)) {
+      deactivateDocument(db, collectionName, path);
+      removed++;
+    }
+  }
+
+  const orphanedCleaned = cleanupOrphanedContent(db);
+
+  return {
+    added, updated, unchanged, removed, renamed,
+    skippedMtime, skippedHash, orphanedCleaned,
+    filesScanned: files.length,
+  };
 }
 
 export type EmbedProgress = {
@@ -1635,10 +1873,10 @@ export function createStore(dbPath?: string): Store {
 
     // Document indexing operations
     insertContent: (hash: string, content: string, createdAt: string) => insertContent(db, hash, content, createdAt),
-    insertDocument: (collectionName: string, path: string, title: string, hash: string, createdAt: string, modifiedAt: string) => insertDocument(db, collectionName, path, title, hash, createdAt, modifiedAt),
+    insertDocument: (collectionName: string, path: string, title: string, hash: string, createdAt: string, modifiedAt: string, diskMtime?: string) => insertDocument(db, collectionName, path, title, hash, createdAt, modifiedAt, diskMtime),
     findActiveDocument: (collectionName: string, path: string) => findActiveDocument(db, collectionName, path),
     updateDocumentTitle: (documentId: number, title: string, modifiedAt: string) => updateDocumentTitle(db, documentId, title, modifiedAt),
-    updateDocument: (documentId: number, title: string, hash: string, modifiedAt: string) => updateDocument(db, documentId, title, hash, modifiedAt),
+    updateDocument: (documentId: number, title: string, hash: string, modifiedAt: string, diskMtime?: string) => updateDocument(db, documentId, title, hash, modifiedAt, diskMtime),
     deactivateDocument: (collectionName: string, path: string) => deactivateDocument(db, collectionName, path),
     getActiveDocumentPaths: (collectionName: string) => getActiveDocumentPaths(db, collectionName),
 
@@ -2063,17 +2301,19 @@ export function insertDocument(
   title: string,
   hash: string,
   createdAt: string,
-  modifiedAt: string
+  modifiedAt: string,
+  diskMtime?: string
 ): void {
   db.prepare(`
-    INSERT INTO documents (collection, path, title, hash, created_at, modified_at, active)
-    VALUES (?, ?, ?, ?, ?, ?, 1)
+    INSERT INTO documents (collection, path, title, hash, created_at, modified_at, disk_mtime, active)
+    VALUES (?, ?, ?, ?, ?, ?, ?, 1)
     ON CONFLICT(collection, path) DO UPDATE SET
       title = excluded.title,
       hash = excluded.hash,
       modified_at = excluded.modified_at,
+      disk_mtime = excluded.disk_mtime,
       active = 1
-  `).run(collectionName, path, title, hash, createdAt, modifiedAt);
+  `).run(collectionName, path, title, hash, createdAt, modifiedAt, diskMtime ?? modifiedAt);
 }
 
 /**
@@ -2113,10 +2353,11 @@ export function updateDocument(
   documentId: number,
   title: string,
   hash: string,
-  modifiedAt: string
+  modifiedAt: string,
+  diskMtime?: string
 ): void {
-  db.prepare(`UPDATE documents SET title = ?, hash = ?, modified_at = ? WHERE id = ?`)
-    .run(title, hash, modifiedAt, documentId);
+  db.prepare(`UPDATE documents SET title = ?, hash = ?, modified_at = ?, disk_mtime = ? WHERE id = ?`)
+    .run(title, hash, modifiedAt, diskMtime ?? modifiedAt, documentId);
 }
 
 /**

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -1,0 +1,361 @@
+/**
+ * sync.test.ts - Tests for the syncCollection() mtime-first differential sync
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
+import { mkdtemp, writeFile, mkdir, rm, unlink, rename, utimes } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { statSync, writeFileSync } from "node:fs";
+import YAML from "yaml";
+import {
+  createStore,
+  syncCollection,
+  reindexCollection,
+  hashContent,
+  syncConfigToDb,
+  type Store,
+  type SyncResult,
+} from "../src/store.js";
+import type { CollectionConfig } from "../src/collections.js";
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+let testDir: string;
+let configDir: string;
+
+beforeAll(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "qmd-sync-test-"));
+});
+
+afterAll(async () => {
+  try {
+    await rm(testDir, { recursive: true, force: true });
+  } catch {}
+});
+
+async function createTestEnv() {
+  const dir = await mkdtemp(join(testDir, "coll-"));
+  const dbPath = join(testDir, `db-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+  configDir = await mkdtemp(join(testDir, "config-"));
+  process.env.QMD_CONFIG_DIR = configDir;
+
+  const config: CollectionConfig = { collections: {} };
+  await writeFile(join(configDir, "index.yml"), YAML.stringify(config));
+
+  const store = createStore(dbPath);
+  return { dir, store };
+}
+
+async function cleanupEnv(store: Store) {
+  store.close();
+  delete process.env.QMD_CONFIG_DIR;
+}
+
+// =============================================================================
+// syncCollection Tests
+// =============================================================================
+
+describe("syncCollection", () => {
+  test("indexes new files on first sync", async () => {
+    const { dir, store } = await createTestEnv();
+
+    await writeFile(join(dir, "hello.md"), "# Hello\n\nWorld\n");
+    await writeFile(join(dir, "goodbye.md"), "# Goodbye\n\nSee you later\n");
+
+    const result = await syncCollection(store, dir, "**/*.md", "test");
+
+    expect(result.added).toBe(2);
+    expect(result.updated).toBe(0);
+    expect(result.removed).toBe(0);
+    expect(result.unchanged).toBe(0);
+    expect(result.filesScanned).toBe(2);
+
+    await cleanupEnv(store);
+  });
+
+  test("skips unchanged files by mtime", async () => {
+    const { dir, store } = await createTestEnv();
+
+    await writeFile(join(dir, "stable.md"), "# Stable\n\nThis doesn't change\n");
+
+    // First sync to populate index
+    const first = await syncCollection(store, dir, "**/*.md", "test");
+    expect(first.added).toBe(1);
+
+    // Second sync — file hasn't changed
+    const second = await syncCollection(store, dir, "**/*.md", "test");
+    expect(second.added).toBe(0);
+    expect(second.updated).toBe(0);
+    expect(second.unchanged).toBe(1);
+    expect(second.skippedMtime).toBe(1);
+
+    await cleanupEnv(store);
+  });
+
+  test("detects modified files via mtime then hash", async () => {
+    const { dir, store } = await createTestEnv();
+    const filePath = join(dir, "changing.md");
+
+    await writeFile(filePath, "# Version 1\n\nOriginal content\n");
+
+    const first = await syncCollection(store, dir, "**/*.md", "test");
+    expect(first.added).toBe(1);
+
+    // Modify the file — ensure mtime changes (add small delay)
+    await new Promise(r => setTimeout(r, 50));
+    await writeFile(filePath, "# Version 2\n\nUpdated content\n");
+
+    const second = await syncCollection(store, dir, "**/*.md", "test");
+    expect(second.updated).toBe(1);
+    expect(second.unchanged).toBe(0);
+
+    await cleanupEnv(store);
+  });
+
+  test("detects mtime change but hash unchanged (touch)", async () => {
+    const { dir, store } = await createTestEnv();
+    const filePath = join(dir, "touched.md");
+
+    await writeFile(filePath, "# Touched\n\nContent stays the same\n");
+
+    const first = await syncCollection(store, dir, "**/*.md", "test");
+    expect(first.added).toBe(1);
+
+    // Touch the file — changes mtime but not content
+    await new Promise(r => setTimeout(r, 50));
+    const now = new Date();
+    await utimes(filePath, now, now);
+
+    const second = await syncCollection(store, dir, "**/*.md", "test");
+    expect(second.updated).toBe(0);
+    expect(second.unchanged).toBe(1);
+    expect(second.skippedHash).toBe(1);
+    expect(second.skippedMtime).toBe(0);
+
+    await cleanupEnv(store);
+  });
+
+  test("removes deleted files", async () => {
+    const { dir, store } = await createTestEnv();
+    const filePath = join(dir, "ephemeral.md");
+
+    await writeFile(filePath, "# Temporary\n\nWill be deleted\n");
+    await writeFile(join(dir, "keeper.md"), "# Keeper\n\nStays around\n");
+
+    const first = await syncCollection(store, dir, "**/*.md", "test");
+    expect(first.added).toBe(2);
+
+    // Delete one file
+    await unlink(filePath);
+
+    const second = await syncCollection(store, dir, "**/*.md", "test");
+    expect(second.removed).toBe(1);
+    expect(second.unchanged).toBe(1);
+
+    await cleanupEnv(store);
+  });
+
+  test("detects renamed files and reuses embeddings", async () => {
+    const { dir, store } = await createTestEnv();
+    const content = "# Renameable\n\nThis file will be renamed but content stays the same\n";
+    const oldPath = join(dir, "old-name.md");
+    const newPath = join(dir, "new-name.md");
+
+    await writeFile(oldPath, content);
+
+    const first = await syncCollection(store, dir, "**/*.md", "test");
+    expect(first.added).toBe(1);
+
+    // Rename the file
+    await rename(oldPath, newPath);
+
+    const second = await syncCollection(store, dir, "**/*.md", "test");
+    expect(second.renamed).toBe(1);
+    expect(second.added).toBe(0);
+    expect(second.removed).toBe(0);
+
+    await cleanupEnv(store);
+  });
+
+  test("handles new + deleted + unchanged in same sync", async () => {
+    const { dir, store } = await createTestEnv();
+
+    await writeFile(join(dir, "stays.md"), "# Stays\n\nPermanent file\n");
+    await writeFile(join(dir, "goes.md"), "# Goes\n\nWill be deleted\n");
+
+    const first = await syncCollection(store, dir, "**/*.md", "test");
+    expect(first.added).toBe(2);
+
+    // Delete one, add another
+    await unlink(join(dir, "goes.md"));
+    await writeFile(join(dir, "arrives.md"), "# Arrives\n\nBrand new file\n");
+
+    const second = await syncCollection(store, dir, "**/*.md", "test");
+    expect(second.added).toBe(1);
+    expect(second.removed).toBe(1);
+    expect(second.unchanged).toBe(1);
+
+    await cleanupEnv(store);
+  });
+
+  test("skips empty files", async () => {
+    const { dir, store } = await createTestEnv();
+
+    await writeFile(join(dir, "empty.md"), "");
+    await writeFile(join(dir, "whitespace.md"), "   \n\n  \n");
+    await writeFile(join(dir, "real.md"), "# Real\n\nHas content\n");
+
+    const result = await syncCollection(store, dir, "**/*.md", "test");
+    expect(result.added).toBe(1);
+    expect(result.filesScanned).toBe(3);
+
+    await cleanupEnv(store);
+  });
+
+  test("skips hidden files and directories", async () => {
+    const { dir, store } = await createTestEnv();
+
+    await mkdir(join(dir, ".hidden"), { recursive: true });
+    await writeFile(join(dir, ".hidden", "secret.md"), "# Secret\n");
+    await writeFile(join(dir, ".dotfile.md"), "# Dotfile\n");
+    await writeFile(join(dir, "visible.md"), "# Visible\n\nNormal file\n");
+
+    const result = await syncCollection(store, dir, "**/*.md", "test");
+    expect(result.added).toBe(1);
+
+    await cleanupEnv(store);
+  });
+
+  test("respects ignore patterns", async () => {
+    const { dir, store } = await createTestEnv();
+
+    await mkdir(join(dir, "drafts"), { recursive: true });
+    await writeFile(join(dir, "drafts", "wip.md"), "# WIP\n\nWork in progress\n");
+    await writeFile(join(dir, "published.md"), "# Published\n\nDone\n");
+
+    const result = await syncCollection(store, dir, "**/*.md", "test", {
+      ignorePatterns: ["drafts/**"],
+    });
+    expect(result.added).toBe(1);
+
+    await cleanupEnv(store);
+  });
+
+  test("handles subdirectories", async () => {
+    const { dir, store } = await createTestEnv();
+
+    await mkdir(join(dir, "sub", "deep"), { recursive: true });
+    await writeFile(join(dir, "root.md"), "# Root\n");
+    await writeFile(join(dir, "sub", "child.md"), "# Child\n");
+    await writeFile(join(dir, "sub", "deep", "leaf.md"), "# Leaf\n");
+
+    const result = await syncCollection(store, dir, "**/*.md", "test");
+    expect(result.added).toBe(3);
+    expect(result.filesScanned).toBe(3);
+
+    await cleanupEnv(store);
+  });
+
+  test("first sync after migration populates disk_mtime for all docs", async () => {
+    const { dir, store } = await createTestEnv();
+
+    await writeFile(join(dir, "legacy.md"), "# Legacy\n\nExisting doc\n");
+
+    // Simulate pre-migration: use reindexCollection (which sets disk_mtime),
+    // then NULL it out to simulate legacy state
+    await reindexCollection(store, dir, "**/*.md", "test");
+    store.db.prepare(`UPDATE documents SET disk_mtime = NULL WHERE collection = ?`).run("test");
+
+    // Verify it's NULL
+    const before = store.db.prepare(
+      `SELECT disk_mtime FROM documents WHERE collection = ? AND active = 1`
+    ).get("test") as { disk_mtime: string | null };
+    expect(before.disk_mtime).toBeNull();
+
+    // Sync should read the file (mtime check fails due to NULL) and populate disk_mtime
+    const result = await syncCollection(store, dir, "**/*.md", "test");
+    expect(result.unchanged).toBe(1);
+    expect(result.skippedHash).toBe(1); // mtime changed (null→value), hash same
+
+    const after = store.db.prepare(
+      `SELECT disk_mtime FROM documents WHERE collection = ? AND active = 1`
+    ).get("test") as { disk_mtime: string | null };
+    expect(after.disk_mtime).not.toBeNull();
+
+    await cleanupEnv(store);
+  });
+
+  test("sync results match expectations for mixed operations", async () => {
+    const { dir, store } = await createTestEnv();
+
+    // Initial state: 3 files
+    await writeFile(join(dir, "a.md"), "# File A\n");
+    await writeFile(join(dir, "b.md"), "# File B\n");
+    await writeFile(join(dir, "c.md"), "# File C\n");
+
+    await syncCollection(store, dir, "**/*.md", "test");
+
+    // Modify b, delete c, add d, rename a→e (same content)
+    await new Promise(r => setTimeout(r, 50));
+    await writeFile(join(dir, "b.md"), "# File B Updated\n");
+    await unlink(join(dir, "c.md"));
+    await writeFile(join(dir, "d.md"), "# File D\n");
+    await rename(join(dir, "a.md"), join(dir, "e.md"));
+
+    const result = await syncCollection(store, dir, "**/*.md", "test");
+    expect(result.updated).toBe(1);   // b.md content changed
+    expect(result.removed).toBe(1);   // c.md deleted
+    expect(result.added).toBe(1);     // d.md new
+    expect(result.renamed).toBe(1);   // a.md → e.md
+
+    await cleanupEnv(store);
+  });
+
+  test("fires onProgress callback", async () => {
+    const { dir, store } = await createTestEnv();
+
+    await writeFile(join(dir, "one.md"), "# One\n");
+    await writeFile(join(dir, "two.md"), "# Two\n");
+
+    const phases: string[] = [];
+    await syncCollection(store, dir, "**/*.md", "test", {
+      onProgress: (info) => {
+        if (!phases.includes(info.phase)) {
+          phases.push(info.phase);
+        }
+      },
+    });
+
+    expect(phases).toContain("scanning");
+    expect(phases).toContain("processing");
+
+    await cleanupEnv(store);
+  });
+
+  test("cleans up orphaned content after deletions", async () => {
+    const { dir, store } = await createTestEnv();
+
+    const uniqueContent = `# Unique ${Date.now()}\n\nContent that will be orphaned\n`;
+    await writeFile(join(dir, "orphan.md"), uniqueContent);
+
+    await syncCollection(store, dir, "**/*.md", "test");
+
+    // Verify content exists
+    const hash = await hashContent(uniqueContent);
+    const contentBefore = store.db.prepare(
+      `SELECT hash FROM content WHERE hash = ?`
+    ).get(hash) as { hash: string } | undefined;
+    expect(contentBefore).toBeDefined();
+
+    // Delete the file and sync
+    await unlink(join(dir, "orphan.md"));
+    const result = await syncCollection(store, dir, "**/*.md", "test");
+    expect(result.removed).toBe(1);
+    expect(result.orphanedCleaned).toBeGreaterThanOrEqual(1);
+
+    await cleanupEnv(store);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `qmd collection sync <name>` — an incremental re-indexing command that uses filesystem mtime as a first-pass filter before computing content hashes
- Checks mtime (nearly free OS call) before reading files. Only reads files whose mtime changed since last sync. Of those, only re-embeds files whose content hash actually changed
- Detects renamed files via content hash matching and reuses existing embeddings
- Exposes `sync()` on the SDK `QMDStore` interface for programmatic use

## What changed

| File | Change |
|---|---|
| `src/store.ts` | `disk_mtime` column migration, `syncCollection()` function, updated `insertDocument`/`updateDocument` signatures |
| `src/cli/qmd.ts` | `collection sync` subcommand + help text |
| `src/index.ts` | SDK `sync()` method + type exports |
| `CLAUDE.md` | Document new command |
| `test/sync.test.ts` | 15 tests covering all edge cases |

## How it works

```
File on disk but NOT in index -> NEW -> index it, mark for embedding
File in index but NOT on disk -> DELETED -> deactivate, clean up embedding
File on disk AND in index:
  mtime unchanged -> SKIP (don't even read the file)
  mtime changed -> read file, compute hash:
    hash unchanged -> update mtime, skip embedding
    hash changed -> UPDATED -> re-index, mark for embedding
Same hash at new path -> RENAMED -> update path, reuse embedding
```

## Edge cases handled

- First sync after migration (NULL `disk_mtime`) -- falls through to read+hash, self-heals
- `touch`ed files (mtime changed, content same) -- one read, no re-embedding
- Renamed files -- detected by content hash, embedding reused
- Empty/hidden files -- skipped consistently with `reindexCollection`
- Ignore patterns respected

## Test plan

- [x] 15 unit tests pass (`npx vitest run test/sync.test.ts`)
- [x] Full test suite passes (717/717 non-LLM tests)
- [x] `tsc -p tsconfig.build.json --noEmit` clean
- [ ] Manual test with a real collection