### PR TITLE
Add C# AST chunking with optional Roslyn sidecar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ archive/
 texts/
 .cursor/
 .github/copilot/
+.worktrees/
 *.md
 !README.md
 !CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -566,15 +566,15 @@ qmd embed
 # Force re-embed everything
 qmd embed -f
 
-# Enable AST-aware chunking for code files (TS, JS, Python, Go, Rust)
+# Enable AST-aware chunking for code files (TS, JS, Python, Go, Rust, C#)
 qmd embed --chunk-strategy auto
 
 # Also works with query for consistent chunk selection
 qmd query "auth flow" --chunk-strategy auto
 ```
 
-**AST-aware chunking** (`--chunk-strategy auto`) uses tree-sitter to chunk code
-files at function, class, and import boundaries instead of arbitrary text
+**AST-aware chunking** (`--chunk-strategy auto`) uses AST parsers to chunk code
+files at function, class, namespace, and import boundaries instead of arbitrary text
 positions. This produces higher-quality chunks and better search results for
 codebases. Markdown and other file types always use regex-based chunking
 regardless of strategy.
@@ -871,7 +871,7 @@ For supported code files, QMD also parses the source with [tree-sitter](https://
 | Type alias / enum | 80 | All |
 | Import / use declaration | 60 | All |
 
-Supported for `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.go`, and `.rs` files. Enable with `--chunk-strategy auto`. Markdown and other file types always use regex chunking.
+Supported for `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.go`, `.rs`, and `.cs` files. Enable with `--chunk-strategy auto`. For C#, QMD can optionally use a Roslyn sidecar for enhanced breakpoints and symbol metadata; if unavailable, it falls back to tree-sitter C# and then regex-only chunking. Markdown and other file types always use regex chunking.
 
 ### Query Flow (Hybrid)
 

--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ qmd embed --chunk-strategy auto
 qmd query "auth flow" --chunk-strategy auto
 ```
 
-**AST-aware chunking** (`--chunk-strategy auto`) uses AST parsers to chunk code
+**AST-aware chunking** (`--chunk-strategy auto`) uses tree-sitter to chunk code
 files at function, class, namespace, and import boundaries instead of arbitrary text
 positions. This produces higher-quality chunks and better search results for
 codebases. Markdown and other file types always use regex-based chunking
