### PR TITLE
feat(chunking): code fence pairing, list-aware + XML tag break points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Changes
+
+- List-aware chunking. A new scanner tracks nested list items with a
+  stack-based state machine and emits weighted break points: top-level
+  items score 70, second-level 45, third-level and deeper 25, and the
+  transition from a list back to prose scores 75. Previously the naive
+  `list: 5` and `numlist: 5` patterns produced break points too weak to
+  influence chunking. Long lists now split cleanly at item boundaries
+  instead of mid-item. Ordered `1)` form is newly supported, as is
+  proper detection of nested sublists (which the old regex missed).
+
 ### Fixes
 
 - Code fence detection now follows CommonMark pairing rules. Fences

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@
   instead of mid-item. Ordered `1)` form is newly supported, as is
   proper detection of nested sublists (which the old regex missed).
 
+- XML tag break points for agent-prompt markdown. The chunker now
+  recognizes line-anchored paired tags like `<example>…</example>`,
+  `<instructions>…</instructions>`, and `<thinking>…</thinking>` that
+  commonly appear in agent instruction files, and prefers to split at
+  the close of a tagged block (score 75) rather than mid-block. HTML5
+  element names (`<div>`, `<p>`, etc.) are blocked via a blocklist so
+  inline HTML in markdown is not confused for structural tags. Tags
+  inside code fences are ignored. Supports nested same-tag blocks,
+  namespaced tags (`<xsl:template>`), and custom elements
+  (`<my-widget>`).
+
 ### Fixes
 
 - Code fence detection now follows CommonMark pairing rules. Fences

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixes
+
+- Code fence detection now follows CommonMark pairing rules. Fences
+  opened with 4 or more backticks (or tildes) are correctly recognized
+  and paired, so chunks no longer split inside nested code blocks that
+  wrap shorter fences. Tilde fences are now supported.
+
 ## [2.1.0] - 2026-04-05
 
 Code files now chunk at function and class boundaries via tree-sitter,

--- a/src/html-elements.ts
+++ b/src/html-elements.ts
@@ -1,0 +1,33 @@
+/**
+ * HTML5 element names (lowercase). Used by the XML tag break point scanner
+ * to skip tags that are part of standard HTML — we only care about
+ * custom/structural tags like <example>, <instructions>, <thinking> that
+ * show up in agent/prompt markdown.
+ *
+ * Matching is case-insensitive: callers must `.toLowerCase()` before lookup.
+ */
+export const HTML_ELEMENTS: ReadonlySet<string> = new Set([
+  'a', 'abbr', 'address', 'area', 'article', 'aside', 'audio',
+  'b', 'base', 'bdi', 'bdo', 'blockquote', 'body', 'br', 'button',
+  'canvas', 'caption', 'cite', 'code', 'col', 'colgroup',
+  'data', 'datalist', 'dd', 'del', 'details', 'dfn', 'dialog', 'div', 'dl', 'dt',
+  'em', 'embed',
+  'fieldset', 'figcaption', 'figure', 'footer', 'form',
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header', 'hgroup', 'hr', 'html',
+  'i', 'iframe', 'img', 'input', 'ins',
+  'kbd',
+  'label', 'legend', 'li', 'link',
+  'main', 'map', 'mark', 'menu', 'meta', 'meter',
+  'nav', 'noscript',
+  'object', 'ol', 'optgroup', 'option', 'output',
+  'p', 'picture', 'pre', 'progress',
+  'q',
+  'rp', 'rt', 'ruby',
+  's', 'samp', 'script', 'search', 'section', 'select', 'slot', 'small',
+  'source', 'span', 'strong', 'style', 'sub', 'summary', 'sup',
+  'table', 'tbody', 'td', 'template', 'textarea', 'tfoot', 'th', 'thead',
+  'time', 'title', 'tr', 'track',
+  'u', 'ul',
+  'var', 'video',
+  'wbr',
+]);

--- a/src/store.ts
+++ b/src/store.ts
@@ -80,12 +80,14 @@ export interface BreakPoint {
 }
 
 /**
- * A region where a code fence exists (between ``` markers).
- * We should never split inside a code fence.
+ * A region of the document that the chunker must not split inside.
+ * Code fences are the first producer; future passes may contribute
+ * other kinds (e.g. list items, XML tag regions) to the same shape.
  */
