### PR TITLE
feat(cli): add qmd watch for auto-reindexing on file changes

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -5,7 +5,7 @@ import { execSync, spawn as nodeSpawn } from "child_process";
 import { fileURLToPath } from "url";
 import { basename, dirname, join as pathJoin, relative as relativePath, resolve as pathResolve } from "path";
 import { parseArgs } from "util";
-import { readFileSync, readdirSync, realpathSync, statSync, existsSync, unlinkSync, writeFileSync, openSync, closeSync, mkdirSync, lstatSync, rmSync, symlinkSync, readlinkSync, copyFileSync } from "fs";
+import { readFileSync, readdirSync, realpathSync, statSync, existsSync, unlinkSync, writeFileSync, openSync, closeSync, mkdirSync, lstatSync, rmSync, symlinkSync, readlinkSync, copyFileSync, watch as fsWatch } from "fs";
 import { createInterface } from "readline/promises";
 import {
   getPwd,
@@ -747,6 +747,100 @@ async function updateCollections(): Promise<void> {
   if (needsEmbedding > 0) {
     console.log(`\nRun 'qmd embed' to update embeddings (${needsEmbedding} unique hashes need vectors)`);
   }
+}
+
+/**
+ * Watch all collection directories for file changes and auto-reindex.
+ * Debounces rapid changes per collection (500ms).
+ */
+async function watchCollections(autoEmbed: boolean): Promise<void> {
+  const db = getDb();
+  const storeInstance = getStore();
+  const collections = listCollections(db);
+
+  if (collections.length === 0) {
+    console.log(`${c.dim}No collections found. Run 'qmd collection add .' to index markdown files.${c.reset}`);
+    closeDb();
+    return;
+  }
+
+  const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const watchers: ReturnType<typeof fsWatch>[] = [];
+
+  console.log(`${c.bold}Watching ${collections.length} collection(s) for changes...${c.reset}`);
+  for (const col of collections) {
+    if (!col) continue;
+    console.log(`  ${c.cyan}${col.name}${c.reset} ${c.dim}${col.pwd}${c.reset}`);
+  }
+  console.log(`\n${c.dim}Press Ctrl+C to stop.${c.reset}\n`);
+
+  for (const col of collections) {
+    if (!col) continue;
+    if (!existsSync(col.pwd)) {
+      console.log(`${c.yellow}⚠${c.reset} ${col.name}: directory not found (${col.pwd}), skipping`);
+      continue;
+    }
+
+    try {
+      const watcher = fsWatch(col.pwd, { recursive: true }, (_event, filename) => {
+        if (!filename) return;
+        // Only trigger for files matching the collection glob pattern
+        const ext = filename.split('.').pop()?.toLowerCase();
+        const pattern = col.glob_pattern || "**/*.md";
+        // Simple extension check from glob pattern
+        const globExts = pattern.match(/\*\.(\w+)/g)?.map(m => m.slice(2)) || ["md"];
+        if (ext && !globExts.includes(ext)) return;
+
+        // Debounce per collection
+        const existing = debounceTimers.get(col.name);
+        if (existing) clearTimeout(existing);
+
+        debounceTimers.set(col.name, setTimeout(async () => {
+          debounceTimers.delete(col.name);
+          const timestamp = new Date().toLocaleTimeString();
+          console.log(`${c.dim}[${timestamp}]${c.reset} ${c.cyan}${col.name}${c.reset} changed: ${filename}`);
+
+          try {
+            const yamlCol = getCollectionFromYaml(col.name);
+            const result = await reindexCollection(storeInstance, col.pwd, col.glob_pattern, col.name, {
+              ignorePatterns: yamlCol?.ignore,
+            });
+            console.log(`  Indexed: ${result.indexed} new, ${result.updated} updated, ${result.unchanged} unchanged, ${result.removed} removed`);
+
+            if (autoEmbed) {
+              const needsEmbedding = getHashesNeedingEmbedding(db);
+              if (needsEmbedding > 0) {
+                console.log(`  Embedding ${needsEmbedding} new hash(es)...`);
+                await vectorIndex(DEFAULT_EMBED_MODEL_URI, false, {});
+                console.log(`  ${c.green}✓${c.reset} Embeddings updated`);
+              }
+            } else {
+              const needsEmbedding = getHashesNeedingEmbedding(db);
+              if (needsEmbedding > 0) {
+                console.log(`  ${c.dim}${needsEmbedding} hash(es) need embedding. Run 'qmd embed' to update vectors.${c.reset}`);
+              }
+            }
+          } catch (err) {
+            console.error(`  ${c.yellow}⚠${c.reset} Reindex failed: ${err instanceof Error ? err.message : String(err)}`);
+          }
+        }, 500));
+      });
+      watchers.push(watcher);
+    } catch (err) {
+      console.log(`${c.yellow}⚠${c.reset} ${col.name}: could not watch (${err instanceof Error ? err.message : String(err)})`);
+    }
+  }
+
+  // Keep the process alive and handle clean shutdown
+  await new Promise<void>((resolve) => {
+    process.on("SIGINT", () => {
+      console.log(`\n${c.green}✓${c.reset} Stopped watching.`);
+      for (const w of watchers) w.close();
+      for (const t of debounceTimers.values()) clearTimeout(t);
+      closeDb();
+      resolve();
+    });
+  });
 }
 
 /**
@@ -2750,8 +2844,9 @@ function parseCLI() {
       "max-docs-per-batch": { type: "string" },
       "max-batch-mb": { type: "string" },
       timeout: { type: "string" },  // embed session cap in minutes (0 = no limit; default 30)
-      // Update options
+      // Update/watch options
       pull: { type: "boolean" },  // git pull before update
+      embed: { type: "boolean" },  // auto-embed after watch update
       refresh: { type: "boolean" },
       // Get options
       l: { type: "string" },  // max lines
@@ -3285,6 +3380,7 @@ function showHelp(): void {
   console.log("  qmd init                      - Create a project-local .qmd index");
   console.log("  qmd status                    - View index + collection health");
   console.log("  qmd update [--pull]           - Re-index collections (optionally git pull first)");
+  console.log("  qmd watch [--embed]           - Watch collections for changes, auto-reindex");
   console.log("  qmd embed [-f] [-c <name>]    - Generate/refresh vector embeddings");
   console.log("    --max-docs-per-batch <n>    - Cap docs loaded into memory per embedding batch");
   console.log("    --max-batch-mb <n>          - Cap UTF-8 MB loaded into memory per embedding batch");
@@ -4570,6 +4666,10 @@ if (isMain) {
       break;
     }
 
+    case "watch":
+      await watchCollections(!!cli.values.embed);
+      break;
+
     default:
       console.error(`Unknown command: ${cli.command}`);
       console.error("Run 'qmd --help' for usage.");
@@ -4577,7 +4677,8 @@ if (isMain) {
       process.exit(1);
   }
 
-  if (cli.command !== "mcp") {
+  // `watch` is long-running, so it must not go through the terminal path.
+  if (cli.command !== "mcp" && cli.command !== "watch") {
     await finishSuccessfulCliCommand({
       command: cli.command,
       format: cli.opts.format,


### PR DESCRIPTION
## Summary

Adds `qmd watch [--embed]` that monitors all configured collection directories for file changes and auto-reindexes affected collections with 500ms debouncing.

## Why this matters

QMD requires manual `qmd update` to reindex after file changes. When editing notes throughout the day, search returns stale results until you remember to reindex.

| Source | Evidence | Signal |
|--------|----------|--------|
| [CK](https://github.com/BeaconBay/ck) | Auto-updates index on file changes | Direct competitor, 1.5K stars |
| [Khoj](https://github.com/khoj-ai/khoj) | Auto-syncs data sources on schedule | 34K stars |
| Dogfooding | After `collection add` + editing files, search returned stale results | First-run friction |

## Changes

- New `watchCollections()` function in `src/cli/qmd.ts` using Node.js `fs.watch` with recursive mode
- `watch` case in the CLI switch statement
- `--embed` option in `parseCLI()` to auto-trigger embedding after updates
- Help text updated
- Changelog entry added

Implementation uses `fs.watch` (event-based, macOS FSEvents / Linux inotify) with per-collection debouncing. No new dependencies. Reuses existing `reindexCollection()` for the actual indexing work.

By default, `watch` only reindexes (fast). Pass `--embed` to also regenerate vector embeddings after each update (loads models into VRAM).

## Demo

![qmd watch demo](https://files.catbox.moe/v8jxg3.gif)

## Testing

- All 91 existing CLI tests pass
- Manual testing: started `qmd watch`, created a new `.md` file in a collection directory, observed auto-reindex output within 1 second

This contribution was developed with AI assistance (Claude Code).