### PR TITLE
refactor(chunking): rename CodeFenceRegion to ProtectedRegion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixes
+
+- Code fence detection now follows CommonMark pairing rules. Fences
+  opened with 4 or more backticks (or tildes) are correctly recognized
+  and paired, so chunks no longer split inside nested code blocks that
+  wrap shorter fences. Tilde fences are now supported.
+
 ## [2.1.0] - 2026-04-05
 
 Code files now chunk at function and class boundaries via tree-sitter,

--- a/src/store.ts
+++ b/src/store.ts
@@ -80,12 +80,14 @@ export interface BreakPoint {
 }
 
 /**
- * A region where a code fence exists (between ``` markers).
- * We should never split inside a code fence.
+ * A region of the document that the chunker must not split inside.
+ * Code fences are the first producer; future passes may contribute
+ * other kinds (e.g. list items, XML tag regions) to the same shape.
  */
-export interface CodeFenceRegion {
-  start: number;  // position of opening ```
-  end: number;    // position of closing ``` (or document end if unclosed)
+export interface ProtectedRegion {
+  start: number;     // inclusive start position
+  end: number;       // exclusive end position
+  kind?: string;     // producer tag (e.g. 'fence'); optional for back-compat
 }
 
 /**
@@ -146,8 +148,8 @@ export function scanBreakPoints(text: string): BreakPoint[] {
  *
  * Only column-0 fences are recognized. Indented fences are not detected.
  */
-export function findCodeFences(text: string): CodeFenceRegion[] {
-  const regions: CodeFenceRegion[] = [];
+export function findCodeFences(text: string): ProtectedRegion[] {
+  const regions: ProtectedRegion[] = [];
   // Capture: fence char run, then the rest of the line (info string or close tail).
   const fencePattern = /\n(`{3,}|~{3,})([^\n]*)/g;
   let open: { char: string; len: number; start: number } | null = null;
@@ -166,7 +168,7 @@ export function findCodeFences(text: string): CodeFenceRegion[] {
 
     // To close: same char, length >= opening, and no info string on the close line.
     if (char === open.char && len >= open.len && tail.trim() === '') {
-      regions.push({ start: open.start, end: pos + match[0].length });
+      regions.push({ start: open.start, end: pos + match[0].length, kind: 'fence' });
       open = null;
     }
     // Otherwise it's content inside the open fence; ignore.
@@ -174,17 +176,17 @@ export function findCodeFences(text: string): CodeFenceRegion[] {
 
   // Handle unclosed fence - extends to end of document
   if (open) {
-    regions.push({ start: open.start, end: text.length });
+    regions.push({ start: open.start, end: text.length, kind: 'fence' });
   }
 
   return regions;
 }
 
 /**
- * Check if a position is inside a code fence region.
+ * Check if a position is inside any protected region.
  */
-export function isInsideCodeFence(pos: number, fences: CodeFenceRegion[]): boolean {
-  return fences.some(f => pos > f.start && pos < f.end);
+export function isInsideProtectedRegion(pos: number, regions: ProtectedRegion[]): boolean {
+  return regions.some(r => pos > r.start && pos < r.end);
 }
 
 /**
@@ -197,7 +199,7 @@ export function isInsideCodeFence(pos: number, fences: CodeFenceRegion[]): boole
  * @param targetCharPos - The ideal cut position (e.g., maxChars boundary)
  * @param windowChars - How far back to search for break points (default ~200 tokens)
  * @param decayFactor - How much to penalize distance (0.7 = 30% score at window edge)
- * @param codeFences - Code fence regions to avoid splitting inside
+ * @param protectedRegions - Regions to avoid splitting inside (code fences, etc.)
  * @returns The best position to cut at
  */
 export function findBestCutoff(
@@ -205,7 +207,7 @@ export function findBestCutoff(
   targetCharPos: number,
   windowChars: number = CHUNK_WINDOW_CHARS,
   decayFactor: number = 0.7,
-  codeFences: CodeFenceRegion[] = []
+  protectedRegions: ProtectedRegion[] = []
 ): number {
   const windowStart = targetCharPos - windowChars;
   let bestScore = -1;
@@ -215,8 +217,8 @@ export function findBestCutoff(
     if (bp.pos < windowStart) continue;
     if (bp.pos > targetCharPos) break;  // sorted, so we can stop
 
-    // Skip break points inside code fences
-    if (isInsideCodeFence(bp.pos, codeFences)) continue;
+    // Skip break points inside protected regions
+    if (isInsideProtectedRegion(bp.pos, protectedRegions)) continue;
 
     const distance = targetCharPos - bp.pos;
     // Squared distance decay: gentle early, steep late
@@ -266,13 +268,14 @@ export function mergeBreakPoints(a: BreakPoint[], b: BreakPoint[]): BreakPoint[]
 }
 
 /**
- * Core chunk algorithm that operates on precomputed break points and code fences.
- * This is the shared implementation used by both regex-only and AST-aware chunking.
+ * Core chunk algorithm that operates on precomputed break points and
+ * protected regions. This is the shared implementation used by both
+ * regex-only and AST-aware chunking.
  */
 export function chunkDocumentWithBreakPoints(
   content: string,
   breakPoints: BreakPoint[],
-  codeFences: CodeFenceRegion[],
+  protectedRegions: ProtectedRegion[],
   maxChars: number = CHUNK_SIZE_CHARS,
   overlapChars: number = CHUNK_OVERLAP_CHARS,
   windowChars: number = CHUNK_WINDOW_CHARS
@@ -294,7 +297,7 @@ export function chunkDocumentWithBreakPoints(
         targetEndPos,
         windowChars,
         0.7,
-        codeFences
+        protectedRegions
       );
 
       if (bestCutoff > charPos && bestCutoff <= targetEndPos) {
@@ -2177,8 +2180,8 @@ export function chunkDocument(
   windowChars: number = CHUNK_WINDOW_CHARS
 ): { text: string; pos: number }[] {
   const breakPoints = scanBreakPoints(content);
-  const codeFences = findCodeFences(content);
-  return chunkDocumentWithBreakPoints(content, breakPoints, codeFences, maxChars, overlapChars, windowChars);
+  const protectedRegions = findCodeFences(content);
+  return chunkDocumentWithBreakPoints(content, breakPoints, protectedRegions, maxChars, overlapChars, windowChars);
 }
 
 /**
@@ -2198,7 +2201,7 @@ export async function chunkDocumentAsync(
   chunkStrategy: ChunkStrategy = "regex",
 ): Promise<{ text: string; pos: number }[]> {
   const regexPoints = scanBreakPoints(content);
-  const codeFences = findCodeFences(content);
+  const protectedRegions = findCodeFences(content);
 
   let breakPoints = regexPoints;
   if (chunkStrategy === "auto" && filepath) {
@@ -2209,7 +2212,7 @@ export async function chunkDocumentAsync(
     }
   }
 
-  return chunkDocumentWithBreakPoints(content, breakPoints, codeFences, maxChars, overlapChars, windowChars);
+  return chunkDocumentWithBreakPoints(content, breakPoints, protectedRegions, maxChars, overlapChars, windowChars);
 }
 
 /**

--- a/src/store.ts
+++ b/src/store.ts
@@ -101,7 +101,7 @@ export const BREAK_PATTERNS: [RegExp, number, string][] = [
   [/\n#{4}(?!#)/g, 70, 'h4'],      // #### but not #####
   [/\n#{5}(?!#)/g, 60, 'h5'],      // ##### but not ######
   [/\n#{6}(?!#)/g, 50, 'h6'],      // ######
-  [/\n```/g, 80, 'codeblock'],     // code block boundary (same as h3)
+  [/\n(?:`{3,}|~{3,})/g, 80, 'codeblock'],  // code block boundary (same as h3)
   [/\n(?:---|\*\*\*|___)\s*\n/g, 60, 'hr'],  // horizontal rule
   [/\n\n+/g, 20, 'blank'],         // paragraph boundary
   [/\n[-*]\s/g, 5, 'list'],        // unordered list item
@@ -139,27 +139,42 @@ export function scanBreakPoints(text: string): BreakPoint[] {
 
 /**
  * Find all code fence regions in the text.
- * Code fences are delimited by ``` and we should never split inside them.
+ * Code fences are delimited by runs of ``` or ~~~ (3 or more), and we should
+ * never split inside them. Follows CommonMark pairing rules: the closing fence
+ * must use the same character as the opening fence, be at least as long, and
+ * carry no info string.
+ *
+ * Only column-0 fences are recognized. Indented fences are not detected.
  */
 export function findCodeFences(text: string): CodeFenceRegion[] {
   const regions: CodeFenceRegion[] = [];
-  const fencePattern = /\n```/g;
-  let inFence = false;
-  let fenceStart = 0;
+  // Capture: fence char run, then the rest of the line (info string or close tail).
+  const fencePattern = /\n(`{3,}|~{3,})([^\n]*)/g;
+  let open: { char: string; len: number; start: number } | null = null;
 
   for (const match of text.matchAll(fencePattern)) {
-    if (!inFence) {
-      fenceStart = match.index!;
-      inFence = true;
-    } else {
-      regions.push({ start: fenceStart, end: match.index! + match[0].length });
-      inFence = false;
+    const run = match[1]!;
+    const tail = match[2]!;
+    const char = run[0]!;
+    const len = run.length;
+    const pos = match.index!;
+
+    if (!open) {
+      open = { char, len, start: pos };
+      continue;
     }
+
+    // To close: same char, length >= opening, and no info string on the close line.
+    if (char === open.char && len >= open.len && tail.trim() === '') {
+      regions.push({ start: open.start, end: pos + match[0].length });
+      open = null;
+    }
+    // Otherwise it's content inside the open fence; ignore.
   }
 
   // Handle unclosed fence - extends to end of document
-  if (inFence) {
-    regions.push({ start: fenceStart, end: text.length });
+  if (open) {
+    regions.push({ start: open.start, end: text.length });
   }
 
   return regions;

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -33,10 +33,10 @@ import {
   mergeBreakPoints,
   scanBreakPoints,
   findCodeFences,
-  isInsideCodeFence,
+  isInsideProtectedRegion,
   findBestCutoff,
   type BreakPoint,
-  type CodeFenceRegion,
+  type ProtectedRegion,
   reciprocalRankFusion,
   extractSnippet,
   getCacheKey,
@@ -686,8 +686,8 @@ describe("findCodeFences", () => {
     // Inner ``` positions must be inside the single fence region
     const innerOpen = text.indexOf("```js");
     const innerClose = text.indexOf("```\n````");
-    expect(isInsideCodeFence(innerOpen, fences)).toBe(true);
-    expect(isInsideCodeFence(innerClose, fences)).toBe(true);
+    expect(isInsideProtectedRegion(innerOpen, fences)).toBe(true);
+    expect(isInsideProtectedRegion(innerClose, fences)).toBe(true);
   });
 
   test("recognizes tilde fences", () => {
@@ -710,7 +710,7 @@ describe("findCodeFences", () => {
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
     const strayClose = text.indexOf("```\nstill");
-    expect(isInsideCodeFence(strayClose, fences)).toBe(true);
+    expect(isInsideProtectedRegion(strayClose, fences)).toBe(true);
   });
 
   test("does not close when closing line has info string", () => {
@@ -720,7 +720,7 @@ describe("findCodeFences", () => {
     expect(fences.length).toBe(1);
     // The stray "``` trailing" should still be inside the fence
     const stray = text.indexOf("``` trailing");
-    expect(isInsideCodeFence(stray, fences)).toBe(true);
+    expect(isInsideProtectedRegion(stray, fences)).toBe(true);
     // Real close is the bare ``` line near the end
     expect(fences[0]!.end).toBe(text.indexOf("\nAfter"));
   });
@@ -743,7 +743,7 @@ describe("findCodeFences", () => {
     expect(fences.length).toBe(1);
     // Every inner fence run must be inside the single region.
     for (const needle of ["````\n```", "```\ncode", "```\n````", "````\n`````"]) {
-      expect(isInsideCodeFence(text.indexOf(needle), fences)).toBe(true);
+      expect(isInsideProtectedRegion(text.indexOf(needle), fences)).toBe(true);
     }
   });
 
@@ -751,7 +751,7 @@ describe("findCodeFences", () => {
     const text = "Before\n`````\ncode\n``````\nAfter";
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
-    expect(isInsideCodeFence(text.indexOf("code"), fences)).toBe(true);
+    expect(isInsideProtectedRegion(text.indexOf("code"), fences)).toBe(true);
   });
 
   test("same-length fences do not nest (CommonMark)", () => {
@@ -760,7 +760,7 @@ describe("findCodeFences", () => {
     const text = "Before\n````\n````\ncontent\n````\n````\nAfter";
     const fences = findCodeFences(text);
     expect(fences.length).toBe(2);
-    expect(isInsideCodeFence(text.indexOf("content"), fences)).toBe(false);
+    expect(isInsideProtectedRegion(text.indexOf("content"), fences)).toBe(false);
   });
 
   test("mixed fence chars do not interact", () => {
@@ -768,14 +768,14 @@ describe("findCodeFences", () => {
     const text = "Before\n````\n~~~~\ninner\n~~~~\n````\nAfter";
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
-    expect(isInsideCodeFence(text.indexOf("inner"), fences)).toBe(true);
+    expect(isInsideProtectedRegion(text.indexOf("inner"), fences)).toBe(true);
   });
 
   test("handles info strings on outer and inner fences", () => {
     const text = "Before\n```` wrap\n```js\ncode\n```\n````\nAfter";
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
-    expect(isInsideCodeFence(text.indexOf("```js"), fences)).toBe(true);
+    expect(isInsideProtectedRegion(text.indexOf("```js"), fences)).toBe(true);
   });
 
   test("tilde fences support 5/4/3 nesting", () => {
@@ -792,37 +792,37 @@ describe("findCodeFences", () => {
     ].join("\n");
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
-    expect(isInsideCodeFence(text.indexOf("code"), fences)).toBe(true);
+    expect(isInsideProtectedRegion(text.indexOf("code"), fences)).toBe(true);
   });
 });
 
-describe("isInsideCodeFence", () => {
+describe("isInsideProtectedRegion", () => {
   test("returns true for position inside fence", () => {
-    const fences: CodeFenceRegion[] = [{ start: 10, end: 30 }];
-    expect(isInsideCodeFence(15, fences)).toBe(true);
-    expect(isInsideCodeFence(20, fences)).toBe(true);
+    const fences: ProtectedRegion[] = [{ start: 10, end: 30 }];
+    expect(isInsideProtectedRegion(15, fences)).toBe(true);
+    expect(isInsideProtectedRegion(20, fences)).toBe(true);
   });
 
   test("returns false for position outside fence", () => {
-    const fences: CodeFenceRegion[] = [{ start: 10, end: 30 }];
-    expect(isInsideCodeFence(5, fences)).toBe(false);
-    expect(isInsideCodeFence(35, fences)).toBe(false);
+    const fences: ProtectedRegion[] = [{ start: 10, end: 30 }];
+    expect(isInsideProtectedRegion(5, fences)).toBe(false);
+    expect(isInsideProtectedRegion(35, fences)).toBe(false);
   });
 
   test("returns false for position at fence boundaries", () => {
-    const fences: CodeFenceRegion[] = [{ start: 10, end: 30 }];
-    expect(isInsideCodeFence(10, fences)).toBe(false); // at start
-    expect(isInsideCodeFence(30, fences)).toBe(false); // at end
+    const fences: ProtectedRegion[] = [{ start: 10, end: 30 }];
+    expect(isInsideProtectedRegion(10, fences)).toBe(false); // at start
+    expect(isInsideProtectedRegion(30, fences)).toBe(false); // at end
   });
 
   test("handles multiple fences", () => {
-    const fences: CodeFenceRegion[] = [
+    const fences: ProtectedRegion[] = [
       { start: 10, end: 30 },
       { start: 50, end: 70 }
     ];
-    expect(isInsideCodeFence(20, fences)).toBe(true);
-    expect(isInsideCodeFence(60, fences)).toBe(true);
-    expect(isInsideCodeFence(40, fences)).toBe(false);
+    expect(isInsideProtectedRegion(20, fences)).toBe(true);
+    expect(isInsideProtectedRegion(60, fences)).toBe(true);
+    expect(isInsideProtectedRegion(40, fences)).toBe(false);
   });
 });
 
@@ -876,8 +876,8 @@ describe("findBestCutoff", () => {
       { pos: 150, score: 100, type: 'h1' },  // inside fence
       { pos: 180, score: 20, type: 'blank' }, // outside fence
     ];
-    const codeFences: CodeFenceRegion[] = [{ start: 140, end: 160 }];
-    const cutoff = findBestCutoff(breakPoints, 200, 100, 0.7, codeFences);
+    const regions: ProtectedRegion[] = [{ start: 140, end: 160 }];
+    const cutoff = findBestCutoff(breakPoints, 200, 100, 0.7, regions);
     expect(cutoff).toBe(180); // blank wins since h1 is inside fence
   });
 
@@ -1017,10 +1017,10 @@ describe("chunkDocumentWithBreakPoints", () => {
   test("produces same output as chunkDocument for same input", () => {
     const content = "a".repeat(5000) + "\n\n" + "b".repeat(5000);
     const breakPoints = scanBreakPoints(content);
-    const codeFences = findCodeFences(content);
+    const regions = findCodeFences(content);
 
     const chunksOriginal = chunkDocument(content);
-    const chunksNew = chunkDocumentWithBreakPoints(content, breakPoints, codeFences);
+    const chunksNew = chunkDocumentWithBreakPoints(content, breakPoints, regions);
 
     expect(chunksNew.length).toBe(chunksOriginal.length);
     for (let i = 0; i < chunksNew.length; i++) {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -19,6 +19,7 @@ import {
   createStore,
   verifySqliteVecLoaded,
   getDefaultDbPath,
+  _resetProductionModeForTesting,
   homedir,
   resolve,
   getPwd,
@@ -280,6 +281,10 @@ describe("Store Creation", () => {
     // In test mode, createStore without path should throw to prevent accidental writes
     const originalIndexPath = process.env.INDEX_PATH;
     delete process.env.INDEX_PATH;
+    // Reset production mode in case another test file set it (bun runs all
+    // files in a single process, so module state leaks between files).
+    // Mirrors the fix applied to getDefaultDbPath's parallel test in 66e70c0.
+    _resetProductionModeForTesting();
 
     expect(() => createStore()).toThrow("Database path not set");
 

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -677,6 +677,123 @@ describe("findCodeFences", () => {
     const fences = findCodeFences(text);
     expect(fences.length).toBe(0);
   });
+
+  test("handles 4-backtick fence containing 3-backtick block", () => {
+    // Outer ```` fence wraps an inner ``` that must not close it.
+    const text = "Before\n````md\n```js\ninner\n```\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    // Inner ``` positions must be inside the single fence region
+    const innerOpen = text.indexOf("```js");
+    const innerClose = text.indexOf("```\n````");
+    expect(isInsideCodeFence(innerOpen, fences)).toBe(true);
+    expect(isInsideCodeFence(innerClose, fences)).toBe(true);
+  });
+
+  test("recognizes tilde fences", () => {
+    const text = "Before\n~~~\ncode\n~~~\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+  });
+
+  test("does not close tilde fence with backticks", () => {
+    // Open ~~~, stray ``` should not close it; unclosed extends to end.
+    const text = "Before\n~~~\ncode\n```\nstill inside";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(fences[0]!.end).toBe(text.length);
+  });
+
+  test("does not close with shorter fence run", () => {
+    // Open ````, a ``` inside must not close it.
+    const text = "Before\n````\ncode\n```\nstill inside\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    const strayClose = text.indexOf("```\nstill");
+    expect(isInsideCodeFence(strayClose, fences)).toBe(true);
+  });
+
+  test("does not close when closing line has info string", () => {
+    // Close candidate has trailing text, so it's not a valid close.
+    const text = "Before\n```\ncode\n``` trailing\n```\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    // The stray "``` trailing" should still be inside the fence
+    const stray = text.indexOf("``` trailing");
+    expect(isInsideCodeFence(stray, fences)).toBe(true);
+    // Real close is the bare ``` line near the end
+    expect(fences[0]!.end).toBe(text.indexOf("\nAfter"));
+  });
+
+  test("handles 5/4/3 backtick nesting with bare inner fences", () => {
+    // Outer 5-bt wraps 4-bt wraps 3-bt, all inner fences with no info string.
+    // Only the final 5-bt run may close the outer fence.
+    const text = [
+      "Before",
+      "`````md",
+      "````",
+      "```",
+      "code",
+      "```",
+      "````",
+      "`````",
+      "After",
+    ].join("\n");
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    // Every inner fence run must be inside the single region.
+    for (const needle of ["````\n```", "```\ncode", "```\n````", "````\n`````"]) {
+      expect(isInsideCodeFence(text.indexOf(needle), fences)).toBe(true);
+    }
+  });
+
+  test("longer closing fence is valid (6-bt closes 5-bt)", () => {
+    const text = "Before\n`````\ncode\n``````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(isInsideCodeFence(text.indexOf("code"), fences)).toBe(true);
+  });
+
+  test("same-length fences do not nest (CommonMark)", () => {
+    // ```` inside ```` cannot nest: the second ```` closes the first.
+    // Result is two empty-ish fences with "content" sitting outside both.
+    const text = "Before\n````\n````\ncontent\n````\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(2);
+    expect(isInsideCodeFence(text.indexOf("content"), fences)).toBe(false);
+  });
+
+  test("mixed fence chars do not interact", () => {
+    // Backtick outer, tilde inner — different chars, so the tildes stay inside.
+    const text = "Before\n````\n~~~~\ninner\n~~~~\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(isInsideCodeFence(text.indexOf("inner"), fences)).toBe(true);
+  });
+
+  test("handles info strings on outer and inner fences", () => {
+    const text = "Before\n```` wrap\n```js\ncode\n```\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(isInsideCodeFence(text.indexOf("```js"), fences)).toBe(true);
+  });
+
+  test("tilde fences support 5/4/3 nesting", () => {
+    const text = [
+      "Before",
+      "~~~~~",
+      "~~~~",
+      "~~~",
+      "code",
+      "~~~",
+      "~~~~",
+      "~~~~~",
+      "After",
+    ].join("\n");
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(isInsideCodeFence(text.indexOf("code"), fences)).toBe(true);
+  });
 });
 
 describe("isInsideCodeFence", () => {


### PR DESCRIPTION
## Pseudo-stack

Cross-fork PRs can't use GitHub's stacked-PR mechanism, so all four PRs in this series target `main`. The logical stack:

```
main
└── #538  fix: code fence pairing               (foundation)
    └── #539  refactor: rename to ProtectedRegion   ← you are here
        ├── #540  feat: list-aware chunking            (parallel with #541)
        └── #541  feat: XML tag regions                 (parallel with #540)
```

**This PR: #539.** Stacked on #538. The diff below shows the fence pairing fix commits from #538 in addition to the rename — they'll collapse once #538 merges and I rebase. The two feature PRs above (#540 and #541) both depend on this rename.


> **Full context:** [qmd chunker improvements — four-PR series overview](https://gist.github.com/galligan/a8d3cada1e89633117fcc3f2733e8f8a)

---

## Summary

Pure rename, no behavior change. `CodeFenceRegion` becomes `ProtectedRegion` with an optional `kind` tag. This opens the seam for future chunking passes to contribute other kinds of protected regions without touching the core chunker contract.

## Why now

The fence fix (#538) is the first producer of protected regions. Two follow-up PRs are in flight that both rely on the rename:

- **#540** — list-aware chunking. Adds a scanner that emits weighted **break points** at list item boundaries (not protected regions — list items can be arbitrarily long and must remain splittable when they exceed chunk size).
- **#541** — XML tag regions. Adds a scanner that emits weighted **break points** at paired `<tag>…</tag>` boundaries for agent-prompt-style markdown. Also not protected regions — same reasoning: tag bodies can be large and must remain splittable.

Neither of those PRs introduces new `ProtectedRegion` producers right now — they contribute break points. The rename matters because the shared contract (`findBestCutoff` takes protected regions to filter out split candidates inside them) is now semantically general rather than code-fence-specific, and future passes that do need hard protection (e.g. tables, blockquotes) will have a natural seam to slot into.

Landing the rename on its own keeps the feature PRs focused on behavior rather than mechanical renames, and avoids a merge race between the two parallel feature branches.

## Changes

- `interface CodeFenceRegion` → `ProtectedRegion` with optional `kind?: string` (set to `'fence'` by `findCodeFences`)
- `isInsideCodeFence` → `isInsideProtectedRegion`
- `findBestCutoff` parameter: `codeFences` → `protectedRegions`
- `chunkDocumentWithBreakPoints` parameter: `codeFences` → `protectedRegions`
- Test-local variable names updated for consistency

`findCodeFences` keeps its name — it's now one producer of protected regions (and, for now, the only one). No external callers exist: `CodeFenceRegion` and `isInsideCodeFence` are not re-exported from `src/index.ts`, so the rename is fully contained within `src/store.ts` and its tests.

## Test plan

- [x] `npx vitest run test/store.test.ts` passes (203/203)
- [x] `npx vitest run test/ast-chunking.test.ts` passes (12/12)
- [x] `npx tsc -p tsconfig.build.json --noEmit` clean
- [ ] CI green
