### PR TITLE
feat(chunking): list-aware break point scanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Changes
+
+- List-aware chunking. A new scanner tracks nested list items with a
+  stack-based state machine and emits weighted break points: top-level
+  items score 70, second-level 45, third-level and deeper 25, and the
+  transition from a list back to prose scores 75. Previously the naive
+  `list: 5` and `numlist: 5` patterns produced break points too weak to
+  influence chunking. Long lists now split cleanly at item boundaries
+  instead of mid-item. Ordered `1)` form is newly supported, as is
+  proper detection of nested sublists (which the old regex missed).
+
 ### Fixes
 
 - Code fence detection now follows CommonMark pairing rules. Fences

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixes
+
+- Code fence detection now follows CommonMark pairing rules. Fences
+  opened with 4 or more backticks (or tildes) are correctly recognized
+  and paired, so chunks no longer split inside nested code blocks that
+  wrap shorter fences. Tilde fences are now supported.
+
 ## [2.1.0] - 2026-04-05
 
 Code files now chunk at function and class boundaries via tree-sitter,

--- a/src/store.ts
+++ b/src/store.ts
@@ -80,12 +80,14 @@ export interface BreakPoint {
 }
 
 /**
- * A region where a code fence exists (between ``` markers).
- * We should never split inside a code fence.
+ * A region of the document that the chunker must not split inside.
+ * Code fences are the first producer; future passes may contribute
+ * other kinds (e.g. list items, XML tag regions) to the same shape.
  */
