### PR TITLE
fix(chunking): pair code fences by char and length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixes
+
+- Code fence detection now follows CommonMark pairing rules. Fences
+  opened with 4 or more backticks (or tildes) are correctly recognized
+  and paired, so chunks no longer split inside nested code blocks that
+  wrap shorter fences. Tilde fences are now supported.
+
 ## [2.1.0] - 2026-04-05
 
 Code files now chunk at function and class boundaries via tree-sitter,

--- a/src/store.ts
+++ b/src/store.ts
@@ -101,7 +101,7 @@ export const BREAK_PATTERNS: [RegExp, number, string][] = [
   [/\n#{4}(?!#)/g, 70, 'h4'],      // #### but not #####
   [/\n#{5}(?!#)/g, 60, 'h5'],      // ##### but not ######
   [/\n#{6}(?!#)/g, 50, 'h6'],      // ######
-  [/\n```/g, 80, 'codeblock'],     // code block boundary (same as h3)
+  [/\n(?:`{3,}|~{3,})/g, 80, 'codeblock'],  // code block boundary (same as h3)
   [/\n(?:---|\*\*\*|___)\s*\n/g, 60, 'hr'],  // horizontal rule
   [/\n\n+/g, 20, 'blank'],         // paragraph boundary
   [/\n[-*]\s/g, 5, 'list'],        // unordered list item
@@ -139,27 +139,42 @@ export function scanBreakPoints(text: string): BreakPoint[] {
 
 /**
  * Find all code fence regions in the text.
- * Code fences are delimited by ``` and we should never split inside them.
+ * Code fences are delimited by runs of ``` or ~~~ (3 or more), and we should
+ * never split inside them. Follows CommonMark pairing rules: the closing fence
+ * must use the same character as the opening fence, be at least as long, and
+ * carry no info string.
+ *
+ * Only column-0 fences are recognized. Indented fences are not detected.
  */
 export function findCodeFences(text: string): CodeFenceRegion[] {
   const regions: CodeFenceRegion[] = [];
-  const fencePattern = /\n```/g;
-  let inFence = false;
-  let fenceStart = 0;
+  // Capture: fence char run, then the rest of the line (info string or close tail).
+  const fencePattern = /\n(`{3,}|~{3,})([^\n]*)/g;
+  let open: { char: string; len: number; start: number } | null = null;
 
   for (const match of text.matchAll(fencePattern)) {
-    if (!inFence) {
-      fenceStart = match.index!;
-      inFence = true;
-    } else {
-      regions.push({ start: fenceStart, end: match.index! + match[0].length });
-      inFence = false;
+    const run = match[1]!;
+    const tail = match[2]!;
+    const char = run[0]!;
+    const len = run.length;
+    const pos = match.index!;
+
+    if (!open) {
+      open = { char, len, start: pos };
+      continue;
     }
+
+    // To close: same char, length >= opening, and no info string on the close line.
+    if (char === open.char && len >= open.len && tail.trim() === '') {
+      regions.push({ start: open.start, end: pos + match[0].length });
+      open = null;
+    }
+    // Otherwise it's content inside the open fence; ignore.
   }
 
   // Handle unclosed fence - extends to end of document
-  if (inFence) {
-    regions.push({ start: fenceStart, end: text.length });
+  if (open) {
+    regions.push({ start: open.start, end: text.length });
   }
 
   return regions;

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -677,6 +677,123 @@ describe("findCodeFences", () => {
     const fences = findCodeFences(text);
     expect(fences.length).toBe(0);
   });
+
+  test("handles 4-backtick fence containing 3-backtick block", () => {
+    // Outer ```` fence wraps an inner ``` that must not close it.
+    const text = "Before\n````md\n```js\ninner\n```\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    // Inner ``` positions must be inside the single fence region
+    const innerOpen = text.indexOf("```js");
+    const innerClose = text.indexOf("```\n````");
+    expect(isInsideCodeFence(innerOpen, fences)).toBe(true);
+    expect(isInsideCodeFence(innerClose, fences)).toBe(true);
+  });
+
+  test("recognizes tilde fences", () => {
+    const text = "Before\n~~~\ncode\n~~~\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+  });
+
+  test("does not close tilde fence with backticks", () => {
+    // Open ~~~, stray ``` should not close it; unclosed extends to end.
+    const text = "Before\n~~~\ncode\n```\nstill inside";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(fences[0]!.end).toBe(text.length);
+  });
+
+  test("does not close with shorter fence run", () => {
+    // Open ````, a ``` inside must not close it.
+    const text = "Before\n````\ncode\n```\nstill inside\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    const strayClose = text.indexOf("```\nstill");
+    expect(isInsideCodeFence(strayClose, fences)).toBe(true);
+  });
+
+  test("does not close when closing line has info string", () => {
+    // Close candidate has trailing text, so it's not a valid close.
+    const text = "Before\n```\ncode\n``` trailing\n```\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    // The stray "``` trailing" should still be inside the fence
+    const stray = text.indexOf("``` trailing");
+    expect(isInsideCodeFence(stray, fences)).toBe(true);
+    // Real close is the bare ``` line near the end
+    expect(fences[0]!.end).toBe(text.indexOf("\nAfter"));
+  });
+
+  test("handles 5/4/3 backtick nesting with bare inner fences", () => {
+    // Outer 5-bt wraps 4-bt wraps 3-bt, all inner fences with no info string.
+    // Only the final 5-bt run may close the outer fence.
+    const text = [
+      "Before",
+      "`````md",
+      "````",
+      "```",
+      "code",
+      "```",
+      "````",
+      "`````",
+      "After",
+    ].join("\n");
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    // Every inner fence run must be inside the single region.
+    for (const needle of ["````\n```", "```\ncode", "```\n````", "````\n`````"]) {
+      expect(isInsideCodeFence(text.indexOf(needle), fences)).toBe(true);
+    }
+  });
+
+  test("longer closing fence is valid (6-bt closes 5-bt)", () => {
+    const text = "Before\n`````\ncode\n``````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(isInsideCodeFence(text.indexOf("code"), fences)).toBe(true);
+  });
+
+  test("same-length fences do not nest (CommonMark)", () => {
+    // ```` inside ```` cannot nest: the second ```` closes the first.
+    // Result is two empty-ish fences with "content" sitting outside both.
+    const text = "Before\n````\n````\ncontent\n````\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(2);
+    expect(isInsideCodeFence(text.indexOf("content"), fences)).toBe(false);
+  });
+
+  test("mixed fence chars do not interact", () => {
+    // Backtick outer, tilde inner — different chars, so the tildes stay inside.
+    const text = "Before\n````\n~~~~\ninner\n~~~~\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(isInsideCodeFence(text.indexOf("inner"), fences)).toBe(true);
+  });
+
+  test("handles info strings on outer and inner fences", () => {
+    const text = "Before\n```` wrap\n```js\ncode\n```\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(isInsideCodeFence(text.indexOf("```js"), fences)).toBe(true);
+  });
+
+  test("tilde fences support 5/4/3 nesting", () => {
+    const text = [
+      "Before",
+      "~~~~~",
+      "~~~~",
+      "~~~",
+      "code",
+      "~~~",
+      "~~~~",
+      "~~~~~",
+      "After",
+    ].join("\n");
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(isInsideCodeFence(text.indexOf("code"), fences)).toBe(true);
+  });
 });
 
 describe("isInsideCodeFence", () => {


### PR DESCRIPTION
## Pseudo-stack

Cross-fork PRs can't use GitHub's stacked-PR mechanism, so all four PRs in this series target `main`. The logical stack:

```
main
└── #538  fix: code fence pairing               ← you are here (foundation)
    └── #539  refactor: rename to ProtectedRegion
        ├── #540  feat: list-aware chunking        (parallel with #541)
        └── #541  feat: XML tag regions             (parallel with #540)
```

**This PR: #538.** It's the foundation of the stack — no dependencies. The three PRs above it build on this fix. I'll rebase each of them onto the latest `main` as this one lands.


> **Full context:** [qmd chunker improvements — four-PR series overview](https://gist.github.com/galligan/a8d3cada1e89633117fcc3f2733e8f8a)

---

## Summary

Fixes code fence detection to follow CommonMark pairing rules so the chunker correctly recognizes fences longer than three backticks, tilde fences, and blocks that wrap shorter fences inside longer ones.

## The bug

`findCodeFences` had two problems:

1. The regex (`/
```/g`) only matched exactly three backticks and ignored tildes entirely.
2. Pairing was a naive toggle on every match, so any ` ``` ` flipped the open/close state regardless of length or character.

Consequences:

- A block opened with ` ```` ` (4 backticks) was never recognized as a fence, so the chunker could split inside it.
- Tilde fences (`~~~`) were invisible to the chunker.
- A stray ` ``` ` inside a longer fence would prematurely "close" it, leaving the real tail of the block looking like prose.

These are real content shapes — agent instruction files and tutorials routinely use ` ```` ` to wrap examples that contain ` ``` `.

## The fix

`findCodeFences` now tracks the opening fence's character and length. A later fence run closes the open fence only if:

- it uses the same character (`` ` `` or `~`), **and**
- its length is greater than or equal to the opener, **and**
- its line has no info string (nothing but whitespace after the run)

`BREAK_PATTERNS` now scans for runs of 3+ backticks or tildes as candidate break points.

## Scope & non-goals

- **Column-0 fences only.** Indented fences (≤3 spaces per CommonMark, or inside list items) are not detected. A comment on `findCodeFences` documents this.
- **No type or API changes.** `CodeFenceRegion`, `isInsideCodeFence`, `findBestCutoff`, and all call sites in `store.ts` are unchanged.
- **AST path untouched.** `src/ast.ts` doesn't process markdown, so nothing there needed to change.

## Same-length fences (CommonMark quirk)

You can't nest a 4-backtick block inside a 4-backtick block — the second ` ```` ` legitimately closes the first. To wrap a 4-bt block you need 5 backticks outside. This is CommonMark-spec behavior and matches every conforming parser; disambiguation would require either non-linear lookahead or content heuristics, both of which have worse failure modes than the spec's deterministic rule. Tests codify this so future changes don't accidentally "fix" it.

## Tests

12 new cases under `findCodeFences` in `test/store.test.ts`:

- 4-backtick wrapping 3-backtick
- Tilde fence basic
- Tilde not closed by stray backticks
- Longer fence not closed by shorter run
- Close line with info string is invalid
- 5/4/3 backtick nesting with bare inner fences
- 6-bt closes 5-bt (longer-than-opener close is valid)
- Same-length non-nesting (two regions, content outside)
- Mixed chars (backtick outer, tilde inner)
- Info strings on both outer and inner
- Tilde 5/4/3 nesting

All existing `findCodeFences` / `isInsideCodeFence` / `scanBreakPoints` tests continue to pass without modification. Full `test/store.test.ts` suite (203 tests) and `test/ast-chunking.test.ts` suite (12 tests) green locally.

## Test plan

- [x] `npx vitest run test/store.test.ts` passes locally (203/203)
- [x] `npx vitest run test/ast-chunking.test.ts` passes locally (12/12)
- [x] CI green
