### PR TITLE
feat(chunking): XML tag break point scanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Changes
+
+- XML tag break points for agent-prompt markdown. The chunker now
+  recognizes line-anchored paired tags like `<example>…</example>`,
+  `<instructions>…</instructions>`, and `<thinking>…</thinking>` that
+  commonly appear in agent instruction files, and prefers to split at
+  the close of a tagged block (score 75) rather than mid-block. HTML5
+  element names (`<div>`, `<p>`, etc.) are blocked via a blocklist so
+  inline HTML in markdown is not confused for structural tags. Tags
+  inside code fences are ignored. Supports nested same-tag blocks,
+  namespaced tags (`<xsl:template>`), and custom elements
+  (`<my-widget>`).
+
 ### Fixes
 
 - Code fence detection now follows CommonMark pairing rules. Fences

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixes
+
+- Code fence detection now follows CommonMark pairing rules. Fences
+  opened with 4 or more backticks (or tildes) are correctly recognized
+  and paired, so chunks no longer split inside nested code blocks that
+  wrap shorter fences. Tilde fences are now supported.
+
 ## [2.1.0] - 2026-04-05
 
 Code files now chunk at function and class boundaries via tree-sitter,

--- a/src/html-elements.ts
+++ b/src/html-elements.ts
@@ -1,0 +1,33 @@
+/**
+ * HTML5 element names (lowercase). Used by the XML tag break point scanner
+ * to skip tags that are part of standard HTML — we only care about
+ * custom/structural tags like <example>, <instructions>, <thinking> that
+ * show up in agent/prompt markdown.
+ *
+ * Matching is case-insensitive: callers must `.toLowerCase()` before lookup.
+ */
+export const HTML_ELEMENTS: ReadonlySet<string> = new Set([
+  'a', 'abbr', 'address', 'area', 'article', 'aside', 'audio',
+  'b', 'base', 'bdi', 'bdo', 'blockquote', 'body', 'br', 'button',
+  'canvas', 'caption', 'cite', 'code', 'col', 'colgroup',
+  'data', 'datalist', 'dd', 'del', 'details', 'dfn', 'dialog', 'div', 'dl', 'dt',
+  'em', 'embed',
+  'fieldset', 'figcaption', 'figure', 'footer', 'form',
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header', 'hgroup', 'hr', 'html',
+  'i', 'iframe', 'img', 'input', 'ins',
+  'kbd',
+  'label', 'legend', 'li', 'link',
+  'main', 'map', 'mark', 'menu', 'meta', 'meter',
+  'nav', 'noscript',
+  'object', 'ol', 'optgroup', 'option', 'output',
+  'p', 'picture', 'pre', 'progress',
+  'q',
+  'rp', 'rt', 'ruby',
+  's', 'samp', 'script', 'search', 'section', 'select', 'slot', 'small',
+  'source', 'span', 'strong', 'style', 'sub', 'summary', 'sup',
+  'table', 'tbody', 'td', 'template', 'textarea', 'tfoot', 'th', 'thead',
+  'time', 'title', 'tr', 'track',
+  'u', 'ul',
+  'var', 'video',
+  'wbr',
+]);

--- a/src/store.ts
+++ b/src/store.ts
@@ -12,6 +12,7 @@
  */
 
 import { openDatabase, loadSqliteVec } from "./db.js";
+import { HTML_ELEMENTS } from "./html-elements.js";
 import type { Database } from "./db.js";
 import picomatch from "picomatch";
 import { createHash } from "crypto";
