### PR TITLE
Fix Nix wrapper so `qmd` works on NixOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,9 @@
           outputHashMode = "recursive";
         };
 
+        runtimeLibraryPath = pkgs.lib.makeLibraryPath ([ pkgs.sqlite ]
+          ++ pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.stdenv.cc.cc.lib ]);
+
         qmd = pkgs.stdenv.mkDerivation {
           pname = "qmd";
           inherit version;
@@ -129,8 +132,8 @@
 
             makeWrapper ${pkgs.bun}/bin/bun $out/bin/qmd \
               --add-flags "$out/lib/qmd/src/cli/qmd.ts" \
-              --set DYLD_LIBRARY_PATH "${pkgs.sqlite.out}/lib" \
-              --set LD_LIBRARY_PATH "${pkgs.sqlite.out}/lib"
+              --prefix DYLD_LIBRARY_PATH : "${runtimeLibraryPath}" \
+              --prefix LD_LIBRARY_PATH : "${runtimeLibraryPath}"
           '';
 
           meta = with pkgs.lib; {


### PR DESCRIPTION
`qmd` was failing on NixOS when loading `node-llama-cpp` under Bun.

### Problem

The flake package wrapper set:

```sh
LD_LIBRARY_PATH=${sqlite}/lib
```

which overwrote the runtime library path entirely. On NixOS, the `node-llama-cpp` native addon also needs the C++ runtime (`libstdc++.so.6`). Because that library was no longer visible, the prebuilt addon failed to load.

Once that happened, `node-llama-cpp` tried to fall back to building from source in its install location under `/nix/store`, which is read-only, so `qmd embed` failed with `NoBinaryFoundError`.

### Fix

- add a shared `runtimeLibraryPath`
- include:
  - `sqlite`
  - `stdenv.cc.cc.lib` on Linux
- use `makeWrapper --prefix` instead of `--set` for `LD_LIBRARY_PATH` / `DYLD_LIBRARY_PATH`

This preserves any existing runtime search path while ensuring the packaged binary can find both SQLite and the C++ runtime.

### Why this is needed

`qmd` is wrapped around Bun in the Nix package, and Bun loads the `node-llama-cpp` native module at runtime. On NixOS, that module does not work unless `libstdc++.so.6` is available in the wrapped environment.

### Verification

Built locally with:

```sh
nix build .#qmd
```

Verified that the rebuilt binary can run successfully on NixOS:

```sh
result/bin/qmd status
result/bin/qmd embed
```

`embed` now completes successfully instead of failing during llama initialization.