-export interface CodeFenceRegion {
-  start: number;  // position of opening ```
-  end: number;    // position of closing ``` (or document end if unclosed)
+export interface ProtectedRegion {
+  start: number;     // inclusive start position
+  end: number;       // exclusive end position
+  kind?: string;     // producer tag (e.g. 'fence'); optional for back-compat
 }
 
 /**
@@ -146,8 +148,8 @@ export function scanBreakPoints(text: string): BreakPoint[] {
  *
  * Only column-0 fences are recognized. Indented fences are not detected.
  */
-export function findCodeFences(text: string): CodeFenceRegion[] {
-  const regions: CodeFenceRegion[] = [];
+export function findCodeFences(text: string): ProtectedRegion[] {
+  const regions: ProtectedRegion[] = [];
   // Capture: fence char run, then the rest of the line (info string or close tail).
   const fencePattern = /\n(`{3,}|~{3,})([^\n]*)/g;
   let open: { char: string; len: number; start: number } | null = null;
@@ -166,7 +168,7 @@ export function findCodeFences(text: string): CodeFenceRegion[] {
 
     // To close: same char, length >= opening, and no info string on the close line.
     if (char === open.char && len >= open.len && tail.trim() === '') {
-      regions.push({ start: open.start, end: pos + match[0].length });
+      regions.push({ start: open.start, end: pos + match[0].length, kind: 'fence' });
       open = null;
     }
     // Otherwise it's content inside the open fence; ignore.
@@ -174,17 +176,17 @@ export function findCodeFences(text: string): CodeFenceRegion[] {
 
   // Handle unclosed fence - extends to end of document
   if (open) {
-    regions.push({ start: open.start, end: text.length });
+    regions.push({ start: open.start, end: text.length, kind: 'fence' });
   }
 
   return regions;
 }
 
 /**
- * Check if a position is inside a code fence region.
+ * Check if a position is inside any protected region.
  */
-export function isInsideCodeFence(pos: number, fences: CodeFenceRegion[]): boolean {
-  return fences.some(f => pos > f.start && pos < f.end);
+export function isInsideProtectedRegion(pos: number, regions: ProtectedRegion[]): boolean {
+  return regions.some(r => pos > r.start && pos < r.end);
 }
 
 /**
@@ -197,7 +199,7 @@ export function isInsideCodeFence(pos: number, fences: CodeFenceRegion[]): boole
  * @param targetCharPos - The ideal cut position (e.g., maxChars boundary)
  * @param windowChars - How far back to search for break points (default ~200 tokens)
  * @param decayFactor - How much to penalize distance (0.7 = 30% score at window edge)
- * @param codeFences - Code fence regions to avoid splitting inside
+ * @param protectedRegions - Regions to avoid splitting inside (code fences, etc.)
  * @returns The best position to cut at
  */
 export function findBestCutoff(
@@ -205,7 +207,7 @@ export function findBestCutoff(
   targetCharPos: number,
   windowChars: number = CHUNK_WINDOW_CHARS,
   decayFactor: number = 0.7,
-  codeFences: CodeFenceRegion[] = []
+  protectedRegions: ProtectedRegion[] = []
 ): number {
   const windowStart = targetCharPos - windowChars;
   let bestScore = -1;
@@ -215,8 +217,8 @@ export function findBestCutoff(
     if (bp.pos < windowStart) continue;
     if (bp.pos > targetCharPos) break;  // sorted, so we can stop
 
-    // Skip break points inside code fences
-    if (isInsideCodeFence(bp.pos, codeFences)) continue;
+    // Skip break points inside protected regions
+    if (isInsideProtectedRegion(bp.pos, protectedRegions)) continue;
 
     const distance = targetCharPos - bp.pos;
     // Squared distance decay: gentle early, steep late
@@ -266,13 +268,14 @@ export function mergeBreakPoints(a: BreakPoint[], b: BreakPoint[]): BreakPoint[]
 }
 
 /**
- * Core chunk algorithm that operates on precomputed break points and code fences.
- * This is the shared implementation used by both regex-only and AST-aware chunking.
+ * Core chunk algorithm that operates on precomputed break points and
+ * protected regions. This is the shared implementation used by both
+ * regex-only and AST-aware chunking.
  */
 export function chunkDocumentWithBreakPoints(
   content: string,
   breakPoints: BreakPoint[],
-  codeFences: CodeFenceRegion[],
+  protectedRegions: ProtectedRegion[],
   maxChars: number = CHUNK_SIZE_CHARS,
   overlapChars: number = CHUNK_OVERLAP_CHARS,
   windowChars: number = CHUNK_WINDOW_CHARS
@@ -294,7 +297,7 @@ export function chunkDocumentWithBreakPoints(
         targetEndPos,
         windowChars,
         0.7,
-        codeFences
+        protectedRegions
       );
 
       if (bestCutoff > charPos && bestCutoff <= targetEndPos) {
@@ -2177,8 +2180,8 @@ export function chunkDocument(
   windowChars: number = CHUNK_WINDOW_CHARS
 ): { text: string; pos: number }[] {
   const breakPoints = scanBreakPoints(content);
-  const codeFences = findCodeFences(content);
-  return chunkDocumentWithBreakPoints(content, breakPoints, codeFences, maxChars, overlapChars, windowChars);
+  const protectedRegions = findCodeFences(content);
+  return chunkDocumentWithBreakPoints(content, breakPoints, protectedRegions, maxChars, overlapChars, windowChars);
 }
 
 /**
@@ -2198,7 +2201,7 @@ export async function chunkDocumentAsync(
   chunkStrategy: ChunkStrategy = "regex",
 ): Promise<{ text: string; pos: number }[]> {
   const regexPoints = scanBreakPoints(content);
-  const codeFences = findCodeFences(content);
+  const protectedRegions = findCodeFences(content);
 
   let breakPoints = regexPoints;
   if (chunkStrategy === "auto" && filepath) {
@@ -2209,7 +2212,7 @@ export async function chunkDocumentAsync(
     }
   }
 
-  return chunkDocumentWithBreakPoints(content, breakPoints, codeFences, maxChars, overlapChars, windowChars);
+  return chunkDocumentWithBreakPoints(content, breakPoints, protectedRegions, maxChars, overlapChars, windowChars);
 }
 
 /**

--- a/src/store.ts
+++ b/src/store.ts
@@ -106,8 +106,6 @@ export const BREAK_PATTERNS: [RegExp, number, string][] = [
   [/\n(?:`{3,}|~{3,})/g, 80, 'codeblock'],  // code block boundary (same as h3)
   [/\n(?:---|\*\*\*|___)\s*\n/g, 60, 'hr'],  // horizontal rule
   [/\n\n+/g, 20, 'blank'],         // paragraph boundary
-  [/\n[-*]\s/g, 5, 'list'],        // unordered list item
-  [/\n\d+\.\s/g, 5, 'numlist'],    // ordered list item
   [/\n/g, 1, 'newline'],           // minimal break
 ];
 
@@ -187,6 +185,145 @@ export function findCodeFences(text: string): ProtectedRegion[] {
  */
 export function isInsideProtectedRegion(pos: number, regions: ProtectedRegion[]): boolean {
   return regions.some(r => pos > r.start && pos < r.end);
+}
+
+interface ListFrame {
+  indent: number;       // column of marker character
+  contentCol: number;   // column where item body begins (after marker + space)
+}
+
+/**
+ * List-aware break point scanner. Walks the document line by line, tracking
+ * nested list frames on a stack. Emits break points at list item boundaries
+ * and when a list transitions back to non-list content.
+ *
+ * Scoring:
+ *   - list-end: 75
+ *   - depth 0 item: 70
+ *   - depth 1 item: 45
+ *   - depth 2+ item: 25
+ *
+ * Marker-type transitions at the same indent are ignored (not CommonMark).
+ * Only `-`, `*`, and `\d+[.)]` markers are recognized (no `+`).
+ * Positions match scanBreakPoints convention: the `\n` before the line.
+ */
+export function findListBreakPoints(text: string): BreakPoint[] {
+  const points: BreakPoint[] = [];
+  if (text.length === 0) return points;
+
+  const itemScores = [70, 45, 25];
+  const itemTypes = ['list-item-0', 'list-item-1', 'list-item-2'];
+  const scoreFor = (depth: number): number =>
+    depth < itemScores.length ? itemScores[depth]! : itemScores[itemScores.length - 1]!;
+  const typeFor = (depth: number): string =>
+    depth < itemTypes.length ? itemTypes[depth]! : itemTypes[itemTypes.length - 1]!;
+
+  const stack: ListFrame[] = [];
+
+  // Iterate lines. lineStart is the index of the first character of the line.
+  // The break-point position we emit is lineStart - 1 (the preceding `\n`),
+  // except for the first line where there's no preceding newline.
+  let lineStart = 0;
+  const n = text.length;
+
+  // Match list item: optional leading spaces, then marker + at least one space.
+  // Unordered: - or *  (NOT +)
+  // Ordered: digits followed by . or )
+  //
+  // Known limitations (deliberate, to keep the scanner simple):
+  //   - Space-separated markers only. `-\t` (dash followed by a literal tab)
+  //     is not recognized. This pattern does not occur in practice.
+  //   - Tab-indented lines are not recognized as list items. Modern markdown
+  //     uses spaces for indentation; tab indentation was never supported by
+  //     the previous regex either, so this is not a regression.
+  //   - Loose/tight list distinction, lazy continuation, and 4-space indented
+  //     code blocks inside items are not tracked — those are rendering-level
+  //     concerns that don't change where chunks should split.
+  const itemRegex = /^( *)(?:([-*])|(\d+)([.)]))( +)/;
+
+  while (lineStart <= n) {
+    // Find end of line
+    let lineEnd = text.indexOf('\n', lineStart);
+    if (lineEnd === -1) lineEnd = n;
+    const line = text.slice(lineStart, lineEnd);
+    const bpPos = lineStart === 0 ? 0 : lineStart - 1;
+
+    const isBlank = line.trim().length === 0;
+
+    if (isBlank) {
+      // Don't change state; next non-blank decides.
+      if (lineEnd === n) break;
+      lineStart = lineEnd + 1;
+      continue;
+    }
+
+    const match = itemRegex.exec(line);
+    if (match) {
+      const leading = match[1]!;
+      const indent = leading.length;
+      const bullet = match[2];
+      const digits = match[3];
+      const ordPunct = match[4];
+      const spaces = match[5]!;
+      const markerLen = bullet ? 1 : (digits!.length + ordPunct!.length);
+      const contentCol = indent + markerLen + spaces.length;
+
+      // Pop frames whose indent exceeds this line's indent (dedent).
+      while (stack.length > 0 && indent < stack[stack.length - 1]!.indent) {
+        stack.pop();
+      }
+
+      let depth: number;
+      if (stack.length === 0) {
+        stack.push({ indent, contentCol });
+        depth = 0;
+      } else {
+        const top = stack[stack.length - 1]!;
+        if (indent >= top.contentCol) {
+          // Deeper nesting
+          stack.push({ indent, contentCol });
+          depth = stack.length - 1;
+        } else if (indent === top.indent) {
+          // Sibling
+          depth = stack.length - 1;
+        } else {
+          // Indent between top.indent and top.contentCol, or less than top.indent
+          // after popping. Treat as sibling at current level.
+          depth = stack.length - 1;
+        }
+      }
+
+      // Skip the first line of the document: position 0 can never be a
+      // chunk break (chunks always start at 0) and there's no preceding
+      // newline to point to anyway.
+      if (lineStart > 0) {
+        points.push({ pos: bpPos, score: scoreFor(depth), type: typeFor(depth) });
+      }
+    } else {
+      // Non-blank, non-list line.
+      if (stack.length > 0) {
+        const indent = line.length - line.trimStart().length;
+        const bottom = stack[0]!;
+        if (indent >= bottom.contentCol) {
+          // Continuation of outermost item; keep state.
+        } else {
+          // List ends.
+          stack.length = 0;
+          points.push({ pos: bpPos, score: 75, type: 'list-end' });
+        }
+      }
+    }
+
+    if (lineEnd === n) break;
+    lineStart = lineEnd + 1;
+  }
+
+  // End of document: if still in a list, emit a list-end at text.length.
+  if (stack.length > 0) {
+    points.push({ pos: n, score: 75, type: 'list-end' });
+  }
+
+  return points.sort((a, b) => a.pos - b.pos);
 }
 
 /**
@@ -2179,7 +2316,9 @@ export function chunkDocument(
   overlapChars: number = CHUNK_OVERLAP_CHARS,
   windowChars: number = CHUNK_WINDOW_CHARS
 ): { text: string; pos: number }[] {
-  const breakPoints = scanBreakPoints(content);
+  const regexPoints = scanBreakPoints(content);
+  const listPoints = findListBreakPoints(content);
+  const breakPoints = mergeBreakPoints(regexPoints, listPoints);
   const protectedRegions = findCodeFences(content);
   return chunkDocumentWithBreakPoints(content, breakPoints, protectedRegions, maxChars, overlapChars, windowChars);
 }
@@ -2201,14 +2340,15 @@ export async function chunkDocumentAsync(
   chunkStrategy: ChunkStrategy = "regex",
 ): Promise<{ text: string; pos: number }[]> {
   const regexPoints = scanBreakPoints(content);
+  const listPoints = findListBreakPoints(content);
   const protectedRegions = findCodeFences(content);
 
-  let breakPoints = regexPoints;
+  let breakPoints = mergeBreakPoints(regexPoints, listPoints);
   if (chunkStrategy === "auto" && filepath) {
     const { getASTBreakPoints } = await import("./ast.js");
     const astPoints = await getASTBreakPoints(content, filepath);
     if (astPoints.length > 0) {
-      breakPoints = mergeBreakPoints(regexPoints, astPoints);
+      breakPoints = mergeBreakPoints(breakPoints, astPoints);
     }
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -101,7 +101,7 @@ export const BREAK_PATTERNS: [RegExp, number, string][] = [
   [/\n#{4}(?!#)/g, 70, 'h4'],      // #### but not #####
   [/\n#{5}(?!#)/g, 60, 'h5'],      // ##### but not ######
   [/\n#{6}(?!#)/g, 50, 'h6'],      // ######
-  [/\n```/g, 80, 'codeblock'],     // code block boundary (same as h3)
+  [/\n(?:`{3,}|~{3,})/g, 80, 'codeblock'],  // code block boundary (same as h3)
   [/\n(?:---|\*\*\*|___)\s*\n/g, 60, 'hr'],  // horizontal rule
   [/\n\n+/g, 20, 'blank'],         // paragraph boundary
   [/\n[-*]\s/g, 5, 'list'],        // unordered list item
@@ -139,27 +139,42 @@ export function scanBreakPoints(text: string): BreakPoint[] {
 
 /**
  * Find all code fence regions in the text.
- * Code fences are delimited by ``` and we should never split inside them.
+ * Code fences are delimited by runs of ``` or ~~~ (3 or more), and we should
+ * never split inside them. Follows CommonMark pairing rules: the closing fence
+ * must use the same character as the opening fence, be at least as long, and
+ * carry no info string.
+ *
+ * Only column-0 fences are recognized. Indented fences are not detected.
  */
 export function findCodeFences(text: string): CodeFenceRegion[] {
   const regions: CodeFenceRegion[] = [];
-  const fencePattern = /\n```/g;
-  let inFence = false;
-  let fenceStart = 0;
+  // Capture: fence char run, then the rest of the line (info string or close tail).
+  const fencePattern = /\n(`{3,}|~{3,})([^\n]*)/g;
+  let open: { char: string; len: number; start: number } | null = null;
 
   for (const match of text.matchAll(fencePattern)) {
-    if (!inFence) {
-      fenceStart = match.index!;
-      inFence = true;
-    } else {
-      regions.push({ start: fenceStart, end: match.index! + match[0].length });
-      inFence = false;
+    const run = match[1]!;
+    const tail = match[2]!;
+    const char = run[0]!;
+    const len = run.length;
+    const pos = match.index!;
+
+    if (!open) {
+      open = { char, len, start: pos };
+      continue;
     }
+
+    // To close: same char, length >= opening, and no info string on the close line.
+    if (char === open.char && len >= open.len && tail.trim() === '') {
+      regions.push({ start: open.start, end: pos + match[0].length });
+      open = null;
+    }
+    // Otherwise it's content inside the open fence; ignore.
   }
 
   // Handle unclosed fence - extends to end of document
-  if (inFence) {
-    regions.push({ start: fenceStart, end: text.length });
+  if (open) {
+    regions.push({ start: open.start, end: text.length });
   }
 
   return regions;

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -34,6 +34,7 @@ import {
   mergeBreakPoints,
   scanBreakPoints,
   findCodeFences,
+  findListBreakPoints,
   isInsideProtectedRegion,
   findBestCutoff,
   type BreakPoint,
@@ -614,17 +615,11 @@ describe("scanBreakPoints", () => {
     expect(blank!.score).toBe(20);
   });
 
-  test("detects list items", () => {
+  test("does not detect list items (handled by findListBreakPoints)", () => {
     const text = "Intro\n- Item 1\n- Item 2\n1. Numbered";
     const breaks = scanBreakPoints(text);
-
-    const lists = breaks.filter(b => b.type === 'list');
-    const numLists = breaks.filter(b => b.type === 'numlist');
-
-    expect(lists.length).toBe(2);
-    expect(numLists.length).toBe(1);
-    expect(lists[0]!.score).toBe(5);
-    expect(numLists[0]!.score).toBe(5);
+    expect(breaks.filter(b => b.type === 'list').length).toBe(0);
+    expect(breaks.filter(b => b.type === 'numlist').length).toBe(0);
   });
 
   test("detects newlines as fallback", () => {
@@ -798,6 +793,140 @@ describe("findCodeFences", () => {
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
     expect(isInsideProtectedRegion(text.indexOf("code"), fences)).toBe(true);
+  });
+});
+
+describe("findListBreakPoints", () => {
+  test("empty input produces no break points", () => {
+    expect(findListBreakPoints("")).toEqual([]);
+  });
+
+  test("pure prose produces no break points", () => {
+    const text = "Just a paragraph.\nAnother line of prose.\nAnd more.";
+    expect(findListBreakPoints(text)).toEqual([]);
+  });
+
+  test("single unordered list: item + list-end break points", () => {
+    const text = "Intro\n- one\n- two\n- three\n\nAfter";
+    const bps = findListBreakPoints(text);
+    // 3 item breaks (all depth 0, score 70) + 1 list-end (score 75)
+    const items = bps.filter(b => b.type === 'list-item-0');
+    const ends = bps.filter(b => b.type === 'list-end');
+    expect(items.length).toBe(3);
+    expect(ends.length).toBe(1);
+    expect(items.every(b => b.score === 70)).toBe(true);
+    expect(ends[0]!.score).toBe(75);
+  });
+
+  test("ordered list with 1.", () => {
+    const text = "Intro\n1. one\n2. two\n3. three\n\nAfter";
+    const bps = findListBreakPoints(text);
+    expect(bps.filter(b => b.type === 'list-item-0').length).toBe(3);
+    expect(bps.filter(b => b.type === 'list-end').length).toBe(1);
+  });
+
+  test("ordered list with 1)", () => {
+    const text = "Intro\n1) one\n2) two\n3) three\n\nAfter";
+    const bps = findListBreakPoints(text);
+    expect(bps.filter(b => b.type === 'list-item-0').length).toBe(3);
+    expect(bps.filter(b => b.type === 'list-end').length).toBe(1);
+  });
+
+  test("mixed marker characters at same indent are one list", () => {
+    const text = "Intro\n- one\n* two\n- three\n\nAfter";
+    const bps = findListBreakPoints(text);
+    expect(bps.filter(b => b.type === 'list-item-0').length).toBe(3);
+    expect(bps.filter(b => b.type === 'list-end').length).toBe(1);
+  });
+
+  test("nested unordered list uses depth-based scores", () => {
+    const text = "Intro\n- one\n  - sub1\n  - sub2\n- two\n\nAfter";
+    const bps = findListBreakPoints(text);
+    const top = bps.filter(b => b.type === 'list-item-0');
+    const sub = bps.filter(b => b.type === 'list-item-1');
+    expect(top.length).toBe(2);
+    expect(sub.length).toBe(2);
+    expect(top.every(b => b.score === 70)).toBe(true);
+    expect(sub.every(b => b.score === 45)).toBe(true);
+  });
+
+  test("three-deep nesting produces depth 0/1/2 scores", () => {
+    const text = "Intro\n- one\n  - two\n    - three\n\nAfter";
+    const bps = findListBreakPoints(text);
+    expect(bps.find(b => b.type === 'list-item-0')!.score).toBe(70);
+    expect(bps.find(b => b.type === 'list-item-1')!.score).toBe(45);
+    expect(bps.find(b => b.type === 'list-item-2')!.score).toBe(25);
+  });
+
+  test("mixed nesting: unordered top with ordered sublist", () => {
+    const text = "Intro\n- one\n  1. sub\n  2. sub\n- two\n\nAfter";
+    const bps = findListBreakPoints(text);
+    expect(bps.filter(b => b.type === 'list-item-0').length).toBe(2);
+    expect(bps.filter(b => b.type === 'list-item-1').length).toBe(2);
+  });
+
+  test("list followed by prose emits list-end at position of prose line", () => {
+    const text = "- a\n- b\nprose";
+    const bps = findListBreakPoints(text);
+    const end = bps.find(b => b.type === 'list-end')!;
+    // list-end at the \n before "prose"
+    expect(end.pos).toBe(text.indexOf("\nprose"));
+  });
+
+  test("list at end of document emits list-end at text.length", () => {
+    const text = "- a\n- b\n- c";
+    const bps = findListBreakPoints(text);
+    const end = bps.find(b => b.type === 'list-end')!;
+    expect(end.pos).toBe(text.length);
+  });
+
+  test("single blank line between items does not terminate list", () => {
+    const text = "Intro\n- a\n\n- b\n\nAfter";
+    const bps = findListBreakPoints(text);
+    expect(bps.filter(b => b.type === 'list-item-0').length).toBe(2);
+    expect(bps.filter(b => b.type === 'list-end').length).toBe(1);
+  });
+
+  test("blank then non-list prose terminates list", () => {
+    const text = "- a\n- b\n\nSome prose here";
+    const bps = findListBreakPoints(text);
+    expect(bps.filter(b => b.type === 'list-end').length).toBe(1);
+  });
+
+  test("+ markers are not detected as list items", () => {
+    const text = "Intro\n+ foo\n+ bar\n+ baz\n\nAfter";
+    const bps = findListBreakPoints(text);
+    expect(bps.length).toBe(0);
+  });
+
+  test("position convention: pos is the \\n before the line", () => {
+    const text = "Intro\n- one\n- two\n\nAfter";
+    const bps = findListBreakPoints(text);
+    const items = bps.filter(b => b.type === 'list-item-0');
+    // First item: \n before "- one" at index 5
+    expect(items[0]!.pos).toBe(text.indexOf("\n- one"));
+    expect(items[1]!.pos).toBe(text.indexOf("\n- two"));
+  });
+
+  test("integration: chunkDocument splits a long list at item boundaries", () => {
+    // Build a list long enough to force splitting
+    const items: string[] = [];
+    for (let i = 0; i < 200; i++) {
+      items.push(`- list item number ${i} with some descriptive text here to consume characters`);
+    }
+    const text = "# Header\n\n" + items.join("\n") + "\n";
+    const chunks = chunkDocument(text, 1000, 100, 300);
+    expect(chunks.length).toBeGreaterThan(1);
+    // Each chunk except the last should end on a complete list item line,
+    // meaning the split landed at a list-item break point (the \n before
+    // the next item).
+    for (let i = 0; i < chunks.length - 1; i++) {
+      const chunkText = chunks[i]!.text;
+      const lines = chunkText.split("\n");
+      // Drop trailing empty from a terminal \n
+      const last = lines[lines.length - 1] === "" ? lines[lines.length - 2]! : lines[lines.length - 1]!;
+      expect(last.startsWith("- list item")).toBe(true);
+    }
   });
 });
 

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -33,10 +33,10 @@ import {
   mergeBreakPoints,
   scanBreakPoints,
   findCodeFences,
-  isInsideCodeFence,
+  isInsideProtectedRegion,
   findBestCutoff,
   type BreakPoint,
-  type CodeFenceRegion,
+  type ProtectedRegion,
   reciprocalRankFusion,
   extractSnippet,
   getCacheKey,
@@ -686,8 +686,8 @@ describe("findCodeFences", () => {
     // Inner ``` positions must be inside the single fence region
     const innerOpen = text.indexOf("```js");
     const innerClose = text.indexOf("```\n````");
-    expect(isInsideCodeFence(innerOpen, fences)).toBe(true);
-    expect(isInsideCodeFence(innerClose, fences)).toBe(true);
+    expect(isInsideProtectedRegion(innerOpen, fences)).toBe(true);
+    expect(isInsideProtectedRegion(innerClose, fences)).toBe(true);
   });
 
   test("recognizes tilde fences", () => {
@@ -710,7 +710,7 @@ describe("findCodeFences", () => {
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
     const strayClose = text.indexOf("```\nstill");
-    expect(isInsideCodeFence(strayClose, fences)).toBe(true);
+    expect(isInsideProtectedRegion(strayClose, fences)).toBe(true);
   });
 
   test("does not close when closing line has info string", () => {
@@ -720,7 +720,7 @@ describe("findCodeFences", () => {
     expect(fences.length).toBe(1);
     // The stray "``` trailing" should still be inside the fence
     const stray = text.indexOf("``` trailing");
-    expect(isInsideCodeFence(stray, fences)).toBe(true);
+    expect(isInsideProtectedRegion(stray, fences)).toBe(true);
     // Real close is the bare ``` line near the end
     expect(fences[0]!.end).toBe(text.indexOf("\nAfter"));
   });
@@ -743,7 +743,7 @@ describe("findCodeFences", () => {
     expect(fences.length).toBe(1);
     // Every inner fence run must be inside the single region.
     for (const needle of ["````\n```", "```\ncode", "```\n````", "````\n`````"]) {
-      expect(isInsideCodeFence(text.indexOf(needle), fences)).toBe(true);
+      expect(isInsideProtectedRegion(text.indexOf(needle), fences)).toBe(true);
     }
   });
 
@@ -751,7 +751,7 @@ describe("findCodeFences", () => {
     const text = "Before\n`````\ncode\n``````\nAfter";
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
-    expect(isInsideCodeFence(text.indexOf("code"), fences)).toBe(true);
+    expect(isInsideProtectedRegion(text.indexOf("code"), fences)).toBe(true);
   });
 
   test("same-length fences do not nest (CommonMark)", () => {
@@ -760,7 +760,7 @@ describe("findCodeFences", () => {
     const text = "Before\n````\n````\ncontent\n````\n````\nAfter";
     const fences = findCodeFences(text);
     expect(fences.length).toBe(2);
-    expect(isInsideCodeFence(text.indexOf("content"), fences)).toBe(false);
+    expect(isInsideProtectedRegion(text.indexOf("content"), fences)).toBe(false);
   });
 
   test("mixed fence chars do not interact", () => {
@@ -768,14 +768,14 @@ describe("findCodeFences", () => {
     const text = "Before\n````\n~~~~\ninner\n~~~~\n````\nAfter";
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
-    expect(isInsideCodeFence(text.indexOf("inner"), fences)).toBe(true);
+    expect(isInsideProtectedRegion(text.indexOf("inner"), fences)).toBe(true);
   });
 
   test("handles info strings on outer and inner fences", () => {
     const text = "Before\n```` wrap\n```js\ncode\n```\n````\nAfter";
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
-    expect(isInsideCodeFence(text.indexOf("```js"), fences)).toBe(true);
+    expect(isInsideProtectedRegion(text.indexOf("```js"), fences)).toBe(true);
   });
 
   test("tilde fences support 5/4/3 nesting", () => {
@@ -792,37 +792,37 @@ describe("findCodeFences", () => {
     ].join("\n");
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
-    expect(isInsideCodeFence(text.indexOf("code"), fences)).toBe(true);
+    expect(isInsideProtectedRegion(text.indexOf("code"), fences)).toBe(true);
   });
 });
 
-describe("isInsideCodeFence", () => {
+describe("isInsideProtectedRegion", () => {
   test("returns true for position inside fence", () => {
-    const fences: CodeFenceRegion[] = [{ start: 10, end: 30 }];
-    expect(isInsideCodeFence(15, fences)).toBe(true);
-    expect(isInsideCodeFence(20, fences)).toBe(true);
+    const fences: ProtectedRegion[] = [{ start: 10, end: 30 }];
+    expect(isInsideProtectedRegion(15, fences)).toBe(true);
+    expect(isInsideProtectedRegion(20, fences)).toBe(true);
   });
 
   test("returns false for position outside fence", () => {
-    const fences: CodeFenceRegion[] = [{ start: 10, end: 30 }];
-    expect(isInsideCodeFence(5, fences)).toBe(false);
-    expect(isInsideCodeFence(35, fences)).toBe(false);
+    const fences: ProtectedRegion[] = [{ start: 10, end: 30 }];
+    expect(isInsideProtectedRegion(5, fences)).toBe(false);
+    expect(isInsideProtectedRegion(35, fences)).toBe(false);
   });
 
   test("returns false for position at fence boundaries", () => {
-    const fences: CodeFenceRegion[] = [{ start: 10, end: 30 }];
-    expect(isInsideCodeFence(10, fences)).toBe(false); // at start
-    expect(isInsideCodeFence(30, fences)).toBe(false); // at end
+    const fences: ProtectedRegion[] = [{ start: 10, end: 30 }];
+    expect(isInsideProtectedRegion(10, fences)).toBe(false); // at start
+    expect(isInsideProtectedRegion(30, fences)).toBe(false); // at end
   });
 
   test("handles multiple fences", () => {
-    const fences: CodeFenceRegion[] = [
+    const fences: ProtectedRegion[] = [
       { start: 10, end: 30 },
       { start: 50, end: 70 }
     ];
-    expect(isInsideCodeFence(20, fences)).toBe(true);
-    expect(isInsideCodeFence(60, fences)).toBe(true);
-    expect(isInsideCodeFence(40, fences)).toBe(false);
+    expect(isInsideProtectedRegion(20, fences)).toBe(true);
+    expect(isInsideProtectedRegion(60, fences)).toBe(true);
+    expect(isInsideProtectedRegion(40, fences)).toBe(false);
   });
 });
 
@@ -876,8 +876,8 @@ describe("findBestCutoff", () => {
       { pos: 150, score: 100, type: 'h1' },  // inside fence
       { pos: 180, score: 20, type: 'blank' }, // outside fence
     ];
-    const codeFences: CodeFenceRegion[] = [{ start: 140, end: 160 }];
-    const cutoff = findBestCutoff(breakPoints, 200, 100, 0.7, codeFences);
+    const regions: ProtectedRegion[] = [{ start: 140, end: 160 }];
+    const cutoff = findBestCutoff(breakPoints, 200, 100, 0.7, regions);
     expect(cutoff).toBe(180); // blank wins since h1 is inside fence
   });
 
@@ -1017,10 +1017,10 @@ describe("chunkDocumentWithBreakPoints", () => {
   test("produces same output as chunkDocument for same input", () => {
     const content = "a".repeat(5000) + "\n\n" + "b".repeat(5000);
     const breakPoints = scanBreakPoints(content);
-    const codeFences = findCodeFences(content);
+    const regions = findCodeFences(content);
 
     const chunksOriginal = chunkDocument(content);
-    const chunksNew = chunkDocumentWithBreakPoints(content, breakPoints, codeFences);
+    const chunksNew = chunkDocumentWithBreakPoints(content, breakPoints, regions);
 
     expect(chunksNew.length).toBe(chunksOriginal.length);
     for (let i = 0; i < chunksNew.length; i++) {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -19,6 +19,7 @@ import {
   createStore,
   verifySqliteVecLoaded,
   getDefaultDbPath,
+  _resetProductionModeForTesting,
   homedir,
   resolve,
   getPwd,
@@ -280,6 +281,10 @@ describe("Store Creation", () => {
     // In test mode, createStore without path should throw to prevent accidental writes
     const originalIndexPath = process.env.INDEX_PATH;
     delete process.env.INDEX_PATH;
+    // Reset production mode in case another test file set it (bun runs all
+    // files in a single process, so module state leaks between files).
+    // Mirrors the fix applied to getDefaultDbPath's parallel test in 66e70c0.
+    _resetProductionModeForTesting();
 
     expect(() => createStore()).toThrow("Database path not set");
 

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -677,6 +677,123 @@ describe("findCodeFences", () => {
     const fences = findCodeFences(text);
     expect(fences.length).toBe(0);
   });
+
+  test("handles 4-backtick fence containing 3-backtick block", () => {
+    // Outer ```` fence wraps an inner ``` that must not close it.
+    const text = "Before\n````md\n```js\ninner\n```\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    // Inner ``` positions must be inside the single fence region
+    const innerOpen = text.indexOf("```js");
+    const innerClose = text.indexOf("```\n````");
+    expect(isInsideCodeFence(innerOpen, fences)).toBe(true);
+    expect(isInsideCodeFence(innerClose, fences)).toBe(true);
+  });
+
+  test("recognizes tilde fences", () => {
+    const text = "Before\n~~~\ncode\n~~~\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+  });
+
+  test("does not close tilde fence with backticks", () => {
+    // Open ~~~, stray ``` should not close it; unclosed extends to end.
+    const text = "Before\n~~~\ncode\n```\nstill inside";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(fences[0]!.end).toBe(text.length);
+  });
+
+  test("does not close with shorter fence run", () => {
+    // Open ````, a ``` inside must not close it.
+    const text = "Before\n````\ncode\n```\nstill inside\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    const strayClose = text.indexOf("```\nstill");
+    expect(isInsideCodeFence(strayClose, fences)).toBe(true);
+  });
+
+  test("does not close when closing line has info string", () => {
+    // Close candidate has trailing text, so it's not a valid close.
+    const text = "Before\n```\ncode\n``` trailing\n```\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    // The stray "``` trailing" should still be inside the fence
+    const stray = text.indexOf("``` trailing");
+    expect(isInsideCodeFence(stray, fences)).toBe(true);
+    // Real close is the bare ``` line near the end
+    expect(fences[0]!.end).toBe(text.indexOf("\nAfter"));
+  });
+
+  test("handles 5/4/3 backtick nesting with bare inner fences", () => {
+    // Outer 5-bt wraps 4-bt wraps 3-bt, all inner fences with no info string.
+    // Only the final 5-bt run may close the outer fence.
+    const text = [
+      "Before",
+      "`````md",
+      "````",
+      "```",
+      "code",
+      "```",
+      "````",
+      "`````",
+      "After",
+    ].join("\n");
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    // Every inner fence run must be inside the single region.
+    for (const needle of ["````\n```", "```\ncode", "```\n````", "````\n`````"]) {
+      expect(isInsideCodeFence(text.indexOf(needle), fences)).toBe(true);
+    }
+  });
+
+  test("longer closing fence is valid (6-bt closes 5-bt)", () => {
+    const text = "Before\n`````\ncode\n``````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(isInsideCodeFence(text.indexOf("code"), fences)).toBe(true);
+  });
+
+  test("same-length fences do not nest (CommonMark)", () => {
+    // ```` inside ```` cannot nest: the second ```` closes the first.
+    // Result is two empty-ish fences with "content" sitting outside both.
+    const text = "Before\n````\n````\ncontent\n````\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(2);
+    expect(isInsideCodeFence(text.indexOf("content"), fences)).toBe(false);
+  });
+
+  test("mixed fence chars do not interact", () => {
+    // Backtick outer, tilde inner — different chars, so the tildes stay inside.
+    const text = "Before\n````\n~~~~\ninner\n~~~~\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(isInsideCodeFence(text.indexOf("inner"), fences)).toBe(true);
+  });
+
+  test("handles info strings on outer and inner fences", () => {
+    const text = "Before\n```` wrap\n```js\ncode\n```\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(isInsideCodeFence(text.indexOf("```js"), fences)).toBe(true);
+  });
+
+  test("tilde fences support 5/4/3 nesting", () => {
+    const text = [
+      "Before",
+      "~~~~~",
+      "~~~~",
+      "~~~",
+      "code",
+      "~~~",
+      "~~~~",
+      "~~~~~",
+      "After",
+    ].join("\n");
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(isInsideCodeFence(text.indexOf("code"), fences)).toBe(true);
+  });
 });
 
 describe("isInsideCodeFence", () => {


### PR DESCRIPTION
## Pseudo-stack

Cross-fork PRs can't use GitHub's stacked-PR mechanism, so all four PRs in this series target `main`. The logical stack:

```
main
└── #538  fix: code fence pairing               (foundation)
    └── #539  refactor: rename to ProtectedRegion
        ├── #540  feat: list-aware chunking        ← you are here (parallel with #541)
        └── #541  feat: XML tag regions             (parallel with #540)
```

**This PR: #540.** Stacked on #539 which is stacked on #538. The diff below shows commits from both of those PRs in addition to the list scanner — they'll collapse once the lower PRs land and I rebase. Parallel to #541 (XML tag regions); they branch off #539 independently and don't depend on each other.


> **Full context:** [qmd chunker improvements — four-PR series overview](https://gist.github.com/galligan/a8d3cada1e89633117fcc3f2733e8f8a)

---

## Summary

Replaces the two naive list patterns in `BREAK_PATTERNS` with a stack-based scanner that tracks nested list frames and emits depth-weighted break points plus a list-end transition signal. Long lists now split cleanly at item boundaries instead of mid-item.

## The problem

The existing list detection was two flat regex patterns:

```ts
[/
[-*]\s/g, 5, 'list'],        // unordered
[/
\d+\.\s/g, 5, 'numlist'],    // ordered
```

Two consequences:

1. **Score 5 is so low it almost always loses.** Any nearby blank line (20), hr (60), heading (50–100), or codeblock boundary (80) outranks it. On long prose-heavy lists, the chunker happily splits mid-item because a `

` scored higher than the list-item boundary.

2. **Zero structural awareness.** The regex doesn't know about indentation, so nested sublists are invisible. `  - sub-item` inside a `- top-item` list gets no break point at all. The ordered `1)` form isn't detected either. End-of-list transitions (the single most valuable break point in a document with lists) get no special treatment.

Net effect: lists were the worst-handled structure in the chunker.

## The fix

`findListBreakPoints(text: string): BreakPoint[]` — a line-by-line state machine that maintains a stack of `ListFrame { indent, contentCol }` entries and emits:

| Break point | Score | Meaning |
|---|---|---|
| `list-end` | 75 | Transition from list back to non-list flow. Third-highest score after h1/h2 — list endings are excellent split points. |
| `list-item-0` | 70 | Top-level list item start. Matches h4; items at the top of a list are as good a break as a level-4 heading. |
| `list-item-1` | 45 | Second-level (first sublist) item. Above blank (20), below h6 (50). |
| `list-item-2` | 25 | Third-level and deeper. Just above blank — used only when nothing better is nearby. |

These scores sit in gaps in the existing score table so comparisons stay unambiguous.

## What it handles

- **Unordered markers** `-` and `*` (matches existing behavior; `+` intentionally not supported)
- **Ordered markers** `1.` **and** `1)` (the parenthesis form was previously missed entirely)
- **Mixed marker characters at the same indent** are treated as one list. CommonMark says `- foo` → `* bar` at the same indent ends one list and starts another; we don't follow that rule because it would insert a high-priority break where the user visually sees no break at all. For chunking, "same indent = same list" produces better results.
- **Nested sublists** with proper depth tracking. `- foo
  - bar
    - baz` correctly produces depth 0/1/2 break points.
- **Mixed nesting** (unordered top with ordered sublist, or vice versa) works with the same stack logic.
- **Blank lines inside items** don't terminate the list — state is preserved until a non-indented non-list line appears.
- **Column-0 non-list lines** terminate the list and emit `list-end` at the preceding newline.
- **List at end of document** emits `list-end` at `text.length`.

## What it deliberately doesn't handle

Each of these was evaluated against a strict "don't degrade existing behavior" bar and deferred:

- **Loose vs tight list distinction** — affects rendering, not chunking.
- **Lazy continuation** — a column-0 non-list line that CommonMark folds back into the preceding item. Treated as list-end. The wrong answer is a slightly degraded chunk, not a broken one.
- **4-space indented code blocks inside items** — ambiguous with sublist continuation. Modern docs use fenced code.
- **Tab indentation** — neither the old regex nor the new one handles `
	- item`. The only tab pattern the old regex did match was `-	` (dash followed by literal tab as separator), which is a typing pattern nobody uses in practice. Space-separated markers only.
- **Marker-type transitions at same indent** — see "mixed marker characters" above; intentional deviation from CommonMark.

A block comment on the scanner documents these limitations so the next person doesn't chase them.

## Integration

`chunkDocument` and `chunkDocumentAsync` now merge `findListBreakPoints` output with `scanBreakPoints` before passing to `chunkDocumentWithBreakPoints`. `mergeBreakPoints` already handles the "higher score wins at same position" case, so the merge is trivial:

```ts
const regexPoints = scanBreakPoints(content);
const listPoints = findListBreakPoints(content);
const breakPoints = mergeBreakPoints(regexPoints, listPoints);
```

In the async path, AST points continue to layer on top via a second `mergeBreakPoints` call when `chunkStrategy === 'auto'`.

## Removed

The two old patterns are deleted from `BREAK_PATTERNS`:

```ts
[/
[-*]\s/g, 5, 'list'],
[/
\d+\.\s/g, 5, 'numlist'],
```

An existing test in the `scanBreakPoints` block that asserted list detection was updated to assert non-detection (with a pointer to `findListBreakPoints`).

## Regression analysis

The only pattern that used to score and no longer does is `-	` (dash followed by a literal tab character as the marker separator). This is not a typing pattern that occurs in real markdown — every editor inserts spaces, and every style guide specifies spaces. The "tab-indented list" concern is a non-issue because the old regex never matched tab-indented items in the first place (`
	- foo` was invisible to it).

Everything the old code detected, the new code detects and scores higher. Patterns the old code missed (nested sublists, `1)` form, list-end transitions) are now handled properly.

## Tests

16 new tests in `test/store.test.ts` under `describe("findListBreakPoints", ...)`:

1. Empty input → no break points
2. Pure prose → no break points
3. Single unordered list → item + list-end break points, correct scores
4. Single ordered list with `1.`
5. Single ordered list with `1)`
6. Mixed marker characters at same indent → one list
7. Nested unordered list → depth 0 and depth 1 scores
8. Three-deep nesting → depth 0, 1, 2 scores
9. Mixed nesting (unordered top + ordered sublist)
10. List followed by prose → list-end at correct position
11. List at end of document → list-end at text end
12. Single blank line between items → does not terminate
13. Blank then non-list prose → terminates list
14. `+` markers → not detected (decision 4)
15. Position convention → `pos` is the `
` before the line, matching `scanBreakPoints`
16. Integration test: `chunkDocument` on a 200-item list → splits land on item boundaries

## Test plan

- [x] `npx vitest run test/store.test.ts` passes (219/219, was 203 + 16 new)
- [x] `npx vitest run test/ast-chunking.test.ts` passes (12/12)
- [x] `npx tsc -p tsconfig.build.json --noEmit` clean
- [ ] CI green
