### PR TITLE
feat(update): add -c/--collection filter to qmd update

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -641,7 +641,8 @@ async function updateCollections(collectionFilter?: string[]): Promise<void> {
   const needsEmbedding = getHashesNeedingEmbedding(db);
   closeDb();
 
-  console.log(`${c.green}✓ All collections updated.${c.reset}`);
+  const updatedLabel = collections.length === 1 ? `'${collections[0]!.name}'` : `${collections.length} collections`;
+  console.log(`${c.green}✓ ${updatedLabel} updated.${c.reset}`);
   if (needsEmbedding > 0) {
     console.log(`\nRun 'qmd embed' to update embeddings (${needsEmbedding} unique hashes need vectors)`);
   }
@@ -3115,7 +3116,7 @@ if (isMain) {
       break;
 
     case "update":
-      await updateCollections(cli.opts.collection);
+      await updateCollections(cli.opts.collection ? (Array.isArray(cli.opts.collection) ? cli.opts.collection : [cli.opts.collection]) : undefined);
       break;
 
     case "embed":

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -538,7 +538,7 @@ async function showStatus(): Promise<void> {
   closeDb();
 }
 
-async function updateCollections(): Promise<void> {
+async function updateCollections(collectionFilter?: string[]): Promise<void> {
   const db = getDb();
   const storeInstance = getStore();
   // Collections are defined in YAML; no duplicate cleanup needed.
@@ -546,7 +546,23 @@ async function updateCollections(): Promise<void> {
   // Clear Ollama cache on update
   clearCache(db);
 
-  const collections = listCollections(db);
+  let collections = listCollections(db);
+
+  if (collectionFilter && collectionFilter.length > 0) {
+    for (const name of collectionFilter) {
+      const found = getCollectionFromYaml(name);
+      if (!found) {
+        console.error(`Collection '${name}' not found.`);
+        process.exit(1);
+      }
+    }
+    collections = collections.filter(col => collectionFilter.includes(col.name));
+    if (collections.length === 0) {
+      console.log(`No matching collections found for filter: ${collectionFilter.join(", ")}`);
+      closeDb();
+      return;
+    }
+  }
 
   if (collections.length === 0) {
     console.log(`${c.dim}No collections found. Run 'qmd collection add .' to index markdown files.${c.reset}`);
@@ -3099,7 +3115,7 @@ if (isMain) {
       break;
 
     case "update":
-      await updateCollections();
+      await updateCollections(cli.opts.collection);
       break;
 
     case "embed":

--- a/src/db.ts
+++ b/src/db.ts
@@ -68,6 +68,7 @@ export function openDatabase(path: string): Database {
 export interface Database {
   exec(sql: string): void;
   prepare(sql: string): Statement;
+  transaction<T>(fn: () => T): () => T;
   loadExtension(path: string): void;
   close(): void;
 }


### PR DESCRIPTION
# fix(update): add -c/--collection filter to `qmd update`

## Summary

- `qmd update` now accepts `-c <name>` (or `--collection <name>`) to re-index a single collection instead of all collections
- Multiple `-c` flags are supported (e.g. `qmd update -c notes -c work`)
- The completion message now names the collection when only one was updated (e.g. `✓ 'notes' updated.` vs `✓ 3 collections updated.`)
- Fix: added `transaction` to the `Database` interface in `src/db.ts`, which was used in `store.ts` but missing from the type definition (caused a build failure under updated `better-sqlite3` type declarations)

## Behaviour

```sh
qmd update                    # unchanged — updates all collections
qmd update -c mynotes         # updates only the 'mynotes' collection
qmd update -c notes -c work   # updates two specific collections
qmd update -c nonexistent     # exits with error: "Collection 'nonexistent' not found."
```

## Files changed

- `src/cli/qmd.ts` — `updateCollections()` accepts optional `collectionFilter?: string[]`; filters and validates before iterating; updated completion message
- `src/db.ts` — added `transaction<T>` to the `Database` interface