### PR TITLE
fix(nixos): fix prebuilt binaries via LD_LIBRARY_PATH + skip source build on read-only install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Fixes
 
+- NixOS: fix `qmd embed` crash on immutable-root systems. Prebuilt
+  node-llama-cpp binaries expect FHS paths like `/lib64/libc.so.6`
+  which don't exist on NixOS. The flake wrapper sets `LD_LIBRARY_PATH`
+  to include Nix's glibc and libstdc++. When the install directory
+  is read-only, `getLlama()` uses `build: "never"` to skip source
+  builds that would fail with EACCES.
 - GPU: respect explicit `QMD_LLAMA_GPU=metal|vulkan|cuda` backend overrides instead of always using auto GPU selection. #529
 - Fix: preserve original filename case in `handelize()`. The previous
   `.toLowerCase()` call made indexed paths unreachable on case-sensitive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,12 @@
 - MCP: make `qmd mcp --index <name>` use the selected index for both foreground and daemon HTTP servers instead of falling back to the default store. #343
 - Embedding: respect `QMD_EMBED_MODEL` consistently for vector indexing and vector-backed search, with default-model fallback when unset.
 - Config: use one home-directory resolver for YAML config and the default SQLite cache path, avoiding Windows CLI/MCP split-brain when `HOME` is unset.
+- NixOS: fix `qmd embed` crash on immutable-root systems. Prebuilt
+  node-llama-cpp binaries expect FHS paths like `/lib64/libc.so.6`
+  which don't exist on NixOS. The flake wrapper sets `LD_LIBRARY_PATH`
+  to include Nix's glibc and libstdc++. When the install directory
+  is read-only, `getLlama()` uses `build: "never"` to skip source
+  builds that would fail with EACCES.
 - GPU: respect explicit `QMD_LLAMA_GPU=metal|vulkan|cuda` backend overrides instead of always using auto GPU selection. #529
 - Fix: preserve original filename case in `handelize()`. The previous
   `.toLowerCase()` call made indexed paths unreachable on case-sensitive

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769188852,
-        "narHash": "sha256-aBAGyMum27K7cP5OR7BMioJOF3icquJMZDDgk6ZEg1A=",
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a1bab9e494f5f4939442a57a58d0449a109593fe",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,9 +6,20 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs =
     {
-      homeModules.default = { config, lib, pkgs, ... }:
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    {
+      homeModules.default =
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
         with lib;
         let
           cfg = config.programs.qmd;
@@ -29,8 +40,9 @@
             home.packages = [ cfg.package ];
           };
         };
-    } //
-    flake-utils.lib.eachDefaultSystem (system:
+    }
+    // flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
         packageJson = builtins.fromJSON (builtins.readFile ./package.json);
@@ -38,7 +50,7 @@
 
         # SQLite with loadable extension support for sqlite-vec
         sqliteWithExtensions = pkgs.sqlite.overrideAttrs (old: {
-          configureFlags = (old.configureFlags or []) ++ [
+          configureFlags = (old.configureFlags or [ ]) ++ [
             "--enable-load-extension"
           ];
         });
@@ -103,9 +115,10 @@
             pkgs.makeWrapper
             pkgs.nodejs
             pkgs.node-gyp
-            pkgs.python3  # needed by node-gyp to compile better-sqlite3
-          ] ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
-            pkgs.darwin.cctools  # provides libtool needed by node-gyp on macOS
+            pkgs.python3
+          ]
+          ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+            pkgs.darwin.cctools
           ];
 
           buildInputs = [ pkgs.sqlite ];
@@ -130,7 +143,7 @@
             makeWrapper ${pkgs.bun}/bin/bun $out/bin/qmd \
               --add-flags "$out/lib/qmd/src/cli/qmd.ts" \
               --set DYLD_LIBRARY_PATH "${pkgs.sqlite.out}/lib" \
