### PR TITLE
feat: editor link presets (--editor flag, config key)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+- Editor link presets: `--editor <name>` CLI flag and `editor:` config key
+  replace the raw `editor_uri` template. Built-in presets: `file` (new default),
+  `vscode`, `cursor`, `zed`, `sublime`, `idea`. The `QMD_EDITOR_URI`
+  env var remains supported. Default changed from `vscode://` to `file://`.
+
 ## [2.1.0] - 2026-04-05
 
 Code files now chunk at function and class boundaries via tree-sitter,

--- a/README.md
+++ b/README.md
@@ -692,21 +692,28 @@ Discussion about code quality and craftsmanship
 in the development process.
 ```
 
-Configure the editor link target with `QMD_EDITOR_URI` (or `editor_uri` in config):
+By default, clickable paths use `file://` URIs. Use `--editor` or the `editor` config key to select a named preset:
 
 ```sh
-# VS Code (default)
-export QMD_EDITOR_URI="vscode://file/{path}:{line}:{col}"
+# CLI flag (highest priority)
+qmd search "query" --editor vscode
 
-# Cursor
-export QMD_EDITOR_URI="cursor://file/{path}:{line}:{col}"
-
-# Zed
-export QMD_EDITOR_URI="zed://file/{path}:{line}:{col}"
-
-# Sublime Text
-export QMD_EDITOR_URI="subl://open?url=file://{path}&line={line}"
+# Config file (~/.config/qmd/index.yml)
+editor: vscode
 ```
+
+Available presets: `file` (default), `vscode`, `cursor`, `zed`, `sublime`, `idea`.
+
+For custom editors, pass a raw URI template:
+
+```sh
+qmd search "query" --editor "myeditor://open?file={path}&line={line}"
+
+# Or via environment variable
+export QMD_EDITOR_URI="myeditor://open?file={path}&line={line}"
+```
+
+Resolution order: `--editor` flag > `QMD_EDITOR_URI` env > `editor` config key > default (`file`).
 
 Template placeholders:
 - `{path}` absolute filesystem path (URI-encoded)

--- a/example-index.yml
+++ b/example-index.yml
@@ -4,6 +4,10 @@
 # This file defines all collections and their contexts.
 # You can manually edit this file - changes take effect immediately.
 
+# Editor for clickable terminal links (preset name or URI template)
+# Presets: file (default), vscode, cursor, zed, sublime, idea
+# editor: vscode
+
 # Global context applied to all collections
 # Use this for universal search instructions or patterns
 global_context: "If you see a relevant [[WikiWord]], you can search for that WikiWord to get more context."

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -1789,6 +1789,7 @@ type OutputOptions = {
   intent?: string;       // Domain intent for disambiguation
   skipRerank?: boolean;  // Skip LLM reranking, use RRF scores only
   chunkStrategy?: ChunkStrategy;  // "auto" (default) or "regex"
+  editor?: string;       // Editor preset name or URI template (from --editor CLI flag)
 };
 
 // Highlight query terms in text (skip short words < 3 chars)
@@ -1865,7 +1866,26 @@ type OutputRow = {
   explain?: HybridQueryExplain;
 };
 
