### PR TITLE
fix: remove grammar constraint to fix node-llama-cpp 3.18.1 crash

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -70,6 +70,8 @@ export interface Database {
   prepare(sql: string): Statement;
   loadExtension(path: string): void;
   close(): void;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  transaction<T extends Function>(fn: T): T;
 }
 
 export interface Statement {

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -1139,15 +1139,8 @@ export class LlamaCpp implements LLM {
     const includeLexical = options.includeLexical ?? true;
     const context = options.context;
 
-    const grammar = await llama.createGrammar({
-      grammar: `
-        root ::= line+
-        line ::= type ": " content "\\n"
-        type ::= "lex" | "vec" | "hyde"
-        content ::= [^\\n]+
-      `
-    });
-
+    // Grammar-constrained generation disabled - crashes with node-llama-cpp 3.18.1
+    // Manual parsing (below) handles the output format reliably without grammar constraints
     const intent = options.intent;
     const prompt = intent
       ? `/no_think Expand this search query: ${query}\nQuery intent: ${intent}`
@@ -1165,7 +1158,6 @@ export class LlamaCpp implements LLM {
       // temp=0.7, topP=0.8, topK=20, presence_penalty for repetition
       // DO NOT use greedy decoding (temp=0) - causes infinite loops
       const result = await session.prompt(prompt, {
-        grammar,
         maxTokens: 600,
         temperature: 0.7,
         topK: 20,


### PR DESCRIPTION
## Summary
Fixes crash during `qmd query` expansion phase caused by node-llama-cpp 3.18.1 regression in grammar-constrained generation.

**Error:** `Failed to accept token in sampler: Unexpected empty grammar stack after accepting piece: 0 (15)`

## Root Cause
node-llama-cpp 3.18.1 (bundles llama.cpp b8390) introduced a regression where grammar-constrained generation crashes deterministically with the GBNF grammar used for query expansion. This affects **both Bun and Node.js** — not Bun-specific as initially assumed.

## Changes
- **src/llm.ts**: Remove `grammar` parameter from `expandQuery()` generation call
- **src/db.ts**: Add missing `transaction()` method to Database interface (build fix)

## Why Remove Grammar Instead of Downgrade?

| Approach | Pros | Cons |
|----------|------|------|
| **Remove grammar (chosen)** | • Stays on latest node-llama-cpp (3.18.1)<br>• Includes CVE-2025-52566 & CVE-2026-2069 fixes<br>• No version pinning technical debt | • Slightly less strict output format enforcement |
| **Downgrade to 3.17.1** | • Grammar constraints work | • Misses security fixes<br>• Pins to old version indefinitely<br>• llama.cpp b8390 had no grammar fixes planned |

The grammar was **redundant** — manual parsing already correctly extracts `lex:`, `vec:`, `hyde:` lines from model output and validates types. The GBNF grammar provided no additional safety that wasn't already handled by the parser.

## Test Results
| Runtime | node-llama-cpp | Grammar | Result |
|---------|----------------|---------|--------|
| Bun v1.3.10 | 3.18.1 | Removed | ✓ Works (18.4s) |
| Node.js v24.13.1 | 3.18.1 | Removed | ✓ Works |
| Bun v1.3.10 | 3.17.1 | Enabled | ✓ Works (verified) |
| Node.js v24.13.1 | 3.18.1 | Enabled | ✗ Crash confirmed |

## Verification
- [x] Builds successfully (`npm run build`)
- [x] Tested with Bun — query expansion works
- [x] Tested with Node.js — query expansion works

## Related
- CVE-2025-52566: Fixed in 3.18.1 (tokenizer)
- CVE-2026-2069: Fixed in 3.18.1 (grammar buffer overflow)