@@ -187,6 +188,169 @@ export function findCodeFences(text: string): ProtectedRegion[] {
  */
 export function isInsideProtectedRegion(pos: number, regions: ProtectedRegion[]): boolean {
   return regions.some(r => pos > r.start && pos < r.end);
+}
+
+/**
+ * Find line-anchored XML-style tag break points.
+ *
+ * Agent instruction files and prompt docs frequently wrap structural blocks
+ * in XML tags like `<example>`, `<instructions>`, `<thinking>`, `<tool_use>`.
+ * We emit asymmetric break points at those boundaries so the chunker prefers
+ * to split at the close of a block rather than mid-block.
+ *
+ * Rules (see spec for full decisions):
+ *  - Tags must occupy their own line (leading whitespace allowed). Mid-line
+ *    tags and multi-line openers are ignored.
+ *  - Tag name grammar: `[A-Za-z_][A-Za-z0-9_.:-]*`.
+ *  - HTML5 element names are blocked (case-insensitive) so `<div>`, `<p>`, …
+ *    don't get treated as structural tags.
+ *  - Open/close name matching is case-sensitive (XML semantics).
+ *  - Self-closing `<tag/>` and `<tag />` produce no region.
+ *  - `<!-- … -->`, `<!DOCTYPE …>`, `<![CDATA[…]]>`, `<?xml … ?>` are skipped.
+ *  - Nesting is stack-based. Cross-tag interleaving is treated as malformed
+ *    and the affected tags emit zero break points.
+ *  - Unclosed tags emit nothing.
+ *  - Tags inside passed-in protected regions (code fences) are ignored.
+ *  - `pos` is the `\n` immediately before the tag line (matches
+ *    scanBreakPoints/findListBreakPoints convention). First-line tags at
+ *    position 0 emit no break point.
+ *
+ * Scoring: `tag-open` = 30 (weak — splitting right before content is bad),
+ *          `tag-close` = 75 (strong — splitting after a closed block is great).
+ *
+ * Known limitation: attribute parsing is lazy. The opener regex terminates
+ * at the first `>`, so a `>` inside a quoted attribute value will produce a
+ * malformed match. This is intentional — we don't tokenize attributes.
+ */
+export function findXmlTagBreakPoints(text: string, fences: ProtectedRegion[]): BreakPoint[] {
+  // Whole-line patterns. The line is everything between `\n`s (or start/end).
+  const NAME = '[A-Za-z_][A-Za-z0-9_.:-]*';
+  const openRe = new RegExp(`^\\s*<(${NAME})(?:\\s+[^>]*)?>\\s*$`);
+  const closeRe = new RegExp(`^\\s*</(${NAME})\\s*>\\s*$`);
+  const selfCloseRe = new RegExp(`^\\s*<(${NAME})(?:\\s+[^>]*)?/>\\s*$`);
+  // Non-tag angle-bracket constructs to ignore wholesale.
+  const commentRe = /^\s*<!--.*-->\s*$/;
+  const doctypeRe = /^\s*<!DOCTYPE\b[^>]*>\s*$/i;
+  const cdataRe = /^\s*<!\[CDATA\[.*\]\]>\s*$/;
+  const piRe = /^\s*<\?[\s\S]*\?>\s*$/;
+
+  interface Frame {
+    name: string;
+    checkpoint: number; // index into `pending` where this frame's breaks start
+  }
+
+  const stack: Frame[] = [];
+  // Buffered break points. Committed to `output` only when the outermost
+  // frame closes cleanly. Discarded back to a checkpoint on malformed close.
+  const pending: BreakPoint[] = [];
+  const output: BreakPoint[] = [];
+
+  const commit = () => {
+    if (stack.length === 0) {
+      for (const bp of pending) output.push(bp);
+      pending.length = 0;
+    }
+  };
+
+  let lineStart = 0;
+  while (lineStart <= text.length) {
+    // Find line end.
+    let lineEnd = text.indexOf('\n', lineStart);
+    if (lineEnd === -1) lineEnd = text.length;
+    const line = text.slice(lineStart, lineEnd);
+
+    // Fence precedence: if this line's start is inside a fence, skip it.
+    // Use the line start position; the fence region spans `\n` of the opener
+    // through end of close. lineStart > fence.start && lineStart < fence.end
+    // is exactly what isInsideProtectedRegion checks.
+    const insideFence = fences.some(r => lineStart > r.start && lineStart < r.end);
+    if (insideFence) {
+      if (lineEnd === text.length) break;
+      lineStart = lineEnd + 1;
+      continue;
+    }
+
+    // Skip non-tag angle-bracket constructs entirely.
+    if (commentRe.test(line) || doctypeRe.test(line) || cdataRe.test(line) || piRe.test(line)) {
+      if (lineEnd === text.length) break;
+      lineStart = lineEnd + 1;
+      continue;
+    }
+
+    // Self-closing: recognized but no state change, no break points.
+    // Checked before the plain open regex because `<tag />` would also
+    // match an opener with trailing `/` as an attribute.
+    if (selfCloseRe.test(line)) {
+      if (lineEnd === text.length) break;
+      lineStart = lineEnd + 1;
+      continue;
+    }
+
+    const openMatch = line.match(openRe);
+    if (openMatch) {
+      const name = openMatch[1]!;
+      if (!HTML_ELEMENTS.has(name.toLowerCase())) {
+        // Push frame. Emit tag-open break point into pending (unless lineStart==0).
+        const frame: Frame = { name, checkpoint: pending.length };
+        stack.push(frame);
+        if (lineStart > 0) {
+          pending.push({ pos: lineStart - 1, score: 30, type: 'tag-open' });
+        }
+      }
+      if (lineEnd === text.length) break;
+      lineStart = lineEnd + 1;
+      continue;
+    }
+
+    const closeMatch = line.match(closeRe);
+    if (closeMatch) {
+      const name = closeMatch[1]!;
+      if (!HTML_ELEMENTS.has(name.toLowerCase())) {
+        if (stack.length === 0) {
+          // Stray closing tag — ignore.
+        } else {
+          const top = stack[stack.length - 1]!;
+          if (top.name === name) {
+            // Clean close: emit tag-close break point, pop.
+            if (lineStart > 0) {
+              pending.push({ pos: lineStart - 1, score: 75, type: 'tag-close' });
+            }
+            stack.pop();
+            commit();
+          } else {
+            // Malformed interleaving. Discard all pending entries for the
+            // top frame and everything stacked above it. The simplest way
+            // given our checkpoint convention: truncate pending back to the
+            // top frame's checkpoint and pop just that frame. We do NOT try
+            // to cascade — the outer frames remain, but their pending buffer
+            // is now shorter (the inner frame contributed nothing).
+            //
+            // However the spec asks: "zero break points for all involved
+            // tags". The involved tags here are the unmatched opener(s) at
+            // the top of the stack AND the current close. To be safe and
+            // match the spec's interleaving example `<a><b></a></b>`, we
+            // unwind the entire stack and discard all pending.
+            pending.length = 0;
+            stack.length = 0;
+            // The trailing `</b>` in the example is now a stray close; any
+            // further malformed closes will also be ignored via the
+            // stack-empty branch above.
+          }
+        }
+      }
+      if (lineEnd === text.length) break;
+      lineStart = lineEnd + 1;
+      continue;
+    }
+
+    // Content line — no state change.
+    if (lineEnd === text.length) break;
+    lineStart = lineEnd + 1;
+  }
+
+  // Unclosed tags: discard anything still pending (decision 13).
+  // `output` already has only cleanly committed break points.
+  return output.sort((a, b) => a.pos - b.pos);
 }
 
 /**
@@ -2179,8 +2343,10 @@ export function chunkDocument(
   overlapChars: number = CHUNK_OVERLAP_CHARS,
   windowChars: number = CHUNK_WINDOW_CHARS
 ): { text: string; pos: number }[] {
-  const breakPoints = scanBreakPoints(content);
+  const regexPoints = scanBreakPoints(content);
   const protectedRegions = findCodeFences(content);
+  const tagPoints = findXmlTagBreakPoints(content, protectedRegions);
+  const breakPoints = mergeBreakPoints(regexPoints, tagPoints);
   return chunkDocumentWithBreakPoints(content, breakPoints, protectedRegions, maxChars, overlapChars, windowChars);
 }
 
@@ -2202,13 +2368,14 @@ export async function chunkDocumentAsync(
 ): Promise<{ text: string; pos: number }[]> {
   const regexPoints = scanBreakPoints(content);
   const protectedRegions = findCodeFences(content);
+  const tagPoints = findXmlTagBreakPoints(content, protectedRegions);
 
-  let breakPoints = regexPoints;
+  let breakPoints = mergeBreakPoints(regexPoints, tagPoints);
   if (chunkStrategy === "auto" && filepath) {
     const { getASTBreakPoints } = await import("./ast.js");
     const astPoints = await getASTBreakPoints(content, filepath);
     if (astPoints.length > 0) {
-      breakPoints = mergeBreakPoints(regexPoints, astPoints);
+      breakPoints = mergeBreakPoints(breakPoints, astPoints);
     }
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -80,12 +80,14 @@ export interface BreakPoint {
 }
 
 /**
- * A region where a code fence exists (between ``` markers).
- * We should never split inside a code fence.
+ * A region of the document that the chunker must not split inside.
+ * Code fences are the first producer; future passes may contribute
+ * other kinds (e.g. list items, XML tag regions) to the same shape.
  */
-export interface CodeFenceRegion {
-  start: number;  // position of opening ```
-  end: number;    // position of closing ``` (or document end if unclosed)
+export interface ProtectedRegion {
+  start: number;     // inclusive start position
+  end: number;       // exclusive end position
+  kind?: string;     // producer tag (e.g. 'fence'); optional for back-compat
 }
 
 /**
@@ -146,8 +148,8 @@ export function scanBreakPoints(text: string): BreakPoint[] {
  *
  * Only column-0 fences are recognized. Indented fences are not detected.
  */
-export function findCodeFences(text: string): CodeFenceRegion[] {
-  const regions: CodeFenceRegion[] = [];
+export function findCodeFences(text: string): ProtectedRegion[] {
+  const regions: ProtectedRegion[] = [];
   // Capture: fence char run, then the rest of the line (info string or close tail).
   const fencePattern = /\n(`{3,}|~{3,})([^\n]*)/g;
   let open: { char: string; len: number; start: number } | null = null;
@@ -166,7 +168,7 @@ export function findCodeFences(text: string): CodeFenceRegion[] {
 
     // To close: same char, length >= opening, and no info string on the close line.
     if (char === open.char && len >= open.len && tail.trim() === '') {
-      regions.push({ start: open.start, end: pos + match[0].length });
+      regions.push({ start: open.start, end: pos + match[0].length, kind: 'fence' });
       open = null;
     }
     // Otherwise it's content inside the open fence; ignore.
@@ -174,17 +176,17 @@ export function findCodeFences(text: string): CodeFenceRegion[] {
 
   // Handle unclosed fence - extends to end of document
   if (open) {
-    regions.push({ start: open.start, end: text.length });
+    regions.push({ start: open.start, end: text.length, kind: 'fence' });
   }
 
   return regions;
 }
 
 /**
- * Check if a position is inside a code fence region.
+ * Check if a position is inside any protected region.
  */
-export function isInsideCodeFence(pos: number, fences: CodeFenceRegion[]): boolean {
-  return fences.some(f => pos > f.start && pos < f.end);
+export function isInsideProtectedRegion(pos: number, regions: ProtectedRegion[]): boolean {
+  return regions.some(r => pos > r.start && pos < r.end);
 }
 
 /**
@@ -197,7 +199,7 @@ export function isInsideCodeFence(pos: number, fences: CodeFenceRegion[]): boole
  * @param targetCharPos - The ideal cut position (e.g., maxChars boundary)
  * @param windowChars - How far back to search for break points (default ~200 tokens)
  * @param decayFactor - How much to penalize distance (0.7 = 30% score at window edge)
- * @param codeFences - Code fence regions to avoid splitting inside
+ * @param protectedRegions - Regions to avoid splitting inside (code fences, etc.)
  * @returns The best position to cut at
  */
 export function findBestCutoff(
@@ -205,7 +207,7 @@ export function findBestCutoff(
   targetCharPos: number,
   windowChars: number = CHUNK_WINDOW_CHARS,
   decayFactor: number = 0.7,
-  codeFences: CodeFenceRegion[] = []
+  protectedRegions: ProtectedRegion[] = []
 ): number {
   const windowStart = targetCharPos - windowChars;
   let bestScore = -1;
@@ -215,8 +217,8 @@ export function findBestCutoff(
     if (bp.pos < windowStart) continue;
     if (bp.pos > targetCharPos) break;  // sorted, so we can stop
 
-    // Skip break points inside code fences
-    if (isInsideCodeFence(bp.pos, codeFences)) continue;
+    // Skip break points inside protected regions
+    if (isInsideProtectedRegion(bp.pos, protectedRegions)) continue;
 
     const distance = targetCharPos - bp.pos;
     // Squared distance decay: gentle early, steep late
@@ -266,13 +268,14 @@ export function mergeBreakPoints(a: BreakPoint[], b: BreakPoint[]): BreakPoint[]
 }
 
 /**
- * Core chunk algorithm that operates on precomputed break points and code fences.
- * This is the shared implementation used by both regex-only and AST-aware chunking.
+ * Core chunk algorithm that operates on precomputed break points and
+ * protected regions. This is the shared implementation used by both
+ * regex-only and AST-aware chunking.
  */
 export function chunkDocumentWithBreakPoints(
   content: string,
   breakPoints: BreakPoint[],
-  codeFences: CodeFenceRegion[],
+  protectedRegions: ProtectedRegion[],
   maxChars: number = CHUNK_SIZE_CHARS,
   overlapChars: number = CHUNK_OVERLAP_CHARS,
   windowChars: number = CHUNK_WINDOW_CHARS
@@ -294,7 +297,7 @@ export function chunkDocumentWithBreakPoints(
         targetEndPos,
         windowChars,
         0.7,
-        codeFences
+        protectedRegions
       );
 
       if (bestCutoff > charPos && bestCutoff <= targetEndPos) {
@@ -2177,8 +2180,8 @@ export function chunkDocument(
   windowChars: number = CHUNK_WINDOW_CHARS
 ): { text: string; pos: number }[] {
   const breakPoints = scanBreakPoints(content);
-  const codeFences = findCodeFences(content);
-  return chunkDocumentWithBreakPoints(content, breakPoints, codeFences, maxChars, overlapChars, windowChars);
+  const protectedRegions = findCodeFences(content);
+  return chunkDocumentWithBreakPoints(content, breakPoints, protectedRegions, maxChars, overlapChars, windowChars);
 }
 
 /**
@@ -2198,7 +2201,7 @@ export async function chunkDocumentAsync(
   chunkStrategy: ChunkStrategy = "regex",
 ): Promise<{ text: string; pos: number }[]> {
   const regexPoints = scanBreakPoints(content);
-  const codeFences = findCodeFences(content);
+  const protectedRegions = findCodeFences(content);
 
   let breakPoints = regexPoints;
   if (chunkStrategy === "auto" && filepath) {
@@ -2209,7 +2212,7 @@ export async function chunkDocumentAsync(
     }
   }
 
-  return chunkDocumentWithBreakPoints(content, breakPoints, codeFences, maxChars, overlapChars, windowChars);
+  return chunkDocumentWithBreakPoints(content, breakPoints, protectedRegions, maxChars, overlapChars, windowChars);
 }
 
 /**

--- a/src/store.ts
+++ b/src/store.ts
@@ -101,7 +101,7 @@ export const BREAK_PATTERNS: [RegExp, number, string][] = [
   [/\n#{4}(?!#)/g, 70, 'h4'],      // #### but not #####
   [/\n#{5}(?!#)/g, 60, 'h5'],      // ##### but not ######
   [/\n#{6}(?!#)/g, 50, 'h6'],      // ######
-  [/\n```/g, 80, 'codeblock'],     // code block boundary (same as h3)
+  [/\n(?:`{3,}|~{3,})/g, 80, 'codeblock'],  // code block boundary (same as h3)
   [/\n(?:---|\*\*\*|___)\s*\n/g, 60, 'hr'],  // horizontal rule
   [/\n\n+/g, 20, 'blank'],         // paragraph boundary
   [/\n[-*]\s/g, 5, 'list'],        // unordered list item
@@ -139,27 +139,42 @@ export function scanBreakPoints(text: string): BreakPoint[] {
 
 /**
  * Find all code fence regions in the text.
- * Code fences are delimited by ``` and we should never split inside them.
+ * Code fences are delimited by runs of ``` or ~~~ (3 or more), and we should
+ * never split inside them. Follows CommonMark pairing rules: the closing fence
+ * must use the same character as the opening fence, be at least as long, and
+ * carry no info string.
+ *
+ * Only column-0 fences are recognized. Indented fences are not detected.
  */
 export function findCodeFences(text: string): CodeFenceRegion[] {
   const regions: CodeFenceRegion[] = [];
-  const fencePattern = /\n```/g;
-  let inFence = false;
-  let fenceStart = 0;
+  // Capture: fence char run, then the rest of the line (info string or close tail).
+  const fencePattern = /\n(`{3,}|~{3,})([^\n]*)/g;
+  let open: { char: string; len: number; start: number } | null = null;
 
   for (const match of text.matchAll(fencePattern)) {
-    if (!inFence) {
-      fenceStart = match.index!;
-      inFence = true;
-    } else {
-      regions.push({ start: fenceStart, end: match.index! + match[0].length });
-      inFence = false;
+    const run = match[1]!;
+    const tail = match[2]!;
+    const char = run[0]!;
+    const len = run.length;
+    const pos = match.index!;
+
+    if (!open) {
+      open = { char, len, start: pos };
+      continue;
     }
+
+    // To close: same char, length >= opening, and no info string on the close line.
+    if (char === open.char && len >= open.len && tail.trim() === '') {
+      regions.push({ start: open.start, end: pos + match[0].length });
+      open = null;
+    }
+    // Otherwise it's content inside the open fence; ignore.
   }
 
   // Handle unclosed fence - extends to end of document
-  if (inFence) {
-    regions.push({ start: fenceStart, end: text.length });
+  if (open) {
+    regions.push({ start: open.start, end: text.length });
   }
 
   return regions;

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -33,10 +33,10 @@ import {
   mergeBreakPoints,
   scanBreakPoints,
   findCodeFences,
-  isInsideCodeFence,
+  isInsideProtectedRegion,
   findBestCutoff,
   type BreakPoint,
-  type CodeFenceRegion,
+  type ProtectedRegion,
   reciprocalRankFusion,
   extractSnippet,
   getCacheKey,
@@ -686,8 +686,8 @@ describe("findCodeFences", () => {
     // Inner ``` positions must be inside the single fence region
     const innerOpen = text.indexOf("```js");
     const innerClose = text.indexOf("```\n````");
-    expect(isInsideCodeFence(innerOpen, fences)).toBe(true);
-    expect(isInsideCodeFence(innerClose, fences)).toBe(true);
+    expect(isInsideProtectedRegion(innerOpen, fences)).toBe(true);
+    expect(isInsideProtectedRegion(innerClose, fences)).toBe(true);
   });
 
   test("recognizes tilde fences", () => {
@@ -710,7 +710,7 @@ describe("findCodeFences", () => {
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
     const strayClose = text.indexOf("```\nstill");
-    expect(isInsideCodeFence(strayClose, fences)).toBe(true);
+    expect(isInsideProtectedRegion(strayClose, fences)).toBe(true);
   });
 
   test("does not close when closing line has info string", () => {
@@ -720,7 +720,7 @@ describe("findCodeFences", () => {
     expect(fences.length).toBe(1);
     // The stray "``` trailing" should still be inside the fence
     const stray = text.indexOf("``` trailing");
-    expect(isInsideCodeFence(stray, fences)).toBe(true);
+    expect(isInsideProtectedRegion(stray, fences)).toBe(true);
     // Real close is the bare ``` line near the end
     expect(fences[0]!.end).toBe(text.indexOf("\nAfter"));
   });
@@ -743,7 +743,7 @@ describe("findCodeFences", () => {
     expect(fences.length).toBe(1);
     // Every inner fence run must be inside the single region.
     for (const needle of ["````\n```", "```\ncode", "```\n````", "````\n`````"]) {
-      expect(isInsideCodeFence(text.indexOf(needle), fences)).toBe(true);
+      expect(isInsideProtectedRegion(text.indexOf(needle), fences)).toBe(true);
     }
   });
 
@@ -751,7 +751,7 @@ describe("findCodeFences", () => {
     const text = "Before\n`````\ncode\n``````\nAfter";
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
-    expect(isInsideCodeFence(text.indexOf("code"), fences)).toBe(true);
+    expect(isInsideProtectedRegion(text.indexOf("code"), fences)).toBe(true);
   });
 
   test("same-length fences do not nest (CommonMark)", () => {
@@ -760,7 +760,7 @@ describe("findCodeFences", () => {
     const text = "Before\n````\n````\ncontent\n````\n````\nAfter";
     const fences = findCodeFences(text);
     expect(fences.length).toBe(2);
-    expect(isInsideCodeFence(text.indexOf("content"), fences)).toBe(false);
+    expect(isInsideProtectedRegion(text.indexOf("content"), fences)).toBe(false);
   });
 
   test("mixed fence chars do not interact", () => {
@@ -768,14 +768,14 @@ describe("findCodeFences", () => {
     const text = "Before\n````\n~~~~\ninner\n~~~~\n````\nAfter";
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
-    expect(isInsideCodeFence(text.indexOf("inner"), fences)).toBe(true);
+    expect(isInsideProtectedRegion(text.indexOf("inner"), fences)).toBe(true);
   });
 
   test("handles info strings on outer and inner fences", () => {
     const text = "Before\n```` wrap\n```js\ncode\n```\n````\nAfter";
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
-    expect(isInsideCodeFence(text.indexOf("```js"), fences)).toBe(true);
+    expect(isInsideProtectedRegion(text.indexOf("```js"), fences)).toBe(true);
   });
 
   test("tilde fences support 5/4/3 nesting", () => {
@@ -792,37 +792,37 @@ describe("findCodeFences", () => {
     ].join("\n");
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
-    expect(isInsideCodeFence(text.indexOf("code"), fences)).toBe(true);
+    expect(isInsideProtectedRegion(text.indexOf("code"), fences)).toBe(true);
   });
 });
 
-describe("isInsideCodeFence", () => {
+describe("isInsideProtectedRegion", () => {
   test("returns true for position inside fence", () => {
-    const fences: CodeFenceRegion[] = [{ start: 10, end: 30 }];
-    expect(isInsideCodeFence(15, fences)).toBe(true);
-    expect(isInsideCodeFence(20, fences)).toBe(true);
+    const fences: ProtectedRegion[] = [{ start: 10, end: 30 }];
+    expect(isInsideProtectedRegion(15, fences)).toBe(true);
+    expect(isInsideProtectedRegion(20, fences)).toBe(true);
   });
 
   test("returns false for position outside fence", () => {
-    const fences: CodeFenceRegion[] = [{ start: 10, end: 30 }];
-    expect(isInsideCodeFence(5, fences)).toBe(false);
-    expect(isInsideCodeFence(35, fences)).toBe(false);
+    const fences: ProtectedRegion[] = [{ start: 10, end: 30 }];
+    expect(isInsideProtectedRegion(5, fences)).toBe(false);
+    expect(isInsideProtectedRegion(35, fences)).toBe(false);
   });
 
   test("returns false for position at fence boundaries", () => {
-    const fences: CodeFenceRegion[] = [{ start: 10, end: 30 }];
-    expect(isInsideCodeFence(10, fences)).toBe(false); // at start
-    expect(isInsideCodeFence(30, fences)).toBe(false); // at end
+    const fences: ProtectedRegion[] = [{ start: 10, end: 30 }];
+    expect(isInsideProtectedRegion(10, fences)).toBe(false); // at start
+    expect(isInsideProtectedRegion(30, fences)).toBe(false); // at end
   });
 
   test("handles multiple fences", () => {
-    const fences: CodeFenceRegion[] = [
+    const fences: ProtectedRegion[] = [
       { start: 10, end: 30 },
       { start: 50, end: 70 }
     ];
-    expect(isInsideCodeFence(20, fences)).toBe(true);
-    expect(isInsideCodeFence(60, fences)).toBe(true);
-    expect(isInsideCodeFence(40, fences)).toBe(false);
+    expect(isInsideProtectedRegion(20, fences)).toBe(true);
+    expect(isInsideProtectedRegion(60, fences)).toBe(true);
+    expect(isInsideProtectedRegion(40, fences)).toBe(false);
   });
 });
 
@@ -876,8 +876,8 @@ describe("findBestCutoff", () => {
       { pos: 150, score: 100, type: 'h1' },  // inside fence
       { pos: 180, score: 20, type: 'blank' }, // outside fence
     ];
-    const codeFences: CodeFenceRegion[] = [{ start: 140, end: 160 }];
-    const cutoff = findBestCutoff(breakPoints, 200, 100, 0.7, codeFences);
+    const regions: ProtectedRegion[] = [{ start: 140, end: 160 }];
+    const cutoff = findBestCutoff(breakPoints, 200, 100, 0.7, regions);
     expect(cutoff).toBe(180); // blank wins since h1 is inside fence
   });
 
@@ -1017,10 +1017,10 @@ describe("chunkDocumentWithBreakPoints", () => {
   test("produces same output as chunkDocument for same input", () => {
     const content = "a".repeat(5000) + "\n\n" + "b".repeat(5000);
     const breakPoints = scanBreakPoints(content);
-    const codeFences = findCodeFences(content);
+    const regions = findCodeFences(content);
 
     const chunksOriginal = chunkDocument(content);
-    const chunksNew = chunkDocumentWithBreakPoints(content, breakPoints, codeFences);
+    const chunksNew = chunkDocumentWithBreakPoints(content, breakPoints, regions);
 
     expect(chunksNew.length).toBe(chunksOriginal.length);
     for (let i = 0; i < chunksNew.length; i++) {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -19,6 +19,7 @@ import {
   createStore,
   verifySqliteVecLoaded,
   getDefaultDbPath,
+  _resetProductionModeForTesting,
   homedir,
   resolve,
   getPwd,
@@ -280,6 +281,10 @@ describe("Store Creation", () => {
     // In test mode, createStore without path should throw to prevent accidental writes
     const originalIndexPath = process.env.INDEX_PATH;
     delete process.env.INDEX_PATH;
+    // Reset production mode in case another test file set it (bun runs all
+    // files in a single process, so module state leaks between files).
+    // Mirrors the fix applied to getDefaultDbPath's parallel test in 66e70c0.
+    _resetProductionModeForTesting();
 
     expect(() => createStore()).toThrow("Database path not set");
 

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -34,6 +34,7 @@ import {
   mergeBreakPoints,
   scanBreakPoints,
   findCodeFences,
+  findXmlTagBreakPoints,
   isInsideProtectedRegion,
   findBestCutoff,
   type BreakPoint,
@@ -798,6 +799,193 @@ describe("findCodeFences", () => {
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
     expect(isInsideProtectedRegion(text.indexOf("code"), fences)).toBe(true);
+  });
+});
+
+describe("findXmlTagBreakPoints", () => {
+  test("empty input → no break points", () => {
+    expect(findXmlTagBreakPoints("", [])).toEqual([]);
+  });
+
+  test("pure prose → no break points", () => {
+    const text = "just some prose\nwith multiple lines\nand nothing special";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("single <example> block emits open (30) + close (75)", () => {
+    const text = "prologue\n<example>\ncontent\n</example>\nepilogue";
+    const bps = findXmlTagBreakPoints(text, []);
+    expect(bps.length).toBe(2);
+    expect(bps[0]!.type).toBe("tag-open");
+    expect(bps[0]!.score).toBe(30);
+    expect(bps[1]!.type).toBe("tag-close");
+    expect(bps[1]!.score).toBe(75);
+    // Positions are the \n immediately before the tag line.
+    expect(text[bps[0]!.pos]).toBe("\n");
+    expect(text[bps[1]!.pos]).toBe("\n");
+    expect(text.slice(bps[0]!.pos + 1).startsWith("<example>")).toBe(true);
+    expect(text.slice(bps[1]!.pos + 1).startsWith("</example>")).toBe(true);
+  });
+
+  test("multiple sequential blocks", () => {
+    const text = "intro\n<example>\na\n</example>\nmid\n<note>\nb\n</note>\nend";
+    const bps = findXmlTagBreakPoints(text, []);
+    expect(bps.map(b => b.type)).toEqual(["tag-open", "tag-close", "tag-open", "tag-close"]);
+    expect(bps.map(b => b.score)).toEqual([30, 75, 30, 75]);
+  });
+
+  test("nested same-name tags", () => {
+    const text = "p\n<example>\n<example>\ninner\n</example>\nouter\n</example>\nq";
+    const bps = findXmlTagBreakPoints(text, []);
+    expect(bps.map(b => b.type)).toEqual(["tag-open", "tag-open", "tag-close", "tag-close"]);
+  });
+
+  test("nested different-name tags emit all four break points in order", () => {
+    const text = "p\n<outer>\n<inner>\nx\n</inner>\ny\n</outer>\nq";
+    const bps = findXmlTagBreakPoints(text, []);
+    expect(bps.map(b => b.type)).toEqual(["tag-open", "tag-open", "tag-close", "tag-close"]);
+    for (let i = 1; i < bps.length; i++) {
+      expect(bps[i]!.pos).toBeGreaterThan(bps[i - 1]!.pos);
+    }
+  });
+
+  test("self-closing tag emits nothing", () => {
+    const text = "p\n<thing/>\nq";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("self-closing with space emits nothing", () => {
+    const text = "p\n<thing />\nq";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("tag with attributes is recognized", () => {
+    const text = "p\n<example name=\"foo\">\ncontent\n</example>\nq";
+    const bps = findXmlTagBreakPoints(text, []);
+    expect(bps.length).toBe(2);
+    expect(bps[0]!.type).toBe("tag-open");
+    expect(bps[1]!.type).toBe("tag-close");
+  });
+
+  test("HTML element blocked (div)", () => {
+    const text = "p\n<div>\ncontent\n</div>\nq";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("HTML element blocklist is case-insensitive", () => {
+    const text1 = "p\n<DIV>\nx\n</DIV>\nq";
+    const text2 = "p\n<Div>\nx\n</Div>\nq";
+    expect(findXmlTagBreakPoints(text1, [])).toEqual([]);
+    expect(findXmlTagBreakPoints(text2, [])).toEqual([]);
+  });
+
+  test("custom element with hyphen is recognized", () => {
+    const text = "p\n<my-widget>\nx\n</my-widget>\nq";
+    const bps = findXmlTagBreakPoints(text, []);
+    expect(bps.length).toBe(2);
+  });
+
+  test("namespaced tag is recognized", () => {
+    const text = "p\n<xsl:template>\nx\n</xsl:template>\nq";
+    const bps = findXmlTagBreakPoints(text, []);
+    expect(bps.length).toBe(2);
+  });
+
+  test("case-sensitive tag matching → malformed", () => {
+    // <Example> open, </example> close: names differ → malformed, zero breaks.
+    const text = "p\n<Example>\nx\n</example>\nq";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("unclosed tag emits no break points", () => {
+    const text = "p\n<example>\ncontent with no close";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("stray closing tag is ignored and does not crash", () => {
+    const text = "p\n</example>\nq";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("cross-tag interleaving is malformed → zero break points", () => {
+    const text = "p\n<a-foo>\n<b-bar>\n</a-foo>\n</b-bar>\nq";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("tag inside code fence is ignored", () => {
+    const text = "prologue\n```\n<example>\nfoo\n</example>\n```\nepilogue";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(findXmlTagBreakPoints(text, fences)).toEqual([]);
+  });
+
+  test("mid-line tag is ignored", () => {
+    const text = "Here's an <example>content</example> inline";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("leading whitespace on tag line is recognized", () => {
+    const text = "p\n  <example>\n  x\n  </example>\nq";
+    const bps = findXmlTagBreakPoints(text, []);
+    expect(bps.length).toBe(2);
+  });
+
+  test("HTML comment is ignored", () => {
+    const text = "p\n<!-- comment -->\nq";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("DOCTYPE is ignored", () => {
+    const text = "p\n<!DOCTYPE html>\nq";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("CDATA is ignored", () => {
+    const text = "p\n<![CDATA[some data]]>\nq";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("processing instruction is ignored", () => {
+    const text = "p\n<?xml version=\"1.0\"?>\nq";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("first-line tag skipped (open at position 0)", () => {
+    // Open at position 0 → no tag-open break. Close still emits.
+    const text = "<example>\ncontent\n</example>\nafter";
+    const bps = findXmlTagBreakPoints(text, []);
+    expect(bps.length).toBe(1);
+    expect(bps[0]!.type).toBe("tag-close");
+  });
+
+  test("position convention: pos is the \\n before the tag line", () => {
+    const text = "abc\n<example>\ncontent\n</example>\ndef";
+    const bps = findXmlTagBreakPoints(text, []);
+    expect(text[bps[0]!.pos]).toBe("\n");
+    expect(text.charAt(bps[0]!.pos + 1)).toBe("<");
+  });
+
+  test("chunkDocument integration: prefers close positions when splitting a tagged document", () => {
+    // Build a document larger than CHUNK_SIZE_CHARS so splitting is forced,
+    // with a clearly closed <example> block near the split target. The close
+    // should be chosen over nearby weak breaks.
+    // Size chosen so the </example> close sits inside the first cutoff
+    // window (target ~3600, window back 800).
+    const pre = "pre ".repeat(750);
+    const block = "\n<example>\n" + "body ".repeat(80) + "\n</example>\n";
+    const post = "post ".repeat(500);
+    const text = pre + block + post;
+    const chunks = chunkDocument(text);
+    expect(chunks.length).toBeGreaterThan(1);
+    // The tag-close break point sits at the \n before </example>. A chunk
+    // boundary should land exactly there (or very close to it) since 75
+    // beats the nearby weak blank/newline breaks.
+    const closeBpPos = text.indexOf("\n</example>");
+    const hasBoundaryAtClose = chunks.some(c => {
+      const end = c.pos + c.text.length;
+      return end === closeBpPos;
+    });
+    expect(hasBoundaryAtClose).toBe(true);
   });
 });
 

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -677,6 +677,123 @@ describe("findCodeFences", () => {
     const fences = findCodeFences(text);
     expect(fences.length).toBe(0);
   });
+
+  test("handles 4-backtick fence containing 3-backtick block", () => {
+    // Outer ```` fence wraps an inner ``` that must not close it.
+    const text = "Before\n````md\n```js\ninner\n```\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    // Inner ``` positions must be inside the single fence region
+    const innerOpen = text.indexOf("```js");
+    const innerClose = text.indexOf("```\n````");
+    expect(isInsideCodeFence(innerOpen, fences)).toBe(true);
+    expect(isInsideCodeFence(innerClose, fences)).toBe(true);
+  });
+
+  test("recognizes tilde fences", () => {
+    const text = "Before\n~~~\ncode\n~~~\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+  });
+
+  test("does not close tilde fence with backticks", () => {
+    // Open ~~~, stray ``` should not close it; unclosed extends to end.
+    const text = "Before\n~~~\ncode\n```\nstill inside";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(fences[0]!.end).toBe(text.length);
+  });
+
+  test("does not close with shorter fence run", () => {
+    // Open ````, a ``` inside must not close it.
+    const text = "Before\n````\ncode\n```\nstill inside\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    const strayClose = text.indexOf("```\nstill");
+    expect(isInsideCodeFence(strayClose, fences)).toBe(true);
+  });
+
+  test("does not close when closing line has info string", () => {
+    // Close candidate has trailing text, so it's not a valid close.
+    const text = "Before\n```\ncode\n``` trailing\n```\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    // The stray "``` trailing" should still be inside the fence
+    const stray = text.indexOf("``` trailing");
+    expect(isInsideCodeFence(stray, fences)).toBe(true);
+    // Real close is the bare ``` line near the end
+    expect(fences[0]!.end).toBe(text.indexOf("\nAfter"));
+  });
+
+  test("handles 5/4/3 backtick nesting with bare inner fences", () => {
+    // Outer 5-bt wraps 4-bt wraps 3-bt, all inner fences with no info string.
+    // Only the final 5-bt run may close the outer fence.
+    const text = [
+      "Before",
+      "`````md",
+      "````",
+      "```",
+      "code",
+      "```",
+      "````",
+      "`````",
+      "After",
+    ].join("\n");
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    // Every inner fence run must be inside the single region.
+    for (const needle of ["````\n```", "```\ncode", "```\n````", "````\n`````"]) {
+      expect(isInsideCodeFence(text.indexOf(needle), fences)).toBe(true);
+    }
+  });
+
+  test("longer closing fence is valid (6-bt closes 5-bt)", () => {
+    const text = "Before\n`````\ncode\n``````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(isInsideCodeFence(text.indexOf("code"), fences)).toBe(true);
+  });
+
+  test("same-length fences do not nest (CommonMark)", () => {
+    // ```` inside ```` cannot nest: the second ```` closes the first.
+    // Result is two empty-ish fences with "content" sitting outside both.
+    const text = "Before\n````\n````\ncontent\n````\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(2);
+    expect(isInsideCodeFence(text.indexOf("content"), fences)).toBe(false);
+  });
+
+  test("mixed fence chars do not interact", () => {
+    // Backtick outer, tilde inner — different chars, so the tildes stay inside.
+    const text = "Before\n````\n~~~~\ninner\n~~~~\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(isInsideCodeFence(text.indexOf("inner"), fences)).toBe(true);
+  });
+
+  test("handles info strings on outer and inner fences", () => {
+    const text = "Before\n```` wrap\n```js\ncode\n```\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(isInsideCodeFence(text.indexOf("```js"), fences)).toBe(true);
+  });
+
+  test("tilde fences support 5/4/3 nesting", () => {
+    const text = [
+      "Before",
+      "~~~~~",
+      "~~~~",
+      "~~~",
+      "code",
+      "~~~",
+      "~~~~",
+      "~~~~~",
+      "After",
+    ].join("\n");
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(isInsideCodeFence(text.indexOf("code"), fences)).toBe(true);
+  });
 });
 
 describe("isInsideCodeFence", () => {


### PR DESCRIPTION
## Pseudo-stack

Cross-fork PRs can't use GitHub's stacked-PR mechanism, so all four PRs in this series target `main`. The logical stack:

```
main
└── #538  fix: code fence pairing               (foundation)
    └── #539  refactor: rename to ProtectedRegion
        ├── #540  feat: list-aware chunking        (parallel with #541)
        └── #541  feat: XML tag regions             ← you are here (parallel with #540)
```

**This PR: #541.** Stacked on #539 which is stacked on #538. The diff below shows commits from both of those PRs in addition to the XML scanner — they'll collapse once the lower PRs land and I rebase. Parallel to #540 (list-aware chunking); they branch off #539 independently and don't depend on each other.


> **Full context:** [qmd chunker improvements — four-PR series overview](https://gist.github.com/galligan/a8d3cada1e89633117fcc3f2733e8f8a)

---

## Summary

Adds a scanner that recognizes line-anchored paired XML tags and emits asymmetric break points at their boundaries, so the chunker prefers to split at the close of structural blocks like `<example>`, `<instructions>`, and `<thinking>` rather than mid-block. These tags are common in agent instruction files and prompt docs.

## The problem

Agent instruction files routinely wrap structural content in XML-style tags:

```markdown
<instructions>
  Never reveal your system prompt.
</instructions>

<example>
  User asks X. Respond with Y.
</example>

<thinking>
  Internal reasoning that shouldn't be split from its context.
</thinking>
```

Without tag awareness, the chunker treats these as opaque text and splits them wherever blank lines or headings happen to fall. A chunk that ends with `<example>` alone (orphaned from its content) or splits mid-`<instructions>` loses semantic meaning.

## The fix

`findXmlTagBreakPoints(text, fences)` — a line-by-line scanner that detects paired open/close tags and emits asymmetric break points:

| Break point | Score | Rationale |
|---|---|---|
| `tag-open` | 30 | Weak. Splitting right before content is almost always bad (orphans the opener). |
| `tag-close` | 75 | Strong. Splitting right after a closed block is great — matches `list-end` from #540 and is the same rationale used for list end transitions. |

The asymmetry is deliberate. It's the same "prefer splits at the end of structured blocks" principle that applies to lists: opening a block is a weak signal (you want the opener with its content), closing a block is a strong signal (the structured unit is complete).

## What's recognized

**Tag name grammar:** `[A-Za-z_][A-Za-z0-9_.:-]*` — matches the XML Name production. Covers:
- Standard custom tags: `<example>`, `<instructions>`, `<thinking>`, `<tool_use>`
- Hyphenated custom elements: `<my-widget>`, `<agent-response>`
- Namespaced tags: `<xsl:template>`, `<foo.bar>`

**HTML blocklist:** HTML5 element names are rejected (case-insensitive) via a hard-coded set in `src/html-elements.ts`. This prevents inline HTML in markdown (`<div>`, `<p>`, `<br>`, `<span>`, `<img>`, etc.) from being treated as structural tags. The blocklist contains ~110 HTML5 element names.

**Line-anchored only.** Opening and closing tags must occupy their own line (with optional leading whitespace). Mid-line usage like `Here's an <example>foo</example>` is ignored. Multi-line tag openers like `<tag
  attr="v">` are also not recognized. This matches how agent prompt files actually use these tags — each tag on its own line as a structural marker.

**Case-sensitive matching.** `<Example>` does not match `</example>`. This is XML semantics, not HTML's forgiving case-insensitivity.

**Stack-based nesting.** Same-name nesting (`<example><example>…</example></example>`) and different-name nesting (`<outer><inner>…</inner>…</outer>`) both work via a frame stack.

**Non-tag constructs skipped:** `<!-- comment -->`, `<!DOCTYPE …>`, `<![CDATA[…]]>`, and `<?xml … ?>` are recognized as non-tag lines and ignored. They don't confuse the scanner even when they appear inside an open tag frame.

**Self-closing tags** (`<tag/>` and `<tag />`) create no region.

**Fence precedence.** Tags inside code fences are ignored entirely. The fence scan runs first; its regions are passed to the tag scanner, which skips any line whose start is inside a fence. So a `<example>` inside a ` ``` `-block won't be confused for structural content.

## What's not handled

Deliberate scope cuts, each documented on the scanner:

- **Mid-line tags.** `Here's <example>...</example>` in the middle of a sentence is ignored. Inline tag usage isn't a structural signal.
- **Multi-line tag openers.** `<tag
  attr="v">` (attributes split across lines) isn't recognized. Real agent docs don't do this.
- **Attribute `>` inside quotes.** The opener regex terminates at the first `>`, so `<tag foo="bar > baz">` produces a malformed match and no region. Rare in practice.
- **Multi-line comments/CDATA/PI.** The non-tag construct regexes require the full construct on one line. Multi-line HTML comments would flow through as content lines — not a crash, just suboptimal.

## Malformed input

- **Unclosed tag** (`<example>` with no `</example>`) → emits nothing, same as a fence that wraps around EOF. Unlike fences, we don't extend to EOF because the "tag region" concept has no useful meaning for an unclosed tag.
- **Stray closing tag** (`</example>` with no prior open) → ignored.
- **Cross-tag interleaving** (`<a><b></a></b>`) → treated as malformed. All involved tags emit zero break points. Clean nesting is required.

## Integration

`chunkDocument` and `chunkDocumentAsync` compute fences first, then pass them to `findXmlTagBreakPoints`, then merge the tag points with `scanBreakPoints` output via `mergeBreakPoints`:

```ts
const regexPoints = scanBreakPoints(content);
const protectedRegions = findCodeFences(content);
const tagPoints = findXmlTagBreakPoints(content, protectedRegions);
const breakPoints = mergeBreakPoints(regexPoints, tagPoints);
```

Order matters: fences must be computed before tags so the fence precedence rule works.

## Tests

27 new tests in `test/store.test.ts` under `describe("findXmlTagBreakPoints", …)`:

1. Empty input → no break points
2. Pure prose → no break points
3. Single `<example>` block → correct open (30) + close (75) with positions verified
4. Multiple sequential blocks
5. Nested same-name tags
6. Nested different-name tags (ordered break point emission)
7. Self-closing `<thing/>` → no break points
8. Self-closing with space `<thing />` → no break points
9. Tag with attributes
10. HTML element blocked (`<div>`)
11. HTML blocklist case-insensitive (`<DIV>`, `<Div>`)
12. Custom element with hyphen (`<my-widget>`)
13. Namespaced tag (`<xsl:template>`)
14. Case-sensitive tag matching → malformed
15. Unclosed tag → no break points
16. Stray closing tag → ignored, no crash
17. Cross-tag interleaving → zero break points
18. Tag inside code fence → ignored
19. Mid-line tag → ignored
20. Leading whitespace on tag line → recognized
21. HTML comment → ignored
22. DOCTYPE → ignored
23. CDATA → ignored
24. Processing instruction → ignored
25. First-line tag skipped (position 0 can't be a chunk break)
26. Position convention (`pos` is the `
` before the tag line)
27. `chunkDocument` integration: long document with tagged block → splits land at tag-close positions

## Files

- **New:** `src/html-elements.ts` — HTML5 element blocklist (~110 names)
- **Modified:** `src/store.ts` — `findXmlTagBreakPoints` function, integration into `chunkDocument` and `chunkDocumentAsync`
- **Modified:** `test/store.test.ts` — new describe block with 27 tests

## Test plan

- [x] `npx vitest run test/store.test.ts` passes (230/230, was 203 + 27 new)
- [x] `npx vitest run test/ast-chunking.test.ts` passes (12/12)
- [x] `npx tsc -p tsconfig.build.json --noEmit` clean
- [ ] CI green
