### PR TITLE
fix: add QMD_MAX_PARALLEL_CONTEXTS env var to prevent Metal deadlocks

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -704,6 +704,14 @@ export class LlamaCpp implements LLM {
    *      half the math cores, with at least 4 threads per context.
    */
   private async computeParallelism(perContextMB: number): Promise<number> {
+    // QMD_MAX_PARALLEL_CONTEXTS: hard cap on context count.
+    // Set to 1 in MCP mode to prevent node-llama-cpp Metal deadlocks
+    // when multiple contexts call getEmbeddingFor/rankAll via Promise.all.
+    const maxOverride = parseInt(process.env.QMD_MAX_PARALLEL_CONTEXTS ?? "", 10);
+    if (Number.isFinite(maxOverride) && maxOverride > 0) {
+      return maxOverride;
+    }
+
     const llama = await this.ensureLlama();
 
     if (llama.gpu) {


### PR DESCRIPTION
## Summary
- Adds `QMD_MAX_PARALLEL_CONTEXTS` env var check at the top of `computeParallelism()` in `src/llm.ts`
- When set (e.g., `QMD_MAX_PARALLEL_CONTEXTS=1`), caps context count before any GPU/CPU heuristic runs
- Prevents node-llama-cpp Metal deadlocks when running as MCP server with multiple concurrent `getEmbeddingFor`/`rankAll` calls via `Promise.all`

## Context
This was already patched in `dist/llm.js` as a production hotfix (2026-04-11). This PR ports the identical fix to the TypeScript source so it survives `bun install -g @tobilu/qmd`.

The deadlock manifests on macOS with Metal GPU acceleration when multiple MCP tool calls trigger parallel embedding/reranking contexts. Setting the env var to 1 in `.mcp.json` serializes context creation and eliminates the deadlock.

## Test plan
- [x] Verified fix matches the working `dist/llm.js` patch (identical logic)
- [ ] Build from source and confirm `QMD_MAX_PARALLEL_CONTEXTS=1` limits to 1 context
- [ ] Run MCP server with concurrent queries to confirm no deadlock

🤖 Generated with [Claude Code](https://claude.com/claude-code)