-              --set LD_LIBRARY_PATH "${pkgs.sqlite.out}/lib"
+              --set LD_LIBRARY_PATH "${pkgs.sqlite.out}/lib:${pkgs.stdenv.cc.libc.out}/lib:${pkgs.stdenv.cc.cc.lib}/lib"
           '';
 
           meta = with pkgs.lib; {

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -15,8 +15,9 @@ import {
   type Token as LlamaToken,
 } from "node-llama-cpp";
 import { homedir } from "os";
-import { join } from "path";
-import { existsSync, mkdirSync, statSync, unlinkSync, readdirSync, readFileSync, writeFileSync, openSync, readSync, closeSync } from "fs";
+import { dirname, join } from "path";
+import { accessSync, constants, existsSync, mkdirSync, statSync, unlinkSync, readdirSync, readFileSync, writeFileSync, openSync, readSync, closeSync } from "fs";
+import { createRequire } from "module";
 
 // =============================================================================
 // Embedding Formatting Functions
@@ -55,6 +56,23 @@ export function formatDocForEmbedding(text: string, title?: string, modelUri?: s
     return title ? `${title}\n${text}` : text;
   }
   return `title: ${title || "none"} | text: ${text}`;
+}
+
+// =============================================================================
+// Build Writability Check
+// =============================================================================
+
+const require = createRequire(import.meta.url);
+
+/** Whether node-llama-cpp can write to its llama/ directory (false on NixOS). */
+function canWriteLlamaDir(): boolean {
+  try {
+    const pkgDir = dirname(require.resolve("node-llama-cpp/package.json"));
+    accessSync(join(pkgDir, "llama"), constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 // =============================================================================
@@ -618,13 +636,14 @@ export class LlamaCpp implements LLM {
   private async ensureLlama(allowBuild = true): Promise<Llama> {
     if (!this.llama) {
       const gpuMode = resolveLlamaGpuMode();
+      const buildMode = allowBuild && canWriteLlamaDir() ? "autoAttempt" : "never";
 
       const loadLlama = async (gpu: LlamaGpuMode) =>
         await getLlama({
-          build: allowBuild ? "autoAttempt" : "never",
+          build: buildMode,
           logLevel: LlamaLogLevel.error,
           gpu,
-          skipDownload: !allowBuild,
+          skipDownload: buildMode === "never",
         });
 
       let llama: Llama;

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -71,8 +71,9 @@ export async function withNativeStdoutRedirectedToStderr<T>(fn: () => Promise<T>
 }
 
 import { homedir } from "os";
-import { join } from "path";
-import { existsSync, mkdirSync, statSync, unlinkSync, readdirSync, readFileSync, writeFileSync, openSync, readSync, closeSync } from "fs";
+import { dirname, join } from "path";
+import { accessSync, constants, existsSync, mkdirSync, statSync, unlinkSync, readdirSync, readFileSync, writeFileSync, openSync, readSync, closeSync } from "fs";
+import { createRequire } from "module";
 
 // =============================================================================
 // Embedding Formatting Functions
@@ -111,6 +112,23 @@ export function formatDocForEmbedding(text: string, title?: string, modelUri?: s
     return title ? `${title}\n${text}` : text;
   }
   return `title: ${title || "none"} | text: ${text}`;
+}
+
+// =============================================================================
+// Build Writability Check
+// =============================================================================
+
+const require = createRequire(import.meta.url);
+
+/** Whether node-llama-cpp can write to its llama/ directory (false on NixOS). */
+function canWriteLlamaDir(): boolean {
+  try {
+    const pkgDir = dirname(require.resolve("node-llama-cpp/package.json"));
+    accessSync(join(pkgDir, "llama"), constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 // =============================================================================
@@ -871,9 +889,11 @@ export class LlamaCpp implements LLM {
   private async loadLlamaRuntime(allowBuild = true): Promise<Llama> {
     if (!this.llama) {
       const gpuMode = resolveLlamaGpuMode();
+      // Skip source build when install dir is read-only (e.g. NixOS store).
+      const canBuild = allowBuild && canWriteLlamaDir();
 
       const { getLlama, getLlamaGpuTypes, LlamaLogLevel } = await loadNodeLlamaCpp();
-      const loadLlama = async (gpu: LlamaGpuMode, sourceBuildAllowed = allowBuild, buildOverride?: "auto" | "never") =>
+      const loadLlama = async (gpu: LlamaGpuMode, sourceBuildAllowed = canBuild, buildOverride?: "auto" | "never") =>
         await withNativeStdoutRedirectedToStderr(() => getLlama({
           // Prefer packaged prebuilt bindings before compiling llama.cpp locally.
           // node-llama-cpp documents gpu:"auto" as the best default: Metal on


### PR DESCRIPTION
## Summary

On NixOS (and other immutable-root systems), `qmd embed` crashes with `EACCES` because node-llama-cpp tries to compile llama.cpp into its read-only `node_modules/` directory inside `/nix/store`. Even when source builds are skipped, the prebuilt binaries fail because they expect FHS paths like `/lib64/libc.so.6` which don't exist on NixOS.

Two fixes:
1. **`LD_LIBRARY_PATH` in wrapper** — the flake wrapper sets `LD_LIBRARY_PATH` to include Nix's glibc and libstdc++, covering what the prebuilt binaries need without modifying them
2. **skip source builds** when the install directory is read-only (`canWriteLlamaDir()`)

## Changes

- **flake.nix**: Add glibc and libstdc++ to `LD_LIBRARY_PATH` in the wrapper. No binary modification needed — `LD_LIBRARY_PATH` takes precedence over RUNPATH for `dlopen`.
- **src/llm.ts**: Add `canWriteLlamaDir()` that probes write access on node-llama-cpp's `llama/` directory. When unwritable, `ensureLlama()` passes `build: "never"` to `getLlama()`.
- **CHANGELOG.md**: Unreleased entry under Fixes.

Closes #87

## Testing

- [x] `nix build` succeeds
- [x] `./result/bin/qmd status` shows CPU backend loaded, no EACCES, no NoBinaryFoundError
- [x] `./result/bin/qmd embed` completes successfully