### PR TITLE
Fix: derive embed model label from actual model URI

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -24,6 +24,7 @@ import {
   formatQueryForEmbedding,
   formatDocForEmbedding,
   withLLMSessionForLlm,
+  DEFAULT_EMBED_MODEL_URI,
   type RerankDocument,
   type ILLMSession,
 } from "./llm.js";
@@ -39,7 +40,17 @@ import type {
 // =============================================================================
 
 const HOME = process.env.HOME || "/tmp";
-export const DEFAULT_EMBED_MODEL = "embeddinggemma";
+/** Derive a short model label from an hf: URI or return as-is for plain names. */
+export function embedModelLabel(uri: string): string {
+  // hf:org/repo/filename.gguf → filename (without extension and quantization)
+  if (uri.startsWith("hf:")) {
+    const file = uri.split("/").pop() ?? uri;
+    return file.replace(/[-.](?:Q\d[^.]*)?\.gguf$/i, "").replace(/\.gguf$/i, "");
+  }
+  return uri;
+}
+
+export const DEFAULT_EMBED_MODEL = embedModelLabel(DEFAULT_EMBED_MODEL_URI);
 export const DEFAULT_RERANK_MODEL = "ExpedientFalcon/qwen3-reranker:0.6b-q8_0";
 export const DEFAULT_QUERY_MODEL = "Qwen/Qwen3-1.7B";
 export const DEFAULT_GLOB = "**/*.md";

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -49,12 +49,41 @@ import {
   STRONG_SIGNAL_MIN_SCORE,
   STRONG_SIGNAL_MIN_GAP,
   generateEmbeddings,
+  embedModelLabel,
   type Store,
   type DocumentResult,
   type SearchResult,
   type RankedResult,
 } from "../src/store.js";
 import type { CollectionConfig } from "../src/collections.js";
+
+// =============================================================================
+// embedModelLabel
+// =============================================================================
+
+describe("embedModelLabel", () => {
+  test("extracts model name from hf: URI, stripping quantization and .gguf", () => {
+    expect(embedModelLabel("hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf"))
+      .toBe("embeddinggemma-300M");
+    expect(embedModelLabel("hf:nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.Q8_0.gguf"))
+      .toBe("nomic-embed-text-v1.5");
+    expect(embedModelLabel("hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf"))
+      .toBe("Qwen3-Embedding-0.6B");
+  });
+
+  test("produces same label for different quantizations of the same model", () => {
+    const q8 = embedModelLabel("hf:nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.Q8_0.gguf");
+    const q6 = embedModelLabel("hf:nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.Q6_K.gguf");
+    const q4 = embedModelLabel("hf:nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5-Q4_K_M.gguf");
+    expect(q8).toBe(q6);
+    expect(q6).toBe(q4);
+  });
+
+  test("passes through plain model names unchanged", () => {
+    expect(embedModelLabel("embeddinggemma")).toBe("embeddinggemma");
+    expect(embedModelLabel("my-custom-model")).toBe("my-custom-model");
+  });
+});
 
 // =============================================================================
 // LlamaCpp Setup


### PR DESCRIPTION
## Summary

- `DEFAULT_EMBED_MODEL` in `store.ts` was hardcoded as `"embeddinggemma"` regardless of the actual embedding model loaded
- When using a different model (e.g. `nomic-embed-text-v1.5` via per-collection config), all vectors in `content_vectors.model` were still labeled `"embeddinggemma"`, making the model discriminator column meaningless
- Derives the label from `DEFAULT_EMBED_MODEL_URI` instead, stripping the `hf:` prefix, path, quantization suffix, and `.gguf` extension to produce a clean model family name

Examples:
| URI | Label |
|-----|-------|
| `hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf` | `embeddinggemma-300M` |
| `hf:nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.Q8_0.gguf` | `nomic-embed-text-v1.5` |
| `hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf` | `Qwen3-Embedding-0.6B` |

Different quantizations of the same model (Q8_0, Q6_K, Q4_K_M) produce identical labels. Plain model names pass through unchanged for backward compatibility.

## Test plan

- [x] 3 unit tests added covering URI extraction, quantization-agnostic labels, and plain name passthrough
- [x] `bun test --grep embedModelLabel` passes