### PR TITLE
fix: add USERPROFILE fallback for Windows HOME resolution

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -38,7 +38,7 @@ import type {
 // Configuration
 // =============================================================================
 
-const HOME = process.env.HOME || "/tmp";
+const HOME = process.env.HOME || process.env.USERPROFILE || "/tmp";
 export const DEFAULT_EMBED_MODEL = "embeddinggemma";
 export const DEFAULT_RERANK_MODEL = "ExpedientFalcon/qwen3-reranker:0.6b-q8_0";
 export const DEFAULT_QUERY_MODEL = "Qwen/Qwen3-1.7B";


### PR DESCRIPTION
## Problem

On Windows, `HOME` is not a standard environment variable — the equivalent is `USERPROFILE`. When MCP clients (e.g. Claude Code) spawn the QMD server as a subprocess, they pass `USERPROFILE` but not `HOME`.

`store.ts:41`:
```ts
const HOME = process.env.HOME || "/tmp";
```

This causes QMD to fall back to `/tmp`, creating/opening an empty database at `/tmp/.cache/qmd/index.sqlite` instead of `~/.cache/qmd/index.sqlite`. The CLI works because shells like Git Bash/MSYS2 set `HOME`, but MCP subprocesses spawned via `cmd /c node` or direct `node` do not.

**Symptom:** `qmd status` via CLI shows 552 docs, but MCP `status` tool returns 0 documents.

## Fix

```ts
const HOME = process.env.HOME || process.env.USERPROFILE || "/tmp";
```

One-line change. `USERPROFILE` is always set on Windows. Falls through to `/tmp` on systems where neither is set (shouldn't happen in practice).

## Environment

- QMD 2.0.1
- Windows 11
- Node.js 24.12.0
- Claude Code 2.1.92 (MCP client)