### PR TITLE
fix: include line in CLI --json search output

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -1932,7 +1932,8 @@ function outputResults(results: OutputRow[], query: string, opts: OutputOptions)
     const output = filtered.map(row => {
       const docid = row.docid || (row.hash ? row.hash.slice(0, 6) : undefined);
       let body = opts.full ? row.body : undefined;
-      let snippet = !opts.full ? extractSnippet(row.body, query, 300, row.chunkPos, undefined, opts.intent).snippet : undefined;
+      const snippetInfo = !opts.full ? extractSnippet(row.body, query, 300, row.chunkPos, undefined, opts.intent) : undefined;
+      let snippet = snippetInfo?.snippet;
       if (opts.lineNumbers) {
         if (body) body = addLineNumbers(body);
         if (snippet) snippet = addLineNumbers(snippet);
@@ -1941,6 +1942,7 @@ function outputResults(results: OutputRow[], query: string, opts: OutputOptions)
         ...(docid && { docid: `#${docid}` }),
         score: Math.round(row.score * 100) / 100,
         file: toQmdPath(row.displayPath),
+        ...(snippetInfo && { line: snippetInfo.line }),
         title: row.title,
         ...(row.context && { context: row.context }),
         ...(body && { body }),


### PR DESCRIPTION
## Summary

- `--json` search output now includes a `line` field (1-indexed) pointing to the best-matching line in the document, enabling editor integrations like `code --goto file:line`

## Problem

#505 requested a `line` field in `--json` output for editor integrations. #506 was merged to fix it, but the fix landed in `searchResultsToJson()` in `formatter.ts` — a function with **no callers**. The CLI's actual JSON output is generated by `outputResults()` in `qmd.ts`, which has its own inline formatting. That inline path destructured only `.snippet` from `extractSnippet()`, discarding the `.line` property.

## Fix

Extract the full `SnippetResult` from `extractSnippet()` and spread `line` into the JSON output object — matching what the CLI display path already does for terminal output.

**Before:**
```json
{"file": "qmd://blog/post.md", "snippet": "@@ -42,4 @@ ..."}
```

**After:**
```json
{"file": "qmd://blog/post.md", "line": 42, "snippet": "@@ -42,4 @@ ..."}
```

## Test plan

- [x] `qmd search "term" --json` includes `line` field in each result
- [x] `qmd query "term" --json` includes `line` field in each result
- [x] `qmd search "term" --json --full` omits `line` (no snippet extraction when showing full body)
- [x] Existing CLI tests pass (`npx vitest run test/cli.test.ts` — 91/91)

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)