-const DEFAULT_EDITOR_URI_TEMPLATE = "vscode://file/{path}:{line}:{col}";
+export const EDITOR_PRESETS: Record<string, string> = {
+  file:     "file://{path}",
+  vscode:   "vscode://file/{path}:{line}:{col}",
+  cursor:   "cursor://file/{path}:{line}:{col}",
+  zed:      "zed://file/{path}:{line}:{col}",
+  sublime:  "subl://open?url=file://{path}&line={line}",
+  idea:     "idea://open?file={path}&line={line}&column={col}",
+};
+
+const DEFAULT_EDITOR_PRESET = "file";
+
+export function resolveEditorTemplate(value: string): string {
+  const trimmed = value.trim();
+  const preset = EDITOR_PRESETS[trimmed.toLowerCase()];
+  if (preset) return preset;
+  if (trimmed.includes("{path}") || trimmed.includes("://")) return trimmed;
+  const names = Object.keys(EDITOR_PRESETS).join(", ");
+  process.stderr.write(`Warning: unknown editor "${trimmed}". Valid presets: ${names}\n`);
+  return EDITOR_PRESETS[DEFAULT_EDITOR_PRESET]!;
+}
 
 function encodePathForEditorUri(absolutePath: string): string {
   return encodeURI(absolutePath)
@@ -1873,30 +1893,31 @@ function encodePathForEditorUri(absolutePath: string): string {
     .replace(/#/g, "%23");
 }
 
-function getEditorUriTemplate(): string {
-  const envTemplate = process.env.QMD_EDITOR_URI?.trim();
-  if (envTemplate) return envTemplate;
+function getEditorUriTemplate(cliEditor?: string): string {
+  // 1. CLI --editor flag (highest priority)
+  if (cliEditor?.trim()) {
+    return resolveEditorTemplate(cliEditor);
+  }
 
+  // 2. QMD_EDITOR_URI env var (accepts preset names or raw templates)
+  const envValue = process.env.QMD_EDITOR_URI?.trim();
+  if (envValue) {
+    return resolveEditorTemplate(envValue);
+  }
+
+  // 3. Config file "editor" key
   try {
-    const config = loadConfig() as unknown as {
-      editor_uri?: string;
-      editor_uri_template?: string;
-      editorUri?: string;
-      [key: string]: unknown;
-    };
-    const configTemplate = (
-      config.editor_uri
-      || config.editor_uri_template
-      || config.editorUri
-      || (typeof config["editor-uri"] === "string" ? config["editor-uri"] : undefined)
-    )?.trim();
-
-    if (configTemplate) return configTemplate;
+    const config = loadConfig();
+    const editorValue = config.editor?.trim();
+    if (editorValue) {
+      return resolveEditorTemplate(editorValue);
+    }
   } catch {
     // Ignore config parsing issues and use default template.
   }
 
-  return DEFAULT_EDITOR_URI_TEMPLATE;
+  // 4. Default
+  return EDITOR_PRESETS[DEFAULT_EDITOR_PRESET]!;
 }
 
 export function buildEditorUri(template: string, absolutePath: string, line: number, col: number): string {
@@ -1957,7 +1978,7 @@ function outputResults(results: OutputRow[], query: string, opts: OutputOptions)
       console.log(`#${docid},${row.score.toFixed(2)},${toQmdPath(row.displayPath)}${ctx}`);
     }
   } else if (opts.format === "cli") {
-    const editorUriTemplate = getEditorUriTemplate();
+    const editorUriTemplate = getEditorUriTemplate(opts.editor);
     const linkDb = getDb();
 
     for (let i = 0; i < filtered.length; i++) {
@@ -2487,6 +2508,8 @@ function parseCLI() {
       intent: { type: "string" },
       // Chunking options
       "chunk-strategy": { type: "string" },  // "regex" (default) or "auto" (AST for code files)
+      // Editor options
+      editor: { type: "string" },
       // MCP HTTP transport options
       http: { type: "boolean" },
       daemon: { type: "boolean" },
@@ -2529,6 +2552,7 @@ function parseCLI() {
     explain: !!values.explain,
     intent: values.intent as string | undefined,
     chunkStrategy: parseChunkStrategy(values["chunk-strategy"]),
+    editor: values.editor as string | undefined,
   };
 
   return {
@@ -2739,7 +2763,7 @@ function showHelp(): void {
   console.log("");
   console.log("Global options:");
   console.log("  --index <name>             - Use a named index (default: index)");
-  console.log("  QMD_EDITOR_URI             - Editor link template for clickable TTY search output");
+  console.log("  --editor <name|template>   - Editor for clickable links (file, vscode, cursor, zed, sublime, idea)");
   console.log("");
   console.log("Search options:");
   console.log("  -n <num>                   - Max results (default 5, or 20 for --files/--json)");

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -47,8 +47,7 @@ export interface ModelsConfig {
  */
 export interface CollectionConfig {
   global_context?: string;                    // Context applied to all collections
-  editor_uri?: string;                        // Editor URI template for terminal hyperlinks
-  editor_uri_template?: string;               // Alias for editor_uri
+  editor?: string;                            // Editor preset name or URI template for terminal hyperlinks
   collections: Record<string, Collection>;    // Collection name -> config
   models?: ModelsConfig;
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -13,7 +13,7 @@ import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { spawn } from "child_process";
 import { setTimeout as sleep } from "timers/promises";
-import { buildEditorUri, termLink } from "../src/cli/qmd.ts";
+import { buildEditorUri, termLink, EDITOR_PRESETS, resolveEditorTemplate } from "../src/cli/qmd.ts";
 
 // Test fixtures directory and database path
 let testDir: string;
@@ -1222,6 +1222,53 @@ describe("editor URI templates", () => {
     const linked = termLink("docs/api.md:12", "vscode://file//tmp/docs/api.md:12:1", true);
 
     expect(linked).toBe("\x1b]8;;vscode://file//tmp/docs/api.md:12:1\x07docs/api.md:12\x1b]8;;\x07");
+  });
+
+  test("buildEditorUri with file:// template omits unused line/col placeholders", () => {
+    const uri = buildEditorUri("file://{path}", "/tmp/test.md", 10, 1);
+
+    expect(uri).toBe("file:///tmp/test.md");
+  });
+});
+
+describe("editor presets", () => {
+  test("resolveEditorTemplate resolves known preset name", () => {
+    expect(resolveEditorTemplate("vscode")).toBe("vscode://file/{path}:{line}:{col}");
+  });
+
+  test("resolveEditorTemplate is case-insensitive", () => {
+    expect(resolveEditorTemplate("VSCode")).toBe("vscode://file/{path}:{line}:{col}");
+    expect(resolveEditorTemplate("CURSOR")).toBe("cursor://file/{path}:{line}:{col}");
+  });
+
+  test("resolveEditorTemplate passes through raw URI templates", () => {
+    const custom = "myeditor://open?file={path}&line={line}";
+    expect(resolveEditorTemplate(custom)).toBe(custom);
+  });
+
+  test("resolveEditorTemplate falls back to file:// for unknown preset", () => {
+    const stderrWrite = process.stderr.write;
+    const warnings: string[] = [];
+    process.stderr.write = ((chunk: string) => { warnings.push(chunk); return true; }) as typeof process.stderr.write;
+    try {
+      expect(resolveEditorTemplate("notepad")).toBe("file://{path}");
+      expect(warnings[0]).toContain("unknown editor");
+    } finally {
+      process.stderr.write = stderrWrite;
+    }
+  });
+
+  test("EDITOR_PRESETS contains expected editors", () => {
+    expect(EDITOR_PRESETS).toHaveProperty("file");
+    expect(EDITOR_PRESETS).toHaveProperty("vscode");
+    expect(EDITOR_PRESETS).toHaveProperty("cursor");
+    expect(EDITOR_PRESETS).toHaveProperty("zed");
+    expect(EDITOR_PRESETS).toHaveProperty("sublime");
+    expect(EDITOR_PRESETS).toHaveProperty("idea");
+  });
+
+  test("default preset is file://", () => {
+    expect(EDITOR_PRESETS["file"]).toBe("file://{path}");
   });
 });
 


### PR DESCRIPTION
## Summary

- Replace raw `editor_uri` / `editor_uri_template` config with named **editor presets**
- Default changed from `vscode://` to `file://` for universal compatibility
- New `--editor <name|template>` CLI flag and `editor:` YAML config key
- Built-in presets: `file`, `vscode`, `cursor`, `zed`, `sublime`, `idea`
- Resolution order: `--editor` flag > `QMD_EDITOR_URI` env > `editor` config > default
- `QMD_EDITOR_URI` env var now also accepts preset names (not just raw templates)

Closes #507. Supersedes #508.

## Test plan

- [x] All 98 existing tests pass (including 11 editor-related tests)
- [x] New tests for preset resolution, case-insensitivity, raw template passthrough, unknown preset fallback
- [ ] Manual: `qmd search "test" --editor vscode` emits `vscode://` OSC 8 links
- [ ] Manual: default output uses `file://` links

🤖 Generated with [Claude Code](https://claude.com/claude-code)