### PR TITLE
fix: use configured models instead of hardcoded defaults

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -78,7 +78,7 @@ import {
   type ReindexResult,
   type ChunkStrategy,
 } from "../store.js";
-import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, setDefaultLlamaCpp, LlamaCpp, withLLMSession, pullModels, DEFAULT_EMBED_MODEL_URI, DEFAULT_GENERATE_MODEL_URI, DEFAULT_RERANK_MODEL_URI, DEFAULT_MODEL_CACHE_DIR } from "../llm.js";
+import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, setDefaultLlamaCpp, LlamaCpp, withLLMSession, pullModels, DEFAULT_EMBED_MODEL_URI, DEFAULT_MODEL_CACHE_DIR } from "../llm.js";
 import {
   formatSearchResults,
   formatDocuments,
@@ -462,9 +462,10 @@ async function showStatus(): Promise<void> {
       return match ? `https://huggingface.co/${match[1]}` : uri;
     };
     console.log(`\n${c.bold}Models${c.reset}`);
-    console.log(`  Embedding:   ${hfLink(DEFAULT_EMBED_MODEL_URI)}`);
-    console.log(`  Reranking:   ${hfLink(DEFAULT_RERANK_MODEL_URI)}`);
-    console.log(`  Generation:  ${hfLink(DEFAULT_GENERATE_MODEL_URI)}`);
+    const llm = getDefaultLlamaCpp();
+    console.log(`  Embedding:   ${hfLink(llm.embedModelName)}`);
+    console.log(`  Reranking:   ${hfLink(llm.rerankModelName)}`);
+    console.log(`  Generation:  ${hfLink(llm.generateModelName)}`);
   }
 
   // Device / GPU info
@@ -3107,7 +3108,7 @@ if (isMain) {
         const maxDocsPerBatch = parseEmbedBatchOption("maxDocsPerBatch", cli.values["max-docs-per-batch"]);
         const maxBatchMb = parseEmbedBatchOption("maxBatchBytes", cli.values["max-batch-mb"]);
         const embedChunkStrategy = parseChunkStrategy(cli.values["chunk-strategy"]);
-        await vectorIndex(DEFAULT_EMBED_MODEL_URI, !!cli.values.force, {
+        await vectorIndex(getDefaultLlamaCpp().embedModelName, !!cli.values.force, {
           maxDocsPerBatch,
           maxBatchBytes: maxBatchMb === undefined ? undefined : maxBatchMb * 1024 * 1024,
           chunkStrategy: embedChunkStrategy,
@@ -3120,10 +3121,11 @@ if (isMain) {
 
     case "pull": {
       const refresh = cli.values.refresh === undefined ? false : Boolean(cli.values.refresh);
+      const llm = getDefaultLlamaCpp();
       const models = [
-        DEFAULT_EMBED_MODEL_URI,
-        DEFAULT_GENERATE_MODEL_URI,
-        DEFAULT_RERANK_MODEL_URI,
+        llm.embedModelName,
+        llm.generateModelName,
+        llm.rerankModelName,
       ];
       console.log(`${c.bold}Pulling models${c.reset}`);
       const results = await pullModels(models, {

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -514,6 +514,14 @@ export class LlamaCpp implements LLM {
     return this.embedModelUri;
   }
 
+  get generateModelName(): string {
+    return this.generateModelUri;
+  }
+
+  get rerankModelName(): string {
+    return this.rerankModelUri;
+  }
+
   /**
    * Reset the inactivity timer. Called after each model operation.
    * When timer fires, models are unloaded to free memory (if no active sessions).


### PR DESCRIPTION
## Summary

`status`, `embed`, and `pull` commands ignore `models.embed` / `models.generate` / `models.rerank` from `index.yml` and the corresponding `QMD_*_MODEL` env vars. They always use the hardcoded defaults (e.g. embeddinggemma-300M).

**Root cause:** These commands reference the compile-time constants (`DEFAULT_EMBED_MODEL_URI` etc.) directly, bypassing the `LlamaCpp` instance that `getStore()` already configures via `setDefaultLlamaCpp()`.

**Fix:** Read model URIs from `getDefaultLlamaCpp().embedModelName` (and new `generateModelName` / `rerankModelName` getters) instead of the constants.

## Changes

- `src/cli/qmd.ts`: 3 call sites updated (status display, embed command, pull command)
- `src/llm.ts`: Added `generateModelName` and `rerankModelName` getters to `LlamaCpp` (mirrors existing `embedModelName`)

## Test plan

- [ ] `qmd status` shows configured model (not default) when `models.embed` is set in index.yml
- [ ] `qmd embed -f` uses configured model
- [ ] `qmd pull` downloads configured models
- [ ] Without config: falls back to defaults as before

Fixes #562