### PR TITLE
fix: set PRAGMA busy_timeout to prevent SQLITE_BUSY_RECOVERY errors

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -59,7 +59,11 @@ if (isBun) {
  * Open a SQLite database. Works with both bun:sqlite and better-sqlite3.
  */
 export function openDatabase(path: string): Database {
-  return new _Database(path) as Database;
+  const db = new _Database(path) as Database;
+  // Allow up to 5 s for concurrent writers to release the lock instead of
+  // failing immediately with SQLITE_BUSY / SQLITE_BUSY_RECOVERY.
+  db.exec("PRAGMA busy_timeout = 5000");
+  return db;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Set `PRAGMA busy_timeout = 5000` in `openDatabase()` so SQLite retries for up to 5 seconds when another process holds the lock, instead of immediately failing with `SQLITE_BUSY` / `SQLITE_BUSY_RECOVERY`.

## Context

When openclaw gateway manages multiple agents (e.g. main, coding, content), each agent spawns `qmd update` and `qmd search` on overlapping 5-minute timers. Without a busy timeout, concurrent access to the same SQLite index causes `SQLITE_BUSY_RECOVERY` errors at `initializeDatabase` → `PRAGMA journal_mode = WAL`, which cascades as a misleading "does not support dynamic extension loading / set BREW_PREFIX" message (because the real error is re-thrown from the same try-catch block).

This has been silently breaking qmd memory search since early April on affected setups — the gateway falls back to its builtin index and the qmd index goes stale.

## Change

One-line PRAGMA in `src/db.ts:openDatabase()` — applied before any other initialization so all database opens benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)