-export interface CodeFenceRegion {
-  start: number;  // position of opening ```
-  end: number;    // position of closing ``` (or document end if unclosed)
+export interface ProtectedRegion {
+  start: number;     // inclusive start position
+  end: number;       // exclusive end position
+  kind?: string;     // producer tag (e.g. 'fence'); optional for back-compat
 }
 
 /**
@@ -146,8 +148,8 @@ export function scanBreakPoints(text: string): BreakPoint[] {
  *
  * Only column-0 fences are recognized. Indented fences are not detected.
  */
-export function findCodeFences(text: string): CodeFenceRegion[] {
-  const regions: CodeFenceRegion[] = [];
+export function findCodeFences(text: string): ProtectedRegion[] {
+  const regions: ProtectedRegion[] = [];
   // Capture: fence char run, then the rest of the line (info string or close tail).
   const fencePattern = /\n(`{3,}|~{3,})([^\n]*)/g;
   let open: { char: string; len: number; start: number } | null = null;
@@ -166,7 +168,7 @@ export function findCodeFences(text: string): CodeFenceRegion[] {
 
     // To close: same char, length >= opening, and no info string on the close line.
     if (char === open.char && len >= open.len && tail.trim() === '') {
-      regions.push({ start: open.start, end: pos + match[0].length });
+      regions.push({ start: open.start, end: pos + match[0].length, kind: 'fence' });
       open = null;
     }
     // Otherwise it's content inside the open fence; ignore.
@@ -174,17 +176,17 @@ export function findCodeFences(text: string): CodeFenceRegion[] {
 
   // Handle unclosed fence - extends to end of document
   if (open) {
-    regions.push({ start: open.start, end: text.length });
+    regions.push({ start: open.start, end: text.length, kind: 'fence' });
   }
 
   return regions;
 }
 
 /**
- * Check if a position is inside a code fence region.
+ * Check if a position is inside any protected region.
  */
-export function isInsideCodeFence(pos: number, fences: CodeFenceRegion[]): boolean {
-  return fences.some(f => pos > f.start && pos < f.end);
+export function isInsideProtectedRegion(pos: number, regions: ProtectedRegion[]): boolean {
+  return regions.some(r => pos > r.start && pos < r.end);
 }
 
 /**
@@ -197,7 +199,7 @@ export function isInsideCodeFence(pos: number, fences: CodeFenceRegion[]): boole
  * @param targetCharPos - The ideal cut position (e.g., maxChars boundary)
  * @param windowChars - How far back to search for break points (default ~200 tokens)
  * @param decayFactor - How much to penalize distance (0.7 = 30% score at window edge)
- * @param codeFences - Code fence regions to avoid splitting inside
+ * @param protectedRegions - Regions to avoid splitting inside (code fences, etc.)
  * @returns The best position to cut at
  */
 export function findBestCutoff(
@@ -205,7 +207,7 @@ export function findBestCutoff(
   targetCharPos: number,
   windowChars: number = CHUNK_WINDOW_CHARS,
   decayFactor: number = 0.7,
-  codeFences: CodeFenceRegion[] = []
+  protectedRegions: ProtectedRegion[] = []
 ): number {
   const windowStart = targetCharPos - windowChars;
   let bestScore = -1;
@@ -215,8 +217,8 @@ export function findBestCutoff(
     if (bp.pos < windowStart) continue;
     if (bp.pos > targetCharPos) break;  // sorted, so we can stop
 
-    // Skip break points inside code fences
-    if (isInsideCodeFence(bp.pos, codeFences)) continue;
+    // Skip break points inside protected regions
+    if (isInsideProtectedRegion(bp.pos, protectedRegions)) continue;
 
     const distance = targetCharPos - bp.pos;
     // Squared distance decay: gentle early, steep late
@@ -266,13 +268,14 @@ export function mergeBreakPoints(a: BreakPoint[], b: BreakPoint[]): BreakPoint[]
 }
 
 /**
- * Core chunk algorithm that operates on precomputed break points and code fences.
- * This is the shared implementation used by both regex-only and AST-aware chunking.
+ * Core chunk algorithm that operates on precomputed break points and
+ * protected regions. This is the shared implementation used by both
+ * regex-only and AST-aware chunking.
  */
 export function chunkDocumentWithBreakPoints(
   content: string,
   breakPoints: BreakPoint[],
-  codeFences: CodeFenceRegion[],
+  protectedRegions: ProtectedRegion[],
   maxChars: number = CHUNK_SIZE_CHARS,
   overlapChars: number = CHUNK_OVERLAP_CHARS,
   windowChars: number = CHUNK_WINDOW_CHARS
@@ -294,7 +297,7 @@ export function chunkDocumentWithBreakPoints(
         targetEndPos,
         windowChars,
         0.7,
-        codeFences
+        protectedRegions
       );
 
       if (bestCutoff > charPos && bestCutoff <= targetEndPos) {
@@ -2177,8 +2180,8 @@ export function chunkDocument(
   windowChars: number = CHUNK_WINDOW_CHARS
 ): { text: string; pos: number }[] {
   const breakPoints = scanBreakPoints(content);
-  const codeFences = findCodeFences(content);
-  return chunkDocumentWithBreakPoints(content, breakPoints, codeFences, maxChars, overlapChars, windowChars);
+  const protectedRegions = findCodeFences(content);
+  return chunkDocumentWithBreakPoints(content, breakPoints, protectedRegions, maxChars, overlapChars, windowChars);
 }
 
 /**
@@ -2198,7 +2201,7 @@ export async function chunkDocumentAsync(
   chunkStrategy: ChunkStrategy = "regex",
 ): Promise<{ text: string; pos: number }[]> {
   const regexPoints = scanBreakPoints(content);
-  const codeFences = findCodeFences(content);
+  const protectedRegions = findCodeFences(content);
 
   let breakPoints = regexPoints;
   if (chunkStrategy === "auto" && filepath) {
@@ -2209,7 +2212,7 @@ export async function chunkDocumentAsync(
     }
   }
 
-  return chunkDocumentWithBreakPoints(content, breakPoints, codeFences, maxChars, overlapChars, windowChars);
+  return chunkDocumentWithBreakPoints(content, breakPoints, protectedRegions, maxChars, overlapChars, windowChars);
 }
 
 /**

--- a/src/store.ts
+++ b/src/store.ts
@@ -106,8 +106,6 @@ export const BREAK_PATTERNS: [RegExp, number, string][] = [
   [/\n(?:`{3,}|~{3,})/g, 80, 'codeblock'],  // code block boundary (same as h3)
   [/\n(?:---|\*\*\*|___)\s*\n/g, 60, 'hr'],  // horizontal rule
   [/\n\n+/g, 20, 'blank'],         // paragraph boundary
-  [/\n[-*]\s/g, 5, 'list'],        // unordered list item
-  [/\n\d+\.\s/g, 5, 'numlist'],    // ordered list item
   [/\n/g, 1, 'newline'],           // minimal break
 ];
 
@@ -187,6 +185,145 @@ export function findCodeFences(text: string): ProtectedRegion[] {
  */
 export function isInsideProtectedRegion(pos: number, regions: ProtectedRegion[]): boolean {
   return regions.some(r => pos > r.start && pos < r.end);
+}
+
+interface ListFrame {
+  indent: number;       // column of marker character
+  contentCol: number;   // column where item body begins (after marker + space)
+}
+
+/**
+ * List-aware break point scanner. Walks the document line by line, tracking
+ * nested list frames on a stack. Emits break points at list item boundaries
+ * and when a list transitions back to non-list content.
+ *
+ * Scoring:
+ *   - list-end: 75
+ *   - depth 0 item: 70
+ *   - depth 1 item: 45
+ *   - depth 2+ item: 25
+ *
+ * Marker-type transitions at the same indent are ignored (not CommonMark).
+ * Only `-`, `*`, and `\d+[.)]` markers are recognized (no `+`).
+ * Positions match scanBreakPoints convention: the `\n` before the line.
+ */
+export function findListBreakPoints(text: string): BreakPoint[] {
+  const points: BreakPoint[] = [];
+  if (text.length === 0) return points;
+
+  const itemScores = [70, 45, 25];
+  const itemTypes = ['list-item-0', 'list-item-1', 'list-item-2'];
+  const scoreFor = (depth: number): number =>
+    depth < itemScores.length ? itemScores[depth]! : itemScores[itemScores.length - 1]!;
+  const typeFor = (depth: number): string =>
+    depth < itemTypes.length ? itemTypes[depth]! : itemTypes[itemTypes.length - 1]!;
+
+  const stack: ListFrame[] = [];
+
+  // Iterate lines. lineStart is the index of the first character of the line.
+  // The break-point position we emit is lineStart - 1 (the preceding `\n`),
+  // except for the first line where there's no preceding newline.
+  let lineStart = 0;
+  const n = text.length;
+
+  // Match list item: optional leading spaces, then marker + at least one space.
+  // Unordered: - or *  (NOT +)
+  // Ordered: digits followed by . or )
+  //
+  // Known limitations (deliberate, to keep the scanner simple):
+  //   - Space-separated markers only. `-\t` (dash followed by a literal tab)
+  //     is not recognized. This pattern does not occur in practice.
+  //   - Tab-indented lines are not recognized as list items. Modern markdown
+  //     uses spaces for indentation; tab indentation was never supported by
+  //     the previous regex either, so this is not a regression.
+  //   - Loose/tight list distinction, lazy continuation, and 4-space indented
+  //     code blocks inside items are not tracked — those are rendering-level
+  //     concerns that don't change where chunks should split.
+  const itemRegex = /^( *)(?:([-*])|(\d+)([.)]))( +)/;
+
+  while (lineStart <= n) {
+    // Find end of line
+    let lineEnd = text.indexOf('\n', lineStart);
+    if (lineEnd === -1) lineEnd = n;
+    const line = text.slice(lineStart, lineEnd);
+    const bpPos = lineStart === 0 ? 0 : lineStart - 1;
+
+    const isBlank = line.trim().length === 0;
+
+    if (isBlank) {
+      // Don't change state; next non-blank decides.
+      if (lineEnd === n) break;
+      lineStart = lineEnd + 1;
+      continue;
+    }
+
+    const match = itemRegex.exec(line);
+    if (match) {
+      const leading = match[1]!;
+      const indent = leading.length;
+      const bullet = match[2];
+      const digits = match[3];
+      const ordPunct = match[4];
+      const spaces = match[5]!;
+      const markerLen = bullet ? 1 : (digits!.length + ordPunct!.length);
+      const contentCol = indent + markerLen + spaces.length;
+
+      // Pop frames whose indent exceeds this line's indent (dedent).
+      while (stack.length > 0 && indent < stack[stack.length - 1]!.indent) {
+        stack.pop();
+      }
+
+      let depth: number;
+      if (stack.length === 0) {
+        stack.push({ indent, contentCol });
+        depth = 0;
+      } else {
+        const top = stack[stack.length - 1]!;
+        if (indent >= top.contentCol) {
+          // Deeper nesting
+          stack.push({ indent, contentCol });
+          depth = stack.length - 1;
+        } else if (indent === top.indent) {
+          // Sibling
+          depth = stack.length - 1;
+        } else {
+          // Indent between top.indent and top.contentCol, or less than top.indent
+          // after popping. Treat as sibling at current level.
+          depth = stack.length - 1;
+        }
+      }
+
+      // Skip the first line of the document: position 0 can never be a
+      // chunk break (chunks always start at 0) and there's no preceding
+      // newline to point to anyway.
+      if (lineStart > 0) {
+        points.push({ pos: bpPos, score: scoreFor(depth), type: typeFor(depth) });
+      }
+    } else {
+      // Non-blank, non-list line.
+      if (stack.length > 0) {
+        const indent = line.length - line.trimStart().length;
+        const bottom = stack[0]!;
+        if (indent >= bottom.contentCol) {
+          // Continuation of outermost item; keep state.
+        } else {
+          // List ends.
+          stack.length = 0;
+          points.push({ pos: bpPos, score: 75, type: 'list-end' });
+        }
+      }
+    }
+
+    if (lineEnd === n) break;
+    lineStart = lineEnd + 1;
+  }
+
+  // End of document: if still in a list, emit a list-end at text.length.
+  if (stack.length > 0) {
+    points.push({ pos: n, score: 75, type: 'list-end' });
+  }
+
+  return points.sort((a, b) => a.pos - b.pos);
 }
 
 /**
@@ -2179,7 +2316,9 @@ export function chunkDocument(
   overlapChars: number = CHUNK_OVERLAP_CHARS,
   windowChars: number = CHUNK_WINDOW_CHARS
 ): { text: string; pos: number }[] {
-  const breakPoints = scanBreakPoints(content);
+  const regexPoints = scanBreakPoints(content);
+  const listPoints = findListBreakPoints(content);
+  const breakPoints = mergeBreakPoints(regexPoints, listPoints);
   const protectedRegions = findCodeFences(content);
   return chunkDocumentWithBreakPoints(content, breakPoints, protectedRegions, maxChars, overlapChars, windowChars);
 }
@@ -2201,14 +2340,15 @@ export async function chunkDocumentAsync(
   chunkStrategy: ChunkStrategy = "regex",
 ): Promise<{ text: string; pos: number }[]> {
   const regexPoints = scanBreakPoints(content);
+  const listPoints = findListBreakPoints(content);
   const protectedRegions = findCodeFences(content);
 
-  let breakPoints = regexPoints;
+  let breakPoints = mergeBreakPoints(regexPoints, listPoints);
   if (chunkStrategy === "auto" && filepath) {
     const { getASTBreakPoints } = await import("./ast.js");
     const astPoints = await getASTBreakPoints(content, filepath);
     if (astPoints.length > 0) {
-      breakPoints = mergeBreakPoints(regexPoints, astPoints);
+      breakPoints = mergeBreakPoints(breakPoints, astPoints);
     }
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -12,6 +12,7 @@
  */
 
 import { openDatabase, loadSqliteVec } from "./db.js";
+import { HTML_ELEMENTS } from "./html-elements.js";
 import type { Database } from "./db.js";
 import picomatch from "picomatch";
 import { createHash } from "crypto";
@@ -324,6 +325,169 @@ export function findListBreakPoints(text: string): BreakPoint[] {
   }
 
   return points.sort((a, b) => a.pos - b.pos);
+}
+
+/**
+ * Find line-anchored XML-style tag break points.
+ *
+ * Agent instruction files and prompt docs frequently wrap structural blocks
+ * in XML tags like `<example>`, `<instructions>`, `<thinking>`, `<tool_use>`.
+ * We emit asymmetric break points at those boundaries so the chunker prefers
+ * to split at the close of a block rather than mid-block.
+ *
+ * Rules (see spec for full decisions):
+ *  - Tags must occupy their own line (leading whitespace allowed). Mid-line
+ *    tags and multi-line openers are ignored.
+ *  - Tag name grammar: `[A-Za-z_][A-Za-z0-9_.:-]*`.
+ *  - HTML5 element names are blocked (case-insensitive) so `<div>`, `<p>`, …
+ *    don't get treated as structural tags.
+ *  - Open/close name matching is case-sensitive (XML semantics).
+ *  - Self-closing `<tag/>` and `<tag />` produce no region.
+ *  - `<!-- … -->`, `<!DOCTYPE …>`, `<![CDATA[…]]>`, `<?xml … ?>` are skipped.
+ *  - Nesting is stack-based. Cross-tag interleaving is treated as malformed
+ *    and the affected tags emit zero break points.
+ *  - Unclosed tags emit nothing.
+ *  - Tags inside passed-in protected regions (code fences) are ignored.
+ *  - `pos` is the `\n` immediately before the tag line (matches
+ *    scanBreakPoints/findListBreakPoints convention). First-line tags at
+ *    position 0 emit no break point.
+ *
+ * Scoring: `tag-open` = 30 (weak — splitting right before content is bad),
+ *          `tag-close` = 75 (strong — splitting after a closed block is great).
+ *
+ * Known limitation: attribute parsing is lazy. The opener regex terminates
+ * at the first `>`, so a `>` inside a quoted attribute value will produce a
+ * malformed match. This is intentional — we don't tokenize attributes.
+ */
+export function findXmlTagBreakPoints(text: string, fences: ProtectedRegion[]): BreakPoint[] {
+  // Whole-line patterns. The line is everything between `\n`s (or start/end).
+  const NAME = '[A-Za-z_][A-Za-z0-9_.:-]*';
+  const openRe = new RegExp(`^\\s*<(${NAME})(?:\\s+[^>]*)?>\\s*$`);
+  const closeRe = new RegExp(`^\\s*</(${NAME})\\s*>\\s*$`);
+  const selfCloseRe = new RegExp(`^\\s*<(${NAME})(?:\\s+[^>]*)?/>\\s*$`);
+  // Non-tag angle-bracket constructs to ignore wholesale.
+  const commentRe = /^\s*<!--.*-->\s*$/;
+  const doctypeRe = /^\s*<!DOCTYPE\b[^>]*>\s*$/i;
+  const cdataRe = /^\s*<!\[CDATA\[.*\]\]>\s*$/;
+  const piRe = /^\s*<\?[\s\S]*\?>\s*$/;
+
+  interface Frame {
+    name: string;
+    checkpoint: number; // index into `pending` where this frame's breaks start
+  }
+
+  const stack: Frame[] = [];
+  // Buffered break points. Committed to `output` only when the outermost
+  // frame closes cleanly. Discarded back to a checkpoint on malformed close.
+  const pending: BreakPoint[] = [];
+  const output: BreakPoint[] = [];
+
+  const commit = () => {
+    if (stack.length === 0) {
+      for (const bp of pending) output.push(bp);
+      pending.length = 0;
+    }
+  };
+
+  let lineStart = 0;
+  while (lineStart <= text.length) {
+    // Find line end.
+    let lineEnd = text.indexOf('\n', lineStart);
+    if (lineEnd === -1) lineEnd = text.length;
+    const line = text.slice(lineStart, lineEnd);
+
+    // Fence precedence: if this line's start is inside a fence, skip it.
+    // Use the line start position; the fence region spans `\n` of the opener
+    // through end of close. lineStart > fence.start && lineStart < fence.end
+    // is exactly what isInsideProtectedRegion checks.
+    const insideFence = fences.some(r => lineStart > r.start && lineStart < r.end);
+    if (insideFence) {
+      if (lineEnd === text.length) break;
+      lineStart = lineEnd + 1;
+      continue;
+    }
+
+    // Skip non-tag angle-bracket constructs entirely.
+    if (commentRe.test(line) || doctypeRe.test(line) || cdataRe.test(line) || piRe.test(line)) {
+      if (lineEnd === text.length) break;
+      lineStart = lineEnd + 1;
+      continue;
+    }
+
+    // Self-closing: recognized but no state change, no break points.
+    // Checked before the plain open regex because `<tag />` would also
+    // match an opener with trailing `/` as an attribute.
+    if (selfCloseRe.test(line)) {
+      if (lineEnd === text.length) break;
+      lineStart = lineEnd + 1;
+      continue;
+    }
+
+    const openMatch = line.match(openRe);
+    if (openMatch) {
+      const name = openMatch[1]!;
+      if (!HTML_ELEMENTS.has(name.toLowerCase())) {
+        // Push frame. Emit tag-open break point into pending (unless lineStart==0).
+        const frame: Frame = { name, checkpoint: pending.length };
+        stack.push(frame);
+        if (lineStart > 0) {
+          pending.push({ pos: lineStart - 1, score: 30, type: 'tag-open' });
+        }
+      }
+      if (lineEnd === text.length) break;
+      lineStart = lineEnd + 1;
+      continue;
+    }
+
+    const closeMatch = line.match(closeRe);
+    if (closeMatch) {
+      const name = closeMatch[1]!;
+      if (!HTML_ELEMENTS.has(name.toLowerCase())) {
+        if (stack.length === 0) {
+          // Stray closing tag — ignore.
+        } else {
+          const top = stack[stack.length - 1]!;
+          if (top.name === name) {
+            // Clean close: emit tag-close break point, pop.
+            if (lineStart > 0) {
+              pending.push({ pos: lineStart - 1, score: 75, type: 'tag-close' });
+            }
+            stack.pop();
+            commit();
+          } else {
+            // Malformed interleaving. Discard all pending entries for the
+            // top frame and everything stacked above it. The simplest way
+            // given our checkpoint convention: truncate pending back to the
+            // top frame's checkpoint and pop just that frame. We do NOT try
+            // to cascade — the outer frames remain, but their pending buffer
+            // is now shorter (the inner frame contributed nothing).
+            //
+            // However the spec asks: "zero break points for all involved
+            // tags". The involved tags here are the unmatched opener(s) at
+            // the top of the stack AND the current close. To be safe and
+            // match the spec's interleaving example `<a><b></a></b>`, we
+            // unwind the entire stack and discard all pending.
+            pending.length = 0;
+            stack.length = 0;
+            // The trailing `</b>` in the example is now a stray close; any
+            // further malformed closes will also be ignored via the
+            // stack-empty branch above.
+          }
+        }
+      }
+      if (lineEnd === text.length) break;
+      lineStart = lineEnd + 1;
+      continue;
+    }
+
+    // Content line — no state change.
+    if (lineEnd === text.length) break;
+    lineStart = lineEnd + 1;
+  }
+
+  // Unclosed tags: discard anything still pending (decision 13).
+  // `output` already has only cleanly committed break points.
+  return output.sort((a, b) => a.pos - b.pos);
 }
 
 /**
@@ -2318,8 +2482,9 @@ export function chunkDocument(
 ): { text: string; pos: number }[] {
   const regexPoints = scanBreakPoints(content);
   const listPoints = findListBreakPoints(content);
-  const breakPoints = mergeBreakPoints(regexPoints, listPoints);
   const protectedRegions = findCodeFences(content);
+  const tagPoints = findXmlTagBreakPoints(content, protectedRegions);
+  const breakPoints = mergeBreakPoints(mergeBreakPoints(regexPoints, listPoints), tagPoints);
   return chunkDocumentWithBreakPoints(content, breakPoints, protectedRegions, maxChars, overlapChars, windowChars);
 }
 
@@ -2342,8 +2507,9 @@ export async function chunkDocumentAsync(
   const regexPoints = scanBreakPoints(content);
   const listPoints = findListBreakPoints(content);
   const protectedRegions = findCodeFences(content);
+  const tagPoints = findXmlTagBreakPoints(content, protectedRegions);
 
-  let breakPoints = mergeBreakPoints(regexPoints, listPoints);
+  let breakPoints = mergeBreakPoints(mergeBreakPoints(regexPoints, listPoints), tagPoints);
   if (chunkStrategy === "auto" && filepath) {
     const { getASTBreakPoints } = await import("./ast.js");
     const astPoints = await getASTBreakPoints(content, filepath);

--- a/src/store.ts
+++ b/src/store.ts
@@ -101,7 +101,7 @@ export const BREAK_PATTERNS: [RegExp, number, string][] = [
   [/\n#{4}(?!#)/g, 70, 'h4'],      // #### but not #####
   [/\n#{5}(?!#)/g, 60, 'h5'],      // ##### but not ######
   [/\n#{6}(?!#)/g, 50, 'h6'],      // ######
-  [/\n```/g, 80, 'codeblock'],     // code block boundary (same as h3)
+  [/\n(?:`{3,}|~{3,})/g, 80, 'codeblock'],  // code block boundary (same as h3)
   [/\n(?:---|\*\*\*|___)\s*\n/g, 60, 'hr'],  // horizontal rule
   [/\n\n+/g, 20, 'blank'],         // paragraph boundary
   [/\n[-*]\s/g, 5, 'list'],        // unordered list item
@@ -139,27 +139,42 @@ export function scanBreakPoints(text: string): BreakPoint[] {
 
 /**
  * Find all code fence regions in the text.
- * Code fences are delimited by ``` and we should never split inside them.
+ * Code fences are delimited by runs of ``` or ~~~ (3 or more), and we should
+ * never split inside them. Follows CommonMark pairing rules: the closing fence
+ * must use the same character as the opening fence, be at least as long, and
+ * carry no info string.
+ *
+ * Only column-0 fences are recognized. Indented fences are not detected.
  */
 export function findCodeFences(text: string): CodeFenceRegion[] {
   const regions: CodeFenceRegion[] = [];
-  const fencePattern = /\n```/g;
-  let inFence = false;
-  let fenceStart = 0;
+  // Capture: fence char run, then the rest of the line (info string or close tail).
+  const fencePattern = /\n(`{3,}|~{3,})([^\n]*)/g;
+  let open: { char: string; len: number; start: number } | null = null;
 
   for (const match of text.matchAll(fencePattern)) {
-    if (!inFence) {
-      fenceStart = match.index!;
-      inFence = true;
-    } else {
-      regions.push({ start: fenceStart, end: match.index! + match[0].length });
-      inFence = false;
+    const run = match[1]!;
+    const tail = match[2]!;
+    const char = run[0]!;
+    const len = run.length;
+    const pos = match.index!;
+
+    if (!open) {
+      open = { char, len, start: pos };
+      continue;
     }
+
+    // To close: same char, length >= opening, and no info string on the close line.
+    if (char === open.char && len >= open.len && tail.trim() === '') {
+      regions.push({ start: open.start, end: pos + match[0].length });
+      open = null;
+    }
+    // Otherwise it's content inside the open fence; ignore.
   }
 
   // Handle unclosed fence - extends to end of document
-  if (inFence) {
-    regions.push({ start: fenceStart, end: text.length });
+  if (open) {
+    regions.push({ start: open.start, end: text.length });
   }
 
   return regions;

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -34,6 +34,7 @@ import {
   mergeBreakPoints,
   scanBreakPoints,
   findCodeFences,
+  findListBreakPoints,
   isInsideProtectedRegion,
   findBestCutoff,
   type BreakPoint,
@@ -614,17 +615,11 @@ describe("scanBreakPoints", () => {
     expect(blank!.score).toBe(20);
   });
 
-  test("detects list items", () => {
+  test("does not detect list items (handled by findListBreakPoints)", () => {
     const text = "Intro\n- Item 1\n- Item 2\n1. Numbered";
     const breaks = scanBreakPoints(text);
-
-    const lists = breaks.filter(b => b.type === 'list');
-    const numLists = breaks.filter(b => b.type === 'numlist');
-
-    expect(lists.length).toBe(2);
-    expect(numLists.length).toBe(1);
-    expect(lists[0]!.score).toBe(5);
-    expect(numLists[0]!.score).toBe(5);
+    expect(breaks.filter(b => b.type === 'list').length).toBe(0);
+    expect(breaks.filter(b => b.type === 'numlist').length).toBe(0);
   });
 
   test("detects newlines as fallback", () => {
@@ -798,6 +793,140 @@ describe("findCodeFences", () => {
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
     expect(isInsideProtectedRegion(text.indexOf("code"), fences)).toBe(true);
+  });
+});
+
+describe("findListBreakPoints", () => {
+  test("empty input produces no break points", () => {
+    expect(findListBreakPoints("")).toEqual([]);
+  });
+
+  test("pure prose produces no break points", () => {
+    const text = "Just a paragraph.\nAnother line of prose.\nAnd more.";
+    expect(findListBreakPoints(text)).toEqual([]);
+  });
+
+  test("single unordered list: item + list-end break points", () => {
+    const text = "Intro\n- one\n- two\n- three\n\nAfter";
+    const bps = findListBreakPoints(text);
+    // 3 item breaks (all depth 0, score 70) + 1 list-end (score 75)
+    const items = bps.filter(b => b.type === 'list-item-0');
+    const ends = bps.filter(b => b.type === 'list-end');
+    expect(items.length).toBe(3);
+    expect(ends.length).toBe(1);
+    expect(items.every(b => b.score === 70)).toBe(true);
+    expect(ends[0]!.score).toBe(75);
+  });
+
+  test("ordered list with 1.", () => {
+    const text = "Intro\n1. one\n2. two\n3. three\n\nAfter";
+    const bps = findListBreakPoints(text);
+    expect(bps.filter(b => b.type === 'list-item-0').length).toBe(3);
+    expect(bps.filter(b => b.type === 'list-end').length).toBe(1);
+  });
+
+  test("ordered list with 1)", () => {
+    const text = "Intro\n1) one\n2) two\n3) three\n\nAfter";
+    const bps = findListBreakPoints(text);
+    expect(bps.filter(b => b.type === 'list-item-0').length).toBe(3);
+    expect(bps.filter(b => b.type === 'list-end').length).toBe(1);
+  });
+
+  test("mixed marker characters at same indent are one list", () => {
+    const text = "Intro\n- one\n* two\n- three\n\nAfter";
+    const bps = findListBreakPoints(text);
+    expect(bps.filter(b => b.type === 'list-item-0').length).toBe(3);
+    expect(bps.filter(b => b.type === 'list-end').length).toBe(1);
+  });
+
+  test("nested unordered list uses depth-based scores", () => {
+    const text = "Intro\n- one\n  - sub1\n  - sub2\n- two\n\nAfter";
+    const bps = findListBreakPoints(text);
+    const top = bps.filter(b => b.type === 'list-item-0');
+    const sub = bps.filter(b => b.type === 'list-item-1');
+    expect(top.length).toBe(2);
+    expect(sub.length).toBe(2);
+    expect(top.every(b => b.score === 70)).toBe(true);
+    expect(sub.every(b => b.score === 45)).toBe(true);
+  });
+
+  test("three-deep nesting produces depth 0/1/2 scores", () => {
+    const text = "Intro\n- one\n  - two\n    - three\n\nAfter";
+    const bps = findListBreakPoints(text);
+    expect(bps.find(b => b.type === 'list-item-0')!.score).toBe(70);
+    expect(bps.find(b => b.type === 'list-item-1')!.score).toBe(45);
+    expect(bps.find(b => b.type === 'list-item-2')!.score).toBe(25);
+  });
+
+  test("mixed nesting: unordered top with ordered sublist", () => {
+    const text = "Intro\n- one\n  1. sub\n  2. sub\n- two\n\nAfter";
+    const bps = findListBreakPoints(text);
+    expect(bps.filter(b => b.type === 'list-item-0').length).toBe(2);
+    expect(bps.filter(b => b.type === 'list-item-1').length).toBe(2);
+  });
+
+  test("list followed by prose emits list-end at position of prose line", () => {
+    const text = "- a\n- b\nprose";
+    const bps = findListBreakPoints(text);
+    const end = bps.find(b => b.type === 'list-end')!;
+    // list-end at the \n before "prose"
+    expect(end.pos).toBe(text.indexOf("\nprose"));
+  });
+
+  test("list at end of document emits list-end at text.length", () => {
+    const text = "- a\n- b\n- c";
+    const bps = findListBreakPoints(text);
+    const end = bps.find(b => b.type === 'list-end')!;
+    expect(end.pos).toBe(text.length);
+  });
+
+  test("single blank line between items does not terminate list", () => {
+    const text = "Intro\n- a\n\n- b\n\nAfter";
+    const bps = findListBreakPoints(text);
+    expect(bps.filter(b => b.type === 'list-item-0').length).toBe(2);
+    expect(bps.filter(b => b.type === 'list-end').length).toBe(1);
+  });
+
+  test("blank then non-list prose terminates list", () => {
+    const text = "- a\n- b\n\nSome prose here";
+    const bps = findListBreakPoints(text);
+    expect(bps.filter(b => b.type === 'list-end').length).toBe(1);
+  });
+
+  test("+ markers are not detected as list items", () => {
+    const text = "Intro\n+ foo\n+ bar\n+ baz\n\nAfter";
+    const bps = findListBreakPoints(text);
+    expect(bps.length).toBe(0);
+  });
+
+  test("position convention: pos is the \\n before the line", () => {
+    const text = "Intro\n- one\n- two\n\nAfter";
+    const bps = findListBreakPoints(text);
+    const items = bps.filter(b => b.type === 'list-item-0');
+    // First item: \n before "- one" at index 5
+    expect(items[0]!.pos).toBe(text.indexOf("\n- one"));
+    expect(items[1]!.pos).toBe(text.indexOf("\n- two"));
+  });
+
+  test("integration: chunkDocument splits a long list at item boundaries", () => {
+    // Build a list long enough to force splitting
+    const items: string[] = [];
+    for (let i = 0; i < 200; i++) {
+      items.push(`- list item number ${i} with some descriptive text here to consume characters`);
+    }
+    const text = "# Header\n\n" + items.join("\n") + "\n";
+    const chunks = chunkDocument(text, 1000, 100, 300);
+    expect(chunks.length).toBeGreaterThan(1);
+    // Each chunk except the last should end on a complete list item line,
+    // meaning the split landed at a list-item break point (the \n before
+    // the next item).
+    for (let i = 0; i < chunks.length - 1; i++) {
+      const chunkText = chunks[i]!.text;
+      const lines = chunkText.split("\n");
+      // Drop trailing empty from a terminal \n
+      const last = lines[lines.length - 1] === "" ? lines[lines.length - 2]! : lines[lines.length - 1]!;
+      expect(last.startsWith("- list item")).toBe(true);
+    }
   });
 });
 

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -33,10 +33,10 @@ import {
   mergeBreakPoints,
   scanBreakPoints,
   findCodeFences,
-  isInsideCodeFence,
+  isInsideProtectedRegion,
   findBestCutoff,
   type BreakPoint,
-  type CodeFenceRegion,
+  type ProtectedRegion,
   reciprocalRankFusion,
   extractSnippet,
   getCacheKey,
@@ -686,8 +686,8 @@ describe("findCodeFences", () => {
     // Inner ``` positions must be inside the single fence region
     const innerOpen = text.indexOf("```js");
     const innerClose = text.indexOf("```\n````");
-    expect(isInsideCodeFence(innerOpen, fences)).toBe(true);
-    expect(isInsideCodeFence(innerClose, fences)).toBe(true);
+    expect(isInsideProtectedRegion(innerOpen, fences)).toBe(true);
+    expect(isInsideProtectedRegion(innerClose, fences)).toBe(true);
   });
 
   test("recognizes tilde fences", () => {
@@ -710,7 +710,7 @@ describe("findCodeFences", () => {
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
     const strayClose = text.indexOf("```\nstill");
-    expect(isInsideCodeFence(strayClose, fences)).toBe(true);
+    expect(isInsideProtectedRegion(strayClose, fences)).toBe(true);
   });
 
   test("does not close when closing line has info string", () => {
@@ -720,7 +720,7 @@ describe("findCodeFences", () => {
     expect(fences.length).toBe(1);
     // The stray "``` trailing" should still be inside the fence
     const stray = text.indexOf("``` trailing");
-    expect(isInsideCodeFence(stray, fences)).toBe(true);
+    expect(isInsideProtectedRegion(stray, fences)).toBe(true);
     // Real close is the bare ``` line near the end
     expect(fences[0]!.end).toBe(text.indexOf("\nAfter"));
   });
@@ -743,7 +743,7 @@ describe("findCodeFences", () => {
     expect(fences.length).toBe(1);
     // Every inner fence run must be inside the single region.
     for (const needle of ["````\n```", "```\ncode", "```\n````", "````\n`````"]) {
-      expect(isInsideCodeFence(text.indexOf(needle), fences)).toBe(true);
+      expect(isInsideProtectedRegion(text.indexOf(needle), fences)).toBe(true);
     }
   });
 
@@ -751,7 +751,7 @@ describe("findCodeFences", () => {
     const text = "Before\n`````\ncode\n``````\nAfter";
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
-    expect(isInsideCodeFence(text.indexOf("code"), fences)).toBe(true);
+    expect(isInsideProtectedRegion(text.indexOf("code"), fences)).toBe(true);
   });
 
   test("same-length fences do not nest (CommonMark)", () => {
@@ -760,7 +760,7 @@ describe("findCodeFences", () => {
     const text = "Before\n````\n````\ncontent\n````\n````\nAfter";
     const fences = findCodeFences(text);
     expect(fences.length).toBe(2);
-    expect(isInsideCodeFence(text.indexOf("content"), fences)).toBe(false);
+    expect(isInsideProtectedRegion(text.indexOf("content"), fences)).toBe(false);
   });
 
   test("mixed fence chars do not interact", () => {
@@ -768,14 +768,14 @@ describe("findCodeFences", () => {
     const text = "Before\n````\n~~~~\ninner\n~~~~\n````\nAfter";
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
-    expect(isInsideCodeFence(text.indexOf("inner"), fences)).toBe(true);
+    expect(isInsideProtectedRegion(text.indexOf("inner"), fences)).toBe(true);
   });
 
   test("handles info strings on outer and inner fences", () => {
     const text = "Before\n```` wrap\n```js\ncode\n```\n````\nAfter";
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
-    expect(isInsideCodeFence(text.indexOf("```js"), fences)).toBe(true);
+    expect(isInsideProtectedRegion(text.indexOf("```js"), fences)).toBe(true);
   });
 
   test("tilde fences support 5/4/3 nesting", () => {
@@ -792,37 +792,37 @@ describe("findCodeFences", () => {
     ].join("\n");
     const fences = findCodeFences(text);
     expect(fences.length).toBe(1);
-    expect(isInsideCodeFence(text.indexOf("code"), fences)).toBe(true);
+    expect(isInsideProtectedRegion(text.indexOf("code"), fences)).toBe(true);
   });
 });
 
-describe("isInsideCodeFence", () => {
+describe("isInsideProtectedRegion", () => {
   test("returns true for position inside fence", () => {
-    const fences: CodeFenceRegion[] = [{ start: 10, end: 30 }];
-    expect(isInsideCodeFence(15, fences)).toBe(true);
-    expect(isInsideCodeFence(20, fences)).toBe(true);
+    const fences: ProtectedRegion[] = [{ start: 10, end: 30 }];
+    expect(isInsideProtectedRegion(15, fences)).toBe(true);
+    expect(isInsideProtectedRegion(20, fences)).toBe(true);
   });
 
   test("returns false for position outside fence", () => {
-    const fences: CodeFenceRegion[] = [{ start: 10, end: 30 }];
-    expect(isInsideCodeFence(5, fences)).toBe(false);
-    expect(isInsideCodeFence(35, fences)).toBe(false);
+    const fences: ProtectedRegion[] = [{ start: 10, end: 30 }];
+    expect(isInsideProtectedRegion(5, fences)).toBe(false);
+    expect(isInsideProtectedRegion(35, fences)).toBe(false);
   });
 
   test("returns false for position at fence boundaries", () => {
-    const fences: CodeFenceRegion[] = [{ start: 10, end: 30 }];
-    expect(isInsideCodeFence(10, fences)).toBe(false); // at start
-    expect(isInsideCodeFence(30, fences)).toBe(false); // at end
+    const fences: ProtectedRegion[] = [{ start: 10, end: 30 }];
+    expect(isInsideProtectedRegion(10, fences)).toBe(false); // at start
+    expect(isInsideProtectedRegion(30, fences)).toBe(false); // at end
   });
 
   test("handles multiple fences", () => {
-    const fences: CodeFenceRegion[] = [
+    const fences: ProtectedRegion[] = [
       { start: 10, end: 30 },
       { start: 50, end: 70 }
     ];
-    expect(isInsideCodeFence(20, fences)).toBe(true);
-    expect(isInsideCodeFence(60, fences)).toBe(true);
-    expect(isInsideCodeFence(40, fences)).toBe(false);
+    expect(isInsideProtectedRegion(20, fences)).toBe(true);
+    expect(isInsideProtectedRegion(60, fences)).toBe(true);
+    expect(isInsideProtectedRegion(40, fences)).toBe(false);
   });
 });
 
@@ -876,8 +876,8 @@ describe("findBestCutoff", () => {
       { pos: 150, score: 100, type: 'h1' },  // inside fence
       { pos: 180, score: 20, type: 'blank' }, // outside fence
     ];
-    const codeFences: CodeFenceRegion[] = [{ start: 140, end: 160 }];
-    const cutoff = findBestCutoff(breakPoints, 200, 100, 0.7, codeFences);
+    const regions: ProtectedRegion[] = [{ start: 140, end: 160 }];
+    const cutoff = findBestCutoff(breakPoints, 200, 100, 0.7, regions);
     expect(cutoff).toBe(180); // blank wins since h1 is inside fence
   });
 
@@ -1017,10 +1017,10 @@ describe("chunkDocumentWithBreakPoints", () => {
   test("produces same output as chunkDocument for same input", () => {
     const content = "a".repeat(5000) + "\n\n" + "b".repeat(5000);
     const breakPoints = scanBreakPoints(content);
-    const codeFences = findCodeFences(content);
+    const regions = findCodeFences(content);
 
     const chunksOriginal = chunkDocument(content);
-    const chunksNew = chunkDocumentWithBreakPoints(content, breakPoints, codeFences);
+    const chunksNew = chunkDocumentWithBreakPoints(content, breakPoints, regions);
 
     expect(chunksNew.length).toBe(chunksOriginal.length);
     for (let i = 0; i < chunksNew.length; i++) {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -19,6 +19,7 @@ import {
   createStore,
   verifySqliteVecLoaded,
   getDefaultDbPath,
+  _resetProductionModeForTesting,
   homedir,
   resolve,
   getPwd,
@@ -280,6 +281,10 @@ describe("Store Creation", () => {
     // In test mode, createStore without path should throw to prevent accidental writes
     const originalIndexPath = process.env.INDEX_PATH;
     delete process.env.INDEX_PATH;
+    // Reset production mode in case another test file set it (bun runs all
+    // files in a single process, so module state leaks between files).
+    // Mirrors the fix applied to getDefaultDbPath's parallel test in 66e70c0.
+    _resetProductionModeForTesting();
 
     expect(() => createStore()).toThrow("Database path not set");
 

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -677,6 +677,123 @@ describe("findCodeFences", () => {
     const fences = findCodeFences(text);
     expect(fences.length).toBe(0);
   });
+
+  test("handles 4-backtick fence containing 3-backtick block", () => {
+    // Outer ```` fence wraps an inner ``` that must not close it.
+    const text = "Before\n````md\n```js\ninner\n```\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    // Inner ``` positions must be inside the single fence region
+    const innerOpen = text.indexOf("```js");
+    const innerClose = text.indexOf("```\n````");
+    expect(isInsideCodeFence(innerOpen, fences)).toBe(true);
+    expect(isInsideCodeFence(innerClose, fences)).toBe(true);
+  });
+
+  test("recognizes tilde fences", () => {
+    const text = "Before\n~~~\ncode\n~~~\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+  });
+
+  test("does not close tilde fence with backticks", () => {
+    // Open ~~~, stray ``` should not close it; unclosed extends to end.
+    const text = "Before\n~~~\ncode\n```\nstill inside";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(fences[0]!.end).toBe(text.length);
+  });
+
+  test("does not close with shorter fence run", () => {
+    // Open ````, a ``` inside must not close it.
+    const text = "Before\n````\ncode\n```\nstill inside\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    const strayClose = text.indexOf("```\nstill");
+    expect(isInsideCodeFence(strayClose, fences)).toBe(true);
+  });
+
+  test("does not close when closing line has info string", () => {
+    // Close candidate has trailing text, so it's not a valid close.
+    const text = "Before\n```\ncode\n``` trailing\n```\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    // The stray "``` trailing" should still be inside the fence
+    const stray = text.indexOf("``` trailing");
+    expect(isInsideCodeFence(stray, fences)).toBe(true);
+    // Real close is the bare ``` line near the end
+    expect(fences[0]!.end).toBe(text.indexOf("\nAfter"));
+  });
+
+  test("handles 5/4/3 backtick nesting with bare inner fences", () => {
+    // Outer 5-bt wraps 4-bt wraps 3-bt, all inner fences with no info string.
+    // Only the final 5-bt run may close the outer fence.
+    const text = [
+      "Before",
+      "`````md",
+      "````",
+      "```",
+      "code",
+      "```",
+      "````",
+      "`````",
+      "After",
+    ].join("\n");
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    // Every inner fence run must be inside the single region.
+    for (const needle of ["````\n```", "```\ncode", "```\n````", "````\n`````"]) {
+      expect(isInsideCodeFence(text.indexOf(needle), fences)).toBe(true);
+    }
+  });
+
+  test("longer closing fence is valid (6-bt closes 5-bt)", () => {
+    const text = "Before\n`````\ncode\n``````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(isInsideCodeFence(text.indexOf("code"), fences)).toBe(true);
+  });
+
+  test("same-length fences do not nest (CommonMark)", () => {
+    // ```` inside ```` cannot nest: the second ```` closes the first.
+    // Result is two empty-ish fences with "content" sitting outside both.
+    const text = "Before\n````\n````\ncontent\n````\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(2);
+    expect(isInsideCodeFence(text.indexOf("content"), fences)).toBe(false);
+  });
+
+  test("mixed fence chars do not interact", () => {
+    // Backtick outer, tilde inner — different chars, so the tildes stay inside.
+    const text = "Before\n````\n~~~~\ninner\n~~~~\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(isInsideCodeFence(text.indexOf("inner"), fences)).toBe(true);
+  });
+
+  test("handles info strings on outer and inner fences", () => {
+    const text = "Before\n```` wrap\n```js\ncode\n```\n````\nAfter";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(isInsideCodeFence(text.indexOf("```js"), fences)).toBe(true);
+  });
+
+  test("tilde fences support 5/4/3 nesting", () => {
+    const text = [
+      "Before",
+      "~~~~~",
+      "~~~~",
+      "~~~",
+      "code",
+      "~~~",
+      "~~~~",
+      "~~~~~",
+      "After",
+    ].join("\n");
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(isInsideCodeFence(text.indexOf("code"), fences)).toBe(true);
+  });
 });
 
 describe("isInsideCodeFence", () => {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -35,6 +35,7 @@ import {
   scanBreakPoints,
   findCodeFences,
   findListBreakPoints,
+  findXmlTagBreakPoints,
   isInsideProtectedRegion,
   findBestCutoff,
   type BreakPoint,
@@ -927,6 +928,193 @@ describe("findListBreakPoints", () => {
       const last = lines[lines.length - 1] === "" ? lines[lines.length - 2]! : lines[lines.length - 1]!;
       expect(last.startsWith("- list item")).toBe(true);
     }
+  });
+});
+
+describe("findXmlTagBreakPoints", () => {
+  test("empty input → no break points", () => {
+    expect(findXmlTagBreakPoints("", [])).toEqual([]);
+  });
+
+  test("pure prose → no break points", () => {
+    const text = "just some prose\nwith multiple lines\nand nothing special";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("single <example> block emits open (30) + close (75)", () => {
+    const text = "prologue\n<example>\ncontent\n</example>\nepilogue";
+    const bps = findXmlTagBreakPoints(text, []);
+    expect(bps.length).toBe(2);
+    expect(bps[0]!.type).toBe("tag-open");
+    expect(bps[0]!.score).toBe(30);
+    expect(bps[1]!.type).toBe("tag-close");
+    expect(bps[1]!.score).toBe(75);
+    // Positions are the \n immediately before the tag line.
+    expect(text[bps[0]!.pos]).toBe("\n");
+    expect(text[bps[1]!.pos]).toBe("\n");
+    expect(text.slice(bps[0]!.pos + 1).startsWith("<example>")).toBe(true);
+    expect(text.slice(bps[1]!.pos + 1).startsWith("</example>")).toBe(true);
+  });
+
+  test("multiple sequential blocks", () => {
+    const text = "intro\n<example>\na\n</example>\nmid\n<note>\nb\n</note>\nend";
+    const bps = findXmlTagBreakPoints(text, []);
+    expect(bps.map(b => b.type)).toEqual(["tag-open", "tag-close", "tag-open", "tag-close"]);
+    expect(bps.map(b => b.score)).toEqual([30, 75, 30, 75]);
+  });
+
+  test("nested same-name tags", () => {
+    const text = "p\n<example>\n<example>\ninner\n</example>\nouter\n</example>\nq";
+    const bps = findXmlTagBreakPoints(text, []);
+    expect(bps.map(b => b.type)).toEqual(["tag-open", "tag-open", "tag-close", "tag-close"]);
+  });
+
+  test("nested different-name tags emit all four break points in order", () => {
+    const text = "p\n<outer>\n<inner>\nx\n</inner>\ny\n</outer>\nq";
+    const bps = findXmlTagBreakPoints(text, []);
+    expect(bps.map(b => b.type)).toEqual(["tag-open", "tag-open", "tag-close", "tag-close"]);
+    for (let i = 1; i < bps.length; i++) {
+      expect(bps[i]!.pos).toBeGreaterThan(bps[i - 1]!.pos);
+    }
+  });
+
+  test("self-closing tag emits nothing", () => {
+    const text = "p\n<thing/>\nq";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("self-closing with space emits nothing", () => {
+    const text = "p\n<thing />\nq";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("tag with attributes is recognized", () => {
+    const text = "p\n<example name=\"foo\">\ncontent\n</example>\nq";
+    const bps = findXmlTagBreakPoints(text, []);
+    expect(bps.length).toBe(2);
+    expect(bps[0]!.type).toBe("tag-open");
+    expect(bps[1]!.type).toBe("tag-close");
+  });
+
+  test("HTML element blocked (div)", () => {
+    const text = "p\n<div>\ncontent\n</div>\nq";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("HTML element blocklist is case-insensitive", () => {
+    const text1 = "p\n<DIV>\nx\n</DIV>\nq";
+    const text2 = "p\n<Div>\nx\n</Div>\nq";
+    expect(findXmlTagBreakPoints(text1, [])).toEqual([]);
+    expect(findXmlTagBreakPoints(text2, [])).toEqual([]);
+  });
+
+  test("custom element with hyphen is recognized", () => {
+    const text = "p\n<my-widget>\nx\n</my-widget>\nq";
+    const bps = findXmlTagBreakPoints(text, []);
+    expect(bps.length).toBe(2);
+  });
+
+  test("namespaced tag is recognized", () => {
+    const text = "p\n<xsl:template>\nx\n</xsl:template>\nq";
+    const bps = findXmlTagBreakPoints(text, []);
+    expect(bps.length).toBe(2);
+  });
+
+  test("case-sensitive tag matching → malformed", () => {
+    // <Example> open, </example> close: names differ → malformed, zero breaks.
+    const text = "p\n<Example>\nx\n</example>\nq";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("unclosed tag emits no break points", () => {
+    const text = "p\n<example>\ncontent with no close";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("stray closing tag is ignored and does not crash", () => {
+    const text = "p\n</example>\nq";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("cross-tag interleaving is malformed → zero break points", () => {
+    const text = "p\n<a-foo>\n<b-bar>\n</a-foo>\n</b-bar>\nq";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("tag inside code fence is ignored", () => {
+    const text = "prologue\n```\n<example>\nfoo\n</example>\n```\nepilogue";
+    const fences = findCodeFences(text);
+    expect(fences.length).toBe(1);
+    expect(findXmlTagBreakPoints(text, fences)).toEqual([]);
+  });
+
+  test("mid-line tag is ignored", () => {
+    const text = "Here's an <example>content</example> inline";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("leading whitespace on tag line is recognized", () => {
+    const text = "p\n  <example>\n  x\n  </example>\nq";
+    const bps = findXmlTagBreakPoints(text, []);
+    expect(bps.length).toBe(2);
+  });
+
+  test("HTML comment is ignored", () => {
+    const text = "p\n<!-- comment -->\nq";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("DOCTYPE is ignored", () => {
+    const text = "p\n<!DOCTYPE html>\nq";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("CDATA is ignored", () => {
+    const text = "p\n<![CDATA[some data]]>\nq";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("processing instruction is ignored", () => {
+    const text = "p\n<?xml version=\"1.0\"?>\nq";
+    expect(findXmlTagBreakPoints(text, [])).toEqual([]);
+  });
+
+  test("first-line tag skipped (open at position 0)", () => {
+    // Open at position 0 → no tag-open break. Close still emits.
+    const text = "<example>\ncontent\n</example>\nafter";
+    const bps = findXmlTagBreakPoints(text, []);
+    expect(bps.length).toBe(1);
+    expect(bps[0]!.type).toBe("tag-close");
+  });
+
+  test("position convention: pos is the \\n before the tag line", () => {
+    const text = "abc\n<example>\ncontent\n</example>\ndef";
+    const bps = findXmlTagBreakPoints(text, []);
+    expect(text[bps[0]!.pos]).toBe("\n");
+    expect(text.charAt(bps[0]!.pos + 1)).toBe("<");
+  });
+
+  test("chunkDocument integration: prefers close positions when splitting a tagged document", () => {
+    // Build a document larger than CHUNK_SIZE_CHARS so splitting is forced,
+    // with a clearly closed <example> block near the split target. The close
+    // should be chosen over nearby weak breaks.
+    // Size chosen so the </example> close sits inside the first cutoff
+    // window (target ~3600, window back 800).
+    const pre = "pre ".repeat(750);
+    const block = "\n<example>\n" + "body ".repeat(80) + "\n</example>\n";
+    const post = "post ".repeat(500);
+    const text = pre + block + post;
+    const chunks = chunkDocument(text);
+    expect(chunks.length).toBeGreaterThan(1);
+    // The tag-close break point sits at the \n before </example>. A chunk
+    // boundary should land exactly there (or very close to it) since 75
+    // beats the nearby weak blank/newline breaks.
+    const closeBpPos = text.indexOf("\n</example>");
+    const hasBoundaryAtClose = chunks.some(c => {
+      const end = c.pos + c.text.length;
+      return end === closeBpPos;
+    });
+    expect(hasBoundaryAtClose).toBe(true);
   });
 });
 


### PR DESCRIPTION
> This consolidates what was previously four stacked PRs (#538, #539, #540, #541) into a single PR for simpler review. The stacked approach created unnecessary friction for a cross-fork contribution. Full context in the [overview gist](https://gist.github.com/galligan/a8d3cada1e89633117fcc3f2733e8f8a). Each logical change is its own commit if you prefer to review commit-by-commit.

## Summary

Four chunking improvements, each in its own commit:

1. **Fix code fence pairing** to follow CommonMark rules (char + length matching, tilde support)
2. **Rename `CodeFenceRegion` to `ProtectedRegion`** with an optional `kind` tag (pure mechanical refactor)
3. **List-aware break point scanner** with depth-weighted scoring and nested sublist tracking
4. **XML tag break point scanner** for agent-prompt tags like `<example>`, `<instructions>`, `<thinking>`

Plus a test isolation fix for a pre-existing flaky test (`createStore throws without explicit path in test mode` on Bun ubuntu, same root cause as upstream commit 66e70c0).

## Splitting

These changes sit on clean seams and can be split into separate PRs if that's preferable. The commits are ordered so any prefix is self-contained:

- **Commits 1-2** (fence fix + rename) are a standalone bugfix with no feature additions
- **Commit 3** (list-aware) is independent of commit 4 (XML tags)
- **Commit 4** (XML tags) is independent of commit 3 (list-aware)

If you'd rather land these incrementally, I'm happy to split them back out.

## Commit 1: fix code fence pairing

`findCodeFences` had two problems: the regex only matched exactly three backticks (ignoring tildes and longer runs), and pairing was a naive toggle. A fence opened with ```` ```` ```` was never recognized. A stray ` ``` ` inside a longer fence prematurely closed it.

Now tracks the opening fence's character and length. A close candidate must use the same char, be at least as long, and carry no info string. `BREAK_PATTERNS` updated to scan for 3+ backticks or tildes.

**Scope:** column-0 fences only. Indented fences are not detected (documented).

**12 new tests** covering 4/5/6-backtick nesting, tilde fences, mixed chars, same-length non-nesting (CommonMark quirk), info-string validation.

## Commit 2: rename CodeFenceRegion to ProtectedRegion

Pure mechanical rename. `CodeFenceRegion` becomes `ProtectedRegion` with optional `kind?: string` (set to `'fence'` by `findCodeFences`). `isInsideCodeFence` becomes `isInsideProtectedRegion`. All parameter names updated. No behavior change. Not re-exported from `src/index.ts`, so fully contained.

## Commit 3: list-aware break point scanner

Replaces the two naive `BREAK_PATTERNS` entries (`list: 5`, `numlist: 5`) with `findListBreakPoints`, a stack-based scanner that tracks nested list frames and emits depth-weighted break points:

| Break point | Score |
|---|---|
| list-end (list to non-list transition) | 75 |
| Top-level item (depth 0) | 70 |
| Second-level item (depth 1) | 45 |
| Third-level and deeper (depth 2+) | 25 |

Handles: `-` and `*` unordered markers, `1.` and `1)` ordered markers, mixed marker characters at same indent (treated as one list), nested sublists, blank lines inside items, list-end detection.

Deliberately deferred: loose/tight distinction, lazy continuation, 4-space indented code blocks, tab indentation. Each documented in a block comment.

**16 new tests** including an end-to-end integration test through `chunkDocument` confirming long lists split at item boundaries.

## Commit 4: XML tag break point scanner

`findXmlTagBreakPoints` detects line-anchored paired XML tags and emits asymmetric break points:

| Break point | Score |
|---|---|
| tag-open | 30 (weak: splitting right before content orphans the opener) |
| tag-close | 75 (strong: splitting after a closed block is great) |

Tag name grammar: `[A-Za-z_][A-Za-z0-9_.:-]*` (XML Name production, custom elements, namespaced tags).

HTML5 element names are blocked via a case-insensitive blocklist in `src/html-elements.ts` so inline HTML (`<div>`, `<p>`, `<br>`) isn't confused for structural tags.

Key rules:
- Line-anchored only (tag must be on its own line, leading whitespace OK)
- Case-sensitive open/close matching (XML semantics)
- Stack-based nesting (same-name and different-name)
- Self-closing `<tag/>` produces nothing
- `<!-- -->`, `<!DOCTYPE>`, `<![CDATA[]]>`, `<?xml ?>` skipped
- Cross-tag interleaving is malformed (zero break points)
- Unclosed tags emit nothing
- Tags inside code fences are ignored (fence scan runs first)

**27 new tests** including fence precedence, HTML blocklist, case sensitivity, malformed input handling, and an integration test through `chunkDocument`.

## Regression analysis

The only pattern that used to score and no longer does is `-\t` (dash followed by literal tab as marker separator). The old regex `\n[-*]\s` matched it at score 5; the new scanner requires space-separated markers. Tab-indented list items were never detected by the old regex either (`\n\t- foo` was invisible). Not a regression in practice.

Everything the old code detected, the new code detects and scores higher. Previously undetected patterns (nested sublists, `1)` form, list-end transitions, XML tags, tilde fences, 4+ backtick fences) are now handled.

## Files changed

- **Modified:** `src/store.ts` (fence fix, rename, list scanner, XML scanner, integration)
- **Modified:** `test/store.test.ts` (55 new tests + test isolation fix)
- **Modified:** `CHANGELOG.md` (changelog entries under `[Unreleased]`)
- **New:** `src/html-elements.ts` (HTML5 element blocklist)

## Test plan

- [x] `npx vitest run test/store.test.ts` passes (246/246, was 203 + 43 new)
- [x] `npx vitest run test/ast-chunking.test.ts` passes (12/12)
- [x] `npx tsc -p tsconfig.build.json --noEmit` clean
- [ ] CI green