### PR TITLE
fix: embed and pull commands now respect models config and env vars

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -112,23 +112,36 @@ enableProductionMode();
 let store: ReturnType<typeof createStore> | null = null;
 let storeDbPathOverride: string | undefined;
 let currentIndexName = "index";
+/** Resolved model URIs: YAML config > env var > built-in default */
+const models = {
+  embed: DEFAULT_EMBED_MODEL_URI,
+  generate: DEFAULT_GENERATE_MODEL_URI,
+  rerank: DEFAULT_RERANK_MODEL_URI,
+};
 
 function getStore(): ReturnType<typeof createStore> {
   if (!store) {
     store = createStore(storeDbPathOverride);
-    // Sync YAML config into SQLite store_collections so store.ts reads from DB
+    // Resolve model URIs from config/env before anything else
     try {
       const config = loadConfig();
+      models.embed = config.models?.embed || process.env.QMD_EMBED_MODEL || DEFAULT_EMBED_MODEL_URI;
+      models.generate = config.models?.generate || process.env.QMD_GENERATE_MODEL || DEFAULT_GENERATE_MODEL_URI;
+      models.rerank = config.models?.rerank || process.env.QMD_RERANK_MODEL || DEFAULT_RERANK_MODEL_URI;
+      // Sync YAML config into SQLite store_collections
       syncConfigToDb(store.db, config);
       if (config.models) {
         setDefaultLlamaCpp(new LlamaCpp({
-          embedModel: config.models.embed,
-          generateModel: config.models.generate,
-          rerankModel: config.models.rerank,
+          embedModel: models.embed,
+          generateModel: models.generate,
+          rerankModel: models.rerank,
         }));
       }
     } catch {
-      // Config may not exist yet — that's fine, DB works without it
+      // Config may not exist yet — resolve from env/defaults
+      models.embed = process.env.QMD_EMBED_MODEL || DEFAULT_EMBED_MODEL_URI;
+      models.generate = process.env.QMD_GENERATE_MODEL || DEFAULT_GENERATE_MODEL_URI;
+      models.rerank = process.env.QMD_RERANK_MODEL || DEFAULT_RERANK_MODEL_URI;
     }
   }
   return store;
@@ -462,9 +475,9 @@ async function showStatus(): Promise<void> {
       return match ? `https://huggingface.co/${match[1]}` : uri;
     };
     console.log(`\n${c.bold}Models${c.reset}`);
-    console.log(`  Embedding:   ${hfLink(DEFAULT_EMBED_MODEL_URI)}`);
-    console.log(`  Reranking:   ${hfLink(DEFAULT_RERANK_MODEL_URI)}`);
-    console.log(`  Generation:  ${hfLink(DEFAULT_GENERATE_MODEL_URI)}`);
+    console.log(`  Embedding:   ${hfLink(models.embed)}`);
+    console.log(`  Reranking:   ${hfLink(models.rerank)}`);
+    console.log(`  Generation:  ${hfLink(models.generate)}`);
   }
 
   // Device / GPU info
@@ -3104,10 +3117,11 @@ if (isMain) {
 
     case "embed":
       try {
+        getStore(); // ensure models are resolved from config before reading
         const maxDocsPerBatch = parseEmbedBatchOption("maxDocsPerBatch", cli.values["max-docs-per-batch"]);
         const maxBatchMb = parseEmbedBatchOption("maxBatchBytes", cli.values["max-batch-mb"]);
         const embedChunkStrategy = parseChunkStrategy(cli.values["chunk-strategy"]);
-        await vectorIndex(DEFAULT_EMBED_MODEL_URI, !!cli.values.force, {
+        await vectorIndex(models.embed, !!cli.values.force, {
           maxDocsPerBatch,
           maxBatchBytes: maxBatchMb === undefined ? undefined : maxBatchMb * 1024 * 1024,
           chunkStrategy: embedChunkStrategy,
@@ -3119,14 +3133,10 @@ if (isMain) {
       break;
 
     case "pull": {
+      getStore(); // ensure models are resolved from config
       const refresh = cli.values.refresh === undefined ? false : Boolean(cli.values.refresh);
-      const models = [
-        DEFAULT_EMBED_MODEL_URI,
-        DEFAULT_GENERATE_MODEL_URI,
-        DEFAULT_RERANK_MODEL_URI,
-      ];
       console.log(`${c.bold}Pulling models${c.reset}`);
-      const results = await pullModels(models, {
+      const results = await pullModels(Object.values(models), {
         refresh,
         cacheDir: DEFAULT_MODEL_CACHE_DIR,
       });


### PR DESCRIPTION
## Summary

- `qmd embed` and `qmd pull` hardcoded `DEFAULT_*_MODEL_URI`, ignoring the `models:` section in `index.yml` and `QMD_EMBED_MODEL` / `QMD_RERANK_MODEL` / `QMD_GENERATE_MODEL` environment variables
- `qmd status` always displayed default model URIs even when custom models were configured
- Only `query` and `vsearch` honored custom models (via the `LlamaCpp` instance set up in `getStore()`)

## Fix

Adds a module-level `models` object initialized with defaults, resolved to configured values (config > env > default) during `getStore()` initialization. The `embed`, `pull`, and `status` commands read from this object instead of hardcoded defaults.

The catch path in `getStore()` also resolves models from env/defaults, so the POJO is never stale even if config loading fails.

## Motivation

Discovered while trying to use `Qwen3-Embedding-8B` via `models.embed` in `index.yml` — `qmd query` used the configured model correctly, but `qmd embed -f` always re-embedded with the default 300M model.

## Test plan

- [x] All 250 existing tests pass
- [x] Verified `qmd embed` prints configured model URI (was: always `embeddinggemma-300M`)
- [x] Verified `qmd status` shows configured model

Happy to add CLI-level tests for model config propagation if desired.

Relates to #494 (v2.1.0 fix only covered `LlamaCpp` init, not `embed`/`pull`/`status` code paths).