@@ -871,7 +871,7 @@ For supported code files, QMD also parses the source with [tree-sitter](https://
 | Type alias / enum | 80 | All |
 | Import / use declaration | 60 | All |
 
-Supported for `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.go`, `.rs`, and `.cs` files. Enable with `--chunk-strategy auto`. For C#, QMD can optionally use a Roslyn sidecar for enhanced breakpoints and symbol metadata; if unavailable, it falls back to tree-sitter C# and then regex-only chunking. Markdown and other file types always use regex chunking.
+Supported for `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.go`, `.rs`, and `.cs` files. Enable with `--chunk-strategy auto`. Today, C# chunking uses tree-sitter C# and falls back to regex-only chunking when grammars are unavailable. A future optional Roslyn sidecar may provide enhanced breakpoints and symbol metadata for C# while preserving the same regex fallback behavior.
 
 ### Query Flow (Hybrid)
 

--- a/README.md
+++ b/README.md
@@ -586,6 +586,36 @@ opt in. Run `qmd status` to verify which grammars are available.
 > installed, `--chunk-strategy auto` falls back to regex-only chunking
 > automatically. Tested on both Node.js and Bun.
 
+### Optional C# Roslyn Sidecar
+
+QMD can optionally use a Roslyn sidecar for C# enhanced breakpoints and symbol
+metadata when you run `qmd embed --chunk-strategy auto` (or the equivalent
+`npx @tobilu/qmd ...` / `bunx @tobilu/qmd ...` command).
+
+Build the sidecar:
+
+```sh
+dotnet build tools/csharp-sidecar/Qmd.CSharp.Sidecar/Qmd.CSharp.Sidecar.csproj -c Release
+```
+
+Point QMD at the built sidecar executable:
+
+```sh
+export QMD_CSHARP_SIDECAR="$PWD/tools/csharp-sidecar/Qmd.CSharp.Sidecar/bin/Release/net9.0/Qmd.CSharp.Sidecar"
+qmd embed --chunk-strategy auto
+```
+
+On Windows PowerShell, set the `.exe` path instead:
+
+```powershell
+$env:QMD_CSHARP_SIDECAR = "$PWD\\tools\\csharp-sidecar\\Qmd.CSharp.Sidecar\\bin\\Release\\net9.0\\Qmd.CSharp.Sidecar.exe"
+qmd embed --chunk-strategy auto
+```
+
+If the sidecar is unset, missing, times out, or returns invalid output, QMD
+falls back to tree-sitter C# breakpoints and then to regex-only chunking when
+the C# grammar is unavailable.
+
 ### Context Management
 
 Context adds descriptive metadata to collections and paths, helping search understand your content.
@@ -871,7 +901,7 @@ For supported code files, QMD also parses the source with [tree-sitter](https://
 | Type alias / enum | 80 | All |
 | Import / use declaration | 60 | All |
 
-Supported for `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.go`, `.rs`, and `.cs` files. Enable with `--chunk-strategy auto`. Today, C# chunking uses tree-sitter C# and falls back to regex-only chunking when grammars are unavailable. A future optional Roslyn sidecar may provide enhanced breakpoints and symbol metadata for C# while preserving the same regex fallback behavior.
+Supported for `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.go`, `.rs`, and `.cs` files. Enable with `--chunk-strategy auto`. By default, C# chunking uses tree-sitter C#. If `QMD_CSHARP_SIDECAR` points to a working Roslyn sidecar, QMD can add enhanced breakpoints and symbol metadata for C# while preserving the same regex fallback behavior when the sidecar or grammar is unavailable.
 
 ### Query Flow (Hybrid)
 

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "sqlite-vec-linux-arm64": "0.1.9",
         "sqlite-vec-linux-x64": "0.1.9",
         "sqlite-vec-windows-x64": "0.1.9",
+        "tree-sitter-c-sharp": "0.23.1",
         "tree-sitter-go": "0.23.4",
         "tree-sitter-python": "0.23.4",
         "tree-sitter-rust": "0.24.0",
@@ -509,7 +510,7 @@
 
     "node-abi": ["node-abi@3.87.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ=="],
 
-    "node-addon-api": ["node-addon-api@8.5.0", "", {}, "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A=="],
+    "node-addon-api": ["node-addon-api@8.7.0", "", {}, "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA=="],
 
     "node-api-headers": ["node-api-headers@1.8.0", "", {}, "sha512-jfnmiKWjRAGbdD1yQS28bknFM1tbHC1oucyuMPjmkEs+kpiu76aRs40WlTmBmyEgzDM76ge1DQ7XJ3R5deiVjQ=="],
 
@@ -687,6 +688,8 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
+    "tree-sitter-c-sharp": ["tree-sitter-c-sharp@0.23.1", "", { "dependencies": { "node-addon-api": "^8.2.2", "node-gyp-build": "^4.8.2" }, "peerDependencies": { "tree-sitter": "^0.21.1" }, "optionalPeers": ["tree-sitter"] }, "sha512-9zZ4FlcTRWWfRf6f4PgGhG8saPls6qOOt75tDfX7un9vQZJmARjPrAC6yBNCX2T/VKcCjIDbgq0evFaB3iGhQw=="],
+
     "tree-sitter-go": ["tree-sitter-go@0.23.4", "", { "dependencies": { "node-addon-api": "^8.2.1", "node-gyp-build": "^4.8.2" }, "peerDependencies": { "tree-sitter": "^0.21.1" }, "optionalPeers": ["tree-sitter"] }, "sha512-iQaHEs4yMa/hMo/ZCGqLfG61F0miinULU1fFh+GZreCRtKylFLtvn798ocCZjO2r/ungNZgAY1s1hPFyAwkc7w=="],
 
     "tree-sitter-javascript": ["tree-sitter-javascript@0.23.1", "", { "dependencies": { "node-addon-api": "^8.2.2", "node-gyp-build": "^4.8.2" }, "peerDependencies": { "tree-sitter": "^0.21.1" }, "optionalPeers": ["tree-sitter"] }, "sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA=="],
@@ -773,8 +776,6 @@
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
-    "node-llama-cpp/node-addon-api": ["node-addon-api@8.7.0", "", {}, "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA=="],
-
     "ora/cli-spinners": ["cli-spinners@3.4.0", "", {}, "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw=="],
 
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
@@ -792,6 +793,16 @@
     "tar/chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "tree-sitter-go/node-addon-api": ["node-addon-api@8.5.0", "", {}, "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A=="],
+
+    "tree-sitter-javascript/node-addon-api": ["node-addon-api@8.5.0", "", {}, "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A=="],
+
+    "tree-sitter-python/node-addon-api": ["node-addon-api@8.5.0", "", {}, "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A=="],
+
+    "tree-sitter-rust/node-addon-api": ["node-addon-api@8.5.0", "", {}, "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A=="],
+
+    "tree-sitter-typescript/node-addon-api": ["node-addon-api@8.5.0", "", {}, "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A=="],
 
     "vite/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 

--- a/docs/superpowers/specs/2026-04-07-csharp-analysis-design.md
+++ b/docs/superpowers/specs/2026-04-07-csharp-analysis-design.md
@@ -1,0 +1,563 @@
+# QMD C# Analysis Design
+
+Date: 2026-04-07
+Status: Proposed
+Scope: `qmd` repository only
+
+## Goal
+
+Add C# support to QMD's AST-aware chunking pipeline while preserving QMD's existing architecture:
+
+- Node/Bun remains the primary runtime.
+- `--chunk-strategy auto` remains the user-facing entry point.
+- C# support degrades gracefully:
+  - Roslyn enhanced analysis -> tree-sitter baseline -> regex fallback.
+
+The design must improve chunk quality for `.cs` files immediately, while creating a path for richer C#-specific structure understanding without turning QMD into a .NET-first tool.
+
+## Non-Goals
+
+- Do not redesign QMD into a multi-runtime primary application.
+- Do not require .NET to use QMD on non-C# projects.
+- Do not introduce full semantic indexing, cross-reference search, inheritance graphs, or call graphs in the first implementation plan.
+- Do not change the existing CLI contract beyond improving what happens under `--chunk-strategy auto`.
+- Do not include `hydra-p4`-specific ingestion or collection setup in this design.
+
+## Problem Statement
+
+QMD currently supports AST-aware chunking for TypeScript, JavaScript, Python, Go, and Rust. For unsupported file types, including C#, QMD falls back to regex-only chunking.
+
+Regex chunking works, but it is weak for large C# codebases that contain:
+
+- long type declarations with attributes and modifiers
+- partial classes and partial structs
+- records and file-scoped namespaces
+- source-generator-heavy code
+- ECS and DI code with many small declaration blocks
+
+In those codebases, regex chunking often splits files at positions that do not align with declaration boundaries. This harms retrieval quality because semantically related code is separated across chunks.
+
+At the same time, QMD's current AST layer is intentionally lightweight. It is used to improve breakpoints for chunking, not to perform compiler-grade language analysis. That constraint is useful and should remain true for the baseline.
+
+## Design Summary
+
+QMD will support C# through a layered model:
+
+1. Regex fallback
+2. Tree-sitter C# baseline
+3. Optional Roslyn enhanced sidecar
+
+All three layers are hidden behind the existing `--chunk-strategy auto` behavior.
+
+The baseline layer makes `.cs` files first-class participants in AST-aware chunking with low integration cost and no .NET requirement.
+
+The enhanced layer adds C#-specific structure and metadata through a separate Roslyn sidecar process. It is optional, auto-detected, and safe to ignore when unavailable.
+
+## Architecture
+
+### Layer 1: Regex fallback
+
+This is the current behavior and remains the final safety net.
+
+Responsibilities:
+
+- ensure indexing and query chunking always complete
+- preserve current behavior on unsupported or failing analysis paths
+
+Constraints:
+
+- never becomes C#-specific
+- no new behavior beyond existing fallback semantics
+
+### Layer 2: Tree-sitter C# baseline
+
+This layer extends the existing AST chunking architecture in `src/ast.ts`.
+
+Responsibilities:
+
+- detect `.cs` files
+- load `tree-sitter-c-sharp`
+- produce structural breakpoints from syntax nodes
+- merge those breakpoints into the existing chunking pipeline
+
+Properties:
+
+- no .NET dependency
+- same lifecycle as other QMD AST languages
+- same graceful failure contract as the current AST implementation
+
+This is the minimum guaranteed structured experience for C#.
+
+### Layer 3: Roslyn enhanced sidecar
+
+This layer is an optional C#-only enhancement.
+
+Responsibilities:
+
+- produce more reliable C# declaration boundaries in cases where syntax-only analysis is weak
+- emit symbol metadata that can later be used for chunk labeling or retrieval enhancements
+
+Properties:
+
+- not embedded in the Node process
+- invoked as a child process
+- can fail or be absent without affecting QMD correctness
+
+This layer is an additive enhancement, not a replacement for the baseline.
+
+## User Experience
+
+The user experience remains:
+
+```bash
+qmd embed --chunk-strategy auto
+qmd query "inventory operation flow" --chunk-strategy auto
+```
+
+For `.cs` files:
+
+- if tree-sitter C# is available, baseline C# AST chunking is used
+- if the Roslyn sidecar is also available, enhanced C# signals are added automatically
+- if either layer fails, QMD degrades silently to the next lower layer with low-noise warnings
+
+No new mandatory CLI switch is introduced for the first implementation plan.
+
+Optional future debug switches may be added later if needed, but they are not part of this design.
+
+## C# Baseline Breakpoint Model
+
+The baseline layer should extract only declaration-level breakpoints that materially improve chunking.
+
+### Baseline node coverage
+
+Map the following tree-sitter C# nodes into QMD breakpoints:
+
+- `using_directive`
+- `namespace_declaration`
+- `file_scoped_namespace_declaration`
+- `class_declaration`
+- `struct_declaration`
+- `interface_declaration`
+- `record_declaration`
+- `enum_declaration`
+- `constructor_declaration`
+- `method_declaration`
+
+### Baseline breakpoint types
+
+Use QMD-style normalized breakpoint categories:
+
+- `ast:import`
+- `ast:namespace`
+- `ast:type`
+- `ast:enum`
+- `ast:ctor`
+- `ast:method`
+
+### Baseline scores
+
+Keep the scoring system aligned with QMD's existing AST score model:
+
+- namespace: `100`
+- type: `100`
+- ctor: `90`
+- method: `90`
+- enum: `80`
+- import: `60`
+
+This preserves compatibility with the current cutoff selection logic and avoids a special case for C#.
+
+### Baseline exclusions
+
+Do not include the following in the first baseline:
+
+- property declarations
+- field declarations
+- local functions
+- attribute lists as standalone breakpoints
+- using aliases and other subforms as separate categories
+
+Reason:
+
+- property and field boundaries are often too dense and increase the risk of over-fragmenting chunk selection
+- local functions are useful but not necessary for the first stage
+- attribute handling is better solved by the Roslyn enhanced layer
+
+## Roslyn Enhanced Signal Model
+
+The enhanced layer is responsible for C#-specific structural precision, not for replacing the entire chunking algorithm.
+
+### Enhanced responsibilities
+
+The first enhanced version should provide:
+
+1. breakpoint refinement
+2. symbol metadata
+
+### Breakpoint refinement
+
+Roslyn can improve positions for declarations that are awkward in syntax-only extraction, such as:
+
+- attributed declarations
+- partial declarations with modifiers and long headers
+- record declarations with primary constructors
+- nested type declarations
+- declarations where the useful chunk boundary should start before a syntax node that tree-sitter may anchor too narrowly
+
+Enhanced breakpoints should be emitted with `roslyn:*` type names, for example:
+
+- `roslyn:type`
+- `roslyn:method`
+- `roslyn:ctor`
+- `roslyn:namespace`
+
+QMD should merge them using the same existing merge behavior used for AST breakpoints today.
+
+### Symbol metadata
+
+The first enhanced symbol model should include:
+
+- `name`
+- `kind`
+- `line`
+- `containerName`
+- `signature`
+- `modifiers`
+
+Supported `kind` values in the first version:
+
+- class
+- struct
+- interface
+- record
+- enum
+- constructor
+- method
+- property
+
+This metadata is primarily for future retrieval and formatting improvements. It is not required for chunking correctness.
+
+### Enhanced exclusions
+
+The first Roslyn enhanced version explicitly does not include:
+
+- full semantic graph export
+- project-wide reference resolution
+- inheritance or call graph indexing
+- analyzer diagnostics indexing
+- symbol cross-linking across files
+
+These would turn the sidecar into a much larger system and are out of scope for the first implementation plan.
+
+## Sidecar Execution Model
+
+### Process model
+
+The Roslyn layer should be implemented as an on-demand CLI sidecar process in the first iteration.
+
+Why:
+
+- easier to implement and debug
+- avoids service lifetime and port management complexity
+- fits the current QMD usage model, where AST analysis is an indexing/query-time enhancement rather than a persistent language service
+
+### Invocation flow
+
+For `.cs` files under `--chunk-strategy auto`:
+
+1. QMD computes regex breakpoints.
+2. QMD computes tree-sitter C# breakpoints when available.
+3. QMD checks whether the Roslyn sidecar is available.
+4. If available, QMD invokes it for the file.
+5. QMD merges enhanced breakpoints into the baseline set.
+6. QMD continues chunking with the merged result set.
+
+If sidecar execution fails at any point, QMD continues with the baseline result.
+
+### Availability model
+
+The sidecar is optional.
+
+Detection should occur lazily on first C# usage, not at QMD startup.
+
+QMD should support sidecar discovery through one of:
+
+- explicit config path
+- environment variable
+- executable available on `PATH`
+
+The implementation plan should choose one primary discovery path and one fallback path, not many parallel mechanisms.
+
+## Sidecar Protocol
+
+Use a simple JSON-over-stdio protocol for the first version.
+
+### Request
+
+```json
+{
+  "version": 1,
+  "language": "csharp",
+  "filePath": "src/Foo.cs",
+  "content": "using System; ...",
+  "features": {
+    "breakpoints": true,
+    "symbols": true
+  }
+}
+```
+
+### Response
+
+```json
+{
+  "version": 1,
+  "language": "csharp",
+  "breakpoints": [
+    { "pos": 120, "score": 100, "type": "roslyn:type" },
+    { "pos": 420, "score": 90, "type": "roslyn:method" }
+  ],
+  "symbols": [
+    {
+      "name": "InventoryOperationRuntimeService",
+      "kind": "class",
+      "line": 72,
+      "containerName": "Bokura.Hydra.World.Client.Session.Inventory",
+      "signature": "public sealed class InventoryOperationRuntimeService",
+      "modifiers": ["public", "sealed"]
+    }
+  ],
+  "diagnostics": []
+}
+```
+
+### Protocol requirements
+
+- versioned from the start
+- deterministic JSON schema
+- zero dependency on long-lived transport
+- robust to unknown future fields
+
+### Compatibility policy
+
+- QMD accepts matching major versions only
+- protocol mismatch causes downgrade, not hard failure
+
+## Failure and Degradation Policy
+
+Failure handling is a core design requirement.
+
+### Degradation chain
+
+- Roslyn enhanced failure -> baseline tree-sitter C#
+- baseline tree-sitter C# failure -> regex
+- regex remains the final fallback
+
+### Failure classes
+
+QMD must handle these as non-fatal:
+
+- grammar load failure
+- parse failure
+- sidecar executable missing
+- sidecar timeout
+- sidecar non-zero exit
+- malformed sidecar JSON
+- protocol version mismatch
+
+### Logging policy
+
+Warnings should be low-noise and rate-limited:
+
+- one warning per process per failure class
+- no per-file spam in large repositories
+
+This keeps QMD usable in large indexing runs.
+
+## Caching Strategy
+
+### Existing cache
+
+Tree-sitter language and query caches remain unchanged in principle.
+
+### New sidecar caches
+
+Add two sidecar-related caches:
+
+1. capability cache
+   - is sidecar available
+   - what protocol version does it support
+
+2. file result cache
+   - keyed by content hash + feature set + sidecar version
+
+This prevents repeated sidecar work during the same process when the same file content is analyzed more than once.
+
+### Cache invalidation
+
+The file result cache must invalidate when any of the following changes:
+
+- file content hash
+- sidecar version
+- requested feature set
+- protocol major version
+
+## Testing Strategy
+
+Testing should be split across three layers.
+
+### Node-side tests
+
+Add tests for:
+
+- `.cs` language detection
+- C# baseline breakpoint extraction
+- breakpoint score mapping
+- merge behavior between regex, tree-sitter, and Roslyn breakpoints
+- sidecar unavailable fallback
+- sidecar timeout fallback
+- sidecar malformed response fallback
+- protocol version mismatch fallback
+
+### Sidecar tests
+
+Add .NET tests for:
+
+- class, struct, interface, enum, record
+- file-scoped namespace
+- constructor and method extraction
+- attributed declarations
+- partial declarations
+- nested declarations
+- stable line and position reporting
+- JSON output shape
+
+### End-to-end samples
+
+Add fixtures that resemble real large C# codebases with:
+
+- partial types
+- source generator code
+- ECS or DI-heavy declarations
+- long declaration headers
+
+The purpose is to verify that important declaration units remain intact more often than under regex-only chunking.
+
+## Phased Delivery
+
+### Phase 1: Baseline C# AST chunking
+
+Deliver:
+
+- `.cs` language detection
+- `tree-sitter-c-sharp` integration
+- C# query definitions
+- C# tests
+- docs updates
+
+Success criteria:
+
+- `.cs` files participate in `--chunk-strategy auto`
+- C# chunk quality improves without any .NET dependency
+
+### Phase 2: Roslyn sidecar with enhanced breakpoints
+
+Deliver:
+
+- sidecar CLI
+- JSON protocol v1
+- auto-detection and fallback
+- enhanced breakpoint merge
+
+Success criteria:
+
+- QMD uses enhanced C# breakpoints automatically when sidecar is available
+- absence of sidecar does not break indexing or querying
+
+### Phase 3: Symbol metadata
+
+Deliver:
+
+- symbol extraction in sidecar
+- QMD-side symbol handling API
+- tests and caching improvements
+
+Success criteria:
+
+- QMD can retain symbol metadata for future retrieval or formatting use
+- symbol extraction remains optional and non-fatal
+
+## Implementation Boundaries
+
+The implementation plan derived from this design should remain focused enough for a single feature track if it is split by phase.
+
+Recommended first implementation target:
+
+- complete Phase 1
+- scaffold protocol and interfaces for Phase 2 without fully implementing all future capabilities
+
+This keeps the first delivery reviewable and upstream-friendly.
+
+## Risks
+
+### Risk: Roslyn sidecar scope expands too quickly
+
+If the sidecar starts requiring full solution restoration, project graph reconstruction, and semantic compilation for all scenarios, the implementation will become much larger than the chunking problem requires.
+
+Mitigation:
+
+- keep first sidecar input file-oriented
+- restrict first output to breakpoints and metadata
+- avoid project-wide semantic promises in the first plan
+
+### Risk: Over-fragmented C# breakpoints
+
+Adding too many C# node types can reduce chunk quality by making cuts too eager.
+
+Mitigation:
+
+- keep baseline query narrow
+- avoid properties and fields in the first baseline
+- validate with large real-world fixtures
+
+### Risk: Cross-platform packaging complexity
+
+Optional multi-runtime tooling can become painful if installation and discovery are vague.
+
+Mitigation:
+
+- make sidecar optional
+- choose a single simple discovery mechanism first
+- treat sidecar absence as normal, not exceptional
+
+### Risk: User confusion about what "C# support" means
+
+Users may assume semantic search over full C# program structure when the first version primarily improves chunking.
+
+Mitigation:
+
+- document baseline vs enhanced clearly
+- describe Roslyn as an optional enhancement layer
+- avoid overstating semantic capabilities
+
+## Acceptance Criteria
+
+This design is considered successfully implemented when:
+
+- QMD supports `.cs` under `--chunk-strategy auto`
+- baseline C# support works with no .NET requirement
+- optional Roslyn enhancement can be auto-detected and used without new mandatory CLI switches
+- all failure modes degrade safely
+- tests cover language detection, breakpoint extraction, fallback behavior, and protocol handling
+- docs explain the layered behavior clearly
+
+## Recommendation
+
+Adopt this design and implement it in phases, starting with baseline tree-sitter C# support.
+
+Reason:
+
+- it delivers immediate user value
+- it aligns with QMD's current architecture
+- it preserves Node/Bun as the primary runtime
+- it creates a safe path toward deeper C# understanding without forcing the entire project into compiler-tooling complexity on day one

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "sqlite-vec-linux-x64": "0.1.9",
     "sqlite-vec-windows-x64": "0.1.9",
     "tree-sitter-go": "0.23.4",
+    "tree-sitter-c-sharp": "0.23.1",
     "tree-sitter-python": "0.23.4",
     "tree-sitter-rust": "0.24.0",
     "tree-sitter-typescript": "0.23.2"
@@ -77,6 +78,7 @@
       "esbuild",
       "node-llama-cpp",
       "tree-sitter-go",
+      "tree-sitter-c-sharp",
       "tree-sitter-javascript",
       "tree-sitter-python",
       "tree-sitter-rust",

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -417,6 +417,8 @@ export interface SymbolInfo {
   kind: string;
   signature?: string;
   line: number;
+  containerName?: string;
+  modifiers?: string[];
 }
 
 /**
@@ -449,6 +451,8 @@ export async function extractSymbolsAsync(
       kind: symbol.kind,
       signature: symbol.signature,
       line: symbol.line,
+      containerName: symbol.containerName,
+      modifiers: symbol.modifiers,
     })) ?? [];
   } catch {
     return [];

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -31,7 +31,7 @@ type QueryType = import("web-tree-sitter").Query;
 // Language Detection
 // =============================================================================
 
-export type SupportedLanguage = "typescript" | "tsx" | "javascript" | "python" | "go" | "rust";
+export type SupportedLanguage = "typescript" | "tsx" | "javascript" | "python" | "go" | "rust" | "csharp";
 
 const EXTENSION_MAP: Record<string, SupportedLanguage> = {
   ".ts": "typescript",
@@ -45,6 +45,7 @@ const EXTENSION_MAP: Record<string, SupportedLanguage> = {
   ".py": "python",
   ".go": "go",
   ".rs": "rust",
+  ".cs": "csharp",
 };
 
 /**
@@ -70,6 +71,7 @@ const GRAMMAR_MAP: Record<SupportedLanguage, { pkg: string; wasm: string }> = {
   python:     { pkg: "tree-sitter-python",     wasm: "tree-sitter-python.wasm" },
   go:         { pkg: "tree-sitter-go",         wasm: "tree-sitter-go.wasm" },
   rust:       { pkg: "tree-sitter-rust",        wasm: "tree-sitter-rust.wasm" },
+  csharp:     { pkg: "tree-sitter-c-sharp",    wasm: "tree-sitter-c_sharp.wasm" },
 };
 
 // =============================================================================
@@ -141,6 +143,18 @@ const LANGUAGE_QUERIES: Record<SupportedLanguage, string> = {
     (type_item) @type
     (mod_item) @mod
   `,
+  csharp: `
+    (using_directive) @import
+    (namespace_declaration) @namespace
+    (file_scoped_namespace_declaration) @namespace
+    (class_declaration) @type
+    (struct_declaration) @type
+    (interface_declaration) @type
+    (record_declaration) @type
+    (enum_declaration) @enum
+    (constructor_declaration) @ctor
+    (method_declaration) @method
+  `,
 };
 
 /**
@@ -155,11 +169,13 @@ const SCORE_MAP: Record<string, number> = {
   trait:     100,
   impl:      100,
   mod:       100,
+  namespace: 100,
   export:     90,
   func:       90,
   method:     90,
+  ctor:       90,
   decorated:  90,
-  type:       80,
+  type:      100,
   enum:       80,
   import:     60,
 };

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -421,7 +421,8 @@ export interface SymbolInfo {
 
 /**
  * Extract symbol metadata for code within a byte range.
- * Stubbed for Phase 2 — returns empty array.
+ * C# symbol extraction lives in extractSymbolsAsync via the sidecar.
+ * This synchronous helper stays as a compatibility stub for non-C# callers.
  */
 export function extractSymbols(
   _content: string,
@@ -430,4 +431,26 @@ export function extractSymbols(
   _endPos: number,
 ): SymbolInfo[] {
   return [];
+}
+
+export async function extractSymbolsAsync(
+  content: string,
+  language: string,
+  filepath: string,
+): Promise<SymbolInfo[]> {
+  if (language !== "csharp") {
+    return [];
+  }
+
+  try {
+    const enhanced = await callCSharpSidecar(filepath, content);
+    return enhanced?.symbols.map(symbol => ({
+      name: symbol.name,
+      kind: symbol.kind,
+      signature: symbol.signature,
+      line: symbol.line,
+    })) ?? [];
+  } catch {
+    return [];
+  }
 }

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -175,9 +175,20 @@ const SCORE_MAP: Record<string, number> = {
   method:     90,
   ctor:       90,
   decorated:  90,
-  type:      100,
+  type:       80,
   enum:       80,
   import:     60,
+};
+
+/**
+ * Language-specific score overrides for capture names.
+ * Keep baseline scores stable across existing languages and only
+ * elevate scores where the language semantics require it.
+ */
+const LANGUAGE_SCORE_OVERRIDES: Partial<Record<SupportedLanguage, Partial<Record<string, number>>>> = {
+  csharp: {
+    type: 100,
+  },
 };
 
 // =============================================================================
@@ -307,7 +318,7 @@ export async function getASTBreakPoints(
 
     for (const cap of captures) {
       const pos = cap.node.startIndex;
-      const score = SCORE_MAP[cap.name] ?? 20;
+      const score = LANGUAGE_SCORE_OVERRIDES[language]?.[cap.name] ?? SCORE_MAP[cap.name] ?? 20;
       const type = `ast:${cap.name}`;
 
       const existing = seen.get(pos);

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -20,7 +20,8 @@
 
 import { createRequire } from "node:module";
 import { extname } from "node:path";
-import type { BreakPoint } from "./store.js";
+import { callCSharpSidecar } from "./csharp-sidecar.js";
+import { mergeBreakPoints, type BreakPoint } from "./store.js";
 
 // web-tree-sitter types — imported dynamically to avoid top-level WASM init
 type ParserType = import("web-tree-sitter").Parser;
@@ -330,7 +331,21 @@ export async function getASTBreakPoints(
     tree.delete();
     parser.delete();
 
-    return Array.from(seen.values()).sort((a, b) => a.pos - b.pos);
+    const points = Array.from(seen.values()).sort((a, b) => a.pos - b.pos);
+    if (language !== "csharp") {
+      return points;
+    }
+
+    try {
+      const enhanced = await callCSharpSidecar(filepath, content);
+      if (enhanced?.breakpoints.length) {
+        return mergeBreakPoints(points, enhanced.breakpoints);
+      }
+    } catch {
+      // Fall back to baseline tree-sitter breakpoints if the sidecar is unavailable.
+    }
+
+    return points;
   } catch (err) {
     console.warn(`[qmd] AST parse failed for ${filepath}, falling back to regex: ${err instanceof Error ? err.message : err}`);
     return [];

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -308,6 +308,19 @@ function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
 }
 
+function stopProcessTree(pid: number): void {
+  if (process.platform === "win32") {
+    execSync(`taskkill /PID ${pid} /T /F`, { stdio: "ignore" });
+    return;
+  }
+
+  try {
+    process.kill(-pid, "SIGTERM");
+  } catch {
+    process.kill(pid, "SIGTERM");
+  }
+}
+
 async function showStatus(): Promise<void> {
   const dbPath = getDbPath();
   const db = getDb();
@@ -1412,7 +1425,7 @@ async function collectionAdd(pwd: string, globPattern: string, name?: string): P
   // If name not provided, generate from pwd basename
   let collName = name;
   if (!collName) {
-    const parts = pwd.split('/').filter(Boolean);
+    const parts = pwd.replace(/[\\/]+$/, "").split(/[\\/]/).filter(Boolean);
     collName = parts[parts.length - 1] || 'root';
   }
 
@@ -2542,14 +2555,14 @@ function parseCLI() {
 
 function getSkillInstallDir(globalInstall: boolean): string {
   return globalInstall
-    ? resolve(homedir(), ".agents", "skills", "qmd")
-    : resolve(getPwd(), ".agents", "skills", "qmd");
+    ? pathJoin(homedir(), ".agents", "skills", "qmd")
+    : pathJoin(getPwd(), ".agents", "skills", "qmd");
 }
 
 function getClaudeSkillLinkPath(globalInstall: boolean): string {
   return globalInstall
-    ? resolve(homedir(), ".claude", "skills", "qmd")
-    : resolve(getPwd(), ".claude", "skills", "qmd");
+    ? pathJoin(homedir(), ".claude", "skills", "qmd")
+    : pathJoin(getPwd(), ".claude", "skills", "qmd");
 }
 
 function pathExists(path: string): boolean {
@@ -3176,7 +3189,7 @@ if (isMain) {
         const pid = parseInt(readFileSync(pidPath, "utf-8").trim());
         try {
           process.kill(pid, 0); // alive?
-          process.kill(pid, "SIGTERM");
+          stopProcessTree(pid);
           unlinkSync(pidPath);
           console.log(`Stopped QMD MCP server (PID ${pid}).`);
         } catch {
@@ -3206,8 +3219,9 @@ if (isMain) {
           const logPath = resolve(cacheDir, "mcp.log");
           const logFd = openSync(logPath, "w"); // truncate — fresh log per daemon run
           const selfPath = fileURLToPath(import.meta.url);
+          const tsxCliPath = pathJoin(dirname(selfPath), "..", "..", "node_modules", "tsx", "dist", "cli.mjs");
           const spawnArgs = selfPath.endsWith(".ts")
-            ? ["--import", pathJoin(dirname(selfPath), "..", "..", "node_modules", "tsx", "dist", "esm", "index.mjs"), selfPath, "mcp", "--http", "--port", String(port)]
+            ? [tsxCliPath, selfPath, "mcp", "--http", "--port", String(port)]
             : [selfPath, "mcp", "--http", "--port", String(port)];
           const child = nodeSpawn(process.execPath, spawnArgs, {
             stdio: ["ignore", logFd, logFd],

--- a/src/csharp-sidecar.ts
+++ b/src/csharp-sidecar.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 
 export interface CSharpSidecarOptions {
   command?: string;
@@ -22,6 +22,60 @@ type RawSidecarResponse = {
   breakpoints?: unknown;
   symbols?: unknown;
 };
+
+function parseSidecarResponse(value: unknown): CSharpSidecarResult | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const response = value as RawSidecarResponse;
+  if (response.version !== 1 || !Array.isArray(response.breakpoints) || !Array.isArray(response.symbols)) {
+    return null;
+  }
+
+  const breakpoints = response.breakpoints.filter(isBreakpoint);
+  const symbols = response.symbols.filter(isSymbol);
+
+  if (breakpoints.length !== response.breakpoints.length || symbols.length !== response.symbols.length) {
+    return null;
+  }
+
+  return { breakpoints, symbols };
+}
+
+async function terminateChildProcess(child: ChildProcess): Promise<void> {
+  const pid = child.pid;
+  if (!pid) {
+    return;
+  }
+
+  if (process.platform === "win32") {
+    await new Promise<void>((resolve) => {
+      const killer = spawn("taskkill", ["/pid", String(pid), "/t", "/f"], {
+        stdio: "ignore",
+        windowsHide: true,
+      });
+
+      killer.on("error", () => {
+        resolve();
+      });
+      killer.on("close", () => {
+        resolve();
+      });
+    });
+    return;
+  }
+
+  try {
+    process.kill(-pid, "SIGKILL");
+  } catch {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // Ignore cleanup failures; the wrapper still degrades to null.
+    }
+  }
+}
 
 function isBreakpoint(value: unknown): value is CSharpSidecarResult["breakpoints"][number] {
   if (!value || typeof value !== "object") return false;
@@ -86,14 +140,16 @@ export async function callCSharpSidecar(
     };
 
     const child = spawn(command, [], {
+      detached: process.platform !== "win32",
       shell: true,
       stdio: "pipe",
       windowsHide: true,
     });
 
     const timer = setTimeout(() => {
-      child.kill();
-      finish(null);
+      void terminateChildProcess(child).finally(() => {
+        finish(null);
+      });
     }, timeoutMs);
 
     child.stdout.setEncoding("utf8");
@@ -111,28 +167,21 @@ export async function callCSharpSidecar(
         return;
       }
 
-      let response: RawSidecarResponse;
+      let response: unknown;
       try {
-        response = JSON.parse(stdout) as RawSidecarResponse;
+        response = JSON.parse(stdout) as unknown;
       } catch {
         finish(null);
         return;
       }
 
-      if (response.version !== 1) {
+      const parsedResponse = parseSidecarResponse(response);
+      if (!parsedResponse) {
         finish(null);
         return;
       }
 
-      const breakpoints = Array.isArray(response.breakpoints) ? response.breakpoints.filter(isBreakpoint) : null;
-      const symbols = Array.isArray(response.symbols) ? response.symbols.filter(isSymbol) : null;
-
-      if (!breakpoints || !symbols || breakpoints.length !== response.breakpoints.length || symbols.length !== response.symbols.length) {
-        finish(null);
-        return;
-      }
-
-      finish({ breakpoints, symbols });
+      finish(parsedResponse);
     });
 
     child.stdin.on("error", () => {

--- a/src/csharp-sidecar.ts
+++ b/src/csharp-sidecar.ts
@@ -1,0 +1,144 @@
+import { spawn } from "node:child_process";
+
+export interface CSharpSidecarOptions {
+  command?: string;
+  timeoutMs?: number;
+}
+
+export interface CSharpSidecarResult {
+  breakpoints: { pos: number; score: number; type: string }[];
+  symbols: {
+    name: string;
+    kind: string;
+    line: number;
+    containerName?: string;
+    signature?: string;
+    modifiers?: string[];
+  }[];
+}
+
+type RawSidecarResponse = {
+  version?: unknown;
+  breakpoints?: unknown;
+  symbols?: unknown;
+};
+
+function isBreakpoint(value: unknown): value is CSharpSidecarResult["breakpoints"][number] {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.pos === "number"
+    && typeof candidate.score === "number"
+    && typeof candidate.type === "string";
+}
+
+function isSymbol(value: unknown): value is CSharpSidecarResult["symbols"][number] {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate.name !== "string" || typeof candidate.kind !== "string" || typeof candidate.line !== "number") {
+    return false;
+  }
+  if (candidate.containerName !== undefined && typeof candidate.containerName !== "string") {
+    return false;
+  }
+  if (candidate.signature !== undefined && typeof candidate.signature !== "string") {
+    return false;
+  }
+  if (candidate.modifiers !== undefined && (!Array.isArray(candidate.modifiers) || candidate.modifiers.some(item => typeof item !== "string"))) {
+    return false;
+  }
+
+  return true;
+}
+
+export async function callCSharpSidecar(
+  filePath: string,
+  content: string,
+  options: CSharpSidecarOptions = {},
+): Promise<CSharpSidecarResult | null> {
+  const command = options.command ?? process.env.QMD_CSHARP_SIDECAR;
+  if (!command) {
+    return null;
+  }
+
+  const timeoutMs = options.timeoutMs ?? 1500;
+  const requestPayload = JSON.stringify({
+    version: 1,
+    language: "csharp",
+    filePath,
+    content,
+    features: {
+      breakpoints: true,
+      symbols: true,
+    },
+  });
+
+  return await new Promise<CSharpSidecarResult | null>((resolve) => {
+    let settled = false;
+    let stdout = "";
+
+    const finish = (result: CSharpSidecarResult | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    const child = spawn(command, [], {
+      shell: true,
+      stdio: "pipe",
+      windowsHide: true,
+    });
+
+    const timer = setTimeout(() => {
+      child.kill();
+      finish(null);
+    }, timeoutMs);
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+
+    child.on("error", () => {
+      finish(null);
+    });
+
+    child.on("close", (code) => {
+      if (code !== 0) {
+        finish(null);
+        return;
+      }
+
+      let response: RawSidecarResponse;
+      try {
+        response = JSON.parse(stdout) as RawSidecarResponse;
+      } catch {
+        finish(null);
+        return;
+      }
+
+      if (response.version !== 1) {
+        finish(null);
+        return;
+      }
+
+      const breakpoints = Array.isArray(response.breakpoints) ? response.breakpoints.filter(isBreakpoint) : null;
+      const symbols = Array.isArray(response.symbols) ? response.symbols.filter(isSymbol) : null;
+
+      if (!breakpoints || !symbols || breakpoints.length !== response.breakpoints.length || symbols.length !== response.symbols.length) {
+        finish(null);
+        return;
+      }
+
+      finish({ breakpoints, symbols });
+    });
+
+    child.stdin.on("error", () => {
+      finish(null);
+    });
+
+    child.stdin.end(requestPayload);
+  });
+}

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -481,6 +481,19 @@ export class LlamaCpp implements LLM {
   }
 
   /**
+   * Best-effort disposal for short-lived contexts. Native dispose can hang after
+   * aborted/disposed prompts, so bound cleanup time instead of stalling callers.
+   */
+  private async disposeTransientContext(
+    context: { dispose(): Promise<void> },
+    timeoutMs: number = 1000
+  ): Promise<void> {
+    const disposePromise = context.dispose();
+    const timeoutPromise = new Promise<void>((resolve) => setTimeout(resolve, timeoutMs));
+    await Promise.race([disposePromise, timeoutPromise]);
+  }
+
+  /**
    * Check if any contexts are currently loaded (and therefore worth unloading on inactivity).
    */
   private hasLoadedContexts(): boolean {
@@ -1027,7 +1040,7 @@ export class LlamaCpp implements LLM {
       };
     } finally {
       // Dispose context (which disposes dependent sequences/sessions per lifecycle rules)
-      await context.dispose();
+      await this.disposeTransientContext(context);
     }
   }
 
@@ -1135,7 +1148,7 @@ export class LlamaCpp implements LLM {
       if (includeLexical) fallback.unshift({ type: 'lex', text: query });
       return fallback;
     } finally {
-      await genContext.dispose();
+      await this.disposeTransientContext(genContext);
     }
   }
 

--- a/test/ast-chunking.test.ts
+++ b/test/ast-chunking.test.ts
@@ -147,6 +147,70 @@ export function handler${i}(req: Request, res: Response): void {
     const smallChunks = await chunkDocumentAsync("export const x = 1;", undefined, undefined, undefined, "s.ts", "auto");
     expect(smallChunks).toHaveLength(1);
   });
+
+  test("C# files use AST-aware chunking in auto mode", async () => {
+    const csharpParts: string[] = [];
+    for (let i = 0; i < 30; i++) {
+      csharpParts.push(`
+using System;
+using System.Collections.Generic;
+
+namespace Inventory.App.Services;
+
+public sealed class InventoryService${i}
+{
+  public int GetAvailableStock${i}(string sku)
+  {
+    if (string.IsNullOrWhiteSpace(sku))
+    {
+      throw new ArgumentException("sku is required", nameof(sku));
+    }
+
+    return sku.Length + ${i};
+  }
+}
+`);
+    }
+    const largeCS = csharpParts.join("\n");
+
+    const chunks = await chunkDocumentAsync(largeCS, undefined, undefined, undefined, "InventoryService.cs", "auto");
+    expect(chunks.length).toBeGreaterThan(0);
+  });
+
+  test("C# regex mode matches sync chunkDocument output", async () => {
+    const csharpParts: string[] = [];
+    for (let i = 0; i < 30; i++) {
+      csharpParts.push(`
+using System;
+using System.Collections.Generic;
+
+namespace Inventory.App.Services;
+
+public sealed class InventoryService${i}
+{
+  public int GetAvailableStock${i}(string sku)
+  {
+    if (string.IsNullOrWhiteSpace(sku))
+    {
+      throw new ArgumentException("sku is required", nameof(sku));
+    }
+
+    return sku.Length + ${i};
+  }
+}
+`);
+    }
+    const largeCS = csharpParts.join("\n");
+
+    const regexAsync = await chunkDocumentAsync(largeCS, undefined, undefined, undefined, "InventoryService.cs", "regex");
+    const regexSync = chunkDocument(largeCS);
+
+    expect(regexAsync).toHaveLength(regexSync.length);
+    for (let i = 0; i < regexSync.length; i++) {
+      expect(regexAsync[i]?.text).toBe(regexSync[i]?.text);
+      expect(regexAsync[i]?.pos).toBe(regexSync[i]?.pos);
+    }
+  });
 });
 
 // ==========================================================================

--- a/test/ast-chunking.test.ts
+++ b/test/ast-chunking.test.ts
@@ -173,8 +173,19 @@ public sealed class InventoryService${i}
     }
     const largeCS = csharpParts.join("\n");
 
-    const chunks = await chunkDocumentAsync(largeCS, undefined, undefined, undefined, "InventoryService.cs", "auto");
-    expect(chunks.length).toBeGreaterThan(0);
+    const autoChunks = await chunkDocumentAsync(largeCS, undefined, undefined, undefined, "InventoryService.cs", "auto");
+    const regexChunks = await chunkDocumentAsync(largeCS, undefined, undefined, undefined, "InventoryService.cs", "regex");
+
+    expect(autoChunks.length).toBeGreaterThan(0);
+
+    let hasDifference = autoChunks.length !== regexChunks.length;
+    for (let i = 0; i < Math.min(autoChunks.length, regexChunks.length); i++) {
+      if (autoChunks[i]?.pos !== regexChunks[i]?.pos || autoChunks[i]?.text !== regexChunks[i]?.text) {
+        hasDifference = true;
+        break;
+      }
+    }
+    expect(hasDifference).toBe(true);
   });
 
   test("C# regex mode matches sync chunkDocument output", async () => {

--- a/test/ast-chunking.test.ts
+++ b/test/ast-chunking.test.ts
@@ -6,7 +6,8 @@
  * and the chunking pipeline — areas not tested by the unit-level ast.test.ts.
  */
 
-import { describe, test, expect } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { callCSharpSidecar } from "../src/csharp-sidecar.js";
 import { getASTBreakPoints } from "../src/ast.js";
 import {
   chunkDocument,
@@ -16,6 +17,15 @@ import {
   scanBreakPoints,
   findCodeFences,
 } from "../src/store.js";
+
+vi.mock("../src/csharp-sidecar.js", () => ({
+  callCSharpSidecar: vi.fn(async () => null),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(callCSharpSidecar).mockResolvedValue(null);
+});
 
 // ==========================================================================
 // mergeBreakPoints
@@ -49,6 +59,78 @@ describe("mergeBreakPoints", () => {
       [{ pos: 5, score: 50, type: "b" }],
     );
     expect(merged[0]!.pos).toBeLessThan(merged[1]!.pos);
+  });
+
+  test("merges baseline and enhanced C# break points and preserves roslyn-only method points", () => {
+    const baselinePoints = [
+      { pos: 0, score: 60, type: "ast:import" },
+      { pos: 32, score: 100, type: "ast:type" },
+    ];
+    const enhancedPoints = [
+      { pos: 32, score: 100, type: "roslyn:type" },
+      { pos: 78, score: 90, type: "roslyn:method" },
+    ];
+
+    const merged = mergeBreakPoints(baselinePoints, enhancedPoints);
+
+    expect(merged).toEqual([
+      { pos: 0, score: 60, type: "ast:import" },
+      { pos: 32, score: 100, type: "ast:type" },
+      { pos: 78, score: 90, type: "roslyn:method" },
+    ]);
+  });
+});
+
+// ==========================================================================
+// C# sidecar integration
+// ==========================================================================
+
+describe("C# sidecar integration", () => {
+  const CSHARP_SAMPLE = `using System;
+
+namespace Inventory.App;
+
+public sealed class InventoryService
+{
+  public int Recount(string sku)
+  {
+    return sku.Length;
+  }
+}
+`;
+
+  test("falls back to baseline C# AST break points when sidecar analysis fails", async () => {
+    vi.mocked(callCSharpSidecar).mockResolvedValue(null);
+
+    const points = await getASTBreakPoints(CSHARP_SAMPLE, "InventoryService.cs");
+
+    expect(callCSharpSidecar).toHaveBeenCalledWith("InventoryService.cs", CSHARP_SAMPLE);
+    expect(points.some(point => point.type === "ast:import")).toBe(true);
+    expect(points.some(point => point.type === "ast:namespace")).toBe(true);
+    expect(points.some(point => point.type === "ast:type")).toBe(true);
+    expect(points.some(point => point.type === "ast:method")).toBe(true);
+  });
+
+  test("merges enhanced C# sidecar break points with baseline AST results", async () => {
+    vi.mocked(callCSharpSidecar).mockResolvedValue({
+      breakpoints: [
+        {
+          pos: CSHARP_SAMPLE.indexOf("Recount"),
+          score: 90,
+          type: "roslyn:method",
+        },
+      ],
+      symbols: [],
+    });
+
+    const points = await getASTBreakPoints(CSHARP_SAMPLE, "InventoryService.cs");
+
+    expect(points.some(point => point.type === "ast:type")).toBe(true);
+    expect(points).toContainEqual({
+      pos: CSHARP_SAMPLE.indexOf("Recount"),
+      score: 90,
+      type: "roslyn:method",
+    });
   });
 });
 

--- a/test/ast.test.ts
+++ b/test/ast.test.ts
@@ -5,9 +5,20 @@
  * supported language, and graceful fallback on errors.
  */
 
-import { describe, test, expect } from "vitest";
-import { detectLanguage, getASTBreakPoints, extractSymbols } from "../src/ast.js";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { callCSharpSidecar } from "../src/csharp-sidecar.js";
+import { detectLanguage, getASTBreakPoints, extractSymbols, extractSymbolsAsync } from "../src/ast.js";
 import type { SupportedLanguage } from "../src/ast.js";
+
+vi.mock("../src/csharp-sidecar.js", () => ({
+  callCSharpSidecar: vi.fn(),
+}));
+
+const mockedCallCSharpSidecar = vi.mocked(callCSharpSidecar);
+
+afterEach(() => {
+  mockedCallCSharpSidecar.mockReset();
+});
 
 // =============================================================================
 // Language Detection
@@ -387,5 +398,36 @@ describe("extractSymbols", () => {
   test("returns an array for C# content", () => {
     const symbols = extractSymbols("public class InventoryService {}", "csharp", 0, 32);
     expect(Array.isArray(symbols)).toBe(true);
+  });
+});
+
+describe("extractSymbolsAsync", () => {
+  test("surfaces containerName and modifiers from sidecar symbols", async () => {
+    mockedCallCSharpSidecar.mockResolvedValue({
+      breakpoints: [],
+      symbols: [
+        {
+          name: "Rebuild",
+          kind: "method",
+          signature: "public void Rebuild()",
+          line: 6,
+          containerName: "InventoryService",
+          modifiers: ["public", "static"],
+        },
+      ],
+    });
+
+    await expect(
+      extractSymbolsAsync("public class InventoryService {}", "csharp", "src/InventoryService.cs"),
+    ).resolves.toEqual([
+      {
+        name: "Rebuild",
+        kind: "method",
+        signature: "public void Rebuild()",
+        line: 6,
+        containerName: "InventoryService",
+        modifiers: ["public", "static"],
+      },
+    ]);
   });
 });

--- a/test/ast.test.ts
+++ b/test/ast.test.ts
@@ -383,4 +383,9 @@ describe("extractSymbols", () => {
     const symbols = extractSymbols("function foo() {}", "typescript", 0, 18);
     expect(symbols).toEqual([]);
   });
+
+  test("returns an array for C# content", () => {
+    const symbols = extractSymbols("public class InventoryService {}", "csharp", 0, 32);
+    expect(Array.isArray(symbols)).toBe(true);
+  });
 });

--- a/test/ast.test.ts
+++ b/test/ast.test.ts
@@ -46,6 +46,10 @@ describe("detectLanguage", () => {
     expect(detectLanguage("src/auth.rs")).toBe("rust");
   });
 
+  test("recognizes C# extension", () => {
+    expect(detectLanguage("src/AuthService.cs")).toBe("csharp");
+  });
+
   test("returns null for markdown", () => {
     expect(detectLanguage("docs/README.md")).toBeNull();
   });
@@ -285,6 +289,59 @@ fn hash_password(password: &str) -> String {
     expect(structPoint?.score).toBe(100);
     expect(implPoint?.score).toBe(100);
     expect(traitPoint?.score).toBe(100);
+  });
+});
+
+// =============================================================================
+// AST Break Points - C#
+// =============================================================================
+
+describe("getASTBreakPoints - C#", () => {
+  const CS_SAMPLE = `using System;
+using System.Collections.Generic;
+
+namespace Qmd.Auth;
+
+public class AuthService
+{
+    public AuthService(IDictionary<string, string> config)
+    {
+    }
+
+    public bool Authenticate(string token)
+    {
+        return token.Length > 0;
+    }
+}
+
+public record AuthResult(bool Success, string? Error);
+`;
+
+  test("produces break points for using, namespace, type, constructor, and method", async () => {
+    const points = await getASTBreakPoints(CS_SAMPLE, "src/AuthService.cs");
+    const types = points.map(p => p.type);
+
+    expect(types).toContain("ast:import");
+    expect(types).toContain("ast:namespace");
+    expect(types).toContain("ast:type");
+    expect(types).toContain("ast:ctor");
+    expect(types).toContain("ast:method");
+  });
+
+  test("scores align with expected hierarchy", async () => {
+    const points = await getASTBreakPoints(CS_SAMPLE, "src/AuthService.cs");
+
+    const namespacePoint = points.find(p => p.type === "ast:namespace");
+    const typePoint = points.find(p => p.type === "ast:type");
+    const ctorPoint = points.find(p => p.type === "ast:ctor");
+    const methodPoint = points.find(p => p.type === "ast:method");
+    const importPoint = points.find(p => p.type === "ast:import");
+
+    expect(namespacePoint?.score).toBe(100);
+    expect(typePoint?.score).toBe(100);
+    expect(ctorPoint?.score).toBe(90);
+    expect(methodPoint?.score).toBe(90);
+    expect(importPoint?.score).toBe(60);
   });
 });
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -11,7 +11,7 @@ import { existsSync, lstatSync, readFileSync, symlinkSync, writeFileSync, unlink
 import { tmpdir } from "os";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-import { spawn } from "child_process";
+import { spawn, execSync } from "child_process";
 import { setTimeout as sleep } from "timers/promises";
 import { buildEditorUri, termLink } from "../src/cli/qmd.ts";
 
@@ -26,6 +26,7 @@ let testCounter = 0; // Unique counter for each test run
 const thisDir = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(thisDir, "..");
 const qmdScript = join(projectRoot, "src", "cli", "qmd.ts");
+const tsxCliScript = join(projectRoot, "node_modules", "tsx", "dist", "cli.mjs");
 // Resolve tsx binary from project's node_modules (not cwd-dependent)
 const tsxBin = (() => {
   const candidate = join(projectRoot, "node_modules", ".bin", "tsx");
@@ -1362,7 +1363,7 @@ describe("mcp http daemon", () => {
 
   /** Spawn a foreground HTTP server (non-blocking) and return the process */
   function spawnHttpServer(port: number): import("child_process").ChildProcess {
-    const proc = spawn(tsxBin, [qmdScript, "mcp", "--http", "--port", String(port)], {
+    const proc = spawn(process.execPath, [tsxCliScript, qmdScript, "mcp", "--http", "--port", String(port)], {
       cwd: fixturesDir,
       env: {
         ...process.env,
@@ -1373,6 +1374,29 @@ describe("mcp http daemon", () => {
     });
     if (proc.pid) spawnedPids.push(proc.pid);
     return proc;
+  }
+
+  function killProcessTree(pid: number): void {
+    if (process.platform === "win32") {
+      execSync(`taskkill /PID ${pid} /T /F`, { stdio: "ignore" });
+      return;
+    }
+    process.kill(pid, "SIGTERM");
+  }
+
+  async function stopProcess(proc: import("child_process").ChildProcess): Promise<void> {
+    if (proc.pid) {
+      try { killProcessTree(proc.pid); } catch { /* already dead */ }
+    }
+
+    if (proc.exitCode !== null) {
+      return;
+    }
+
+    await Promise.race([
+      new Promise<void>((resolve) => proc.once("close", () => resolve())),
+      sleep(2000).then(() => undefined),
+    ]);
   }
 
   /** Wait for HTTP server to become ready */
@@ -1407,14 +1431,14 @@ describe("mcp http daemon", () => {
   afterAll(async () => {
     // Kill any leftover spawned processes
     for (const pid of spawnedPids) {
-      try { process.kill(pid, "SIGTERM"); } catch { /* already dead */ }
+      try { killProcessTree(pid); } catch { /* already dead */ }
     }
     // Also clean up via PID file if present
     try {
       const pf = pidPath();
       if (existsSync(pf)) {
         const pid = parseInt(readFileSync(pf, "utf-8").trim());
-        try { process.kill(pid, "SIGTERM"); } catch {}
+        try { killProcessTree(pid); } catch {}
         unlinkSync(pf);
       }
     } catch {}
@@ -1439,8 +1463,7 @@ describe("mcp http daemon", () => {
       const body = await res.json();
       expect(body.status).toBe("ok");
     } finally {
-      proc.kill("SIGTERM");
-      await new Promise(r => proc.on("close", r));
+      await stopProcess(proc);
     }
   });
 
@@ -1467,7 +1490,7 @@ describe("mcp http daemon", () => {
     expect(ready).toBe(true);
 
     // Clean up
-    process.kill(pid, "SIGTERM");
+    killProcessTree(pid);
     await sleep(500);
     try { unlinkSync(pidPath()); } catch {}
   });
@@ -1531,7 +1554,7 @@ describe("mcp http daemon", () => {
     expect(stderr).toContain("Already running");
 
     // Clean up first daemon
-    process.kill(pid, "SIGTERM");
+    killProcessTree(pid);
     await sleep(500);
     try { unlinkSync(pidPath()); } catch {}
   });
@@ -1554,7 +1577,7 @@ describe("mcp http daemon", () => {
     // Clean up
     const ready = await waitForServer(port);
     expect(ready).toBe(true);
-    process.kill(pid, "SIGTERM");
+    killProcessTree(pid);
     await sleep(500);
     try { unlinkSync(pidPath()); } catch {}
   });

--- a/test/csharp-sidecar.test.ts
+++ b/test/csharp-sidecar.test.ts
@@ -1,5 +1,29 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { describe, expect, test } from "vitest";
 import { callCSharpSidecar } from "../src/csharp-sidecar.js";
+
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!processExists(pid)) {
+      return true;
+    }
+    await new Promise(resolve => setTimeout(resolve, 25));
+  }
+  return !processExists(pid);
+}
 
 describe("callCSharpSidecar", () => {
   test("returns null when sidecar command is missing", async () => {
@@ -13,5 +37,34 @@ describe("callCSharpSidecar", () => {
     );
 
     expect(result).toBeNull();
+  });
+
+  test("returns null on timeout and terminates the spawned sidecar process", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "qmd-csharp-sidecar-"));
+    const pidFile = join(tempDir, "sidecar.pid");
+    const script = `require("node:fs").writeFileSync(${JSON.stringify(pidFile)}, String(process.pid)); setInterval(function () {}, 1000);`;
+    const command = `"${process.execPath}" -e ${JSON.stringify(script)}`;
+
+    try {
+      const startedAt = Date.now();
+      const result = await callCSharpSidecar(
+        "InventoryService.cs",
+        "public class Foo {}",
+        {
+          command,
+          timeoutMs: 100,
+        },
+      );
+      const elapsedMs = Date.now() - startedAt;
+
+      expect(result).toBeNull();
+      expect(elapsedMs).toBeLessThan(1500);
+
+      const childPid = Number.parseInt(readFileSync(pidFile, "utf8"), 10);
+      expect(Number.isNaN(childPid)).toBe(false);
+      expect(await waitForExit(childPid, 2000)).toBe(true);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/test/csharp-sidecar.test.ts
+++ b/test/csharp-sidecar.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "vitest";
+import { callCSharpSidecar } from "../src/csharp-sidecar.js";
+
+describe("callCSharpSidecar", () => {
+  test("returns null when sidecar command is missing", async () => {
+    const result = await callCSharpSidecar(
+      "InventoryService.cs",
+      "public class Foo {}",
+      {
+        command: "missing-sidecar-command",
+        timeoutMs: 50,
+      },
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -200,6 +200,7 @@ describe("LlamaCpp rerank deduping", () => {
 describe.skipIf(!!process.env.CI)("LlamaCpp Integration", () => {
   // Use the singleton to avoid multiple Metal contexts
   const llm = getDefaultLlamaCpp();
+  const expandQueryTimeoutMs = process.platform === "win32" ? 60000 : 30000;
 
   afterAll(async () => {
     // Ensure native resources are released to avoid ggml-metal asserts on process exit.
@@ -584,7 +585,7 @@ describe.skipIf(!!process.env.CI)("LlamaCpp Integration", () => {
         expect(["lex", "vec", "hyde"]).toContain(q.type);
         expect(q.text.length).toBeGreaterThan(0);
       }
-    }, 30000); // 30s timeout for model loading
+    }, expandQueryTimeoutMs);
 
     test("can exclude lexical queries", async () => {
       const result = await llm.expandQuery("authentication setup", { includeLexical: false });

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -20,6 +20,8 @@ import type { CollectionConfig } from "../src/collections";
 import { setConfigIndexName } from "../src/collections";
 import { syncConfigToDb } from "../src/store";
 
+const llmIntegrationTimeoutMs = process.platform === "win32" ? 60000 : 30000;
+
 // =============================================================================
 // Test Database Setup
 // =============================================================================
@@ -251,7 +253,7 @@ describe("MCP Server", () => {
     };
     await writeFile(join(testConfigDir, "index.yml"), YAML.stringify(testConfig));
 
-    testDbPath = `/tmp/qmd-mcp-test-${Date.now()}.sqlite`;
+    testDbPath = join(tmpdir(), `qmd-mcp-test-${Date.now()}.sqlite`);
     testDb = openDatabase(testDbPath);
     initTestDatabase(testDb);
     seedTestData(testDb);
@@ -358,7 +360,7 @@ describe("MCP Server", () => {
         expect(['lex', 'vec', 'hyde']).toContain(q.type);
         expect(q.query.length).toBeGreaterThan(0);
       }
-    }, 30000); // 30s timeout for model loading
+    }, llmIntegrationTimeoutMs);
 
     test("performs RRF fusion on multiple result lists", () => {
       const list1: RankedResult[] = [
@@ -908,7 +910,7 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
 
   beforeAll(async () => {
     // Create isolated test database with seeded data
-    httpTestDbPath = `/tmp/qmd-mcp-http-test-${Date.now()}.sqlite`;
+    httpTestDbPath = join(tmpdir(), `qmd-mcp-http-test-${Date.now()}.sqlite`);
     const db = openDatabase(httpTestDbPath);
     initTestDatabase(db);
     seedTestData(db);

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -54,6 +54,8 @@ import {
   type SearchResult,
   type RankedResult,
 } from "../src/store.js";
+
+const llmIntegrationTimeoutMs = process.platform === "win32" ? 60000 : 30000;
 import type { CollectionConfig } from "../src/collections.js";
 
 // =============================================================================
@@ -2480,7 +2482,7 @@ describe.skipIf(!!process.env.CI)("LlamaCpp Integration", () => {
     }
 
     await cleanupTestDb(store);
-  }, 30000);
+  }, llmIntegrationTimeoutMs);
 
   test("expandQuery caches results as JSON with types", async () => {
     const store = await createTestStore();
@@ -2495,7 +2497,7 @@ describe.skipIf(!!process.env.CI)("LlamaCpp Integration", () => {
     expect(queries2[0]?.type).toBeDefined();
 
     await cleanupTestDb(store);
-  }, 30000);
+  }, llmIntegrationTimeoutMs);
 
   test("rerank scores documents", async () => {
     const store = await createTestStore();

--- a/tools/csharp-sidecar/Qmd.CSharp.Sidecar.Tests/CSharpAnalysisServiceTests.cs
+++ b/tools/csharp-sidecar/Qmd.CSharp.Sidecar.Tests/CSharpAnalysisServiceTests.cs
@@ -59,9 +59,8 @@ public sealed class CSharpAnalysisServiceTests
 
             public class InventoryService
             {
-                public void Rebuild()
-                {
-                }
+                [Obsolete]
+                public void Rebuild() { }
             }
             """;
 
@@ -77,13 +76,20 @@ public sealed class CSharpAnalysisServiceTests
         };
 
         var response = service.Analyze(request);
+        var classSymbol = Assert.Single(response.Symbols, static symbol => symbol.Name == "InventoryService");
+        var methodSymbol = Assert.Single(response.Symbols, static symbol => symbol.Name == "Rebuild");
 
-        Assert.Contains(
-            response.Symbols,
-            static symbol => symbol.Name == "InventoryService" && symbol.Kind == "class");
-        Assert.Contains(
-            response.Symbols,
-            static symbol => symbol.Name == "Rebuild" && symbol.Kind == "method");
+        Assert.Equal("class", classSymbol.Kind);
+        Assert.Equal(3, classSymbol.Line);
+        Assert.Equal("Demo.App", classSymbol.ContainerName);
+        Assert.Equal("public class InventoryService", classSymbol.Signature);
+        Assert.Equal(["public"], classSymbol.Modifiers);
+
+        Assert.Equal("method", methodSymbol.Kind);
+        Assert.Equal(5, methodSymbol.Line);
+        Assert.Equal("InventoryService", methodSymbol.ContainerName);
+        Assert.Equal("public void Rebuild()", methodSymbol.Signature);
+        Assert.Equal(["public"], methodSymbol.Modifiers);
     }
 
     [Fact]

--- a/tools/csharp-sidecar/Qmd.CSharp.Sidecar.Tests/CSharpAnalysisServiceTests.cs
+++ b/tools/csharp-sidecar/Qmd.CSharp.Sidecar.Tests/CSharpAnalysisServiceTests.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using System.Text.Json;
 using Qmd.CSharp.Sidecar;
 using Xunit;
 
@@ -6,7 +8,7 @@ namespace Qmd.CSharp.Sidecar.Tests;
 public sealed class CSharpAnalysisServiceTests
 {
     [Fact]
-    public void Analyze_collects_expected_breakpoint_kinds_for_simple_csharp()
+    public void Analyze_returns_protocol_envelope_for_simple_csharp()
     {
         const string content = """
             using System;
@@ -38,11 +40,122 @@ public sealed class CSharpAnalysisServiceTests
         };
 
         var response = service.Analyze(request);
-        var kinds = response.Breakpoints.Select(static breakpoint => breakpoint.Kind).ToArray();
+        var types = response.Breakpoints.Select(static breakpoint => breakpoint.Type).ToArray();
 
+        Assert.Equal(1, response.Version);
+        Assert.Equal("csharp", response.Language);
         Assert.Equal(
             ["roslyn:import", "roslyn:namespace", "roslyn:type", "roslyn:ctor", "roslyn:method"],
-            kinds);
+            types);
         Assert.Empty(response.Symbols);
+        Assert.Empty(response.Diagnostics);
+    }
+
+    [Fact]
+    public void Analyze_serializes_response_with_expected_protocol_property_names()
+    {
+        const string content = "using System;";
+
+        var service = new CSharpAnalysisService();
+        var request = new AnalysisRequest
+        {
+            Version = 1,
+            Language = "csharp",
+            FilePath = "/workspace/Greeter.cs",
+            Content = content,
+            Features = new AnalysisFeatures
+            {
+                Breakpoints = true,
+                Symbols = true
+            }
+        };
+
+        var response = service.Analyze(request);
+        var json = JsonSerializer.Serialize(response, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        Assert.Equal(1, root.GetProperty("version").GetInt32());
+        Assert.Equal("csharp", root.GetProperty("language").GetString());
+        Assert.True(root.TryGetProperty("breakpoints", out var breakpointsElement));
+        Assert.True(root.TryGetProperty("symbols", out var symbolsElement));
+        Assert.True(root.TryGetProperty("diagnostics", out var diagnosticsElement));
+        Assert.Equal(JsonValueKind.Array, breakpointsElement.ValueKind);
+        Assert.Equal(JsonValueKind.Array, symbolsElement.ValueKind);
+        Assert.Equal(JsonValueKind.Array, diagnosticsElement.ValueKind);
+
+        var breakpoint = Assert.Single(breakpointsElement.EnumerateArray());
+        Assert.Equal(0, breakpoint.GetProperty("pos").GetInt32());
+        Assert.Equal("roslyn:import", breakpoint.GetProperty("type").GetString());
+        Assert.Equal(60, breakpoint.GetProperty("score").GetInt32());
+        Assert.False(breakpoint.TryGetProperty("kind", out _));
+    }
+
+    [Fact]
+    public void AnalysisRequest_deserializes_expected_protocol_fields()
+    {
+        const string json = """
+            {
+              "version": 1,
+              "language": "csharp",
+              "filePath": "/workspace/Greeter.cs",
+              "content": "using System;",
+              "features": {
+                "breakpoints": true,
+                "symbols": false
+              }
+            }
+            """;
+
+        var request = JsonSerializer.Deserialize<AnalysisRequest>(
+            json,
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        Assert.NotNull(request);
+        Assert.Equal(1, request.Version);
+        Assert.Equal("csharp", request.Language);
+        Assert.Equal("/workspace/Greeter.cs", request.FilePath);
+        Assert.Equal("using System;", request.Content);
+        Assert.True(request.Features?.Breakpoints);
+        Assert.False(request.Features?.Symbols);
+    }
+
+    [Fact]
+    public void SymbolDto_serializes_expected_protocol_fields()
+    {
+        var symbol = new SymbolDto
+        {
+            Name = "SayHello",
+            Kind = "method",
+            Line = 10,
+            ContainerName = "Greeter",
+            Signature = "void SayHello()",
+            Modifiers = ["public"]
+        };
+
+        var json = JsonSerializer.Serialize(symbol, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        Assert.Equal("SayHello", root.GetProperty("name").GetString());
+        Assert.Equal("method", root.GetProperty("kind").GetString());
+        Assert.Equal(10, root.GetProperty("line").GetInt32());
+        Assert.Equal("Greeter", root.GetProperty("containerName").GetString());
+        Assert.Equal("void SayHello()", root.GetProperty("signature").GetString());
+        Assert.Equal("public", Assert.Single(root.GetProperty("modifiers").EnumerateArray()).GetString());
+    }
+
+    [Fact]
+    public async Task Program_returns_error_for_invalid_request_payload()
+    {
+        await using var input = new MemoryStream(Encoding.UTF8.GetBytes(string.Empty));
+        await using var output = new MemoryStream();
+        await using var error = new StringWriter();
+
+        var exitCode = await Program.RunAsync(input, output, error);
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal("Invalid request payload." + Environment.NewLine, error.ToString());
+        Assert.Equal(0, output.Length);
     }
 }

--- a/tools/csharp-sidecar/Qmd.CSharp.Sidecar.Tests/CSharpAnalysisServiceTests.cs
+++ b/tools/csharp-sidecar/Qmd.CSharp.Sidecar.Tests/CSharpAnalysisServiceTests.cs
@@ -52,6 +52,41 @@ public sealed class CSharpAnalysisServiceTests
     }
 
     [Fact]
+    public void Analyze_returns_class_and_method_symbols_when_requested()
+    {
+        const string content = """
+            namespace Demo.App;
+
+            public class InventoryService
+            {
+                public void Rebuild()
+                {
+                }
+            }
+            """;
+
+        var service = new CSharpAnalysisService();
+        var request = new AnalysisRequest
+        {
+            FilePath = "/workspace/InventoryService.cs",
+            Content = content,
+            Features = new AnalysisFeatures
+            {
+                Symbols = true
+            }
+        };
+
+        var response = service.Analyze(request);
+
+        Assert.Contains(
+            response.Symbols,
+            static symbol => symbol.Name == "InventoryService" && symbol.Kind == "class");
+        Assert.Contains(
+            response.Symbols,
+            static symbol => symbol.Name == "Rebuild" && symbol.Kind == "method");
+    }
+
+    [Fact]
     public void Analyze_serializes_response_with_expected_protocol_property_names()
     {
         const string content = "using System;";

--- a/tools/csharp-sidecar/Qmd.CSharp.Sidecar.Tests/CSharpAnalysisServiceTests.cs
+++ b/tools/csharp-sidecar/Qmd.CSharp.Sidecar.Tests/CSharpAnalysisServiceTests.cs
@@ -1,0 +1,48 @@
+using Qmd.CSharp.Sidecar;
+using Xunit;
+
+namespace Qmd.CSharp.Sidecar.Tests;
+
+public sealed class CSharpAnalysisServiceTests
+{
+    [Fact]
+    public void Analyze_collects_expected_breakpoint_kinds_for_simple_csharp()
+    {
+        const string content = """
+            using System;
+
+            namespace Demo.App;
+
+            public class Greeter
+            {
+                public Greeter()
+                {
+                }
+
+                public void SayHello()
+                {
+                    Console.WriteLine("hi");
+                }
+            }
+            """;
+
+        var service = new CSharpAnalysisService();
+        var request = new AnalysisRequest
+        {
+            FilePath = "/workspace/Greeter.cs",
+            Content = content,
+            Features = new AnalysisFeatures
+            {
+                Breakpoints = true
+            }
+        };
+
+        var response = service.Analyze(request);
+        var kinds = response.Breakpoints.Select(static breakpoint => breakpoint.Kind).ToArray();
+
+        Assert.Equal(
+            ["roslyn:import", "roslyn:namespace", "roslyn:type", "roslyn:ctor", "roslyn:method"],
+            kinds);
+        Assert.Empty(response.Symbols);
+    }
+}

--- a/tools/csharp-sidecar/Qmd.CSharp.Sidecar.Tests/Qmd.CSharp.Sidecar.Tests.csproj
+++ b/tools/csharp-sidecar/Qmd.CSharp.Sidecar.Tests/Qmd.CSharp.Sidecar.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Qmd.CSharp.Sidecar\Qmd.CSharp.Sidecar.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/csharp-sidecar/Qmd.CSharp.Sidecar/CSharpAnalysisService.cs
+++ b/tools/csharp-sidecar/Qmd.CSharp.Sidecar/CSharpAnalysisService.cs
@@ -1,0 +1,82 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Qmd.CSharp.Sidecar;
+
+public sealed class CSharpAnalysisService
+{
+    public AnalysisResponse Analyze(AnalysisRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var tree = CSharpSyntaxTree.ParseText(request.Content, path: request.FilePath);
+        var root = tree.GetRoot();
+
+        return new AnalysisResponse
+        {
+            Breakpoints = request.Features?.Breakpoints == true ? CollectBreakpoints(root) : [],
+            Symbols = request.Features?.Symbols == true ? CollectSymbols(root) : []
+        };
+    }
+
+    public IReadOnlyList<BreakpointDto> CollectBreakpoints(SyntaxNode root)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+
+        var breakpoints = new Dictionary<int, BreakpointDto>();
+
+        foreach (var node in root.DescendantNodesAndSelf())
+        {
+            switch (node)
+            {
+                case UsingDirectiveSyntax usingDirective:
+                    AddOrUpdateBreakpoint(breakpoints, usingDirective.SpanStart, "roslyn:import", 60);
+                    break;
+                case BaseNamespaceDeclarationSyntax namespaceDeclaration:
+                    AddOrUpdateBreakpoint(breakpoints, namespaceDeclaration.SpanStart, "roslyn:namespace", 100);
+                    break;
+                case EnumDeclarationSyntax enumDeclaration:
+                    AddOrUpdateBreakpoint(breakpoints, enumDeclaration.SpanStart, "roslyn:enum", 80);
+                    break;
+                case RecordDeclarationSyntax recordDeclaration:
+                    AddOrUpdateBreakpoint(breakpoints, recordDeclaration.SpanStart, "roslyn:type", 100);
+                    break;
+                case TypeDeclarationSyntax typeDeclaration:
+                    AddOrUpdateBreakpoint(breakpoints, typeDeclaration.SpanStart, "roslyn:type", 100);
+                    break;
+                case ConstructorDeclarationSyntax constructorDeclaration:
+                    AddOrUpdateBreakpoint(breakpoints, constructorDeclaration.SpanStart, "roslyn:ctor", 90);
+                    break;
+                case MethodDeclarationSyntax methodDeclaration:
+                    AddOrUpdateBreakpoint(breakpoints, methodDeclaration.SpanStart, "roslyn:method", 90);
+                    break;
+            }
+        }
+
+        return breakpoints.Values.OrderBy(static breakpoint => breakpoint.Pos).ToArray();
+    }
+
+    public IReadOnlyList<SymbolDto> CollectSymbols(SyntaxNode root)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+        return [];
+    }
+
+    private static void AddOrUpdateBreakpoint(
+        IDictionary<int, BreakpointDto> breakpoints,
+        int pos,
+        string kind,
+        int score)
+    {
+        if (!breakpoints.TryGetValue(pos, out var existing) || score > existing.Score)
+        {
+            breakpoints[pos] = new BreakpointDto
+            {
+                Pos = pos,
+                Kind = kind,
+                Score = score
+            };
+        }
+    }
+}

--- a/tools/csharp-sidecar/Qmd.CSharp.Sidecar/CSharpAnalysisService.cs
+++ b/tools/csharp-sidecar/Qmd.CSharp.Sidecar/CSharpAnalysisService.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Text.RegularExpressions;
 
 namespace Qmd.CSharp.Sidecar;
 
@@ -121,9 +122,7 @@ public sealed class CSharpAnalysisService
     {
         var line = declaration.SyntaxTree.GetLineSpan(declaration.Span).StartLinePosition.Line + 1;
         var containerName = GetContainerName(declaration.Parent);
-        var signature = declaration.ToString()
-            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)[0]
-            .Trim();
+        var signature = GetSignature(declaration);
 
         return new SymbolDto
         {
@@ -152,6 +151,43 @@ public sealed class CSharpAnalysisService
         }
 
         return null;
+    }
+
+    private static string? GetSignature(MemberDeclarationSyntax declaration)
+    {
+        var headerLines = declaration
+            .ToString()
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .SkipWhile(static line => line.StartsWith("[", StringComparison.Ordinal));
+
+        var header = Regex.Replace(string.Join(" ", headerLines), "\\s+", " ").Trim();
+        if (string.IsNullOrWhiteSpace(header))
+        {
+            return null;
+        }
+
+        var cutIndex = FindHeaderTerminator(header);
+        return cutIndex >= 0
+            ? header[..cutIndex].TrimEnd()
+            : header;
+    }
+
+    private static int FindHeaderTerminator(string header)
+    {
+        var arrowIndex = header.IndexOf("=>", StringComparison.Ordinal);
+        if (arrowIndex >= 0)
+        {
+            return arrowIndex;
+        }
+
+        var blockIndex = header.IndexOf('{');
+        if (blockIndex >= 0)
+        {
+            return blockIndex;
+        }
+
+        var semicolonIndex = header.IndexOf(';');
+        return semicolonIndex;
     }
 }
 

--- a/tools/csharp-sidecar/Qmd.CSharp.Sidecar/CSharpAnalysisService.cs
+++ b/tools/csharp-sidecar/Qmd.CSharp.Sidecar/CSharpAnalysisService.cs
@@ -11,12 +11,15 @@ public sealed class CSharpAnalysisService
         ArgumentNullException.ThrowIfNull(request);
 
         var tree = CSharpSyntaxTree.ParseText(request.Content, path: request.FilePath);
-        var root = tree.GetRoot();
+        var root = tree.GetCompilationUnitRoot();
 
         return new AnalysisResponse
         {
+            Version = 1,
+            Language = "csharp",
             Breakpoints = request.Features?.Breakpoints == true ? CollectBreakpoints(root) : [],
-            Symbols = request.Features?.Symbols == true ? CollectSymbols(root) : []
+            Symbols = request.Features?.Symbols == true ? CollectSymbols(root) : [],
+            Diagnostics = []
         };
     }
 
@@ -66,7 +69,7 @@ public sealed class CSharpAnalysisService
     private static void AddOrUpdateBreakpoint(
         IDictionary<int, BreakpointDto> breakpoints,
         int pos,
-        string kind,
+        string type,
         int score)
     {
         if (!breakpoints.TryGetValue(pos, out var existing) || score > existing.Score)
@@ -74,7 +77,7 @@ public sealed class CSharpAnalysisService
             breakpoints[pos] = new BreakpointDto
             {
                 Pos = pos,
-                Kind = kind,
+                Type = type,
                 Score = score
             };
         }

--- a/tools/csharp-sidecar/Qmd.CSharp.Sidecar/CSharpAnalysisService.cs
+++ b/tools/csharp-sidecar/Qmd.CSharp.Sidecar/CSharpAnalysisService.cs
@@ -63,7 +63,41 @@ public sealed class CSharpAnalysisService
     public IReadOnlyList<SymbolDto> CollectSymbols(SyntaxNode root)
     {
         ArgumentNullException.ThrowIfNull(root);
-        return [];
+
+        var symbols = new List<SymbolDto>();
+
+        foreach (var node in root.DescendantNodesAndSelf())
+        {
+            switch (node)
+            {
+                case ClassDeclarationSyntax classDeclaration:
+                    symbols.Add(CreateSymbol(classDeclaration.Identifier.ValueText, "class", classDeclaration));
+                    break;
+                case StructDeclarationSyntax structDeclaration:
+                    symbols.Add(CreateSymbol(structDeclaration.Identifier.ValueText, "struct", structDeclaration));
+                    break;
+                case InterfaceDeclarationSyntax interfaceDeclaration:
+                    symbols.Add(CreateSymbol(interfaceDeclaration.Identifier.ValueText, "interface", interfaceDeclaration));
+                    break;
+                case RecordDeclarationSyntax recordDeclaration:
+                    symbols.Add(CreateSymbol(recordDeclaration.Identifier.ValueText, "record", recordDeclaration));
+                    break;
+                case EnumDeclarationSyntax enumDeclaration:
+                    symbols.Add(CreateSymbol(enumDeclaration.Identifier.ValueText, "enum", enumDeclaration));
+                    break;
+                case ConstructorDeclarationSyntax constructorDeclaration:
+                    symbols.Add(CreateSymbol(constructorDeclaration.Identifier.ValueText, "constructor", constructorDeclaration));
+                    break;
+                case MethodDeclarationSyntax methodDeclaration:
+                    symbols.Add(CreateSymbol(methodDeclaration.Identifier.ValueText, "method", methodDeclaration));
+                    break;
+                case PropertyDeclarationSyntax propertyDeclaration:
+                    symbols.Add(CreateSymbol(propertyDeclaration.Identifier.ValueText, "property", propertyDeclaration));
+                    break;
+            }
+        }
+
+        return symbols;
     }
 
     private static void AddOrUpdateBreakpoint(
@@ -82,4 +116,60 @@ public sealed class CSharpAnalysisService
             };
         }
     }
+
+    private static SymbolDto CreateSymbol(string name, string kind, MemberDeclarationSyntax declaration)
+    {
+        var line = declaration.SyntaxTree.GetLineSpan(declaration.Span).StartLinePosition.Line + 1;
+        var containerName = GetContainerName(declaration.Parent);
+        var signature = declaration.ToString()
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)[0]
+            .Trim();
+
+        return new SymbolDto
+        {
+            Name = name,
+            Kind = kind,
+            Line = line,
+            ContainerName = containerName,
+            Signature = string.IsNullOrWhiteSpace(signature) ? null : signature,
+            Modifiers = declaration.GetModifierTexts()
+        };
+    }
+
+    private static string? GetContainerName(SyntaxNode? parent)
+    {
+        while (parent is not null)
+        {
+            switch (parent)
+            {
+                case BaseNamespaceDeclarationSyntax namespaceDeclaration:
+                    return namespaceDeclaration.Name.ToString();
+                case BaseTypeDeclarationSyntax typeDeclaration:
+                    return typeDeclaration.Identifier.ValueText;
+            }
+
+            parent = parent.Parent;
+        }
+
+        return null;
+    }
+}
+
+internal static class MemberDeclarationSyntaxExtensions
+{
+    public static IReadOnlyList<string> GetModifierTexts(this MemberDeclarationSyntax declaration) =>
+        GetModifiers(declaration).Select(static modifier => modifier.ValueText).ToArray();
+
+    private static SyntaxTokenList GetModifiers(MemberDeclarationSyntax declaration) =>
+        declaration switch
+        {
+            BaseTypeDeclarationSyntax typeDeclaration => typeDeclaration.Modifiers,
+            BaseMethodDeclarationSyntax methodDeclaration => methodDeclaration.Modifiers,
+            PropertyDeclarationSyntax propertyDeclaration => propertyDeclaration.Modifiers,
+            EventDeclarationSyntax eventDeclaration => eventDeclaration.Modifiers,
+            FieldDeclarationSyntax fieldDeclaration => fieldDeclaration.Modifiers,
+            DelegateDeclarationSyntax delegateDeclaration => delegateDeclaration.Modifiers,
+            EnumMemberDeclarationSyntax => default,
+            _ => default
+        };
 }

--- a/tools/csharp-sidecar/Qmd.CSharp.Sidecar/Program.cs
+++ b/tools/csharp-sidecar/Qmd.CSharp.Sidecar/Program.cs
@@ -1,0 +1,26 @@
+using System.Text.Json;
+
+namespace Qmd.CSharp.Sidecar;
+
+public static class Program
+{
+    public static async Task<int> Main()
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        await using var input = Console.OpenStandardInput();
+        var request = await JsonSerializer.DeserializeAsync<AnalysisRequest>(input, options);
+
+        if (request is null)
+        {
+            await Console.Error.WriteLineAsync("Request payload was null.");
+            return 1;
+        }
+
+        var service = new CSharpAnalysisService();
+        var response = service.Analyze(request);
+
+        await using var output = Console.OpenStandardOutput();
+        await JsonSerializer.SerializeAsync(output, response, options);
+        return 0;
+    }
+}

--- a/tools/csharp-sidecar/Qmd.CSharp.Sidecar/Program.cs
+++ b/tools/csharp-sidecar/Qmd.CSharp.Sidecar/Program.cs
@@ -6,20 +6,39 @@ public static class Program
 {
     public static async Task<int> Main()
     {
-        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
         await using var input = Console.OpenStandardInput();
-        var request = await JsonSerializer.DeserializeAsync<AnalysisRequest>(input, options);
+        await using var output = Console.OpenStandardOutput();
+        return await RunAsync(input, output, Console.Error);
+    }
+
+    public static async Task<int> RunAsync(Stream input, Stream output, TextWriter error)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(output);
+        ArgumentNullException.ThrowIfNull(error);
+
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        AnalysisRequest? request;
+
+        try
+        {
+            request = await JsonSerializer.DeserializeAsync<AnalysisRequest>(input, options);
+        }
+        catch (JsonException)
+        {
+            await error.WriteLineAsync("Invalid request payload.");
+            return 1;
+        }
 
         if (request is null)
         {
-            await Console.Error.WriteLineAsync("Request payload was null.");
+            await error.WriteLineAsync("Invalid request payload.");
             return 1;
         }
 
         var service = new CSharpAnalysisService();
         var response = service.Analyze(request);
 
-        await using var output = Console.OpenStandardOutput();
         await JsonSerializer.SerializeAsync(output, response, options);
         return 0;
     }

--- a/tools/csharp-sidecar/Qmd.CSharp.Sidecar/Protocol.cs
+++ b/tools/csharp-sidecar/Qmd.CSharp.Sidecar/Protocol.cs
@@ -1,0 +1,61 @@
+using System.Text.Json.Serialization;
+
+namespace Qmd.CSharp.Sidecar;
+
+public sealed class AnalysisRequest
+{
+    [JsonPropertyName("filePath")]
+    public string FilePath { get; init; } = string.Empty;
+
+    [JsonPropertyName("content")]
+    public string Content { get; init; } = string.Empty;
+
+    [JsonPropertyName("features")]
+    public AnalysisFeatures? Features { get; init; }
+}
+
+public sealed class AnalysisFeatures
+{
+    [JsonPropertyName("breakpoints")]
+    public bool Breakpoints { get; init; }
+
+    [JsonPropertyName("symbols")]
+    public bool Symbols { get; init; }
+}
+
+public sealed class AnalysisResponse
+{
+    [JsonPropertyName("breakpoints")]
+    public IReadOnlyList<BreakpointDto> Breakpoints { get; init; } = [];
+
+    [JsonPropertyName("symbols")]
+    public IReadOnlyList<SymbolDto> Symbols { get; init; } = [];
+}
+
+public sealed class BreakpointDto
+{
+    [JsonPropertyName("pos")]
+    public required int Pos { get; init; }
+
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("score")]
+    public required int Score { get; init; }
+}
+
+public sealed class SymbolDto
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("line")]
+    public required int Line { get; init; }
+
+    [JsonPropertyName("signature")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Signature { get; init; }
+}

--- a/tools/csharp-sidecar/Qmd.CSharp.Sidecar/Protocol.cs
+++ b/tools/csharp-sidecar/Qmd.CSharp.Sidecar/Protocol.cs
@@ -4,6 +4,12 @@ namespace Qmd.CSharp.Sidecar;
 
 public sealed class AnalysisRequest
 {
+    [JsonPropertyName("version")]
+    public int Version { get; init; }
+
+    [JsonPropertyName("language")]
+    public string Language { get; init; } = string.Empty;
+
     [JsonPropertyName("filePath")]
     public string FilePath { get; init; } = string.Empty;
 
@@ -25,11 +31,20 @@ public sealed class AnalysisFeatures
 
 public sealed class AnalysisResponse
 {
+    [JsonPropertyName("version")]
+    public int Version { get; init; }
+
+    [JsonPropertyName("language")]
+    public string Language { get; init; } = string.Empty;
+
     [JsonPropertyName("breakpoints")]
     public IReadOnlyList<BreakpointDto> Breakpoints { get; init; } = [];
 
     [JsonPropertyName("symbols")]
     public IReadOnlyList<SymbolDto> Symbols { get; init; } = [];
+
+    [JsonPropertyName("diagnostics")]
+    public IReadOnlyList<string> Diagnostics { get; init; } = [];
 }
 
 public sealed class BreakpointDto
@@ -37,8 +52,8 @@ public sealed class BreakpointDto
     [JsonPropertyName("pos")]
     public required int Pos { get; init; }
 
-    [JsonPropertyName("kind")]
-    public required string Kind { get; init; }
+    [JsonPropertyName("type")]
+    public required string Type { get; init; }
 
     [JsonPropertyName("score")]
     public required int Score { get; init; }
@@ -55,7 +70,14 @@ public sealed class SymbolDto
     [JsonPropertyName("line")]
     public required int Line { get; init; }
 
+    [JsonPropertyName("containerName")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ContainerName { get; init; }
+
     [JsonPropertyName("signature")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Signature { get; init; }
+
+    [JsonPropertyName("modifiers")]
+    public IReadOnlyList<string> Modifiers { get; init; } = [];
 }

--- a/tools/csharp-sidecar/Qmd.CSharp.Sidecar/Qmd.CSharp.Sidecar.csproj
+++ b/tools/csharp-sidecar/Qmd.CSharp.Sidecar/Qmd.CSharp.Sidecar.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
+  </ItemGroup>
+</Project>

--- a/tools/csharp-sidecar/csharp-sidecar.slnx
+++ b/tools/csharp-sidecar/csharp-sidecar.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="Qmd.CSharp.Sidecar.Tests/Qmd.CSharp.Sidecar.Tests.csproj" />
+  <Project Path="Qmd.CSharp.Sidecar/Qmd.CSharp.Sidecar.csproj" />
+</Solution>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,10 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    testTimeout: 30000,
+    testTimeout: process.platform === "win32" ? 60000 : 30000,
     include: ["test/**/*.test.ts"],
+    // Native LLM integration tests share process-global state and are flaky on
+    // Windows when files run in parallel.
+    fileParallelism: process.platform !== "win32",
   },
 });


### PR DESCRIPTION
## Summary
- add baseline C# AST chunking and integration coverage using the existing tree-sitter pipeline
- integrate an optional Roslyn-based C# sidecar for richer symbol extraction, metadata preservation, and documented usage
- harden Windows CLI, MCP daemon, and LLM integration test behavior so the branch verifies cleanly on Windows

## Test Plan
- [x] `npm test`
- [x] `npm run build`
- [x] `dotnet test tools/csharp-sidecar -v minimal`
- [x] `dotnet build tools/csharp-sidecar -c Release`
