### PR TITLE
fix(embed,status): show resolved models instead of hardcoded defaults

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -461,10 +461,11 @@ async function showStatus(): Promise<void> {
       const match = uri.match(/^hf:([^/]+\/[^/]+)\//);
       return match ? `https://huggingface.co/${match[1]}` : uri;
     };
+    const llamaCpp = getDefaultLlamaCpp();
     console.log(`\n${c.bold}Models${c.reset}`);
-    console.log(`  Embedding:   ${hfLink(DEFAULT_EMBED_MODEL_URI)}`);
-    console.log(`  Reranking:   ${hfLink(DEFAULT_RERANK_MODEL_URI)}`);
-    console.log(`  Generation:  ${hfLink(DEFAULT_GENERATE_MODEL_URI)}`);
+    console.log(`  Embedding:   ${hfLink(llamaCpp.embedModelName)}`);
+    console.log(`  Reranking:   ${hfLink(llamaCpp.rerankModelName)}`);
+    console.log(`  Generation:  ${hfLink(llamaCpp.generateModelName)}`);
   }
 
   // Device / GPU info

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -1693,7 +1693,7 @@ async function vectorIndex(
     return;
   }
 
-  console.log(`${c.dim}Model: ${model}${c.reset}\n`);
+  console.log(`${c.dim}Model: ${getDefaultLlamaCpp().embedModelName}${c.reset}\n`);
   if (batchOptions?.maxDocsPerBatch !== undefined || batchOptions?.maxBatchBytes !== undefined) {
     const maxDocsPerBatch = batchOptions.maxDocsPerBatch ?? DEFAULT_EMBED_MAX_DOCS_PER_BATCH;
     const maxBatchBytes = batchOptions.maxBatchBytes ?? DEFAULT_EMBED_MAX_BATCH_BYTES;

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -514,6 +514,14 @@ export class LlamaCpp implements LLM {
     return this.embedModelUri;
   }
 
+  get rerankModelName(): string {
+    return this.rerankModelUri;
+  }
+
+  get generateModelName(): string {
+    return this.generateModelUri;
+  }
+
   /**
    * Reset the inactivity timer. Called after each model operation.
    * When timer fires, models are unloaded to free memory (if no active sessions).


### PR DESCRIPTION
## Problem

Two commands displayed hardcoded default model URIs regardless of `QMD_EMBED_MODEL` env var or `models.*` config values, misleading users into thinking their overrides were not applied.

**`qmd embed`** — `vectorIndex()` logged its `model` parameter directly, but the `embed` case always passed `DEFAULT_EMBED_MODEL_URI` as that argument:

```ts
// always DEFAULT_EMBED_MODEL_URI, ignores env var / config
await vectorIndex(DEFAULT_EMBED_MODEL_URI, ...)
...
console.log(`Model: ${model}`)
```

**`qmd status`** — the Models section hardcoded all three constants:

```ts
console.log(`  Embedding:   ${hfLink(DEFAULT_EMBED_MODEL_URI)}`);
console.log(`  Reranking:   ${hfLink(DEFAULT_RERANK_MODEL_URI)}`);
console.log(`  Generation:  ${hfLink(DEFAULT_GENERATE_MODEL_URI)}`);
```

The actual embedding always ran with the correct model (`LlamaCpp` resolves env var at construction time) — only the display was wrong.

## Fix

Read resolved URIs from the `LlamaCpp` instance, which reflects env var and config after resolution. Added `rerankModelName` and `generateModelName` getters to `LlamaCpp` alongside the existing `embedModelName`.

## Before / After

```
# Before (QMD_EMBED_MODEL set to Qwen model)
qmd embed:  Model: hf:ggml-org/embeddinggemma-300M-GGUF/...
qmd status: Embedding: https://huggingface.co/ggml-org/embeddinggemma-300M-GGUF

# After
qmd embed:  Model: hf:Qwen/Qwen3-Embedding-0.6B-GGUF/...
qmd status: Embedding: https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF
```

## Files

- `src/cli/qmd.ts` — fix embed output and status Models section
- `src/llm.ts` — add `rerankModelName` and `generateModelName` getters