### PR TITLE
fix: point bin entry to dist/cli/qmd.js for Windows compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     }
   },
   "bin": {
-    "qmd": "bin/qmd"
+    "qmd": "dist/cli/qmd.js"
   },
   "files": [
     "bin/",


### PR DESCRIPTION
## Problem

`npm install -g @tobilu/qmd` on Windows produces:

```
> qmd --help
Invalid executable path: C:\bin
```

npm generates `.cmd` and `.ps1` wrappers for the `bin` entry. Because `bin/qmd` is a shell script, the wrappers try to invoke it via `/bin/sh`, which doesn't exist on Windows.

## Fix

Point the `bin` entry in `package.json` to `dist/cli/qmd.js` instead of `bin/qmd`.

The build already prepends a `#!/usr/bin/env node` shebang to `dist/cli/qmd.js`, so npm creates proper cross-platform wrappers that invoke `node` directly. This is a one-line change.

`bin/qmd` is preserved in the repo for source-level development (`npm link`, bun/node detection via lockfile heuristics).

## Testing

Verified on Windows 11 with Node v24.8.0 / npm 11.6.0:

```
> qmd --help
qmd — Quick Markdown Search
...

> qmd status
QMD Status
...

> qmd collection add ~/Documents --name docs
✓ Collection 'docs' created successfully

> qmd search "test" -n 3
(results returned correctly)
```
