### PR TITLE
fix(windows): add qmd.cmd launcher that invokes node/bun directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Windows: ship `bin/qmd.cmd` — a native CMD launcher that invokes `node`/`bun` directly without requiring `/bin/sh`. The npm-generated wrapper calls `/bin/sh` to run `bin/qmd`, which fails silently when MCP clients spawn qmd as a stdio subprocess via Node.js `child_process.spawn()` (Git for Windows is absent from the subprocess PATH even when available in interactive shells).
 - GPU: respect explicit `QMD_LLAMA_GPU=metal|vulkan|cuda` backend overrides instead of always using auto GPU selection. #529
 - Fix: preserve original filename case in `handelize()`. The previous
   `.toLowerCase()` call made indexed paths unreachable on case-sensitive

--- a/bin/qmd.cmd
+++ b/bin/qmd.cmd
@@ -1,0 +1,37 @@
+@echo off
+:: Windows CMD launcher for QMD.
+::
+:: npm auto-generates a qmd.cmd wrapper that calls /bin/sh to run bin/qmd.
+:: When MCP clients (e.g. Claude Code) spawn qmd as a stdio subprocess via
+:: Node.js child_process.spawn(), /bin/sh is not reliably available — Git
+:: for Windows is often absent from the subprocess PATH even when present
+:: in interactive shells. This causes the MCP server to fail silently.
+::
+:: This hand-crafted launcher mirrors the runtime-detection logic in bin/qmd
+:: (bun.lock → bun, package-lock.json → node, fallback → node) without
+:: requiring a POSIX shell, making stdio MCP spawning work on any Windows
+:: machine regardless of Git installation.
+::
+:: npm places this file in the global bin directory. The package root is
+:: always at node_modules\@tobilu\qmd relative to that directory (matching
+:: the path npm itself uses in auto-generated wrappers).
+
+setlocal enabledelayedexpansion
+
+set "PKG_DIR=%~dp0node_modules\@tobilu\qmd"
+
+:: For local dev installs (npm link, direct repo use), fall back to
+:: the parent of the bin/ directory.
+if not exist "%PKG_DIR%\package.json" (
+    set "PKG_DIR=%~dp0.."
+)
+
+if exist "%PKG_DIR%\package-lock.json" (
+    node "%PKG_DIR%\dist\cli\qmd.js" %*
+) else if exist "%PKG_DIR%\bun.lock" (
+    bun "%PKG_DIR%\dist\cli\qmd.js" %*
+) else if exist "%PKG_DIR%\bun.lockb" (
+    bun "%PKG_DIR%\dist\cli\qmd.js" %*
+) else (
+    node "%PKG_DIR%\dist\cli\qmd.js" %*
+)


### PR DESCRIPTION
## Problem

On Windows, the npm-generated `qmd.cmd` wrapper calls `/bin/sh` to run `bin/qmd`. When MCP clients (e.g. Claude Code, Cursor, or any tool using Node.js `child_process.spawn()`) start qmd as a stdio subprocess, `/bin/sh` is not reliably available — Git for Windows is often absent from the subprocess PATH even when present in interactive shells.

The result: `qmd mcp` silently fails to start when configured as an MCP stdio server. No error is shown to the user; the MCP client simply never sees the server.

Example broken config (fails on Windows via Node.js spawn):
```json
{
  "mcpServers": {
    "qmd": { "command": "qmd", "args": ["mcp"] }
  }
}
```

## Fix

Add `bin/qmd.cmd`: a native CMD launcher that mirrors the runtime-detection logic already in `bin/qmd` (checks `package-lock.json` → `node`, `bun.lock` / `bun.lockb` → `bun`, fallback → `node`) without requiring a POSIX shell.

npm uses a hand-crafted `qmd.cmd` over its auto-generated wrapper when both share the same base name — so this file is picked up automatically on `npm install -g` with no changes to `package.json`.

## Verification

Tested via Node.js `spawnSync` (exactly how MCP clients spawn the server):

```js
const r = spawnSync('cmd.exe', ['/c', 'qmd.cmd', '--help'], { encoding: 'utf8' });
// stdout: "qmd — Quick Markdown Search\n\nUsage:\n  qmd <command> [options]..."
// status: 0
```

MCP stdio handshake works end-to-end after this change.

## Related

Similar in spirit to #555 (USERPROFILE fallback for Windows HOME resolution).