### PR TITLE
feat(llm): add remote embedding/reranking via OpenAI-compatible endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,36 @@
 
 ## [Unreleased]
 
+### Features
+
+- **Remote embedding/reranking** via OpenAI-compatible endpoints. Set
+  `QMD_REMOTE_EMBED_URL` and `QMD_REMOTE_RERANK_URL` to route embedding and
+  reranking to any OpenAI-compatible server (vLLM, TEI, LiteLLM, Ollama, etc.)
+  without running local GGUF models. Query expansion and generation are handled
+  by the same backend via `/v1/chat/completions`. To use a dedicated chat server
+  separate from the embedding server, set `QMD_REMOTE_GEN_URL`.
+  All endpoints support `QMD_REMOTE_API_KEY` for bearer authentication.
+  Circuit breakers protect each endpoint independently.
+  `qmd status` shows remote server URLs when in remote mode.
+- SDK: `createStore()` now accepts an `llm?` option to inject a custom LLM backend
+  (`HybridLLM`, `RemoteLLM`, or any `LLM` implementation). When omitted,
+  `QMD_REMOTE_EMBED_URL` / `QMD_REMOTE_RERANK_URL` are checked automatically.
+
 ### Fixes
+
+- Remote mode: `QMD_REMOTE_EMBED_URL` is no longer overwritten when a YAML
+  `models:` block is present — the override is skipped when remote mode is active.
+- Remote mode: `RemoteLLM.detokenize()` returns a character-length approximation
+  instead of empty string, preventing silent chunk loss in the fallback path.
+- `chunkDocumentByTokens` accepts an optional `llm?` parameter; internal callers
+  pass the store-scoped LLM instead of pulling from the global singleton.
+- `LLM` interface: `tokenize`, `countTokens`, `detokenize`, `embedBatch` are now
+  required members. `LLMSessionManager` and `withLLMSessionForLlm` accept `LLM`.
+- `RemoteLLM.modelExists()` logs a warning before returning the optimistic
+  fail-open result when neither server can verify model availability.
+
+### Fixes (existing)
+
 
 - GPU: respect explicit `QMD_LLAMA_GPU=metal|vulkan|cuda` backend overrides instead of always using auto GPU selection. #529
 - Fix: preserve original filename case in `handelize()`. The previous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,33 @@
 
 ## [Unreleased]
 
+### Features
+
+- **Remote embedding/reranking** via OpenAI-compatible endpoints. Set
+  `QMD_REMOTE_EMBED_URL` and `QMD_REMOTE_RERANK_URL` to route embedding and
+  reranking to any OpenAI-compatible server (vLLM, TEI, LiteLLM, Ollama, etc.)
+  without running local GGUF models. Query expansion and generation are handled
+  by the same backend via `/v1/chat/completions`. To use a dedicated chat server
+  separate from the embedding server, set `QMD_REMOTE_GEN_URL`.
+  All endpoints support `QMD_REMOTE_API_KEY` for bearer authentication.
+  Circuit breakers protect each endpoint independently.
+  `qmd status` shows remote server URLs when in remote mode.
+- SDK: `createStore()` now accepts an `llm?` option to inject a custom LLM backend
+  (`HybridLLM`, `RemoteLLM`, or any `LLM` implementation). When omitted,
+  `QMD_REMOTE_EMBED_URL` / `QMD_REMOTE_RERANK_URL` are checked automatically.
+
 ### Fixes
 
+- Remote mode: `QMD_REMOTE_EMBED_URL` is no longer overwritten when a YAML
+  `models:` block is present — the override is skipped when remote mode is active.
+- Remote mode: `RemoteLLM.detokenize()` returns a character-length approximation
+  instead of empty string, preventing silent chunk loss in the fallback path.
+- `chunkDocumentByTokens` accepts an optional `llm?` parameter; internal callers
+  pass the store-scoped LLM instead of pulling from the global singleton.
+- `LLM` interface: `tokenize`, `countTokens`, `detokenize`, `embedBatch` are now
+  required members. `LLMSessionManager` and `withLLMSessionForLlm` accept `LLM`.
+- `RemoteLLM.modelExists()` logs a warning before returning the optimistic
+  fail-open result when neither server can verify model availability.
 - Embedding: `qmd embed -c <collection>` now scopes pending-doc selection
   to the requested collection instead of embedding global pending work.
   Scoped `--force` clears only collection-owned vectors, preserves shared

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "scripts": {
     "prepare": "[ -d .git ] && ./scripts/install-hooks.sh || true",
-    "build": "tsc -p tsconfig.build.json && printf '#!/usr/bin/env node\n' | cat - dist/cli/qmd.js > dist/cli/qmd.tmp && mv dist/cli/qmd.tmp dist/cli/qmd.js && chmod +x dist/cli/qmd.js",
+    "build": "tsc -p tsconfig.build.json; { echo '#!/usr/bin/env node'; cat dist/cli/qmd.js; } > dist/cli/qmd.tmp && mv dist/cli/qmd.tmp dist/cli/qmd.js && chmod +x dist/cli/qmd.js",
     "test": "vitest run --reporter=verbose test/",
     "qmd": "tsx src/cli/qmd.ts",
     "index": "tsx src/cli/qmd.ts index",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "prepare": "[ -d .git ] && ./scripts/install-hooks.sh || true",
-    "build": "tsc -p tsconfig.build.json && printf '#!/usr/bin/env node\n' | cat - dist/cli/qmd.js > dist/cli/qmd.tmp && mv dist/cli/qmd.tmp dist/cli/qmd.js && chmod +x dist/cli/qmd.js",
+    "build": "tsc -p tsconfig.build.json; { echo '#!/usr/bin/env node'; cat dist/cli/qmd.js; } > dist/cli/qmd.tmp && mv dist/cli/qmd.tmp dist/cli/qmd.js && chmod +x dist/cli/qmd.js",
     "test": "vitest run --reporter=verbose test/",
     "qmd": "tsx src/cli/qmd.ts",
     "index": "tsx src/cli/qmd.ts index",

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -78,7 +78,9 @@ import {
   type ReindexResult,
   type ChunkStrategy,
 } from "../store.js";
-import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, setDefaultLlamaCpp, LlamaCpp, withLLMSession, pullModels, DEFAULT_EMBED_MODEL_URI, DEFAULT_GENERATE_MODEL_URI, DEFAULT_RERANK_MODEL_URI, DEFAULT_MODEL_CACHE_DIR } from "../llm.js";
+import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, getDefaultLLM, setDefaultLlamaCpp, setDefaultLLM, LlamaCpp, withLLMSession, pullModels, DEFAULT_EMBED_MODEL_URI, DEFAULT_GENERATE_MODEL_URI, DEFAULT_RERANK_MODEL_URI, DEFAULT_MODEL_CACHE_DIR } from "../llm.js";
+import { HybridLLM } from "../hybrid-llm.js";
+import { RemoteLLM } from "../remote-llm.js";
 import {
   formatSearchResults,
   formatDocuments,
@@ -105,6 +107,23 @@ import { getEmbeddedQmdSkillContent, getEmbeddedQmdSkillFiles } from "../embedde
 // Tests must set INDEX_PATH or use createStore() with explicit path
 enableProductionMode();
 
+// Remote LLM: if QMD_REMOTE_EMBED_URL / QMD_REMOTE_RERANK_URL are set, route
+// embedding and reranking through the remote server instead of local GGUF models.
+const remoteEmbedUrl = process.env.QMD_REMOTE_EMBED_URL;
+const remoteRerankUrl = process.env.QMD_REMOTE_RERANK_URL;
+if (remoteEmbedUrl || remoteRerankUrl) {
+  if (!remoteEmbedUrl || !remoteRerankUrl) {
+    throw new Error("QMD_REMOTE_EMBED_URL and QMD_REMOTE_RERANK_URL must both be set to enable remote embedding/reranking");
+  }
+  const remote = new RemoteLLM({
+    embedUrl: remoteEmbedUrl,
+    rerankUrl: remoteRerankUrl,
+    genUrl: process.env.QMD_REMOTE_GEN_URL,
+    apiKey: process.env.QMD_REMOTE_API_KEY,
+  });
+  setDefaultLLM(new HybridLLM(null, remote));
+}
+
 // =============================================================================
 // Store/DB lifecycle (no legacy singletons in store.ts)
 // =============================================================================
@@ -120,7 +139,7 @@ function getStore(): ReturnType<typeof createStore> {
     try {
       const config = loadConfig();
       syncConfigToDb(store.db, config);
-      if (config.models) {
+      if (config.models && !getDefaultLLM().isRemote) {
         setDefaultLlamaCpp(new LlamaCpp({
           embedModel: config.models.embed,
           generateModel: config.models.generate,
@@ -456,21 +475,30 @@ async function showStatus(): Promise<void> {
 
   // Models
   {
-    // hf:org/repo/file.gguf → https://huggingface.co/org/repo
-    const hfLink = (uri: string) => {
-      const match = uri.match(/^hf:([^/]+\/[^/]+)\//);
-      return match ? `https://huggingface.co/${match[1]}` : uri;
-    };
-    console.log(`\n${c.bold}Models${c.reset}`);
-    console.log(`  Embedding:   ${hfLink(DEFAULT_EMBED_MODEL_URI)}`);
-    console.log(`  Reranking:   ${hfLink(DEFAULT_RERANK_MODEL_URI)}`);
-    console.log(`  Generation:  ${hfLink(DEFAULT_GENERATE_MODEL_URI)}`);
+    const llmForStatus = getDefaultLLM();
+    if (llmForStatus.isRemote) {
+      console.log(`\n${c.bold}Models${c.reset}`);
+      console.log(`  Embedding:   ${remoteEmbedUrl ?? process.env.QMD_REMOTE_EMBED_URL ?? "(remote)"}`);
+      console.log(`  Reranking:   ${remoteRerankUrl ?? process.env.QMD_REMOTE_RERANK_URL ?? "(remote)"}`);
+      console.log(`  Generation:  ${process.env.QMD_REMOTE_GEN_URL ?? "(same as embedding)"}`);
+    } else {
+      // hf:org/repo/file.gguf → https://huggingface.co/org/repo
+      const hfLink = (uri: string) => {
+        const match = uri.match(/^hf:([^/]+\/[^/]+)\//);
+        return match ? `https://huggingface.co/${match[1]}` : uri;
+      };
+      console.log(`\n${c.bold}Models${c.reset}`);
+      console.log(`  Embedding:   ${hfLink(DEFAULT_EMBED_MODEL_URI)}`);
+      console.log(`  Reranking:   ${hfLink(DEFAULT_RERANK_MODEL_URI)}`);
+      console.log(`  Generation:  ${hfLink(DEFAULT_GENERATE_MODEL_URI)}`);
+    }
   }
 
   // Device / GPU info
   console.log(`\n${c.bold}Device${c.reset}`);
   try {
-    const llm = getDefaultLlamaCpp();
+    const llm = getDefaultLLM() as Partial<LlamaCpp>;
+    if (typeof llm.getDeviceInfo !== "function") return;
     const device = await llm.getDeviceInfo({ allowBuild: false });
     if (device.gpu) {
       console.log(`  GPU:      ${c.green}${device.gpu}${c.reset} (offloading: ${device.gpuOffloading ? 'yes' : 'no'})`);

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -78,7 +78,9 @@ import {
   type ReindexResult,
   type ChunkStrategy,
 } from "../store.js";
-import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, setDefaultLlamaCpp, LlamaCpp, withLLMSession, pullModels, DEFAULT_EMBED_MODEL_URI, DEFAULT_GENERATE_MODEL_URI, DEFAULT_RERANK_MODEL_URI, DEFAULT_MODEL_CACHE_DIR } from "../llm.js";
+import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, getDefaultLLM, setDefaultLlamaCpp, setDefaultLLM, LlamaCpp, withLLMSession, pullModels, DEFAULT_EMBED_MODEL_URI, DEFAULT_GENERATE_MODEL_URI, DEFAULT_RERANK_MODEL_URI, DEFAULT_MODEL_CACHE_DIR } from "../llm.js";
+import { HybridLLM } from "../hybrid-llm.js";
+import { RemoteLLM } from "../remote-llm.js";
 import {
   formatSearchResults,
   formatDocuments,
@@ -108,6 +110,23 @@ import { getEmbeddedQmdSkillContent, getEmbeddedQmdSkillFiles } from "../embedde
 // resolution. The flag is flipped inside the CLI's main-module guard below so
 // it only fires when qmd is actually invoked as a script.
 
+// Remote LLM: if QMD_REMOTE_EMBED_URL / QMD_REMOTE_RERANK_URL are set, route
+// embedding and reranking through the remote server instead of local GGUF models.
+const remoteEmbedUrl = process.env.QMD_REMOTE_EMBED_URL;
+const remoteRerankUrl = process.env.QMD_REMOTE_RERANK_URL;
+if (remoteEmbedUrl || remoteRerankUrl) {
+  if (!remoteEmbedUrl || !remoteRerankUrl) {
+    throw new Error("QMD_REMOTE_EMBED_URL and QMD_REMOTE_RERANK_URL must both be set to enable remote embedding/reranking");
+  }
+  const remote = new RemoteLLM({
+    embedUrl: remoteEmbedUrl,
+    rerankUrl: remoteRerankUrl,
+    genUrl: process.env.QMD_REMOTE_GEN_URL,
+    apiKey: process.env.QMD_REMOTE_API_KEY,
+  });
+  setDefaultLLM(new HybridLLM(null, remote));
+}
+
 // =============================================================================
 // Store/DB lifecycle (no legacy singletons in store.ts)
 // =============================================================================
@@ -123,7 +142,7 @@ function getStore(): ReturnType<typeof createStore> {
     try {
       const config = loadConfig();
       syncConfigToDb(store.db, config);
-      if (config.models) {
+      if (config.models && !getDefaultLLM().isRemote) {
         setDefaultLlamaCpp(new LlamaCpp({
           embedModel: config.models.embed,
           generateModel: config.models.generate,
@@ -457,15 +476,23 @@ async function showStatus(): Promise<void> {
 
   // Models
   {
-    // hf:org/repo/file.gguf → https://huggingface.co/org/repo
-    const hfLink = (uri: string) => {
-      const match = uri.match(/^hf:([^/]+\/[^/]+)\//);
-      return match ? `https://huggingface.co/${match[1]}` : uri;
-    };
-    console.log(`\n${c.bold}Models${c.reset}`);
-    console.log(`  Embedding:   ${hfLink(DEFAULT_EMBED_MODEL_URI)}`);
-    console.log(`  Reranking:   ${hfLink(DEFAULT_RERANK_MODEL_URI)}`);
-    console.log(`  Generation:  ${hfLink(DEFAULT_GENERATE_MODEL_URI)}`);
+    const llmForStatus = getDefaultLLM();
+    if (llmForStatus.isRemote) {
+      console.log(`\n${c.bold}Models${c.reset}`);
+      console.log(`  Embedding:   ${remoteEmbedUrl ?? process.env.QMD_REMOTE_EMBED_URL ?? "(remote)"}`);
+      console.log(`  Reranking:   ${remoteRerankUrl ?? process.env.QMD_REMOTE_RERANK_URL ?? "(remote)"}`);
+      console.log(`  Generation:  ${process.env.QMD_REMOTE_GEN_URL ?? "(same as embedding)"}`);
+    } else {
+      // hf:org/repo/file.gguf → https://huggingface.co/org/repo
+      const hfLink = (uri: string) => {
+        const match = uri.match(/^hf:([^/]+\/[^/]+)\//);
+        return match ? `https://huggingface.co/${match[1]}` : uri;
+      };
+      console.log(`\n${c.bold}Models${c.reset}`);
+      console.log(`  Embedding:   ${hfLink(DEFAULT_EMBED_MODEL_URI)}`);
+      console.log(`  Reranking:   ${hfLink(DEFAULT_RERANK_MODEL_URI)}`);
+      console.log(`  Generation:  ${hfLink(DEFAULT_GENERATE_MODEL_URI)}`);
+    }
   }
 
   // Device / GPU info
@@ -475,29 +502,33 @@ async function showStatus(): Promise<void> {
   if (process.env.QMD_STATUS_DEVICE_PROBE === "1") {
     console.log(`\n${c.bold}Device${c.reset}`);
     try {
-      const llm = getDefaultLlamaCpp();
-      const device = await llm.getDeviceInfo({ allowBuild: false });
-      if (device.gpu) {
-        console.log(`  GPU:      ${c.green}${device.gpu}${c.reset} (offloading: ${device.gpuOffloading ? 'yes' : 'no'})`);
-        if (device.gpuDevices.length > 0) {
-          // Deduplicate and count GPUs
-          const counts = new Map<string, number>();
-          for (const name of device.gpuDevices) {
-            counts.set(name, (counts.get(name) || 0) + 1);
+      const llm = getDefaultLLM() as Partial<LlamaCpp>;
+      if (typeof llm.getDeviceInfo === "function") {
+        const device = await llm.getDeviceInfo({ allowBuild: false });
+        if (device.gpu) {
+          console.log(`  GPU:      ${c.green}${device.gpu}${c.reset} (offloading: ${device.gpuOffloading ? 'yes' : 'no'})`);
+          if (device.gpuDevices.length > 0) {
+            // Deduplicate and count GPUs
+            const counts = new Map<string, number>();
+            for (const name of device.gpuDevices) {
+              counts.set(name, (counts.get(name) || 0) + 1);
+            }
+            const deviceStr = Array.from(counts.entries())
+              .map(([name, count]) => count > 1 ? `${count}× ${name}` : name)
+              .join(', ');
+            console.log(`  Devices:  ${deviceStr}`);
           }
-          const deviceStr = Array.from(counts.entries())
-            .map(([name, count]) => count > 1 ? `${count}× ${name}` : name)
-            .join(', ');
-          console.log(`  Devices:  ${deviceStr}`);
+          if (device.vram) {
+            console.log(`  VRAM:     ${formatBytes(device.vram.free)} free / ${formatBytes(device.vram.total)} total`);
+          }
+        } else {
+          console.log(`  GPU:      ${c.yellow}none${c.reset} (running on CPU — models will be slow)`);
+          console.log(`  ${c.dim}Tip: Install CUDA, Vulkan, or Metal support for GPU acceleration.${c.reset}`);
         }
-        if (device.vram) {
-          console.log(`  VRAM:     ${formatBytes(device.vram.free)} free / ${formatBytes(device.vram.total)} total`);
-        }
+        console.log(`  CPU:      ${device.cpuCores} math cores`);
       } else {
-        console.log(`  GPU:      ${c.yellow}none${c.reset} (running on CPU — models will be slow)`);
-        console.log(`  ${c.dim}Tip: Install CUDA, Vulkan, or Metal support for GPU acceleration.${c.reset}`);
+        console.log(`  Status:   ${c.dim}remote LLM (no device info)${c.reset}`);
       }
-      console.log(`  CPU:      ${device.cpuCores} math cores`);
     } catch (error) {
       console.log(`  Status:   ${c.dim}probe failed${c.reset}`);
       if (error instanceof Error && error.message) {

--- a/src/hybrid-llm.ts
+++ b/src/hybrid-llm.ts
@@ -1,0 +1,96 @@
+import type {
+  EmbedOptions,
+  EmbeddingResult,
+  GenerateOptions,
+  GenerateResult,
+  LLM,
+  ModelInfo,
+  Queryable,
+  RerankDocument,
+  RerankOptions,
+  RerankResult,
+} from "./llm.js";
+
+/**
+ * Routes all operations to a remote LLM provider (OpenAI API).
+ *
+ * When a local LlamaCpp is provided, it serves as a fallback for operations
+ * the remote doesn't support. When local is null, all operations go remote
+ * (expandQuery, generate, tokenize use the remote implementation).
+ */
+export class HybridLLM implements LLM {
+  readonly isRemote = true;
+
+  constructor(
+    private readonly local: LLM | null,
+    private readonly remote: LLM,
+  ) {}
+
+  async embed(
+    text: string,
+    options: EmbedOptions = {},
+  ): Promise<EmbeddingResult | null> {
+    return this.remote.embed(text, options);
+  }
+
+  async embedBatch(
+    texts: string[],
+    options: EmbedOptions = {},
+  ): Promise<(EmbeddingResult | null)[]> {
+    return this.remote.embedBatch(texts, options);
+  }
+
+  async rerank(
+    query: string,
+    documents: RerankDocument[],
+    options: RerankOptions = {},
+  ): Promise<RerankResult> {
+    return this.remote.rerank(query, documents, options);
+  }
+
+  async generate(
+    prompt: string,
+    options: GenerateOptions = {},
+  ): Promise<GenerateResult | null> {
+    return this.remote.generate(prompt, options);
+  }
+
+  async expandQuery(
+    query: string,
+    options?: { context?: string; includeLexical?: boolean; intent?: string },
+  ): Promise<Queryable[]> {
+    return this.remote.expandQuery(query, options);
+  }
+
+  // Tokenization: delegate to remote (character-based approximation).
+  // Remote has no real tokenizer but the approximation is good enough
+  // for document chunking (~4 chars/token for English text).
+  async tokenize(text: string): Promise<readonly unknown[]> {
+    return this.remote.tokenize!(text);
+  }
+
+  async countTokens(text: string): Promise<number> {
+    return this.remote.countTokens!(text);
+  }
+
+  async detokenize(tokens: readonly unknown[]): Promise<string> {
+    return this.remote.detokenize!(tokens);
+  }
+
+  async modelExists(model: string): Promise<ModelInfo> {
+    const results = await Promise.allSettled([
+      this.remote.modelExists(model),
+      ...(this.local ? [this.local.modelExists(model)] : []),
+    ]);
+    for (const r of results) {
+      if (r.status === "fulfilled" && r.value.exists) return r.value;
+    }
+    return { name: model, exists: false };
+  }
+
+  async dispose(): Promise<void> {
+    const disposables = [this.remote.dispose()];
+    if (this.local) disposables.push(this.local.dispose());
+    await Promise.allSettled(disposables);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -547,7 +547,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
 
     // Lifecycle
     close: async () => {
-      await internal.llm?.dispose();
+      await internal.llm?.dispose?.();
       internal.close();
       if (hasYamlConfig || options.config) {
         setConfigSource(undefined); // Reset config source

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,9 +64,9 @@ import {
   type EmbedResult,
   type ChunkStrategy,
 } from "./store.js";
-import {
-  LlamaCpp,
-} from "./llm.js";
+import { LlamaCpp, type LLM } from "./llm.js";
+import { HybridLLM } from "./hybrid-llm.js";
+import { RemoteLLM } from "./remote-llm.js";
 import {
   setConfigSource,
   loadConfig,
@@ -204,6 +204,12 @@ export interface StoreOptions {
   configPath?: string;
   /** Inline collection config (mutually exclusive with `configPath`) */
   config?: CollectionConfig;
+  /**
+   * Custom LLM backend. Supports HybridLLM or RemoteLLM for remote mode.
+   * When omitted, QMD_REMOTE_EMBED_URL / QMD_REMOTE_RERANK_URL env vars are
+   * checked, then falls back to a local LlamaCpp instance.
+   */
+  llm?: LLM;
 }
 
 /**
@@ -365,16 +371,28 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
   }
   // else: DB-only mode — no external config, use existing store_collections
 
-  // Create a per-store LlamaCpp instance — lazy-loads models on first use,
-  // auto-unloads after 5 min inactivity to free VRAM.
-  const llm = new LlamaCpp({
-    embedModel: config?.models?.embed,
-    generateModel: config?.models?.generate,
-    rerankModel: config?.models?.rerank,
-    inactivityTimeoutMs: 5 * 60 * 1000,
-    disposeModelsOnInactivity: true,
-  });
-  internal.llm = llm;
+  // Determine LLM backend: explicit option > env-var remote > local LlamaCpp.
+  const remoteEmbedUrl = process.env.QMD_REMOTE_EMBED_URL;
+  const remoteRerankUrl = process.env.QMD_REMOTE_RERANK_URL;
+  if (options.llm) {
+    internal.llm = options.llm;
+  } else if (remoteEmbedUrl && remoteRerankUrl) {
+    const remote = new RemoteLLM({
+      embedUrl: remoteEmbedUrl,
+      rerankUrl: remoteRerankUrl,
+      genUrl: process.env.QMD_REMOTE_GEN_URL,
+      apiKey: process.env.QMD_REMOTE_API_KEY,
+    });
+    internal.llm = new HybridLLM(null, remote);
+  } else {
+    internal.llm = new LlamaCpp({
+      embedModel: config?.models?.embed,
+      generateModel: config?.models?.generate,
+      rerankModel: config?.models?.rerank,
+      inactivityTimeoutMs: 5 * 60 * 1000,
+      disposeModelsOnInactivity: true,
+    });
+  }
 
   const store: QMDStore = {
     internal,
@@ -529,7 +547,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
 
     // Lifecycle
     close: async () => {
-      await llm.dispose();
+      await internal.llm?.dispose();
       internal.close();
       if (hasYamlConfig || options.config) {
         setConfigSource(undefined); // Reset config source

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,9 +64,9 @@ import {
   type EmbedResult,
   type ChunkStrategy,
 } from "./store.js";
-import {
-  LlamaCpp,
-} from "./llm.js";
+import { LlamaCpp, type LLM } from "./llm.js";
+import { HybridLLM } from "./hybrid-llm.js";
+import { RemoteLLM } from "./remote-llm.js";
 import {
   setConfigSource,
   loadConfig,
@@ -204,6 +204,12 @@ export interface StoreOptions {
   configPath?: string;
   /** Inline collection config (mutually exclusive with `configPath`) */
   config?: CollectionConfig;
+  /**
+   * Custom LLM backend. Supports HybridLLM or RemoteLLM for remote mode.
+   * When omitted, QMD_REMOTE_EMBED_URL / QMD_REMOTE_RERANK_URL env vars are
+   * checked, then falls back to a local LlamaCpp instance.
+   */
+  llm?: LLM;
 }
 
 /**
@@ -367,16 +373,28 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
   }
   // else: DB-only mode — no external config, use existing store_collections
 
-  // Create a per-store LlamaCpp instance — lazy-loads models on first use,
-  // auto-unloads after 5 min inactivity to free VRAM.
-  const llm = new LlamaCpp({
-    embedModel: config?.models?.embed,
-    generateModel: config?.models?.generate,
-    rerankModel: config?.models?.rerank,
-    inactivityTimeoutMs: 5 * 60 * 1000,
-    disposeModelsOnInactivity: true,
-  });
-  internal.llm = llm;
+  // Determine LLM backend: explicit option > env-var remote > local LlamaCpp.
+  const remoteEmbedUrl = process.env.QMD_REMOTE_EMBED_URL;
+  const remoteRerankUrl = process.env.QMD_REMOTE_RERANK_URL;
+  if (options.llm) {
+    internal.llm = options.llm;
+  } else if (remoteEmbedUrl && remoteRerankUrl) {
+    const remote = new RemoteLLM({
+      embedUrl: remoteEmbedUrl,
+      rerankUrl: remoteRerankUrl,
+      genUrl: process.env.QMD_REMOTE_GEN_URL,
+      apiKey: process.env.QMD_REMOTE_API_KEY,
+    });
+    internal.llm = new HybridLLM(null, remote);
+  } else {
+    internal.llm = new LlamaCpp({
+      embedModel: config?.models?.embed,
+      generateModel: config?.models?.generate,
+      rerankModel: config?.models?.rerank,
+      inactivityTimeoutMs: 5 * 60 * 1000,
+      disposeModelsOnInactivity: true,
+    });
+  }
 
   const store: QMDStore = {
     internal,
@@ -532,7 +550,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
 
     // Lifecycle
     close: async () => {
-      await llm.dispose();
+      await internal.llm?.dispose();
       internal.close();
       if (hasYamlConfig || options.config) {
         setConfigSource(undefined); // Reset config source

--- a/src/index.ts
+++ b/src/index.ts
@@ -550,7 +550,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
 
     // Lifecycle
     close: async () => {
-      await internal.llm?.dispose();
+      await internal.llm?.dispose?.();
       internal.close();
       if (hasYamlConfig || options.config) {
         setConfigSource(undefined); // Reset config source

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -16,7 +16,18 @@ import {
 } from "node-llama-cpp";
 import { homedir } from "os";
 import { join } from "path";
-import { existsSync, mkdirSync, statSync, unlinkSync, readdirSync, readFileSync, writeFileSync, openSync, readSync, closeSync } from "fs";
+import {
+  existsSync,
+  mkdirSync,
+  statSync,
+  unlinkSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  openSync,
+  readSync,
+  closeSync,
+} from "fs";
 
 // =============================================================================
 // Embedding Formatting Functions
@@ -35,7 +46,10 @@ export function isQwen3EmbeddingModel(modelUri: string): boolean {
  * Uses nomic-style task prefix format for embeddinggemma (default).
  * Uses Qwen3-Embedding instruct format when a Qwen embedding model is active.
  */
-export function formatQueryForEmbedding(query: string, modelUri?: string): string {
+export function formatQueryForEmbedding(
+  query: string,
+  modelUri?: string,
+): string {
   const uri = modelUri ?? process.env.QMD_EMBED_MODEL ?? DEFAULT_EMBED_MODEL;
   if (isQwen3EmbeddingModel(uri)) {
     return `Instruct: Retrieve relevant documents for the given query\nQuery: ${query}`;
@@ -48,7 +62,11 @@ export function formatQueryForEmbedding(query: string, modelUri?: string): strin
  * Uses nomic-style format with title and text fields (default).
  * Qwen3-Embedding encodes documents as raw text without special prefixes.
  */
-export function formatDocForEmbedding(text: string, title?: string, modelUri?: string): string {
+export function formatDocForEmbedding(
+  text: string,
+  title?: string,
+  modelUri?: string,
+): string {
   const uri = modelUri ?? process.env.QMD_EMBED_MODEL ?? DEFAULT_EMBED_MODEL;
   if (isQwen3EmbeddingModel(uri)) {
     // Qwen3-Embedding: documents are raw text, no task prefix
@@ -155,9 +173,19 @@ export type LLMSessionOptions = {
  */
 export interface ILLMSession {
   embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null>;
-  embedBatch(texts: string[], options?: EmbedOptions): Promise<(EmbeddingResult | null)[]>;
-  expandQuery(query: string, options?: { context?: string; includeLexical?: boolean }): Promise<Queryable[]>;
-  rerank(query: string, documents: RerankDocument[], options?: RerankOptions): Promise<RerankResult>;
+  embedBatch(
+    texts: string[],
+    options?: EmbedOptions,
+  ): Promise<(EmbeddingResult | null)[]>;
+  expandQuery(
+    query: string,
+    options?: { context?: string; includeLexical?: boolean },
+  ): Promise<Queryable[]>;
+  rerank(
+    query: string,
+    documents: RerankDocument[],
+    options?: RerankOptions,
+  ): Promise<RerankResult>;
   /** Whether this session is still valid (not released or aborted) */
   readonly isValid: boolean;
   /** Abort signal for this session (aborts on release or maxDuration) */
@@ -167,7 +195,7 @@ export interface ILLMSession {
 /**
  * Supported query types for different search backends
  */
-export type QueryType = 'lex' | 'vec' | 'hyde';
+export type QueryType = "lex" | "vec" | "hyde";
 
 /**
  * A single query and its target backend type
@@ -193,16 +221,21 @@ export type RerankDocument = {
 // HuggingFace model URIs for node-llama-cpp
 // Format: hf:<user>/<repo>/<file>
 // Override via QMD_EMBED_MODEL env var (e.g. hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf)
-const DEFAULT_EMBED_MODEL = "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";
-const DEFAULT_RERANK_MODEL = "hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf";
+const DEFAULT_EMBED_MODEL =
+  "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";
+const DEFAULT_RERANK_MODEL =
+  "hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf";
 // const DEFAULT_GENERATE_MODEL = "hf:ggml-org/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf";
-const DEFAULT_GENERATE_MODEL = "hf:tobil/qmd-query-expansion-1.7B-gguf/qmd-query-expansion-1.7B-q4_k_m.gguf";
+const DEFAULT_GENERATE_MODEL =
+  "hf:tobil/qmd-query-expansion-1.7B-gguf/qmd-query-expansion-1.7B-q4_k_m.gguf";
 
 // Alternative generation models for query expansion:
 // LiquidAI LFM2 - hybrid architecture optimized for edge/on-device inference
 // Use these as base for fine-tuning with configs/sft_lfm2.yaml
-export const LFM2_GENERATE_MODEL = "hf:LiquidAI/LFM2-1.2B-GGUF/LFM2-1.2B-Q4_K_M.gguf";
-export const LFM2_INSTRUCT_MODEL = "hf:LiquidAI/LFM2.5-1.2B-Instruct-GGUF/LFM2.5-1.2B-Instruct-Q4_K_M.gguf";
+export const LFM2_GENERATE_MODEL =
+  "hf:LiquidAI/LFM2-1.2B-GGUF/LFM2-1.2B-Q4_K_M.gguf";
+export const LFM2_INSTRUCT_MODEL =
+  "hf:LiquidAI/LFM2.5-1.2B-Instruct-GGUF/LFM2.5-1.2B-Instruct-Q4_K_M.gguf";
 
 export const DEFAULT_EMBED_MODEL_URI = DEFAULT_EMBED_MODEL;
 export const DEFAULT_RERANK_MODEL_URI = DEFAULT_RERANK_MODEL;
@@ -281,28 +314,28 @@ function validateGgufFile(filePath: string, modelUri: string): void {
   if (isHtml) {
     throw new Error(
       `Downloaded model file is an HTML page, not a GGUF model (${sizeKB} KB).\n` +
-      `Something is intercepting the download from huggingface.co (a proxy, firewall, or captive portal).\n\n` +
-      `Model: ${modelUri}\n` +
-      `Path:  ${filePath}\n\n` +
-      `To fix this, either:\n` +
-      `  1. Try a HuggingFace mirror:  HF_ENDPOINT=https://hf-mirror.com qmd embed\n` +
-      `  2. Download the model manually and set the env var, e.g.:\n` +
-      `       QMD_EMBED_MODEL=/path/to/model.gguf qmd embed\n\n` +
-      `Note: 'qmd search' works without any model downloads.`
+        `Something is intercepting the download from huggingface.co (a proxy, firewall, or captive portal).\n\n` +
+        `Model: ${modelUri}\n` +
+        `Path:  ${filePath}\n\n` +
+        `To fix this, either:\n` +
+        `  1. Try a HuggingFace mirror:  HF_ENDPOINT=https://hf-mirror.com qmd embed\n` +
+        `  2. Download the model manually and set the env var, e.g.:\n` +
+        `       QMD_EMBED_MODEL=/path/to/model.gguf qmd embed\n\n` +
+        `Note: 'qmd search' works without any model downloads.`,
     );
   }
 
   throw new Error(
     `Model file is not valid GGUF (expected magic "GGUF", got "${got}", file is ${sizeKB} KB).\n` +
-    `Model: ${modelUri}\n` +
-    `Path:  ${filePath}\n\n` +
-    `The file has been removed. Run the command again to re-download.`
+      `Model: ${modelUri}\n` +
+      `Path:  ${filePath}\n\n` +
+      `The file has been removed. Run the command again to re-download.`,
   );
 }
 
 export async function pullModels(
   models: string[],
-  options: { refresh?: boolean; cacheDir?: string } = {}
+  options: { refresh?: boolean; cacheDir?: string } = {},
 ): Promise<PullResult[]> {
   const cacheDir = options.cacheDir || MODEL_CACHE_DIR;
   if (!existsSync(cacheDir)) {
@@ -328,7 +361,10 @@ export async function pullModels(
         ? readFileSync(etagPath, "utf-8").trim()
         : null;
       const shouldRefresh =
-        options.refresh || !remoteEtag || remoteEtag !== localEtag || cached.length === 0;
+        options.refresh ||
+        !remoteEtag ||
+        remoteEtag !== localEtag ||
+        cached.length === 0;
 
       if (shouldRefresh) {
         for (const candidate of cached) {
@@ -373,9 +409,20 @@ export interface LLM {
   embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null>;
 
   /**
+   * Batch embed multiple texts efficiently
+   */
+  embedBatch(
+    texts: string[],
+    options?: EmbedOptions,
+  ): Promise<(EmbeddingResult | null)[]>;
+
+  /**
    * Generate text completion
    */
-  generate(prompt: string, options?: GenerateOptions): Promise<GenerateResult | null>;
+  generate(
+    prompt: string,
+    options?: GenerateOptions,
+  ): Promise<GenerateResult | null>;
 
   /**
    * Check if a model exists/is available
@@ -386,13 +433,49 @@ export interface LLM {
    * Expand a search query into multiple variations for different backends.
    * Returns a list of Queryable objects.
    */
-  expandQuery(query: string, options?: { context?: string, includeLexical?: boolean }): Promise<Queryable[]>;
+  expandQuery(
+    query: string,
+    options?: { context?: string; includeLexical?: boolean; intent?: string },
+  ): Promise<Queryable[]>;
 
   /**
    * Rerank documents by relevance to a query
    * Returns list of documents with relevance scores (higher = more relevant)
    */
-  rerank(query: string, documents: RerankDocument[], options?: RerankOptions): Promise<RerankResult>;
+  rerank(
+    query: string,
+    documents: RerankDocument[],
+    options?: RerankOptions,
+  ): Promise<RerankResult>;
+
+  /**
+   * Whether this LLM delegates embedding/reranking to a remote provider.
+   * Remote backends may need different text formatting than local GGUF models.
+   */
+  readonly isRemote?: boolean;
+
+  /**
+   * The name/URI of the embedding model in use.
+   * Used by formatDocForEmbedding to pick the right formatting strategy.
+   */
+  readonly embedModelName?: string;
+
+  /**
+   * Tokenize text. Local backends use the model's real tokenizer; remote backends
+   * return opaque index-based tokens suitable for chunk-size estimation.
+   */
+  tokenize(text: string): Promise<readonly unknown[]>;
+
+  /**
+   * Count tokens in text.
+   */
+  countTokens(text: string): Promise<number>;
+
+  /**
+   * Detokenize tokens back to text.
+   * Remote backends return a character-length approximation, not the original text.
+   */
+  detokenize(tokens: readonly unknown[]): Promise<string>;
 
   /**
    * Dispose of resources
@@ -440,20 +523,32 @@ const DEFAULT_EXPAND_CONTEXT_SIZE = 2048;
 
 type LlamaGpuMode = "auto" | "metal" | "vulkan" | "cuda" | false;
 
-export function resolveLlamaGpuMode(envValue = process.env.QMD_LLAMA_GPU): LlamaGpuMode {
+export function resolveLlamaGpuMode(
+  envValue = process.env.QMD_LLAMA_GPU,
+): LlamaGpuMode {
   const normalized = envValue?.trim().toLowerCase() ?? "";
   if (!normalized) return "auto";
-  if (["false", "off", "none", "disable", "disabled", "0"].includes(normalized)) return false;
-  if (normalized === "metal" || normalized === "vulkan" || normalized === "cuda") return normalized;
+  if (["false", "off", "none", "disable", "disabled", "0"].includes(normalized))
+    return false;
+  if (
+    normalized === "metal" ||
+    normalized === "vulkan" ||
+    normalized === "cuda"
+  )
+    return normalized;
 
-  process.stderr.write(`QMD Warning: invalid QMD_LLAMA_GPU="${envValue}", using auto GPU selection.\n`);
+  process.stderr.write(
+    `QMD Warning: invalid QMD_LLAMA_GPU="${envValue}", using auto GPU selection.\n`,
+  );
   return "auto";
 }
 
 function resolveExpandContextSize(configValue?: number): number {
   if (configValue !== undefined) {
     if (!Number.isInteger(configValue) || configValue <= 0) {
-      throw new Error(`Invalid expandContextSize: ${configValue}. Must be a positive integer.`);
+      throw new Error(
+        `Invalid expandContextSize: ${configValue}. Must be a positive integer.`,
+      );
     }
     return configValue;
   }
@@ -464,7 +559,7 @@ function resolveExpandContextSize(configValue?: number): number {
   const parsed = Number.parseInt(envValue, 10);
   if (!Number.isInteger(parsed) || parsed <= 0) {
     process.stderr.write(
-      `QMD Warning: invalid QMD_EXPAND_CONTEXT_SIZE="${envValue}", using default ${DEFAULT_EXPAND_CONTEXT_SIZE}.\n`
+      `QMD Warning: invalid QMD_EXPAND_CONTEXT_SIZE="${envValue}", using default ${DEFAULT_EXPAND_CONTEXT_SIZE}.\n`,
     );
     return DEFAULT_EXPAND_CONTEXT_SIZE;
   }
@@ -478,7 +573,9 @@ export class LlamaCpp implements LLM {
   private embedContexts: LlamaEmbeddingContext[] = [];
   private generateModel: LlamaModel | null = null;
   private rerankModel: LlamaModel | null = null;
-  private rerankContexts: Awaited<ReturnType<LlamaModel["createRankingContext"]>>[] = [];
+  private rerankContexts: Awaited<
+    ReturnType<LlamaModel["createRankingContext"]>
+  >[] = [];
 
   private embedModelUri: string;
   private generateModelUri: string;
@@ -499,14 +596,21 @@ export class LlamaCpp implements LLM {
   // Track disposal state to prevent double-dispose
   private disposed = false;
 
-
   constructor(config: LlamaCppConfig = {}) {
-    this.embedModelUri = config.embedModel || process.env.QMD_EMBED_MODEL || DEFAULT_EMBED_MODEL;
-    this.generateModelUri = config.generateModel || process.env.QMD_GENERATE_MODEL || DEFAULT_GENERATE_MODEL;
-    this.rerankModelUri = config.rerankModel || process.env.QMD_RERANK_MODEL || DEFAULT_RERANK_MODEL;
+    this.embedModelUri =
+      config.embedModel || process.env.QMD_EMBED_MODEL || DEFAULT_EMBED_MODEL;
+    this.generateModelUri =
+      config.generateModel ||
+      process.env.QMD_GENERATE_MODEL ||
+      DEFAULT_GENERATE_MODEL;
+    this.rerankModelUri =
+      config.rerankModel ||
+      process.env.QMD_RERANK_MODEL ||
+      DEFAULT_RERANK_MODEL;
     this.modelCacheDir = config.modelCacheDir || MODEL_CACHE_DIR;
     this.expandContextSize = resolveExpandContextSize(config.expandContextSize);
-    this.inactivityTimeoutMs = config.inactivityTimeoutMs ?? DEFAULT_INACTIVITY_TIMEOUT_MS;
+    this.inactivityTimeoutMs =
+      config.inactivityTimeoutMs ?? DEFAULT_INACTIVITY_TIMEOUT_MS;
     this.disposeModelsOnInactivity = config.disposeModelsOnInactivity ?? false;
   }
 
@@ -531,12 +635,12 @@ export class LlamaCpp implements LLM {
         // Check if session manager allows unloading
         // canUnloadLLM is defined later in this file - it checks the session manager
         // We use dynamic import pattern to avoid circular dependency issues
-        if (typeof canUnloadLLM === 'function' && !canUnloadLLM()) {
+        if (typeof canUnloadLLM === "function" && !canUnloadLLM()) {
           // Active sessions/operations - reschedule timer
           this.touchActivity();
           return;
         }
-        this.unloadIdleResources().catch(err => {
+        this.unloadIdleResources().catch((err) => {
           console.error("Error unloading idle resources:", err);
         });
       }, this.inactivityTimeoutMs);
@@ -637,7 +741,7 @@ export class LlamaCpp implements LLM {
           // GPU backend (e.g. Vulkan on headless/driverless machines) can throw at init.
           // Fall back to CPU so qmd still works.
           process.stderr.write(
-            `QMD Warning: GPU init failed${gpuMode === "auto" ? "" : ` for QMD_LLAMA_GPU=${gpuMode}`} (${err instanceof Error ? err.message : String(err)}), falling back to CPU.\n`
+            `QMD Warning: GPU init failed${gpuMode === "auto" ? "" : ` for QMD_LLAMA_GPU=${gpuMode}`} (${err instanceof Error ? err.message : String(err)}), falling back to CPU.\n`,
           );
           llama = await loadLlama(false);
         }
@@ -645,7 +749,7 @@ export class LlamaCpp implements LLM {
 
       if (llama.gpu === false) {
         process.stderr.write(
-          "QMD Warning: no GPU acceleration, running on CPU (slow). Run 'qmd status' for details.\n"
+          "QMD Warning: no GPU acceleration, running on CPU (slow). Run 'qmd status' for details.\n",
         );
       }
       this.llama = llama;
@@ -738,7 +842,8 @@ export class LlamaCpp implements LLM {
    * Load embedding contexts (lazy). Creates multiple for parallel embedding.
    * Uses promise guard to prevent concurrent context creation race condition.
    */
-  private embedContextsCreatePromise: Promise<LlamaEmbeddingContext[]> | null = null;
+  private embedContextsCreatePromise: Promise<LlamaEmbeddingContext[]> | null =
+    null;
 
   private async ensureEmbedContexts(): Promise<LlamaEmbeddingContext[]> {
     if (this.embedContexts.length > 0) {
@@ -757,12 +862,15 @@ export class LlamaCpp implements LLM {
       const threads = await this.threadsPerContext(n);
       for (let i = 0; i < n; i++) {
         try {
-          this.embedContexts.push(await model.createEmbeddingContext({
-            contextSize: LlamaCpp.EMBED_CONTEXT_SIZE,
-            ...(threads > 0 ? { threads } : {}),
-          }));
+          this.embedContexts.push(
+            await model.createEmbeddingContext({
+              contextSize: LlamaCpp.EMBED_CONTEXT_SIZE,
+              ...(threads > 0 ? { threads } : {}),
+            }),
+          );
         } catch {
-          if (this.embedContexts.length === 0) throw new Error("Failed to create any embedding context");
+          if (this.embedContexts.length === 0)
+            throw new Error("Failed to create any embedding context");
           break;
         }
       }
@@ -868,7 +976,9 @@ export class LlamaCpp implements LLM {
     const v = parseInt(process.env.QMD_EMBED_CONTEXT_SIZE ?? "", 10);
     return Number.isFinite(v) && v > 0 ? v : 2048;
   })();
-  private async ensureRerankContexts(): Promise<Awaited<ReturnType<LlamaModel["createRankingContext"]>>[]> {
+  private async ensureRerankContexts(): Promise<
+    Awaited<ReturnType<LlamaModel["createRankingContext"]>>[]
+  > {
     if (this.rerankContexts.length === 0) {
       const model = await this.ensureRerankModel();
       // ~960 MB per context with flash attention at contextSize 2048
@@ -876,19 +986,23 @@ export class LlamaCpp implements LLM {
       const threads = await this.threadsPerContext(n);
       for (let i = 0; i < n; i++) {
         try {
-          this.rerankContexts.push(await model.createRankingContext({
-            contextSize: LlamaCpp.RERANK_CONTEXT_SIZE,
-            flashAttention: true,
-            ...(threads > 0 ? { threads } : {}),
-          } as any));
+          this.rerankContexts.push(
+            await model.createRankingContext({
+              contextSize: LlamaCpp.RERANK_CONTEXT_SIZE,
+              flashAttention: true,
+              ...(threads > 0 ? { threads } : {}),
+            } as any),
+          );
         } catch {
           if (this.rerankContexts.length === 0) {
             // Flash attention might not be supported — retry without it
             try {
-              this.rerankContexts.push(await model.createRankingContext({
-                contextSize: LlamaCpp.RERANK_CONTEXT_SIZE,
-                ...(threads > 0 ? { threads } : {}),
-              }));
+              this.rerankContexts.push(
+                await model.createRankingContext({
+                  contextSize: LlamaCpp.RERANK_CONTEXT_SIZE,
+                  ...(threads > 0 ? { threads } : {}),
+                }),
+              );
             } catch {
               throw new Error("Failed to create any rerank context");
             }
@@ -909,8 +1023,8 @@ export class LlamaCpp implements LLM {
    * Tokenize text using the embedding model's tokenizer
    * Returns tokenizer tokens (opaque type from node-llama-cpp)
    */
-  async tokenize(text: string): Promise<readonly LlamaToken[]> {
-    await this.ensureEmbedContext();  // Ensure model is loaded
+  async tokenize(text: string): Promise<readonly unknown[]> {
+    await this.ensureEmbedContext(); // Ensure model is loaded
     if (!this.embedModel) {
       throw new Error("Embed model not loaded");
     }
@@ -928,12 +1042,12 @@ export class LlamaCpp implements LLM {
   /**
    * Detokenize token IDs back to text
    */
-  async detokenize(tokens: readonly LlamaToken[]): Promise<string> {
+  async detokenize(tokens: readonly unknown[]): Promise<string> {
     await this.ensureEmbedContext();
     if (!this.embedModel) {
       throw new Error("Embed model not loaded");
     }
-    return this.embedModel.detokenize(tokens);
+    return this.embedModel.detokenize(tokens as readonly LlamaToken[]);
   }
 
   // ==========================================================================
@@ -948,22 +1062,31 @@ export class LlamaCpp implements LLM {
    */
   private resolveEmbedTokenLimit(): number {
     const trainedContextSize = this.embedModel?.trainContextSize;
-    if (typeof trainedContextSize === "number" && Number.isFinite(trainedContextSize) && trainedContextSize > 0) {
-      return Math.max(1, Math.min(LlamaCpp.EMBED_CONTEXT_SIZE, trainedContextSize));
+    if (
+      typeof trainedContextSize === "number" &&
+      Number.isFinite(trainedContextSize) &&
+      trainedContextSize > 0
+    ) {
+      return Math.max(
+        1,
+        Math.min(LlamaCpp.EMBED_CONTEXT_SIZE, trainedContextSize),
+      );
     }
     return LlamaCpp.EMBED_CONTEXT_SIZE;
   }
 
   private async truncateToContextSize(
-    text: string
+    text: string,
   ): Promise<{ text: string; truncated: boolean; limit: number }> {
-    if (!this.embedModel) return { text, truncated: false, limit: LlamaCpp.EMBED_CONTEXT_SIZE };
+    if (!this.embedModel)
+      return { text, truncated: false, limit: LlamaCpp.EMBED_CONTEXT_SIZE };
 
     const maxTokens = this.resolveEmbedTokenLimit();
     if (maxTokens <= 0) return { text, truncated: false, limit: maxTokens };
 
     const tokens = this.embedModel.tokenize(text);
-    if (tokens.length <= maxTokens) return { text, truncated: false, limit: maxTokens };
+    if (tokens.length <= maxTokens)
+      return { text, truncated: false, limit: maxTokens };
 
     // Leave a small margin (4 tokens) for BOS/EOS overhead
     const safeLimit = Math.max(1, maxTokens - 4);
@@ -972,7 +1095,10 @@ export class LlamaCpp implements LLM {
     return { text: truncatedText, truncated: true, limit: maxTokens };
   }
 
-  async embed(text: string, options: EmbedOptions = {}): Promise<EmbeddingResult | null> {
+  async embed(
+    text: string,
+    options: EmbedOptions = {},
+  ): Promise<EmbeddingResult | null> {
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();
 
@@ -980,9 +1106,15 @@ export class LlamaCpp implements LLM {
       const context = await this.ensureEmbedContext();
 
       // Guard: truncate text that exceeds model context window to prevent GGML crash
-      const { text: safeText, truncated, limit } = await this.truncateToContextSize(text);
+      const {
+        text: safeText,
+        truncated,
+        limit,
+      } = await this.truncateToContextSize(text);
       if (truncated) {
-        console.warn(`⚠ Text truncated to fit embedding context (${limit} tokens)`);
+        console.warn(
+          `⚠ Text truncated to fit embedding context (${limit} tokens)`,
+        );
       }
 
       const embedding = await context.getEmbeddingFor(safeText);
@@ -1001,8 +1133,12 @@ export class LlamaCpp implements LLM {
    * Batch embed multiple texts efficiently
    * Uses Promise.all for parallel embedding - node-llama-cpp handles batching internally
    */
-  async embedBatch(texts: string[], options: EmbedOptions = {}): Promise<(EmbeddingResult | null)[]> {
-    if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
+  async embedBatch(
+    texts: string[],
+    options: EmbedOptions = {},
+  ): Promise<(EmbeddingResult | null)[]> {
+    if (this._ciMode)
+      throw new Error("LLM operations are disabled in CI (set CI=true)");
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();
 
@@ -1015,16 +1151,26 @@ export class LlamaCpp implements LLM {
       if (n === 1) {
         // Single context: sequential (no point splitting)
         const context = contexts[0]!;
-        const embeddings: ({ embedding: number[]; model: string } | null)[] = [];
+        const embeddings: ({ embedding: number[]; model: string } | null)[] =
+          [];
         for (const text of texts) {
           try {
-            const { text: safeText, truncated, limit } = await this.truncateToContextSize(text);
+            const {
+              text: safeText,
+              truncated,
+              limit,
+            } = await this.truncateToContextSize(text);
             if (truncated) {
-              console.warn(`⚠ Batch text truncated to fit embedding context (${limit} tokens)`);
+              console.warn(
+                `⚠ Batch text truncated to fit embedding context (${limit} tokens)`,
+              );
             }
             const embedding = await context.getEmbeddingFor(safeText);
             this.touchActivity();
-            embeddings.push({ embedding: Array.from(embedding.vector), model: options.model ?? this.embedModelUri });
+            embeddings.push({
+              embedding: Array.from(embedding.vector),
+              model: options.model ?? this.embedModelUri,
+            });
           } catch (err) {
             console.error("Embedding error for text:", err);
             embeddings.push(null);
@@ -1036,7 +1182,7 @@ export class LlamaCpp implements LLM {
       // Multiple contexts: split texts across contexts for parallel evaluation
       const chunkSize = Math.ceil(texts.length / n);
       const chunks = Array.from({ length: n }, (_, i) =>
-        texts.slice(i * chunkSize, (i + 1) * chunkSize)
+        texts.slice(i * chunkSize, (i + 1) * chunkSize),
       );
 
       const chunkResults = await Promise.all(
@@ -1045,20 +1191,29 @@ export class LlamaCpp implements LLM {
           const results: (EmbeddingResult | null)[] = [];
           for (const text of chunk) {
             try {
-              const { text: safeText, truncated, limit } = await this.truncateToContextSize(text);
+              const {
+                text: safeText,
+                truncated,
+                limit,
+              } = await this.truncateToContextSize(text);
               if (truncated) {
-                console.warn(`⚠ Batch text truncated to fit embedding context (${limit} tokens)`);
+                console.warn(
+                  `⚠ Batch text truncated to fit embedding context (${limit} tokens)`,
+                );
               }
               const embedding = await ctx.getEmbeddingFor(safeText);
               this.touchActivity();
-              results.push({ embedding: Array.from(embedding.vector), model: options.model ?? this.embedModelUri });
+              results.push({
+                embedding: Array.from(embedding.vector),
+                model: options.model ?? this.embedModelUri,
+              });
             } catch (err) {
               console.error("Embedding error for text:", err);
               results.push(null);
             }
           }
           return results;
-        })
+        }),
       );
 
       return chunkResults.flat();
@@ -1068,8 +1223,12 @@ export class LlamaCpp implements LLM {
     }
   }
 
-  async generate(prompt: string, options: GenerateOptions = {}): Promise<GenerateResult | null> {
-    if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
+  async generate(
+    prompt: string,
+    options: GenerateOptions = {},
+  ): Promise<GenerateResult | null> {
+    if (this._ciMode)
+      throw new Error("LLM operations are disabled in CI (set CI=true)");
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();
 
@@ -1128,8 +1287,16 @@ export class LlamaCpp implements LLM {
   // High-level abstractions
   // ==========================================================================
 
-  async expandQuery(query: string, options: { context?: string, includeLexical?: boolean, intent?: string } = {}): Promise<Queryable[]> {
-    if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
+  async expandQuery(
+    query: string,
+    options: {
+      context?: string;
+      includeLexical?: boolean;
+      intent?: string;
+    } = {},
+  ): Promise<Queryable[]> {
+    if (this._ciMode)
+      throw new Error("LLM operations are disabled in CI (set CI=true)");
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();
 
@@ -1145,7 +1312,7 @@ export class LlamaCpp implements LLM {
         line ::= type ": " content "\\n"
         type ::= "lex" | "vec" | "hyde"
         content ::= [^\\n]+
-      `
+      `,
     });
 
     const intent = options.intent;
@@ -1178,39 +1345,48 @@ export class LlamaCpp implements LLM {
 
       const lines = result.trim().split("\n");
       const queryLower = query.toLowerCase();
-      const queryTerms = queryLower.replace(/[^a-z0-9\s]/g, " ").split(/\s+/).filter(Boolean);
+      const queryTerms = queryLower
+        .replace(/[^a-z0-9\s]/g, " ")
+        .split(/\s+/)
+        .filter(Boolean);
 
       const hasQueryTerm = (text: string): boolean => {
         const lower = text.toLowerCase();
         if (queryTerms.length === 0) return true;
-        return queryTerms.some(term => lower.includes(term));
+        return queryTerms.some((term) => lower.includes(term));
       };
 
-      const queryables: Queryable[] = lines.map(line => {
-        const colonIdx = line.indexOf(":");
-        if (colonIdx === -1) return null;
-        const type = line.slice(0, colonIdx).trim();
-        if (type !== 'lex' && type !== 'vec' && type !== 'hyde') return null;
-        const text = line.slice(colonIdx + 1).trim();
-        if (!hasQueryTerm(text)) return null;
-        return { type: type as QueryType, text };
-      }).filter((q): q is Queryable => q !== null);
+      const queryables: Queryable[] = lines
+        .map((line) => {
+          const colonIdx = line.indexOf(":");
+          if (colonIdx === -1) return null;
+          const type = line.slice(0, colonIdx).trim();
+          if (type !== "lex" && type !== "vec" && type !== "hyde") return null;
+          const text = line.slice(colonIdx + 1).trim();
+          if (!hasQueryTerm(text)) return null;
+          return { type: type as QueryType, text };
+        })
+        .filter((q): q is Queryable => q !== null);
 
       // Filter out lex entries if not requested
-      const filtered = includeLexical ? queryables : queryables.filter(q => q.type !== 'lex');
+      const filtered = includeLexical
+        ? queryables
+        : queryables.filter((q) => q.type !== "lex");
       if (filtered.length > 0) return filtered;
 
       const fallback: Queryable[] = [
-        { type: 'hyde', text: `Information about ${query}` },
-        { type: 'lex', text: query },
-        { type: 'vec', text: query },
+        { type: "hyde", text: `Information about ${query}` },
+        { type: "lex", text: query },
+        { type: "vec", text: query },
       ];
-      return includeLexical ? fallback : fallback.filter(q => q.type !== 'lex');
+      return includeLexical
+        ? fallback
+        : fallback.filter((q) => q.type !== "lex");
     } catch (error) {
       console.error("Structured query expansion failed:", error);
       // Fallback to original query
-      const fallback: Queryable[] = [{ type: 'vec', text: query }];
-      if (includeLexical) fallback.unshift({ type: 'lex', text: query });
+      const fallback: Queryable[] = [{ type: "vec", text: query }];
+      if (includeLexical) fallback.unshift({ type: "lex", text: query });
       return fallback;
     } finally {
       await genContext.dispose();
@@ -1226,9 +1402,10 @@ export class LlamaCpp implements LLM {
   async rerank(
     query: string,
     documents: RerankDocument[],
-    options: RerankOptions = {}
+    options: RerankOptions = {},
   ): Promise<RerankResult> {
-    if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
+    if (this._ciMode)
+      throw new Error("LLM operations are disabled in CI (set CI=true)");
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();
 
@@ -1238,7 +1415,10 @@ export class LlamaCpp implements LLM {
     // Truncate documents that would exceed the rerank context size.
     // Budget = contextSize - template overhead - query tokens
     const queryTokens = model.tokenize(query).length;
-    const maxDocTokens = LlamaCpp.RERANK_CONTEXT_SIZE - LlamaCpp.RERANK_TEMPLATE_OVERHEAD - queryTokens;
+    const maxDocTokens =
+      LlamaCpp.RERANK_CONTEXT_SIZE -
+      LlamaCpp.RERANK_TEMPLATE_OVERHEAD -
+      queryTokens;
     const truncationCache = new Map<string, string>();
 
     const truncatedDocs = documents.map((doc) => {
@@ -1248,9 +1428,10 @@ export class LlamaCpp implements LLM {
       }
 
       const tokens = model.tokenize(doc.text);
-      const truncatedText = tokens.length <= maxDocTokens
-        ? doc.text
-        : model.detokenize(tokens.slice(0, maxDocTokens));
+      const truncatedText =
+        tokens.length <= maxDocTokens
+          ? doc.text
+          : model.detokenize(tokens.slice(0, maxDocTokens));
       truncationCache.set(doc.text, truncatedText);
 
       if (truncatedText === doc.text) return doc;
@@ -1280,17 +1461,17 @@ export class LlamaCpp implements LLM {
       1,
       Math.min(
         contexts.length,
-        Math.ceil(texts.length / LlamaCpp.RERANK_TARGET_DOCS_PER_CONTEXT)
-      )
+        Math.ceil(texts.length / LlamaCpp.RERANK_TARGET_DOCS_PER_CONTEXT),
+      ),
     );
     const activeContexts = contexts.slice(0, activeContextCount);
     const chunkSize = Math.ceil(texts.length / activeContexts.length);
     const chunks = Array.from({ length: activeContexts.length }, (_, i) =>
-      texts.slice(i * chunkSize, (i + 1) * chunkSize)
-    ).filter(chunk => chunk.length > 0);
+      texts.slice(i * chunkSize, (i + 1) * chunkSize),
+    ).filter((chunk) => chunk.length > 0);
 
     const allScores = await Promise.all(
-      chunks.map((chunk, i) => activeContexts[i]!.rankAll(query, chunk))
+      chunks.map((chunk, i) => activeContexts[i]!.rankAll(query, chunk)),
     );
 
     // Reassemble scores in original order and sort
@@ -1336,7 +1517,9 @@ export class LlamaCpp implements LLM {
       try {
         const state = await llama.getVramState();
         vram = { total: state.total, used: state.used, free: state.free };
-      } catch { /* no vram info */ }
+      } catch {
+        /* no vram info */
+      }
     }
     return {
       gpu: llama.gpu,
@@ -1365,7 +1548,9 @@ export class LlamaCpp implements LLM {
     // Note: llama.dispose() can hang indefinitely, so we use a timeout
     if (this.llama) {
       const disposePromise = this.llama.dispose();
-      const timeoutPromise = new Promise<void>((resolve) => setTimeout(resolve, 1000));
+      const timeoutPromise = new Promise<void>((resolve) =>
+        setTimeout(resolve, 1000),
+      );
       await Promise.race([disposePromise, timeoutPromise]);
     }
 
@@ -1394,11 +1579,11 @@ export class LlamaCpp implements LLM {
  * Coordinates with LlamaCpp idle timeout to prevent disposal during active sessions.
  */
 class LLMSessionManager {
-  private llm: LlamaCpp;
+  private llm: LLM;
   private _activeSessionCount = 0;
   private _inFlightOperations = 0;
 
-  constructor(llm: LlamaCpp) {
+  constructor(llm: LLM) {
     this.llm = llm;
   }
 
@@ -1434,7 +1619,7 @@ class LLMSessionManager {
     this._inFlightOperations = Math.max(0, this._inFlightOperations - 1);
   }
 
-  getLlamaCpp(): LlamaCpp {
+  getLLM(): LLM {
     return this.llm;
   }
 }
@@ -1470,9 +1655,13 @@ class LLMSession implements ILLMSession {
       if (options.signal.aborted) {
         this.abortController.abort(options.signal.reason);
       } else {
-        options.signal.addEventListener("abort", () => {
-          this.abortController.abort(options.signal!.reason);
-        }, { once: true });
+        options.signal.addEventListener(
+          "abort",
+          () => {
+            this.abortController.abort(options.signal!.reason);
+          },
+          { once: true },
+        );
       }
     }
 
@@ -1480,7 +1669,11 @@ class LLMSession implements ILLMSession {
     const maxDuration = options.maxDuration ?? 10 * 60 * 1000; // Default 10 minutes
     if (maxDuration > 0) {
       this.maxDurationTimer = setTimeout(() => {
-        this.abortController.abort(new Error(`Session "${this.name}" exceeded max duration of ${maxDuration}ms`));
+        this.abortController.abort(
+          new Error(
+            `Session "${this.name}" exceeded max duration of ${maxDuration}ms`,
+          ),
+        );
       }, maxDuration);
       this.maxDurationTimer.unref(); // Don't keep process alive
     }
@@ -1527,7 +1720,7 @@ class LLMSession implements ILLMSession {
       // Check abort before starting
       if (this.abortController.signal.aborted) {
         throw new SessionReleasedError(
-          this.abortController.signal.reason?.message || "Session aborted"
+          this.abortController.signal.reason?.message || "Session aborted",
         );
       }
       return await fn();
@@ -1536,27 +1729,41 @@ class LLMSession implements ILLMSession {
     }
   }
 
-  async embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null> {
-    return this.withOperation(() => this.manager.getLlamaCpp().embed(text, options));
+  async embed(
+    text: string,
+    options?: EmbedOptions,
+  ): Promise<EmbeddingResult | null> {
+    return this.withOperation(() =>
+      this.manager.getLLM().embed(text, options),
+    );
   }
 
-  async embedBatch(texts: string[], options?: EmbedOptions): Promise<(EmbeddingResult | null)[]> {
-    return this.withOperation(() => this.manager.getLlamaCpp().embedBatch(texts, options));
+  async embedBatch(
+    texts: string[],
+    options?: EmbedOptions,
+  ): Promise<(EmbeddingResult | null)[]> {
+    return this.withOperation(() =>
+      this.manager.getLLM().embedBatch(texts, options),
+    );
   }
 
   async expandQuery(
     query: string,
-    options?: { context?: string; includeLexical?: boolean }
+    options?: { context?: string; includeLexical?: boolean },
   ): Promise<Queryable[]> {
-    return this.withOperation(() => this.manager.getLlamaCpp().expandQuery(query, options));
+    return this.withOperation(() =>
+      this.manager.getLLM().expandQuery(query, options),
+    );
   }
 
   async rerank(
     query: string,
     documents: RerankDocument[],
-    options?: RerankOptions
+    options?: RerankOptions,
   ): Promise<RerankResult> {
-    return this.withOperation(() => this.manager.getLlamaCpp().rerank(query, documents, options));
+    return this.withOperation(() =>
+      this.manager.getLLM().rerank(query, documents, options),
+    );
   }
 }
 
@@ -1568,7 +1775,7 @@ let defaultSessionManager: LLMSessionManager | null = null;
  */
 function getSessionManager(): LLMSessionManager {
   const llm = getDefaultLlamaCpp();
-  if (!defaultSessionManager || defaultSessionManager.getLlamaCpp() !== llm) {
+  if (!defaultSessionManager || defaultSessionManager.getLLM() !== llm) {
     defaultSessionManager = new LLMSessionManager(llm);
   }
   return defaultSessionManager;
@@ -1590,7 +1797,7 @@ function getSessionManager(): LLMSessionManager {
  */
 export async function withLLMSession<T>(
   fn: (session: ILLMSession) => Promise<T>,
-  options?: LLMSessionOptions
+  options?: LLMSessionOptions,
 ): Promise<T> {
   const manager = getSessionManager();
   const session = new LLMSession(manager, options);
@@ -1607,9 +1814,9 @@ export async function withLLMSession<T>(
  * Unlike withLLMSession, this does not use the global singleton.
  */
 export async function withLLMSessionForLlm<T>(
-  llm: LlamaCpp,
+  llm: LLM,
   fn: (session: ILLMSession) => Promise<T>,
-  options?: LLMSessionOptions
+  options?: LLMSessionOptions,
 ): Promise<T> {
   const manager = new LLMSessionManager(llm);
   const session = new LLMSession(manager, options);
@@ -1634,23 +1841,39 @@ export function canUnloadLLM(): boolean {
 // Singleton for default LlamaCpp instance
 // =============================================================================
 
-let defaultLlamaCpp: LlamaCpp | null = null;
+let defaultLLMInstance: LLM | null = null;
 
 /**
- * Get the default LlamaCpp instance (creates one if needed)
+ * Get the default LLM instance (creates a local LlamaCpp if needed).
+ * Use this instead of getDefaultLlamaCpp() when the backend may be remote/hybrid.
+ */
+export function getDefaultLLM(): LLM {
+  if (!defaultLLMInstance) {
+    defaultLLMInstance = new LlamaCpp();
+  }
+  return defaultLLMInstance;
+}
+
+/**
+ * Set a custom default LLM instance (useful for remote/hybrid backends and testing).
+ */
+export function setDefaultLLM(llm: LLM | null): void {
+  defaultLLMInstance = llm;
+}
+
+/**
+ * Get the default LlamaCpp instance (creates one if needed).
+ * Prefer getDefaultLLM() when the backend may be remote or hybrid.
  */
 export function getDefaultLlamaCpp(): LlamaCpp {
-  if (!defaultLlamaCpp) {
-    defaultLlamaCpp = new LlamaCpp();
-  }
-  return defaultLlamaCpp;
+  return getDefaultLLM() as LlamaCpp;
 }
 
 /**
  * Set a custom default LlamaCpp instance (useful for testing)
  */
 export function setDefaultLlamaCpp(llm: LlamaCpp | null): void {
-  defaultLlamaCpp = llm;
+  setDefaultLLM(llm);
 }
 
 /**
@@ -1658,8 +1881,8 @@ export function setDefaultLlamaCpp(llm: LlamaCpp | null): void {
  * Call this before process exit to prevent NAPI crashes.
  */
 export async function disposeDefaultLlamaCpp(): Promise<void> {
-  if (defaultLlamaCpp) {
-    await defaultLlamaCpp.dispose();
-    defaultLlamaCpp = null;
+  if (defaultLLMInstance) {
+    await defaultLLMInstance.dispose();
+    defaultLLMInstance = null;
   }
 }

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -28,7 +28,18 @@ async function loadNodeLlamaCpp(): Promise<NodeLlamaCppModule> {
 
 import { homedir } from "os";
 import { join } from "path";
-import { existsSync, mkdirSync, statSync, unlinkSync, readdirSync, readFileSync, writeFileSync, openSync, readSync, closeSync } from "fs";
+import {
+  existsSync,
+  mkdirSync,
+  statSync,
+  unlinkSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  openSync,
+  readSync,
+  closeSync,
+} from "fs";
 
 // =============================================================================
 // Embedding Formatting Functions
@@ -47,7 +58,10 @@ export function isQwen3EmbeddingModel(modelUri: string): boolean {
  * Uses nomic-style task prefix format for embeddinggemma (default).
  * Uses Qwen3-Embedding instruct format when a Qwen embedding model is active.
  */
-export function formatQueryForEmbedding(query: string, modelUri?: string): string {
+export function formatQueryForEmbedding(
+  query: string,
+  modelUri?: string,
+): string {
   const uri = modelUri ?? process.env.QMD_EMBED_MODEL ?? DEFAULT_EMBED_MODEL;
   if (isQwen3EmbeddingModel(uri)) {
     return `Instruct: Retrieve relevant documents for the given query\nQuery: ${query}`;
@@ -60,7 +74,11 @@ export function formatQueryForEmbedding(query: string, modelUri?: string): strin
  * Uses nomic-style format with title and text fields (default).
  * Qwen3-Embedding encodes documents as raw text without special prefixes.
  */
-export function formatDocForEmbedding(text: string, title?: string, modelUri?: string): string {
+export function formatDocForEmbedding(
+  text: string,
+  title?: string,
+  modelUri?: string,
+): string {
   const uri = modelUri ?? process.env.QMD_EMBED_MODEL ?? DEFAULT_EMBED_MODEL;
   if (isQwen3EmbeddingModel(uri)) {
     // Qwen3-Embedding: documents are raw text, no task prefix
@@ -167,9 +185,19 @@ export type LLMSessionOptions = {
  */
 export interface ILLMSession {
   embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null>;
-  embedBatch(texts: string[], options?: EmbedOptions): Promise<(EmbeddingResult | null)[]>;
-  expandQuery(query: string, options?: { context?: string; includeLexical?: boolean }): Promise<Queryable[]>;
-  rerank(query: string, documents: RerankDocument[], options?: RerankOptions): Promise<RerankResult>;
+  embedBatch(
+    texts: string[],
+    options?: EmbedOptions,
+  ): Promise<(EmbeddingResult | null)[]>;
+  expandQuery(
+    query: string,
+    options?: { context?: string; includeLexical?: boolean },
+  ): Promise<Queryable[]>;
+  rerank(
+    query: string,
+    documents: RerankDocument[],
+    options?: RerankOptions,
+  ): Promise<RerankResult>;
   /** Whether this session is still valid (not released or aborted) */
   readonly isValid: boolean;
   /** Abort signal for this session (aborts on release or maxDuration) */
@@ -179,7 +207,7 @@ export interface ILLMSession {
 /**
  * Supported query types for different search backends
  */
-export type QueryType = 'lex' | 'vec' | 'hyde';
+export type QueryType = "lex" | "vec" | "hyde";
 
 /**
  * A single query and its target backend type
@@ -205,16 +233,21 @@ export type RerankDocument = {
 // HuggingFace model URIs for node-llama-cpp
 // Format: hf:<user>/<repo>/<file>
 // Override via QMD_EMBED_MODEL env var (e.g. hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf)
-const DEFAULT_EMBED_MODEL = "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";
-const DEFAULT_RERANK_MODEL = "hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf";
+const DEFAULT_EMBED_MODEL =
+  "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";
+const DEFAULT_RERANK_MODEL =
+  "hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf";
 // const DEFAULT_GENERATE_MODEL = "hf:ggml-org/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf";
-const DEFAULT_GENERATE_MODEL = "hf:tobil/qmd-query-expansion-1.7B-gguf/qmd-query-expansion-1.7B-q4_k_m.gguf";
+const DEFAULT_GENERATE_MODEL =
+  "hf:tobil/qmd-query-expansion-1.7B-gguf/qmd-query-expansion-1.7B-q4_k_m.gguf";
 
 // Alternative generation models for query expansion:
 // LiquidAI LFM2 - hybrid architecture optimized for edge/on-device inference
 // Use these as base for fine-tuning with configs/sft_lfm2.yaml
-export const LFM2_GENERATE_MODEL = "hf:LiquidAI/LFM2-1.2B-GGUF/LFM2-1.2B-Q4_K_M.gguf";
-export const LFM2_INSTRUCT_MODEL = "hf:LiquidAI/LFM2.5-1.2B-Instruct-GGUF/LFM2.5-1.2B-Instruct-Q4_K_M.gguf";
+export const LFM2_GENERATE_MODEL =
+  "hf:LiquidAI/LFM2-1.2B-GGUF/LFM2-1.2B-Q4_K_M.gguf";
+export const LFM2_INSTRUCT_MODEL =
+  "hf:LiquidAI/LFM2.5-1.2B-Instruct-GGUF/LFM2.5-1.2B-Instruct-Q4_K_M.gguf";
 
 export const DEFAULT_EMBED_MODEL_URI = DEFAULT_EMBED_MODEL;
 export const DEFAULT_RERANK_MODEL_URI = DEFAULT_RERANK_MODEL;
@@ -293,28 +326,28 @@ function validateGgufFile(filePath: string, modelUri: string): void {
   if (isHtml) {
     throw new Error(
       `Downloaded model file is an HTML page, not a GGUF model (${sizeKB} KB).\n` +
-      `Something is intercepting the download from huggingface.co (a proxy, firewall, or captive portal).\n\n` +
-      `Model: ${modelUri}\n` +
-      `Path:  ${filePath}\n\n` +
-      `To fix this, either:\n` +
-      `  1. Try a HuggingFace mirror:  HF_ENDPOINT=https://hf-mirror.com qmd embed\n` +
-      `  2. Download the model manually and set the env var, e.g.:\n` +
-      `       QMD_EMBED_MODEL=/path/to/model.gguf qmd embed\n\n` +
-      `Note: 'qmd search' works without any model downloads.`
+        `Something is intercepting the download from huggingface.co (a proxy, firewall, or captive portal).\n\n` +
+        `Model: ${modelUri}\n` +
+        `Path:  ${filePath}\n\n` +
+        `To fix this, either:\n` +
+        `  1. Try a HuggingFace mirror:  HF_ENDPOINT=https://hf-mirror.com qmd embed\n` +
+        `  2. Download the model manually and set the env var, e.g.:\n` +
+        `       QMD_EMBED_MODEL=/path/to/model.gguf qmd embed\n\n` +
+        `Note: 'qmd search' works without any model downloads.`,
     );
   }
 
   throw new Error(
     `Model file is not valid GGUF (expected magic "GGUF", got "${got}", file is ${sizeKB} KB).\n` +
-    `Model: ${modelUri}\n` +
-    `Path:  ${filePath}\n\n` +
-    `The file has been removed. Run the command again to re-download.`
+      `Model: ${modelUri}\n` +
+      `Path:  ${filePath}\n\n` +
+      `The file has been removed. Run the command again to re-download.`,
   );
 }
 
 export async function pullModels(
   models: string[],
-  options: { refresh?: boolean; cacheDir?: string } = {}
+  options: { refresh?: boolean; cacheDir?: string } = {},
 ): Promise<PullResult[]> {
   const cacheDir = options.cacheDir || MODEL_CACHE_DIR;
   if (!existsSync(cacheDir)) {
@@ -340,7 +373,10 @@ export async function pullModels(
         ? readFileSync(etagPath, "utf-8").trim()
         : null;
       const shouldRefresh =
-        options.refresh || !remoteEtag || remoteEtag !== localEtag || cached.length === 0;
+        options.refresh ||
+        !remoteEtag ||
+        remoteEtag !== localEtag ||
+        cached.length === 0;
 
       if (shouldRefresh) {
         for (const candidate of cached) {
@@ -386,9 +422,20 @@ export interface LLM {
   embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null>;
 
   /**
+   * Batch embed multiple texts efficiently
+   */
+  embedBatch(
+    texts: string[],
+    options?: EmbedOptions,
+  ): Promise<(EmbeddingResult | null)[]>;
+
+  /**
    * Generate text completion
    */
-  generate(prompt: string, options?: GenerateOptions): Promise<GenerateResult | null>;
+  generate(
+    prompt: string,
+    options?: GenerateOptions,
+  ): Promise<GenerateResult | null>;
 
   /**
    * Check if a model exists/is available
@@ -399,13 +446,49 @@ export interface LLM {
    * Expand a search query into multiple variations for different backends.
    * Returns a list of Queryable objects.
    */
-  expandQuery(query: string, options?: { context?: string, includeLexical?: boolean }): Promise<Queryable[]>;
+  expandQuery(
+    query: string,
+    options?: { context?: string; includeLexical?: boolean; intent?: string },
+  ): Promise<Queryable[]>;
 
   /**
    * Rerank documents by relevance to a query
    * Returns list of documents with relevance scores (higher = more relevant)
    */
-  rerank(query: string, documents: RerankDocument[], options?: RerankOptions): Promise<RerankResult>;
+  rerank(
+    query: string,
+    documents: RerankDocument[],
+    options?: RerankOptions,
+  ): Promise<RerankResult>;
+
+  /**
+   * Whether this LLM delegates embedding/reranking to a remote provider.
+   * Remote backends may need different text formatting than local GGUF models.
+   */
+  readonly isRemote?: boolean;
+
+  /**
+   * The name/URI of the embedding model in use.
+   * Used by formatDocForEmbedding to pick the right formatting strategy.
+   */
+  readonly embedModelName?: string;
+
+  /**
+   * Tokenize text. Local backends use the model's real tokenizer; remote backends
+   * return opaque index-based tokens suitable for chunk-size estimation.
+   */
+  tokenize(text: string): Promise<readonly unknown[]>;
+
+  /**
+   * Count tokens in text.
+   */
+  countTokens(text: string): Promise<number>;
+
+  /**
+   * Detokenize tokens back to text.
+   * Remote backends return a character-length approximation, not the original text.
+   */
+  detokenize(tokens: readonly unknown[]): Promise<string>;
 
   /**
    * Dispose of resources
@@ -487,20 +570,32 @@ export function resolveSafeParallelism(options: ParallelismOptions): number {
   return Math.max(1, options.computed);
 }
 
-export function resolveLlamaGpuMode(envValue = process.env.QMD_LLAMA_GPU): LlamaGpuMode {
+export function resolveLlamaGpuMode(
+  envValue = process.env.QMD_LLAMA_GPU,
+): LlamaGpuMode {
   const normalized = envValue?.trim().toLowerCase() ?? "";
   if (!normalized) return "auto";
-  if (["false", "off", "none", "disable", "disabled", "0"].includes(normalized)) return false;
-  if (normalized === "metal" || normalized === "vulkan" || normalized === "cuda") return normalized;
+  if (["false", "off", "none", "disable", "disabled", "0"].includes(normalized))
+    return false;
+  if (
+    normalized === "metal" ||
+    normalized === "vulkan" ||
+    normalized === "cuda"
+  )
+    return normalized;
 
-  process.stderr.write(`QMD Warning: invalid QMD_LLAMA_GPU="${envValue}", using auto GPU selection.\n`);
+  process.stderr.write(
+    `QMD Warning: invalid QMD_LLAMA_GPU="${envValue}", using auto GPU selection.\n`,
+  );
   return "auto";
 }
 
 function resolveExpandContextSize(configValue?: number): number {
   if (configValue !== undefined) {
     if (!Number.isInteger(configValue) || configValue <= 0) {
-      throw new Error(`Invalid expandContextSize: ${configValue}. Must be a positive integer.`);
+      throw new Error(
+        `Invalid expandContextSize: ${configValue}. Must be a positive integer.`,
+      );
     }
     return configValue;
   }
@@ -511,7 +606,7 @@ function resolveExpandContextSize(configValue?: number): number {
   const parsed = Number.parseInt(envValue, 10);
   if (!Number.isInteger(parsed) || parsed <= 0) {
     process.stderr.write(
-      `QMD Warning: invalid QMD_EXPAND_CONTEXT_SIZE="${envValue}", using default ${DEFAULT_EXPAND_CONTEXT_SIZE}.\n`
+      `QMD Warning: invalid QMD_EXPAND_CONTEXT_SIZE="${envValue}", using default ${DEFAULT_EXPAND_CONTEXT_SIZE}.\n`,
     );
     return DEFAULT_EXPAND_CONTEXT_SIZE;
   }
@@ -525,7 +620,9 @@ export class LlamaCpp implements LLM {
   private embedContexts: LlamaEmbeddingContext[] = [];
   private generateModel: LlamaModel | null = null;
   private rerankModel: LlamaModel | null = null;
-  private rerankContexts: Awaited<ReturnType<LlamaModel["createRankingContext"]>>[] = [];
+  private rerankContexts: Awaited<
+    ReturnType<LlamaModel["createRankingContext"]>
+  >[] = [];
 
   private embedModelUri: string;
   private generateModelUri: string;
@@ -546,14 +643,21 @@ export class LlamaCpp implements LLM {
   // Track disposal state to prevent double-dispose
   private disposed = false;
 
-
   constructor(config: LlamaCppConfig = {}) {
-    this.embedModelUri = config.embedModel || process.env.QMD_EMBED_MODEL || DEFAULT_EMBED_MODEL;
-    this.generateModelUri = config.generateModel || process.env.QMD_GENERATE_MODEL || DEFAULT_GENERATE_MODEL;
-    this.rerankModelUri = config.rerankModel || process.env.QMD_RERANK_MODEL || DEFAULT_RERANK_MODEL;
+    this.embedModelUri =
+      config.embedModel || process.env.QMD_EMBED_MODEL || DEFAULT_EMBED_MODEL;
+    this.generateModelUri =
+      config.generateModel ||
+      process.env.QMD_GENERATE_MODEL ||
+      DEFAULT_GENERATE_MODEL;
+    this.rerankModelUri =
+      config.rerankModel ||
+      process.env.QMD_RERANK_MODEL ||
+      DEFAULT_RERANK_MODEL;
     this.modelCacheDir = config.modelCacheDir || MODEL_CACHE_DIR;
     this.expandContextSize = resolveExpandContextSize(config.expandContextSize);
-    this.inactivityTimeoutMs = config.inactivityTimeoutMs ?? DEFAULT_INACTIVITY_TIMEOUT_MS;
+    this.inactivityTimeoutMs =
+      config.inactivityTimeoutMs ?? DEFAULT_INACTIVITY_TIMEOUT_MS;
     this.disposeModelsOnInactivity = config.disposeModelsOnInactivity ?? false;
   }
 
@@ -578,12 +682,12 @@ export class LlamaCpp implements LLM {
         // Check if session manager allows unloading
         // canUnloadLLM is defined later in this file - it checks the session manager
         // We use dynamic import pattern to avoid circular dependency issues
-        if (typeof canUnloadLLM === 'function' && !canUnloadLLM()) {
+        if (typeof canUnloadLLM === "function" && !canUnloadLLM()) {
           // Active sessions/operations - reschedule timer
           this.touchActivity();
           return;
         }
-        this.unloadIdleResources().catch(err => {
+        this.unloadIdleResources().catch((err) => {
           console.error("Error unloading idle resources:", err);
         });
       }, this.inactivityTimeoutMs);
@@ -685,7 +789,7 @@ export class LlamaCpp implements LLM {
           // GPU backend (e.g. Vulkan on headless/driverless machines) can throw at init.
           // Fall back to CPU so qmd still works.
           process.stderr.write(
-            `QMD Warning: GPU init failed${gpuMode === "auto" ? "" : ` for QMD_LLAMA_GPU=${gpuMode}`} (${err instanceof Error ? err.message : String(err)}), falling back to CPU.\n`
+            `QMD Warning: GPU init failed${gpuMode === "auto" ? "" : ` for QMD_LLAMA_GPU=${gpuMode}`} (${err instanceof Error ? err.message : String(err)}), falling back to CPU.\n`,
           );
           llama = await loadLlama(false);
         }
@@ -693,7 +797,7 @@ export class LlamaCpp implements LLM {
 
       if (llama.gpu === false) {
         process.stderr.write(
-          "QMD Warning: no GPU acceleration, running on CPU (slow). Run 'qmd status' for details.\n"
+          "QMD Warning: no GPU acceleration, running on CPU (slow). Run 'qmd status' for details.\n",
         );
       }
       this.llama = llama;
@@ -789,7 +893,8 @@ export class LlamaCpp implements LLM {
    * Load embedding contexts (lazy). Creates multiple for parallel embedding.
    * Uses promise guard to prevent concurrent context creation race condition.
    */
-  private embedContextsCreatePromise: Promise<LlamaEmbeddingContext[]> | null = null;
+  private embedContextsCreatePromise: Promise<LlamaEmbeddingContext[]> | null =
+    null;
 
   private async ensureEmbedContexts(): Promise<LlamaEmbeddingContext[]> {
     if (this.embedContexts.length > 0) {
@@ -808,12 +913,15 @@ export class LlamaCpp implements LLM {
       const threads = await this.threadsPerContext(n);
       for (let i = 0; i < n; i++) {
         try {
-          this.embedContexts.push(await model.createEmbeddingContext({
-            contextSize: LlamaCpp.EMBED_CONTEXT_SIZE,
-            ...(threads > 0 ? { threads } : {}),
-          }));
+          this.embedContexts.push(
+            await model.createEmbeddingContext({
+              contextSize: LlamaCpp.EMBED_CONTEXT_SIZE,
+              ...(threads > 0 ? { threads } : {}),
+            }),
+          );
         } catch {
-          if (this.embedContexts.length === 0) throw new Error("Failed to create any embedding context");
+          if (this.embedContexts.length === 0)
+            throw new Error("Failed to create any embedding context");
           break;
         }
       }
@@ -919,7 +1027,9 @@ export class LlamaCpp implements LLM {
     const v = parseInt(process.env.QMD_EMBED_CONTEXT_SIZE ?? "", 10);
     return Number.isFinite(v) && v > 0 ? v : 2048;
   })();
-  private async ensureRerankContexts(): Promise<Awaited<ReturnType<LlamaModel["createRankingContext"]>>[]> {
+  private async ensureRerankContexts(): Promise<
+    Awaited<ReturnType<LlamaModel["createRankingContext"]>>[]
+  > {
     if (this.rerankContexts.length === 0) {
       const model = await this.ensureRerankModel();
       // ~960 MB per context with flash attention at contextSize 2048
@@ -927,19 +1037,23 @@ export class LlamaCpp implements LLM {
       const threads = await this.threadsPerContext(n);
       for (let i = 0; i < n; i++) {
         try {
-          this.rerankContexts.push(await model.createRankingContext({
-            contextSize: LlamaCpp.RERANK_CONTEXT_SIZE,
-            flashAttention: true,
-            ...(threads > 0 ? { threads } : {}),
-          } as any));
+          this.rerankContexts.push(
+            await model.createRankingContext({
+              contextSize: LlamaCpp.RERANK_CONTEXT_SIZE,
+              flashAttention: true,
+              ...(threads > 0 ? { threads } : {}),
+            } as any),
+          );
         } catch {
           if (this.rerankContexts.length === 0) {
             // Flash attention might not be supported — retry without it
             try {
-              this.rerankContexts.push(await model.createRankingContext({
-                contextSize: LlamaCpp.RERANK_CONTEXT_SIZE,
-                ...(threads > 0 ? { threads } : {}),
-              }));
+              this.rerankContexts.push(
+                await model.createRankingContext({
+                  contextSize: LlamaCpp.RERANK_CONTEXT_SIZE,
+                  ...(threads > 0 ? { threads } : {}),
+                }),
+              );
             } catch {
               throw new Error("Failed to create any rerank context");
             }
@@ -960,8 +1074,8 @@ export class LlamaCpp implements LLM {
    * Tokenize text using the embedding model's tokenizer
    * Returns tokenizer tokens (opaque type from node-llama-cpp)
    */
-  async tokenize(text: string): Promise<readonly LlamaToken[]> {
-    await this.ensureEmbedContext();  // Ensure model is loaded
+  async tokenize(text: string): Promise<readonly unknown[]> {
+    await this.ensureEmbedContext(); // Ensure model is loaded
     if (!this.embedModel) {
       throw new Error("Embed model not loaded");
     }
@@ -979,12 +1093,12 @@ export class LlamaCpp implements LLM {
   /**
    * Detokenize token IDs back to text
    */
-  async detokenize(tokens: readonly LlamaToken[]): Promise<string> {
+  async detokenize(tokens: readonly unknown[]): Promise<string> {
     await this.ensureEmbedContext();
     if (!this.embedModel) {
       throw new Error("Embed model not loaded");
     }
-    return this.embedModel.detokenize(tokens);
+    return this.embedModel.detokenize(tokens as readonly LlamaToken[]);
   }
 
   // ==========================================================================
@@ -999,22 +1113,31 @@ export class LlamaCpp implements LLM {
    */
   private resolveEmbedTokenLimit(): number {
     const trainedContextSize = this.embedModel?.trainContextSize;
-    if (typeof trainedContextSize === "number" && Number.isFinite(trainedContextSize) && trainedContextSize > 0) {
-      return Math.max(1, Math.min(LlamaCpp.EMBED_CONTEXT_SIZE, trainedContextSize));
+    if (
+      typeof trainedContextSize === "number" &&
+      Number.isFinite(trainedContextSize) &&
+      trainedContextSize > 0
+    ) {
+      return Math.max(
+        1,
+        Math.min(LlamaCpp.EMBED_CONTEXT_SIZE, trainedContextSize),
+      );
     }
     return LlamaCpp.EMBED_CONTEXT_SIZE;
   }
 
   private async truncateToContextSize(
-    text: string
+    text: string,
   ): Promise<{ text: string; truncated: boolean; limit: number }> {
-    if (!this.embedModel) return { text, truncated: false, limit: LlamaCpp.EMBED_CONTEXT_SIZE };
+    if (!this.embedModel)
+      return { text, truncated: false, limit: LlamaCpp.EMBED_CONTEXT_SIZE };
 
     const maxTokens = this.resolveEmbedTokenLimit();
     if (maxTokens <= 0) return { text, truncated: false, limit: maxTokens };
 
     const tokens = this.embedModel.tokenize(text);
-    if (tokens.length <= maxTokens) return { text, truncated: false, limit: maxTokens };
+    if (tokens.length <= maxTokens)
+      return { text, truncated: false, limit: maxTokens };
 
     // Leave a small margin (4 tokens) for BOS/EOS overhead
     const safeLimit = Math.max(1, maxTokens - 4);
@@ -1023,7 +1146,10 @@ export class LlamaCpp implements LLM {
     return { text: truncatedText, truncated: true, limit: maxTokens };
   }
 
-  async embed(text: string, options: EmbedOptions = {}): Promise<EmbeddingResult | null> {
+  async embed(
+    text: string,
+    options: EmbedOptions = {},
+  ): Promise<EmbeddingResult | null> {
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();
 
@@ -1031,9 +1157,15 @@ export class LlamaCpp implements LLM {
       const context = await this.ensureEmbedContext();
 
       // Guard: truncate text that exceeds model context window to prevent GGML crash
-      const { text: safeText, truncated, limit } = await this.truncateToContextSize(text);
+      const {
+        text: safeText,
+        truncated,
+        limit,
+      } = await this.truncateToContextSize(text);
       if (truncated) {
-        console.warn(`⚠ Text truncated to fit embedding context (${limit} tokens)`);
+        console.warn(
+          `⚠ Text truncated to fit embedding context (${limit} tokens)`,
+        );
       }
 
       const embedding = await context.getEmbeddingFor(safeText);
@@ -1052,8 +1184,12 @@ export class LlamaCpp implements LLM {
    * Batch embed multiple texts efficiently
    * Uses Promise.all for parallel embedding - node-llama-cpp handles batching internally
    */
-  async embedBatch(texts: string[], options: EmbedOptions = {}): Promise<(EmbeddingResult | null)[]> {
-    if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
+  async embedBatch(
+    texts: string[],
+    options: EmbedOptions = {},
+  ): Promise<(EmbeddingResult | null)[]> {
+    if (this._ciMode)
+      throw new Error("LLM operations are disabled in CI (set CI=true)");
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();
 
@@ -1066,16 +1202,26 @@ export class LlamaCpp implements LLM {
       if (n === 1) {
         // Single context: sequential (no point splitting)
         const context = contexts[0]!;
-        const embeddings: ({ embedding: number[]; model: string } | null)[] = [];
+        const embeddings: ({ embedding: number[]; model: string } | null)[] =
+          [];
         for (const text of texts) {
           try {
-            const { text: safeText, truncated, limit } = await this.truncateToContextSize(text);
+            const {
+              text: safeText,
+              truncated,
+              limit,
+            } = await this.truncateToContextSize(text);
             if (truncated) {
-              console.warn(`⚠ Batch text truncated to fit embedding context (${limit} tokens)`);
+              console.warn(
+                `⚠ Batch text truncated to fit embedding context (${limit} tokens)`,
+              );
             }
             const embedding = await context.getEmbeddingFor(safeText);
             this.touchActivity();
-            embeddings.push({ embedding: Array.from(embedding.vector), model: options.model ?? this.embedModelUri });
+            embeddings.push({
+              embedding: Array.from(embedding.vector),
+              model: options.model ?? this.embedModelUri,
+            });
           } catch (err) {
             console.error("Embedding error for text:", err);
             embeddings.push(null);
@@ -1087,7 +1233,7 @@ export class LlamaCpp implements LLM {
       // Multiple contexts: split texts across contexts for parallel evaluation
       const chunkSize = Math.ceil(texts.length / n);
       const chunks = Array.from({ length: n }, (_, i) =>
-        texts.slice(i * chunkSize, (i + 1) * chunkSize)
+        texts.slice(i * chunkSize, (i + 1) * chunkSize),
       );
 
       const chunkResults = await Promise.all(
@@ -1096,20 +1242,29 @@ export class LlamaCpp implements LLM {
           const results: (EmbeddingResult | null)[] = [];
           for (const text of chunk) {
             try {
-              const { text: safeText, truncated, limit } = await this.truncateToContextSize(text);
+              const {
+                text: safeText,
+                truncated,
+                limit,
+              } = await this.truncateToContextSize(text);
               if (truncated) {
-                console.warn(`⚠ Batch text truncated to fit embedding context (${limit} tokens)`);
+                console.warn(
+                  `⚠ Batch text truncated to fit embedding context (${limit} tokens)`,
+                );
               }
               const embedding = await ctx.getEmbeddingFor(safeText);
               this.touchActivity();
-              results.push({ embedding: Array.from(embedding.vector), model: options.model ?? this.embedModelUri });
+              results.push({
+                embedding: Array.from(embedding.vector),
+                model: options.model ?? this.embedModelUri,
+              });
             } catch (err) {
               console.error("Embedding error for text:", err);
               results.push(null);
             }
           }
           return results;
-        })
+        }),
       );
 
       return chunkResults.flat();
@@ -1119,8 +1274,12 @@ export class LlamaCpp implements LLM {
     }
   }
 
-  async generate(prompt: string, options: GenerateOptions = {}): Promise<GenerateResult | null> {
-    if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
+  async generate(
+    prompt: string,
+    options: GenerateOptions = {},
+  ): Promise<GenerateResult | null> {
+    if (this._ciMode)
+      throw new Error("LLM operations are disabled in CI (set CI=true)");
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();
 
@@ -1180,8 +1339,16 @@ export class LlamaCpp implements LLM {
   // High-level abstractions
   // ==========================================================================
 
-  async expandQuery(query: string, options: { context?: string, includeLexical?: boolean, intent?: string } = {}): Promise<Queryable[]> {
-    if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
+  async expandQuery(
+    query: string,
+    options: {
+      context?: string;
+      includeLexical?: boolean;
+      intent?: string;
+    } = {},
+  ): Promise<Queryable[]> {
+    if (this._ciMode)
+      throw new Error("LLM operations are disabled in CI (set CI=true)");
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();
 
@@ -1197,7 +1364,7 @@ export class LlamaCpp implements LLM {
         line ::= type ": " content "\\n"
         type ::= "lex" | "vec" | "hyde"
         content ::= [^\\n]+
-      `
+      `,
     });
 
     const intent = options.intent;
@@ -1231,39 +1398,48 @@ export class LlamaCpp implements LLM {
 
       const lines = result.trim().split("\n");
       const queryLower = query.toLowerCase();
-      const queryTerms = queryLower.replace(/[^a-z0-9\s]/g, " ").split(/\s+/).filter(Boolean);
+      const queryTerms = queryLower
+        .replace(/[^a-z0-9\s]/g, " ")
+        .split(/\s+/)
+        .filter(Boolean);
 
       const hasQueryTerm = (text: string): boolean => {
         const lower = text.toLowerCase();
         if (queryTerms.length === 0) return true;
-        return queryTerms.some(term => lower.includes(term));
+        return queryTerms.some((term) => lower.includes(term));
       };
 
-      const queryables: Queryable[] = lines.map(line => {
-        const colonIdx = line.indexOf(":");
-        if (colonIdx === -1) return null;
-        const type = line.slice(0, colonIdx).trim();
-        if (type !== 'lex' && type !== 'vec' && type !== 'hyde') return null;
-        const text = line.slice(colonIdx + 1).trim();
-        if (!hasQueryTerm(text)) return null;
-        return { type: type as QueryType, text };
-      }).filter((q): q is Queryable => q !== null);
+      const queryables: Queryable[] = lines
+        .map((line) => {
+          const colonIdx = line.indexOf(":");
+          if (colonIdx === -1) return null;
+          const type = line.slice(0, colonIdx).trim();
+          if (type !== "lex" && type !== "vec" && type !== "hyde") return null;
+          const text = line.slice(colonIdx + 1).trim();
+          if (!hasQueryTerm(text)) return null;
+          return { type: type as QueryType, text };
+        })
+        .filter((q): q is Queryable => q !== null);
 
       // Filter out lex entries if not requested
-      const filtered = includeLexical ? queryables : queryables.filter(q => q.type !== 'lex');
+      const filtered = includeLexical
+        ? queryables
+        : queryables.filter((q) => q.type !== "lex");
       if (filtered.length > 0) return filtered;
 
       const fallback: Queryable[] = [
-        { type: 'hyde', text: `Information about ${query}` },
-        { type: 'lex', text: query },
-        { type: 'vec', text: query },
+        { type: "hyde", text: `Information about ${query}` },
+        { type: "lex", text: query },
+        { type: "vec", text: query },
       ];
-      return includeLexical ? fallback : fallback.filter(q => q.type !== 'lex');
+      return includeLexical
+        ? fallback
+        : fallback.filter((q) => q.type !== "lex");
     } catch (error) {
       console.error("Structured query expansion failed:", error);
       // Fallback to original query
-      const fallback: Queryable[] = [{ type: 'vec', text: query }];
-      if (includeLexical) fallback.unshift({ type: 'lex', text: query });
+      const fallback: Queryable[] = [{ type: "vec", text: query }];
+      if (includeLexical) fallback.unshift({ type: "lex", text: query });
       return fallback;
     } finally {
       await genContext.dispose();
@@ -1279,9 +1455,10 @@ export class LlamaCpp implements LLM {
   async rerank(
     query: string,
     documents: RerankDocument[],
-    options: RerankOptions = {}
+    options: RerankOptions = {},
   ): Promise<RerankResult> {
-    if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
+    if (this._ciMode)
+      throw new Error("LLM operations are disabled in CI (set CI=true)");
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();
 
@@ -1291,7 +1468,10 @@ export class LlamaCpp implements LLM {
     // Truncate documents that would exceed the rerank context size.
     // Budget = contextSize - template overhead - query tokens
     const queryTokens = model.tokenize(query).length;
-    const maxDocTokens = LlamaCpp.RERANK_CONTEXT_SIZE - LlamaCpp.RERANK_TEMPLATE_OVERHEAD - queryTokens;
+    const maxDocTokens =
+      LlamaCpp.RERANK_CONTEXT_SIZE -
+      LlamaCpp.RERANK_TEMPLATE_OVERHEAD -
+      queryTokens;
     const truncationCache = new Map<string, string>();
 
     const truncatedDocs = documents.map((doc) => {
@@ -1301,9 +1481,10 @@ export class LlamaCpp implements LLM {
       }
 
       const tokens = model.tokenize(doc.text);
-      const truncatedText = tokens.length <= maxDocTokens
-        ? doc.text
-        : model.detokenize(tokens.slice(0, maxDocTokens));
+      const truncatedText =
+        tokens.length <= maxDocTokens
+          ? doc.text
+          : model.detokenize(tokens.slice(0, maxDocTokens));
       truncationCache.set(doc.text, truncatedText);
 
       if (truncatedText === doc.text) return doc;
@@ -1333,17 +1514,17 @@ export class LlamaCpp implements LLM {
       1,
       Math.min(
         contexts.length,
-        Math.ceil(texts.length / LlamaCpp.RERANK_TARGET_DOCS_PER_CONTEXT)
-      )
+        Math.ceil(texts.length / LlamaCpp.RERANK_TARGET_DOCS_PER_CONTEXT),
+      ),
     );
     const activeContexts = contexts.slice(0, activeContextCount);
     const chunkSize = Math.ceil(texts.length / activeContexts.length);
     const chunks = Array.from({ length: activeContexts.length }, (_, i) =>
-      texts.slice(i * chunkSize, (i + 1) * chunkSize)
-    ).filter(chunk => chunk.length > 0);
+      texts.slice(i * chunkSize, (i + 1) * chunkSize),
+    ).filter((chunk) => chunk.length > 0);
 
     const allScores = await Promise.all(
-      chunks.map((chunk, i) => activeContexts[i]!.rankAll(query, chunk))
+      chunks.map((chunk, i) => activeContexts[i]!.rankAll(query, chunk)),
     );
 
     // Reassemble scores in original order and sort
@@ -1389,7 +1570,9 @@ export class LlamaCpp implements LLM {
       try {
         const state = await llama.getVramState();
         vram = { total: state.total, used: state.used, free: state.free };
-      } catch { /* no vram info */ }
+      } catch {
+        /* no vram info */
+      }
     }
     return {
       gpu: llama.gpu,
@@ -1418,7 +1601,9 @@ export class LlamaCpp implements LLM {
     // Note: llama.dispose() can hang indefinitely, so we use a timeout
     if (this.llama) {
       const disposePromise = this.llama.dispose();
-      const timeoutPromise = new Promise<void>((resolve) => setTimeout(resolve, 1000));
+      const timeoutPromise = new Promise<void>((resolve) =>
+        setTimeout(resolve, 1000),
+      );
       await Promise.race([disposePromise, timeoutPromise]);
     }
 
@@ -1447,11 +1632,11 @@ export class LlamaCpp implements LLM {
  * Coordinates with LlamaCpp idle timeout to prevent disposal during active sessions.
  */
 class LLMSessionManager {
-  private llm: LlamaCpp;
+  private llm: LLM;
   private _activeSessionCount = 0;
   private _inFlightOperations = 0;
 
-  constructor(llm: LlamaCpp) {
+  constructor(llm: LLM) {
     this.llm = llm;
   }
 
@@ -1487,7 +1672,7 @@ class LLMSessionManager {
     this._inFlightOperations = Math.max(0, this._inFlightOperations - 1);
   }
 
-  getLlamaCpp(): LlamaCpp {
+  getLLM(): LLM {
     return this.llm;
   }
 }
@@ -1523,9 +1708,13 @@ class LLMSession implements ILLMSession {
       if (options.signal.aborted) {
         this.abortController.abort(options.signal.reason);
       } else {
-        options.signal.addEventListener("abort", () => {
-          this.abortController.abort(options.signal!.reason);
-        }, { once: true });
+        options.signal.addEventListener(
+          "abort",
+          () => {
+            this.abortController.abort(options.signal!.reason);
+          },
+          { once: true },
+        );
       }
     }
 
@@ -1533,7 +1722,11 @@ class LLMSession implements ILLMSession {
     const maxDuration = options.maxDuration ?? 10 * 60 * 1000; // Default 10 minutes
     if (maxDuration > 0) {
       this.maxDurationTimer = setTimeout(() => {
-        this.abortController.abort(new Error(`Session "${this.name}" exceeded max duration of ${maxDuration}ms`));
+        this.abortController.abort(
+          new Error(
+            `Session "${this.name}" exceeded max duration of ${maxDuration}ms`,
+          ),
+        );
       }, maxDuration);
       this.maxDurationTimer.unref(); // Don't keep process alive
     }
@@ -1580,7 +1773,7 @@ class LLMSession implements ILLMSession {
       // Check abort before starting
       if (this.abortController.signal.aborted) {
         throw new SessionReleasedError(
-          this.abortController.signal.reason?.message || "Session aborted"
+          this.abortController.signal.reason?.message || "Session aborted",
         );
       }
       return await fn();
@@ -1589,27 +1782,41 @@ class LLMSession implements ILLMSession {
     }
   }
 
-  async embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null> {
-    return this.withOperation(() => this.manager.getLlamaCpp().embed(text, options));
+  async embed(
+    text: string,
+    options?: EmbedOptions,
+  ): Promise<EmbeddingResult | null> {
+    return this.withOperation(() =>
+      this.manager.getLLM().embed(text, options),
+    );
   }
 
-  async embedBatch(texts: string[], options?: EmbedOptions): Promise<(EmbeddingResult | null)[]> {
-    return this.withOperation(() => this.manager.getLlamaCpp().embedBatch(texts, options));
+  async embedBatch(
+    texts: string[],
+    options?: EmbedOptions,
+  ): Promise<(EmbeddingResult | null)[]> {
+    return this.withOperation(() =>
+      this.manager.getLLM().embedBatch(texts, options),
+    );
   }
 
   async expandQuery(
     query: string,
-    options?: { context?: string; includeLexical?: boolean }
+    options?: { context?: string; includeLexical?: boolean },
   ): Promise<Queryable[]> {
-    return this.withOperation(() => this.manager.getLlamaCpp().expandQuery(query, options));
+    return this.withOperation(() =>
+      this.manager.getLLM().expandQuery(query, options),
+    );
   }
 
   async rerank(
     query: string,
     documents: RerankDocument[],
-    options?: RerankOptions
+    options?: RerankOptions,
   ): Promise<RerankResult> {
-    return this.withOperation(() => this.manager.getLlamaCpp().rerank(query, documents, options));
+    return this.withOperation(() =>
+      this.manager.getLLM().rerank(query, documents, options),
+    );
   }
 }
 
@@ -1621,7 +1828,7 @@ let defaultSessionManager: LLMSessionManager | null = null;
  */
 function getSessionManager(): LLMSessionManager {
   const llm = getDefaultLlamaCpp();
-  if (!defaultSessionManager || defaultSessionManager.getLlamaCpp() !== llm) {
+  if (!defaultSessionManager || defaultSessionManager.getLLM() !== llm) {
     defaultSessionManager = new LLMSessionManager(llm);
   }
   return defaultSessionManager;
@@ -1643,7 +1850,7 @@ function getSessionManager(): LLMSessionManager {
  */
 export async function withLLMSession<T>(
   fn: (session: ILLMSession) => Promise<T>,
-  options?: LLMSessionOptions
+  options?: LLMSessionOptions,
 ): Promise<T> {
   const manager = getSessionManager();
   const session = new LLMSession(manager, options);
@@ -1660,9 +1867,9 @@ export async function withLLMSession<T>(
  * Unlike withLLMSession, this does not use the global singleton.
  */
 export async function withLLMSessionForLlm<T>(
-  llm: LlamaCpp,
+  llm: LLM,
   fn: (session: ILLMSession) => Promise<T>,
-  options?: LLMSessionOptions
+  options?: LLMSessionOptions,
 ): Promise<T> {
   const manager = new LLMSessionManager(llm);
   const session = new LLMSession(manager, options);
@@ -1687,23 +1894,39 @@ export function canUnloadLLM(): boolean {
 // Singleton for default LlamaCpp instance
 // =============================================================================
 
-let defaultLlamaCpp: LlamaCpp | null = null;
+let defaultLLMInstance: LLM | null = null;
 
 /**
- * Get the default LlamaCpp instance (creates one if needed)
+ * Get the default LLM instance (creates a local LlamaCpp if needed).
+ * Use this instead of getDefaultLlamaCpp() when the backend may be remote/hybrid.
+ */
+export function getDefaultLLM(): LLM {
+  if (!defaultLLMInstance) {
+    defaultLLMInstance = new LlamaCpp();
+  }
+  return defaultLLMInstance;
+}
+
+/**
+ * Set a custom default LLM instance (useful for remote/hybrid backends and testing).
+ */
+export function setDefaultLLM(llm: LLM | null): void {
+  defaultLLMInstance = llm;
+}
+
+/**
+ * Get the default LlamaCpp instance (creates one if needed).
+ * Prefer getDefaultLLM() when the backend may be remote or hybrid.
  */
 export function getDefaultLlamaCpp(): LlamaCpp {
-  if (!defaultLlamaCpp) {
-    defaultLlamaCpp = new LlamaCpp();
-  }
-  return defaultLlamaCpp;
+  return getDefaultLLM() as LlamaCpp;
 }
 
 /**
  * Set a custom default LlamaCpp instance (useful for testing)
  */
 export function setDefaultLlamaCpp(llm: LlamaCpp | null): void {
-  defaultLlamaCpp = llm;
+  setDefaultLLM(llm);
 }
 
 /**
@@ -1711,8 +1934,8 @@ export function setDefaultLlamaCpp(llm: LlamaCpp | null): void {
  * Call this before process exit to prevent NAPI crashes.
  */
 export async function disposeDefaultLlamaCpp(): Promise<void> {
-  if (defaultLlamaCpp) {
-    await defaultLlamaCpp.dispose();
-    defaultLlamaCpp = null;
+  if (defaultLLMInstance) {
+    await defaultLLMInstance.dispose();
+    defaultLLMInstance = null;
   }
 }

--- a/src/remote-llm.ts
+++ b/src/remote-llm.ts
@@ -1,0 +1,719 @@
+import {
+  isQwen3EmbeddingModel,
+  type EmbedOptions,
+  type EmbeddingResult,
+  type GenerateOptions,
+  type GenerateResult,
+  type LLM,
+  type ModelInfo,
+  type Queryable,
+  type RerankDocument,
+  type RerankOptions,
+  type RerankResult,
+} from "./llm.js";
+
+const DEFAULT_CONNECT_TIMEOUT_MS = 5_000;
+const DEFAULT_READ_TIMEOUT_MS = 30_000;
+const DEFAULT_BREAKER_THRESHOLD = 2;
+const DEFAULT_BREAKER_COOLDOWN_MS = 10 * 60 * 1000;
+const QWEN_QUERY_PREFIX =
+  "Instruct: Retrieve relevant documents for the given query\nQuery: ";
+const LEGACY_QUERY_PREFIX = "task: search result | query: ";
+const LEGACY_DOC_PREFIX = /^title:\s*(.*?)\s*\|\s*text:\s*([\s\S]*)$/;
+const COUNTED_FAILURE = Symbol("remoteFailureCounted");
+
+type EndpointName = "embed" | "rerank" | "chat";
+type BreakerStatus = "closed" | "open" | "half-open";
+
+type BreakerState = {
+  failures: number;
+  openUntil: number;
+  state: BreakerStatus;
+};
+
+export type RemoteLLMConfig = {
+  embedUrl?: string;
+  rerankUrl?: string;
+  /**
+   * Base URL for the chat completions endpoint (generate/expandQuery).
+   * Defaults to embedUrl. Set this when your embedding server and chat
+   * server are separate (e.g. TEI for embeddings, vLLM for chat).
+   * Override via QMD_REMOTE_GEN_URL env var.
+   */
+  genUrl?: string;
+  embedModel?: string;
+  rerankModel?: string;
+  genModel?: string;
+  apiKey?: string;
+  connectTimeoutMs?: number;
+  readTimeoutMs?: number;
+  breakerThreshold?: number;
+  breakerCooldownMs?: number;
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function logStderr(message: string): void {
+  process.stderr.write(`[${nowIso()}] ${message}\n`);
+}
+
+function parseTimeout(
+  value: number | string | undefined,
+  fallback: number,
+  label: string,
+): number {
+  if (value === undefined || value === "") {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+  return parsed;
+}
+
+function parsePositiveInt(
+  value: number | undefined,
+  fallback: number,
+  label: string,
+): number {
+  if (value === undefined) return fallback;
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+  return value;
+}
+
+function joinEndpoint(baseUrl: string, path: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}${path}`;
+}
+
+function clipForLog(value: string, max = 300): string {
+  return value.length <= max ? value : `${value.slice(0, max)}...`;
+}
+
+function markFailureCounted(error: unknown): unknown {
+  if (error && typeof error === "object") {
+    Reflect.set(error, COUNTED_FAILURE, true);
+  }
+  return error;
+}
+
+function wasFailureCounted(error: unknown): boolean {
+  return !!(
+    error &&
+    typeof error === "object" &&
+    Reflect.get(error, COUNTED_FAILURE)
+  );
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  let timer: NodeJS.Timeout | null = null;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(`${label} timeout after ${timeoutMs}ms`));
+        }, timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function extractOriginalEmbeddingText(text: string): {
+  kind: "query" | "document" | "unknown";
+  text: string;
+} {
+  if (text.startsWith(QWEN_QUERY_PREFIX)) {
+    logStderr(
+      "[debug] RemoteLLM: stripped Qwen query prefix from embedding input",
+    );
+    return { kind: "query", text: text.slice(QWEN_QUERY_PREFIX.length) };
+  }
+  if (text.startsWith(LEGACY_QUERY_PREFIX)) {
+    logStderr(
+      "[debug] RemoteLLM: stripped legacy query prefix from embedding input",
+    );
+    return { kind: "query", text: text.slice(LEGACY_QUERY_PREFIX.length) };
+  }
+
+  const docMatch = LEGACY_DOC_PREFIX.exec(text);
+  if (docMatch) {
+    const [, title, body] = docMatch;
+    logStderr(
+      "[debug] RemoteLLM: stripped legacy doc prefix from embedding input",
+    );
+    return {
+      kind: "document",
+      text: title ? `${title}\n${body ?? ""}` : (body ?? ""),
+    };
+  }
+
+  return { kind: "unknown", text };
+}
+
+export class RemoteLLM implements LLM {
+  readonly isRemote = true;
+  private readonly embedUrl: string;
+  private readonly rerankUrl: string;
+  private readonly genUrl: string;
+  private readonly embedModel: string;
+  private readonly rerankModel: string;
+  private readonly genModel: string;
+  private readonly apiKey: string;
+  private readonly connectTimeoutMs: number;
+  private readonly readTimeoutMs: number;
+  private readonly breakerThreshold: number;
+  private readonly breakerCooldownMs: number;
+  private readonly breakerState: Record<EndpointName, BreakerState>;
+  private expectedEmbedDim: number | null = null;
+
+  constructor(config: RemoteLLMConfig = {}) {
+    const embedUrl = config.embedUrl ?? process.env.QMD_REMOTE_EMBED_URL;
+    const rerankUrl = config.rerankUrl ?? process.env.QMD_REMOTE_RERANK_URL;
+
+    if (!embedUrl)
+      throw new Error("QMD_REMOTE_EMBED_URL is required for RemoteLLM");
+    if (!rerankUrl)
+      throw new Error("QMD_REMOTE_RERANK_URL is required for RemoteLLM");
+
+    this.embedUrl = String(embedUrl).replace(/\/+$/, "");
+    this.rerankUrl = String(rerankUrl).replace(/\/+$/, "");
+    this.genUrl = String(
+      config.genUrl ?? process.env.QMD_REMOTE_GEN_URL ?? embedUrl,
+    ).replace(/\/+$/, "");
+    this.embedModel =
+      config.embedModel ??
+      process.env.QMD_REMOTE_EMBED_MODEL ??
+      process.env.QMD_EMBED_MODEL ??
+      "remote-embedding";
+    this.rerankModel =
+      config.rerankModel ??
+      process.env.QMD_REMOTE_RERANK_MODEL ??
+      process.env.QMD_RERANK_MODEL ??
+      "remote-reranker";
+    this.genModel =
+      config.genModel ?? process.env.QMD_REMOTE_GEN_MODEL ?? "gpt-5.4-mini";
+    this.apiKey = config.apiKey ?? process.env.QMD_REMOTE_API_KEY ?? "";
+    this.connectTimeoutMs = parseTimeout(
+      config.connectTimeoutMs ?? process.env.QMD_REMOTE_CONNECT_TIMEOUT,
+      DEFAULT_CONNECT_TIMEOUT_MS,
+      "QMD_REMOTE_CONNECT_TIMEOUT",
+    );
+    this.readTimeoutMs = parseTimeout(
+      config.readTimeoutMs ?? process.env.QMD_REMOTE_READ_TIMEOUT,
+      DEFAULT_READ_TIMEOUT_MS,
+      "QMD_REMOTE_READ_TIMEOUT",
+    );
+    this.breakerThreshold = parsePositiveInt(
+      config.breakerThreshold,
+      DEFAULT_BREAKER_THRESHOLD,
+      "breakerThreshold",
+    );
+    this.breakerCooldownMs = parsePositiveInt(
+      config.breakerCooldownMs,
+      DEFAULT_BREAKER_COOLDOWN_MS,
+      "breakerCooldownMs",
+    );
+    this.breakerState = {
+      embed: { failures: 0, openUntil: 0, state: "closed" },
+      rerank: { failures: 0, openUntil: 0, state: "closed" },
+      chat: { failures: 0, openUntil: 0, state: "closed" },
+    };
+  }
+
+  private normalizeEmbeddingInput(
+    text: string,
+    options: EmbedOptions = {},
+  ): string {
+    const extracted = extractOriginalEmbeddingText(text);
+    const kind = options.isQuery ? "query" : extracted.kind;
+    const plainText = extracted.text;
+    const embedModelHint = options.model ?? this.embedModel;
+
+    if (kind === "query" && isQwen3EmbeddingModel(embedModelHint)) {
+      return `${QWEN_QUERY_PREFIX}${plainText}`;
+    }
+
+    return plainText;
+  }
+
+  private buildHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      accept: "application/json",
+    };
+    if (this.apiKey) {
+      headers.authorization = `Bearer ${this.apiKey}`;
+    }
+    return headers;
+  }
+
+  private beforeRequest(endpoint: EndpointName): void {
+    const state = this.breakerState[endpoint];
+    const now = Date.now();
+
+    if (state.openUntil > now) {
+      const retryAt = new Date(state.openUntil).toISOString();
+      logStderr(
+        `RemoteLLM ${endpoint} circuit open until ${retryAt}; skipping request`,
+      );
+      throw markFailureCounted(
+        new Error(
+          `Remote ${endpoint} endpoint is in circuit-breaker cooldown until ${retryAt}`,
+        ),
+      );
+    }
+
+    if (
+      state.state === "open" &&
+      state.openUntil !== 0 &&
+      state.openUntil <= now
+    ) {
+      state.state = "half-open";
+      state.openUntil = 0;
+      logStderr(
+        `RemoteLLM ${endpoint} circuit cooldown elapsed; retrying endpoint`,
+      );
+    }
+  }
+
+  private onSuccess(endpoint: EndpointName): void {
+    const state = this.breakerState[endpoint];
+    const previousState = state.state;
+    const hadFailures = state.failures > 0;
+    state.failures = 0;
+    state.openUntil = 0;
+    state.state = "closed";
+
+    if (previousState !== "closed" || hadFailures) {
+      logStderr(
+        `RemoteLLM ${endpoint} circuit closed after successful request`,
+      );
+    }
+  }
+
+  private onFailure(endpoint: EndpointName, error: unknown): void {
+    const state = this.breakerState[endpoint];
+    state.failures += 1;
+
+    if (state.failures >= this.breakerThreshold) {
+      state.state = "open";
+      state.openUntil = Date.now() + this.breakerCooldownMs;
+      logStderr(
+        `RemoteLLM ${endpoint} circuit opened after ${state.failures} consecutive failures; cooldown ${Math.round(this.breakerCooldownMs / 60000)}m`,
+      );
+    } else {
+      state.state = "closed";
+    }
+
+    logStderr(
+      `RemoteLLM ${endpoint} error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  private async postJson(
+    endpoint: EndpointName,
+    url: string,
+    payload: unknown,
+  ): Promise<any> {
+    this.beforeRequest(endpoint);
+
+    const connectController = new AbortController();
+    const connectTimer = setTimeout(() => {
+      connectController.abort(
+        new Error(`connect timeout after ${this.connectTimeoutMs}ms`),
+      );
+    }, this.connectTimeoutMs);
+    connectTimer.unref?.();
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "POST",
+        headers: this.buildHeaders(),
+        body: JSON.stringify(payload),
+        signal: connectController.signal,
+      });
+    } catch (error) {
+      clearTimeout(connectTimer);
+      this.onFailure(endpoint, error);
+      throw markFailureCounted(error);
+    }
+    clearTimeout(connectTimer);
+
+    let responseText: string;
+    try {
+      responseText = await withTimeout(
+        response.text(),
+        this.readTimeoutMs,
+        "read",
+      );
+    } catch (error) {
+      this.onFailure(endpoint, error);
+      throw markFailureCounted(error);
+    }
+
+    if (!response.ok) {
+      const error = new Error(
+        `HTTP ${response.status} from ${url}: ${clipForLog(responseText)}`,
+      );
+      this.onFailure(endpoint, error);
+      throw markFailureCounted(error);
+    }
+
+    try {
+      return responseText ? JSON.parse(responseText) : {};
+    } catch {
+      const error = new Error(
+        `Invalid JSON from ${url}: ${clipForLog(responseText)}`,
+      );
+      this.onFailure(endpoint, error);
+      throw markFailureCounted(error);
+    }
+  }
+
+  private async fetchModels(
+    endpoint: EndpointName,
+    baseUrl: string,
+  ): Promise<string[]> {
+    this.beforeRequest(endpoint);
+
+    const connectController = new AbortController();
+    const connectTimer = setTimeout(() => {
+      connectController.abort(
+        new Error(`connect timeout after ${this.connectTimeoutMs}ms`),
+      );
+    }, this.connectTimeoutMs);
+    connectTimer.unref?.();
+
+    let response: Response;
+    try {
+      response = await fetch(joinEndpoint(baseUrl, "/v1/models"), {
+        method: "GET",
+        headers: this.buildHeaders(),
+        signal: connectController.signal,
+      });
+    } catch (error) {
+      clearTimeout(connectTimer);
+      this.onFailure(endpoint, error);
+      throw markFailureCounted(error);
+    }
+    clearTimeout(connectTimer);
+
+    let body: string;
+    try {
+      body = await withTimeout(response.text(), this.readTimeoutMs, "read");
+    } catch (error) {
+      this.onFailure(endpoint, error);
+      throw markFailureCounted(error);
+    }
+
+    if (!response.ok) {
+      const error = new Error(
+        `HTTP ${response.status} from ${baseUrl}/v1/models: ${clipForLog(body)}`,
+      );
+      this.onFailure(endpoint, error);
+      throw markFailureCounted(error);
+    }
+
+    try {
+      const parsed = body ? JSON.parse(body) : {};
+      const models = Array.isArray(parsed?.data) ? parsed.data : [];
+      this.onSuccess(endpoint);
+      return models
+        .map((model) => (typeof model?.id === "string" ? model.id : null))
+        .filter((value): value is string => value !== null);
+    } catch {
+      const error = new Error(
+        `Invalid JSON from ${baseUrl}/v1/models: ${clipForLog(body)}`,
+      );
+      this.onFailure(endpoint, error);
+      throw markFailureCounted(error);
+    }
+  }
+
+  async embed(
+    text: string,
+    options: EmbedOptions = {},
+  ): Promise<EmbeddingResult | null> {
+    const [result] = await this.embedBatch([text], options);
+    return result ?? null;
+  }
+
+  async embedBatch(
+    texts: string[],
+    options: EmbedOptions = {},
+  ): Promise<(EmbeddingResult | null)[]> {
+    if (texts.length === 0) return [];
+
+    const input = texts.map((text) =>
+      this.normalizeEmbeddingInput(text, options),
+    );
+    const url = joinEndpoint(this.embedUrl, "/v1/embeddings");
+
+    try {
+      const data = await this.postJson("embed", url, {
+        input,
+        // Always use the configured remote model, not the caller's model name
+        // (which may be a local model like "embeddinggemma" from store.ts).
+        model: this.embedModel,
+      });
+
+      if (!Array.isArray(data?.data)) {
+        throw new Error(
+          `Invalid embedding response from ${url}: missing data array`,
+        );
+      }
+
+      const sorted = [...data.data].sort(
+        (a, b) => (a.index ?? 0) - (b.index ?? 0),
+      );
+      if (sorted.length !== texts.length) {
+        throw new Error(
+          `Invalid embedding response from ${url}: expected ${texts.length} vectors, got ${sorted.length}`,
+        );
+      }
+
+      const results = sorted.map((item) => {
+        if (!Array.isArray(item?.embedding)) {
+          throw new Error(
+            `Invalid embedding response item from ${url}: missing embedding array`,
+          );
+        }
+
+        const dim = item.embedding.length;
+        if (this.expectedEmbedDim === null) {
+          this.expectedEmbedDim = dim;
+          logStderr(`RemoteLLM embed dimension locked: ${dim}`);
+        } else if (dim !== this.expectedEmbedDim) {
+          throw new Error(
+            `Embedding dimension mismatch: expected ${this.expectedEmbedDim}, got ${dim}. Model or server config may have changed.`,
+          );
+        }
+
+        return {
+          embedding: item.embedding,
+          model: data.model ?? this.embedModel,
+        } satisfies EmbeddingResult;
+      });
+
+      this.onSuccess("embed");
+      return results;
+    } catch (error) {
+      if (!wasFailureCounted(error)) {
+        this.onFailure("embed", error);
+      }
+      throw error;
+    }
+  }
+
+  async generate(
+    prompt: string,
+    options: GenerateOptions = {},
+  ): Promise<GenerateResult | null> {
+    const url = joinEndpoint(this.genUrl, "/v1/chat/completions");
+    const model = options.model ?? this.genModel;
+    const data = await this.postJson("chat", url, {
+      model,
+      messages: [{ role: "user", content: prompt }],
+      max_tokens: options.maxTokens ?? 600,
+      temperature: options.temperature ?? 0.7,
+    });
+    const text = data?.choices?.[0]?.message?.content ?? "";
+    return { text, model: data?.model ?? model, done: true };
+  }
+
+  async expandQuery(
+    query: string,
+    options?: { context?: string; includeLexical?: boolean; intent?: string },
+  ): Promise<Queryable[]> {
+    const includeLexical = options?.includeLexical ?? true;
+    const intent = options?.intent;
+    const systemPrompt = [
+      "You expand search queries into 2-4 typed variations for a hybrid search system.",
+      "Each line must be: type: text",
+      "Types: lex (keyword/BM25), vec (semantic), hyde (hypothetical document excerpt).",
+      "Generate at least one vec and one hyde variant. Keep variants concise (under 30 words).",
+      "Output ONLY the typed lines, no other text.",
+    ].join("\n");
+    const userPrompt = intent
+      ? `Expand this search query: ${query}\nQuery intent: ${intent}`
+      : `Expand this search query: ${query}`;
+    const url = joinEndpoint(this.genUrl, "/v1/chat/completions");
+    try {
+      const data = await this.postJson("chat", url, {
+        model: this.genModel,
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userPrompt },
+        ],
+        max_tokens: 300,
+        temperature: 0.7,
+      });
+      const text: string = data?.choices?.[0]?.message?.content ?? "";
+      const lines = text.trim().split("\n");
+      const queryables: Queryable[] = lines
+        .map((line: string) => {
+          const colonIdx = line.indexOf(":");
+          if (colonIdx === -1) return null;
+          const type = line.slice(0, colonIdx).trim().toLowerCase();
+          if (type !== "lex" && type !== "vec" && type !== "hyde") return null;
+          const t = line.slice(colonIdx + 1).trim();
+          if (!t) return null;
+          return { type: type as "lex" | "vec" | "hyde", text: t };
+        })
+        .filter((q: Queryable | null): q is Queryable => q !== null);
+      const filtered = includeLexical
+        ? queryables
+        : queryables.filter((q) => q.type !== "lex");
+      if (filtered.length > 0) return filtered;
+    } catch (error) {
+      logStderr(
+        `RemoteLLM expandQuery error: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    const fallback: Queryable[] = [
+      { type: "hyde", text: `Information about ${query}` },
+      { type: "vec", text: query },
+    ];
+    if (includeLexical) fallback.push({ type: "lex", text: query });
+    return fallback;
+  }
+
+  // Character-based tokenization approximation (~4 chars/token for English).
+  // Good enough for document chunking — exact counts not needed.
+  private static readonly CHARS_PER_TOKEN = 4;
+
+  async tokenize(text: string): Promise<readonly number[]> {
+    const count = Math.ceil(text.length / RemoteLLM.CHARS_PER_TOKEN);
+    return Array.from({ length: count }, (_, i) => i);
+  }
+
+  async countTokens(text: string): Promise<number> {
+    return Math.ceil(text.length / RemoteLLM.CHARS_PER_TOKEN);
+  }
+
+  async detokenize(tokens: readonly unknown[]): Promise<string> {
+    // Character-length approximation: each index-based token represents ~4 chars.
+    // The caller (chunkDocumentByTokens fallback path) only needs non-empty text
+    // for re-chunking — exact content is irrelevant.
+    return "x".repeat(tokens.length * RemoteLLM.CHARS_PER_TOKEN);
+  }
+
+  async rerank(
+    query: string,
+    documents: RerankDocument[],
+    options: RerankOptions = {},
+  ): Promise<RerankResult> {
+    if (documents.length === 0) {
+      return { results: [], model: options.model ?? this.rerankModel };
+    }
+
+    const url = joinEndpoint(this.rerankUrl, "/v1/rerank");
+    try {
+      const data = await this.postJson("rerank", url, {
+        query,
+        documents: documents.map((document) => document.text),
+        model: options.model ?? this.rerankModel,
+        return_documents: false,
+      });
+
+      const results = Array.isArray(data?.results)
+        ? data.results
+        : Array.isArray(data?.data)
+          ? data.data
+          : null;
+      if (!results) {
+        throw new Error(
+          `Invalid rerank response from ${url}: missing results array`,
+        );
+      }
+
+      const normalized = results.map((item) => {
+        const index = item.index ?? item.document_index;
+        const score = item.relevance_score ?? item.score;
+        if (
+          !Number.isInteger(index) ||
+          index < 0 ||
+          index >= documents.length
+        ) {
+          throw new Error(
+            `Invalid rerank response item from ${url}: bad index ${String(index)}`,
+          );
+        }
+        if (typeof score !== "number" || Number.isNaN(score)) {
+          throw new Error(
+            `Invalid rerank response item from ${url}: bad score ${String(score)}`,
+          );
+        }
+        const document = documents[index];
+        if (!document) {
+          throw new Error(
+            `Invalid rerank response item from ${url}: missing document for index ${String(index)}`,
+          );
+        }
+        return {
+          file: document.file,
+          index,
+          score,
+        };
+      });
+
+      normalized.sort((a, b) => b.score - a.score);
+      this.onSuccess("rerank");
+      return {
+        results: normalized,
+        model: data.model ?? options.model ?? this.rerankModel,
+      };
+    } catch (error) {
+      if (!wasFailureCounted(error)) {
+        this.onFailure("rerank", error);
+      }
+      throw error;
+    }
+  }
+
+  async modelExists(model: string): Promise<ModelInfo> {
+    try {
+      const [embedModels, rerankModels] = await Promise.allSettled([
+        this.fetchModels("embed", this.embedUrl),
+        this.fetchModels("rerank", this.rerankUrl),
+      ]);
+
+      const available = new Set<string>();
+      if (embedModels.status === "fulfilled") {
+        for (const name of embedModels.value) available.add(name);
+      }
+      if (rerankModels.status === "fulfilled") {
+        for (const name of rerankModels.value) available.add(name);
+      }
+
+      if (available.size > 0) {
+        return { name: model, exists: available.has(model) };
+      }
+    } catch {
+      // Fall through to optimistic default below.
+    }
+
+    logStderr(
+      `RemoteLLM modelExists: could not verify availability of model "${model}" — assuming available (fail-open)`,
+    );
+    return { name: model, exists: true };
+  }
+
+  async dispose(): Promise<void> {
+    // No local resources to release.
+  }
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -2283,7 +2283,7 @@ export async function chunkDocumentByTokens(
   signal?: AbortSignal,
   llmOverride?: LLM,
 ): Promise<{ text: string; pos: number; tokens: number }[]> {
-  const llm = llmOverride ?? getDefaultLlamaCpp();
+  const llm = llmOverride ?? getDefaultLLM();
 
   // Use moderate chars/token estimate (prose ~4, code ~2, mixed ~3)
   // If chunks exceed limit, they'll be re-split with actual ratio

--- a/src/store.ts
+++ b/src/store.ts
@@ -21,9 +21,11 @@ import fastGlob from "fast-glob";
 import {
   LlamaCpp,
   getDefaultLlamaCpp,
+  getDefaultLLM,
   formatQueryForEmbedding,
   formatDocForEmbedding,
   withLLMSessionForLlm,
+  type LLM,
   type RerankDocument,
   type ILLMSession,
 } from "./llm.js";
@@ -62,8 +64,8 @@ export const CHUNK_WINDOW_CHARS = CHUNK_WINDOW_TOKENS * 4;  // 800 chars
  * Get the LlamaCpp instance for a store — prefers the store's own instance,
  * falls back to the global singleton.
  */
-function getLlm(store: Store): LlamaCpp {
-  return store.llm ?? getDefaultLlamaCpp();
+function getLlm(store: Store): LLM {
+  return store.llm ?? getDefaultLLM();
 }
 
 // =============================================================================
@@ -1087,8 +1089,8 @@ function ensureVecTableInternal(db: Database, dimensions: number): void {
 export type Store = {
   db: Database;
   dbPath: string;
-  /** Optional LlamaCpp instance for this store (overrides the global singleton) */
-  llm?: LlamaCpp;
+  /** Optional LLM instance for this store (overrides the global singleton) */
+  llm?: LLM;
   close: () => void;
   ensureVecTable: (dimensions: number) => void;
 
@@ -1429,9 +1431,12 @@ export async function generateEmbeddings(
   const totalDocs = docsToEmbed.length;
   const startTime = Date.now();
 
-  // Use store's LlamaCpp or global singleton, wrapped in a session
+  // Use store's configured LLM or the global singleton, wrapped in a session
   const llm = getLlm(store);
   const embedModelUri = llm.embedModelName;
+  const formatDoc = llm.isRemote
+    ? (text: string, title?: string) => title ? `${title}\n${text}` : text
+    : (text: string, title?: string) => formatDocForEmbedding(text, title, embedModelUri);
 
   // Create a session manager for this llm instance
   const result = await withLLMSessionForLlm(llm, async (session) => {
@@ -1464,6 +1469,7 @@ export async function generateEmbeddings(
           doc.path,
           options?.chunkStrategy,
           session.signal,
+          llm,
         );
 
         for (let seq = 0; seq < chunks.length; seq++) {
@@ -1489,7 +1495,7 @@ export async function generateEmbeddings(
 
       if (!vectorTableInitialized) {
         const firstChunk = batchChunks[0]!;
-        const firstText = formatDocForEmbedding(firstChunk.text, firstChunk.title, embedModelUri);
+        const firstText = formatDoc(firstChunk.text, firstChunk.title);
         const firstResult = await session.embed(firstText, { model });
         if (!firstResult) {
           throw new Error("Failed to get embedding dimensions from first chunk");
@@ -1521,7 +1527,7 @@ export async function generateEmbeddings(
 
         const batchEnd = Math.min(batchStart + BATCH_SIZE, batchChunks.length);
         const chunkBatch = batchChunks.slice(batchStart, batchEnd);
-        const texts = chunkBatch.map(chunk => formatDocForEmbedding(chunk.text, chunk.title, embedModelUri));
+        const texts = chunkBatch.map(chunk => formatDoc(chunk.text, chunk.title));
 
         try {
           const embeddings = await session.embedBatch(texts, { model });
@@ -1545,7 +1551,7 @@ export async function generateEmbeddings(
           } else {
             for (const chunk of chunkBatch) {
               try {
-                const text = formatDocForEmbedding(chunk.text, chunk.title, embedModelUri);
+                const text = formatDoc(chunk.text, chunk.title);
                 const result = await session.embed(text, { model });
                 if (result) {
                   insertEmbedding(db, chunk.hash, chunk.seq, chunk.pos, new Float32Array(result.embedding), model, now);
@@ -1752,8 +1758,8 @@ export function handelize(path: string): string {
         const nameWithoutExt = ext ? segment.slice(0, -ext.length) : segment;
 
         const cleanedName = nameWithoutExt
-          .replace(/[^\p{L}\p{N}$]+/gu, '-')  // Keep letters, numbers, "$"; dash-separate rest (including dots)
-          .replace(/^-+|-+$/g, ''); // Remove leading/trailing dashes
+          .replace(/[^\p{L}\p{N}$]+/gu, "-") // Keep letters, numbers, "$"; dash-separate rest (including dots)
+          .replace(/^-+|-+$/g, ""); // Remove leading/trailing dashes
 
         return cleanedName + ext;
       } else {
@@ -2274,9 +2280,10 @@ export async function chunkDocumentByTokens(
   windowTokens: number = CHUNK_WINDOW_TOKENS,
   filepath?: string,
   chunkStrategy: ChunkStrategy = "regex",
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  llmOverride?: LLM,
 ): Promise<{ text: string; pos: number; tokens: number }[]> {
-  const llm = getDefaultLlamaCpp();
+  const llm = llmOverride ?? getDefaultLlamaCpp();
 
   // Use moderate chars/token estimate (prose ~4, code ~2, mixed ~3)
   // If chunks exceed limit, they'll be re-split with actual ratio
@@ -3186,7 +3193,7 @@ export async function searchVec(db: Database, query: string, model: string, limi
 // Embeddings
 // =============================================================================
 
-async function getEmbedding(text: string, model: string, isQuery: boolean, session?: ILLMSession, llmOverride?: LlamaCpp): Promise<number[] | null> {
+async function getEmbedding(text: string, model: string, isQuery: boolean, session?: ILLMSession, llmOverride?: LLM): Promise<number[] | null> {
   // Format text using the appropriate prompt template
   const formattedText = isQuery ? formatQueryForEmbedding(text, model) : formatDocForEmbedding(text, undefined, model);
   const result = session
@@ -3255,7 +3262,7 @@ export function insertEmbedding(
 // Query expansion
 // =============================================================================
 
-export async function expandQuery(query: string, model: string = DEFAULT_QUERY_MODEL, db: Database, intent?: string, llmOverride?: LlamaCpp): Promise<ExpandedQuery[]> {
+export async function expandQuery(query: string, model: string = DEFAULT_QUERY_MODEL, db: Database, intent?: string, llmOverride?: LLM): Promise<ExpandedQuery[]> {
   // Check cache first — stored as JSON preserving types
   const cacheKey = getCacheKey("expandQuery", { query, model, ...(intent && { intent }) });
   const cached = getCachedResult(db, cacheKey);
@@ -3294,7 +3301,7 @@ export async function expandQuery(query: string, model: string = DEFAULT_QUERY_M
 // Reranking
 // =============================================================================
 
-export async function rerank(query: string, documents: { file: string; text: string }[], model: string = DEFAULT_RERANK_MODEL, db: Database, intent?: string, llmOverride?: LlamaCpp): Promise<{ file: string; score: number }[]> {
+export async function rerank(query: string, documents: { file: string; text: string }[], model: string = DEFAULT_RERANK_MODEL, db: Database, intent?: string, llmOverride?: LLM): Promise<{ file: string; score: number }[]> {
   // Prepend intent to rerank query so the reranker scores with domain context
   const rerankQuery = intent ? `${intent}\n\n${query}` : query;
 
@@ -4088,7 +4095,9 @@ export async function hybridQuery(
 
     // Batch embed all vector queries in a single call
     const llm = getLlm(store);
-    const textsToEmbed = vecQueries.map(q => formatQueryForEmbedding(q.text, llm.embedModelName));
+    const textsToEmbed = llm.isRemote
+      ? vecQueries.map(q => q.text)
+      : vecQueries.map(q => formatQueryForEmbedding(q.text, llm.embedModelName));
     hooks?.onEmbedStart?.(textsToEmbed.length);
     const embedStart = Date.now();
     const embeddings = await llm.embedBatch(textsToEmbed);
@@ -4471,7 +4480,9 @@ export async function structuredSearch(
     );
     if (vecSearches.length > 0) {
       const llm = getLlm(store);
-      const textsToEmbed = vecSearches.map(s => formatQueryForEmbedding(s.query, llm.embedModelName));
+      const textsToEmbed = llm.isRemote
+        ? vecSearches.map(s => s.query)
+        : vecSearches.map(s => formatQueryForEmbedding(s.query, llm.embedModelName));
       hooks?.onEmbedStart?.(textsToEmbed.length);
       const embedStart = Date.now();
       const embeddings = await llm.embedBatch(textsToEmbed);

--- a/src/store.ts
+++ b/src/store.ts
@@ -2389,7 +2389,7 @@ export async function chunkDocumentByTokens(
   signal?: AbortSignal,
   llmOverride?: LLM,
 ): Promise<{ text: string; pos: number; tokens: number }[]> {
-  const llm = llmOverride ?? getDefaultLlamaCpp();
+  const llm = llmOverride ?? getDefaultLLM();
 
   // Use moderate chars/token estimate (prose ~4, code ~2, mixed ~3)
   // If chunks exceed limit, they'll be re-split with actual ratio

--- a/src/store.ts
+++ b/src/store.ts
@@ -22,9 +22,11 @@ import { qmdHomedir } from "./paths.js";
 import {
   LlamaCpp,
   getDefaultLlamaCpp,
+  getDefaultLLM,
   formatQueryForEmbedding,
   formatDocForEmbedding,
   withLLMSessionForLlm,
+  type LLM,
   type RerankDocument,
   type ILLMSession,
 } from "./llm.js";
@@ -62,8 +64,8 @@ export const CHUNK_WINDOW_CHARS = CHUNK_WINDOW_TOKENS * 4;  // 800 chars
  * Get the LlamaCpp instance for a store — prefers the store's own instance,
  * falls back to the global singleton.
  */
-function getLlm(store: Store): LlamaCpp {
-  return store.llm ?? getDefaultLlamaCpp();
+function getLlm(store: Store): LLM {
+  return store.llm ?? getDefaultLLM();
 }
 
 // =============================================================================
@@ -1161,8 +1163,8 @@ function ensureVecTableInternal(db: Database, dimensions: number): void {
 export type Store = {
   db: Database;
   dbPath: string;
-  /** Optional LlamaCpp instance for this store (overrides the global singleton) */
-  llm?: LlamaCpp;
+  /** Optional LLM instance for this store (overrides the global singleton) */
+  llm?: LLM;
   close: () => void;
   ensureVecTable: (dimensions: number) => void;
 
@@ -1511,8 +1513,11 @@ export async function generateEmbeddings(
   const totalDocs = docsToEmbed.length;
   const startTime = Date.now();
 
-  // Use store's LlamaCpp or global singleton, wrapped in a session
+  // Use store's configured LLM or the global singleton, wrapped in a session
   const embedModelUri = model;
+  const formatDoc = llm.isRemote
+    ? (text: string, title?: string) => title ? `${title}\n${text}` : text
+    : (text: string, title?: string) => formatDocForEmbedding(text, title, embedModelUri);
 
   // Create a session manager for this llm instance
   const result = await withLLMSessionForLlm(llm, async (session) => {
@@ -1545,6 +1550,7 @@ export async function generateEmbeddings(
           doc.path,
           options?.chunkStrategy,
           session.signal,
+          llm,
         );
 
         for (let seq = 0; seq < chunks.length; seq++) {
@@ -1570,7 +1576,7 @@ export async function generateEmbeddings(
 
       if (!vectorTableInitialized) {
         const firstChunk = batchChunks[0]!;
-        const firstText = formatDocForEmbedding(firstChunk.text, firstChunk.title, embedModelUri);
+        const firstText = formatDoc(firstChunk.text, firstChunk.title);
         const firstResult = await session.embed(firstText, { model });
         if (!firstResult) {
           throw new Error("Failed to get embedding dimensions from first chunk");
@@ -1602,7 +1608,7 @@ export async function generateEmbeddings(
 
         const batchEnd = Math.min(batchStart + BATCH_SIZE, batchChunks.length);
         const chunkBatch = batchChunks.slice(batchStart, batchEnd);
-        const texts = chunkBatch.map(chunk => formatDocForEmbedding(chunk.text, chunk.title, embedModelUri));
+        const texts = chunkBatch.map(chunk => formatDoc(chunk.text, chunk.title));
 
         try {
           const embeddings = await session.embedBatch(texts, { model });
@@ -1626,7 +1632,7 @@ export async function generateEmbeddings(
           } else {
             for (const chunk of chunkBatch) {
               try {
-                const text = formatDocForEmbedding(chunk.text, chunk.title, embedModelUri);
+                const text = formatDoc(chunk.text, chunk.title);
                 const result = await session.embed(text, { model });
                 if (result) {
                   insertEmbedding(db, chunk.hash, chunk.seq, chunk.pos, new Float32Array(result.embedding), model, now);
@@ -1833,8 +1839,8 @@ export function handelize(path: string): string {
         const nameWithoutExt = ext ? segment.slice(0, -ext.length) : segment;
 
         const cleanedName = nameWithoutExt
-          .replace(/[^\p{L}\p{N}$]+/gu, '-')  // Keep letters, numbers, "$"; dash-separate rest (including dots)
-          .replace(/^-+|-+$/g, ''); // Remove leading/trailing dashes
+          .replace(/[^\p{L}\p{N}$]+/gu, "-") // Keep letters, numbers, "$"; dash-separate rest (including dots)
+          .replace(/^-+|-+$/g, ""); // Remove leading/trailing dashes
 
         return cleanedName + ext;
       } else {
@@ -2380,9 +2386,10 @@ export async function chunkDocumentByTokens(
   windowTokens: number = CHUNK_WINDOW_TOKENS,
   filepath?: string,
   chunkStrategy: ChunkStrategy = "regex",
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  llmOverride?: LLM,
 ): Promise<{ text: string; pos: number; tokens: number }[]> {
-  const llm = getDefaultLlamaCpp();
+  const llm = llmOverride ?? getDefaultLlamaCpp();
 
   // Use moderate chars/token estimate (prose ~4, code ~2, mixed ~3)
   // If chunks exceed limit, they'll be re-split with actual ratio
@@ -3303,7 +3310,7 @@ export async function searchVec(db: Database, query: string, model: string, limi
 // Embeddings
 // =============================================================================
 
-async function getEmbedding(text: string, model: string, isQuery: boolean, session?: ILLMSession, llmOverride?: LlamaCpp): Promise<number[] | null> {
+async function getEmbedding(text: string, model: string, isQuery: boolean, session?: ILLMSession, llmOverride?: LLM): Promise<number[] | null> {
   // Format text using the appropriate prompt template
   const formattedText = isQuery ? formatQueryForEmbedding(text, model) : formatDocForEmbedding(text, undefined, model);
   const result = session
@@ -3428,7 +3435,7 @@ export function insertEmbedding(
 // Query expansion
 // =============================================================================
 
-export async function expandQuery(query: string, model: string = DEFAULT_QUERY_MODEL, db: Database, intent?: string, llmOverride?: LlamaCpp): Promise<ExpandedQuery[]> {
+export async function expandQuery(query: string, model: string = DEFAULT_QUERY_MODEL, db: Database, intent?: string, llmOverride?: LLM): Promise<ExpandedQuery[]> {
   // Check cache first — stored as JSON preserving types
   const cacheKey = getCacheKey("expandQuery", { query, model, ...(intent && { intent }) });
   const cached = getCachedResult(db, cacheKey);
@@ -3467,7 +3474,7 @@ export async function expandQuery(query: string, model: string = DEFAULT_QUERY_M
 // Reranking
 // =============================================================================
 
-export async function rerank(query: string, documents: { file: string; text: string }[], model: string = DEFAULT_RERANK_MODEL, db: Database, intent?: string, llmOverride?: LlamaCpp): Promise<{ file: string; score: number }[]> {
+export async function rerank(query: string, documents: { file: string; text: string }[], model: string = DEFAULT_RERANK_MODEL, db: Database, intent?: string, llmOverride?: LLM): Promise<{ file: string; score: number }[]> {
   // Prepend intent to rerank query so the reranker scores with domain context
   const rerankQuery = intent ? `${intent}\n\n${query}` : query;
 
@@ -4276,8 +4283,10 @@ export async function hybridQuery(
 
     // Batch embed all vector queries in a single call
     const llm = getLlm(store);
-    const embedModel = llm.embedModelName;
-    const textsToEmbed = vecQueries.map(q => formatQueryForEmbedding(q.text, embedModel));
+    const embedModel = llm.embedModelName ?? DEFAULT_EMBED_MODEL;
+    const textsToEmbed = llm.isRemote
+      ? vecQueries.map(q => q.text)
+      : vecQueries.map(q => formatQueryForEmbedding(q.text, embedModel));
     hooks?.onEmbedStart?.(textsToEmbed.length);
     const embedStart = Date.now();
     const embeddings = await llm.embedBatch(textsToEmbed);
@@ -4520,7 +4529,7 @@ export async function vectorSearchQuery(
   options?.hooks?.onExpand?.(query, vecExpanded, Date.now() - expandStart);
 
   // Run original + vec/hyde expanded through vector, sequentially — concurrent embed() hangs
-  const embedModel = getLlm(store).embedModelName;
+  const embedModel = getLlm(store).embedModelName ?? DEFAULT_EMBED_MODEL;
   const queryTexts = [query, ...vecExpanded.map(q => q.query)];
   const allResults = new Map<string, VectorSearchResult>();
   for (const q of queryTexts) {
@@ -4662,8 +4671,10 @@ export async function structuredSearch(
     );
     if (vecSearches.length > 0) {
       const llm = getLlm(store);
-      const embedModel = llm.embedModelName;
-      const textsToEmbed = vecSearches.map(s => formatQueryForEmbedding(s.query, embedModel));
+      const embedModel = llm.embedModelName ?? DEFAULT_EMBED_MODEL;
+      const textsToEmbed = llm.isRemote
+        ? vecSearches.map(s => s.query)
+        : vecSearches.map(s => formatQueryForEmbedding(s.query, embedModel));
       hooks?.onEmbedStart?.(textsToEmbed.length);
       const embedStart = Date.now();
       const embeddings = await llm.embedBatch(textsToEmbed);

--- a/test/remote-llm.test.ts
+++ b/test/remote-llm.test.ts
@@ -102,7 +102,7 @@ afterAll(async () => {
 });
 
 afterEach(() => {
-  vi.unstubAllGlobals();
+  vi.unstubAllGlobals?.();
   vi.restoreAllMocks();
 });
 
@@ -333,6 +333,7 @@ describe("RemoteLLM", () => {
   });
 
   test("enforces connect timeout", async () => {
+    const originalFetch = globalThis.fetch;
     const fetchStub = vi.fn(async (_url: string, init?: RequestInit) => {
       const signal = init?.signal as AbortSignal | undefined;
       return await new Promise<Response>((resolve, reject) => {
@@ -340,21 +341,26 @@ describe("RemoteLLM", () => {
         void resolve;
       });
     });
-    vi.stubGlobal("fetch", fetchStub);
+    globalThis.fetch = fetchStub as typeof fetch;
 
-    const remote = new RemoteLLM({
-      embedUrl: "http://example.com",
-      rerankUrl: "http://example.com",
-      connectTimeoutMs: 20,
-      readTimeoutMs: 100,
-    });
+    try {
+      const remote = new RemoteLLM({
+        embedUrl: "http://example.com",
+        rerankUrl: "http://example.com",
+        connectTimeoutMs: 20,
+        readTimeoutMs: 100,
+      });
 
-    await expect(remote.embed("hello")).rejects.toThrow(
-      "connect timeout after 20ms",
-    );
+      await expect(remote.embed("hello")).rejects.toThrow(
+        "connect timeout after 20ms",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   test("enforces read timeout", async () => {
+    const originalFetch = globalThis.fetch;
     const fetchStub = vi.fn(
       async () =>
         new Response(null, {
@@ -368,19 +374,23 @@ describe("RemoteLLM", () => {
         return await new Promise<string>(() => {});
       });
 
-    vi.stubGlobal("fetch", fetchStub);
+    globalThis.fetch = fetchStub as typeof fetch;
 
-    const remote = new RemoteLLM({
-      embedUrl: "http://example.com",
-      rerankUrl: "http://example.com",
-      connectTimeoutMs: 50,
-      readTimeoutMs: 20,
-    });
+    try {
+      const remote = new RemoteLLM({
+        embedUrl: "http://example.com",
+        rerankUrl: "http://example.com",
+        connectTimeoutMs: 50,
+        readTimeoutMs: 20,
+      });
 
-    await expect(remote.embed("hello")).rejects.toThrow(
-      "read timeout after 20ms",
-    );
-    responseTextSpy.mockRestore();
+      await expect(remote.embed("hello")).rejects.toThrow(
+        "read timeout after 20ms",
+      );
+    } finally {
+      responseTextSpy.mockRestore();
+      globalThis.fetch = originalFetch;
+    }
   });
 
   test("generate calls chat completions and returns text", async () => {

--- a/test/remote-llm.test.ts
+++ b/test/remote-llm.test.ts
@@ -1,0 +1,720 @@
+import http from "node:http";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import type { LLM } from "../src/llm.js";
+import { HybridLLM } from "../src/hybrid-llm.js";
+import { RemoteLLM } from "../src/remote-llm.js";
+
+type RecordedRequest = {
+  path: string;
+  method: string;
+  headers: http.IncomingHttpHeaders;
+  body: any;
+};
+
+async function createServer(
+  handler: (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    body: any,
+    requests: RecordedRequest[],
+  ) => void,
+): Promise<{
+  server: http.Server;
+  baseUrl: string;
+  requests: RecordedRequest[];
+}> {
+  const requests: RecordedRequest[] = [];
+  const server = http.createServer((req, res) => {
+    let raw = "";
+    req.on("data", (chunk) => {
+      raw += chunk;
+    });
+    req.on("end", () => {
+      const body = raw ? JSON.parse(raw) : {};
+      requests.push({
+        path: req.url ?? "",
+        method: req.method ?? "GET",
+        headers: req.headers,
+        body,
+      });
+      handler(req, res, body, requests);
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address !== "object") {
+    throw new Error("Failed to get server address");
+  }
+
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    requests,
+  };
+}
+
+function createLocalLLM(overrides: Partial<LLM> = {}): LLM {
+  return {
+    embed: async () => ({ embedding: [0.1], model: "local" }),
+    embedBatch: async (texts) =>
+      texts.map(() => ({ embedding: [0.1], model: "local" })),
+    generate: async () => ({
+      text: "local-generated",
+      model: "local",
+      done: true,
+    }),
+    modelExists: async (model) => ({ name: model, exists: true }),
+    expandQuery: async () => [{ type: "vec", text: "expanded-local" }],
+    rerank: async (_query, documents) => ({
+      results: documents.map((document, index) => ({
+        file: document.file,
+        score: 1 - index * 0.1,
+        index,
+      })),
+      model: "local",
+    }),
+    tokenize: async (text) =>
+      Array.from({ length: Math.ceil(text.length / 4) }, (_, i) => i),
+    countTokens: async (text) => Math.ceil(text.length / 4),
+    detokenize: async (tokens) => "x".repeat((tokens as number[]).length * 4),
+    dispose: async () => {},
+    ...overrides,
+  };
+}
+
+const serversToClose: http.Server[] = [];
+
+afterAll(async () => {
+  await Promise.all(
+    serversToClose.map(
+      (server) => new Promise<void>((resolve) => server.close(() => resolve())),
+    ),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("RemoteLLM", () => {
+  beforeEach(() => {
+    delete process.env.QMD_REMOTE_EMBED_URL;
+    delete process.env.QMD_REMOTE_RERANK_URL;
+    delete process.env.QMD_REMOTE_API_KEY;
+    delete process.env.QMD_REMOTE_CONNECT_TIMEOUT;
+    delete process.env.QMD_REMOTE_READ_TIMEOUT;
+  });
+
+  test("uses separate embed and rerank URLs", async () => {
+    const embedServer = await createServer((_req, res, body) => {
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          data: (body.input as string[]).map((_: string, index: number) => ({
+            index,
+            embedding: [0.1, 0.2, 0.3],
+          })),
+          model: body.model,
+        }),
+      );
+    });
+    const rerankServer = await createServer((_req, res, body) => {
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          results: (body.documents as string[]).map(
+            (_: string, index: number) => ({
+              index,
+              relevance_score: 1 - index * 0.1,
+            }),
+          ),
+          model: body.model,
+        }),
+      );
+    });
+    serversToClose.push(embedServer.server, rerankServer.server);
+
+    const remote = new RemoteLLM({
+      embedUrl: embedServer.baseUrl,
+      rerankUrl: rerankServer.baseUrl,
+      embedModel: "embed-model",
+      rerankModel: "rerank-model",
+    });
+
+    await remote.embed("hello");
+    await remote.rerank("query", [{ file: "a.md", text: "doc-a" }]);
+
+    expect(embedServer.requests).toHaveLength(1);
+    expect(embedServer.requests[0]?.path).toBe("/v1/embeddings");
+    expect(rerankServer.requests).toHaveLength(1);
+    expect(rerankServer.requests[0]?.path).toBe("/v1/rerank");
+  });
+
+  test("adds Qwen instruct prefix for query embeddings and strips legacy prefixes", async () => {
+    let lastInput: string[] = [];
+    const embedServer = await createServer((_req, res, body) => {
+      lastInput = body.input;
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          data: [{ index: 0, embedding: [0.1, 0.2, 0.3] }],
+          model: body.model,
+        }),
+      );
+    });
+    const rerankServer = await createServer((_req, res) => {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ results: [] }));
+    });
+    serversToClose.push(embedServer.server, rerankServer.server);
+
+    const remote = new RemoteLLM({
+      embedUrl: embedServer.baseUrl,
+      rerankUrl: rerankServer.baseUrl,
+      embedModel: "Qwen3-Embedding-8B",
+    });
+
+    await remote.embed("task: search result | query: cats", { isQuery: true });
+    expect(lastInput).toEqual([
+      "Instruct: Retrieve relevant documents for the given query\nQuery: cats",
+    ]);
+  });
+
+  test("locks embedding dimension and throws on mismatch", async () => {
+    let callCount = 0;
+    const embedServer = await createServer((_req, res) => {
+      callCount += 1;
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          data: [
+            { index: 0, embedding: callCount === 1 ? [1, 2, 3] : [1, 2, 3, 4] },
+          ],
+        }),
+      );
+    });
+    const rerankServer = await createServer((_req, res) => {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ results: [] }));
+    });
+    serversToClose.push(embedServer.server, rerankServer.server);
+
+    const remote = new RemoteLLM({
+      embedUrl: embedServer.baseUrl,
+      rerankUrl: rerankServer.baseUrl,
+    });
+
+    await remote.embed("first");
+    await expect(remote.embed("second")).rejects.toThrow(
+      "Embedding dimension mismatch",
+    );
+  });
+
+  test("opens the embed circuit after two failures and keeps rerank circuit independent", async () => {
+    let embedHits = 0;
+    const embedServer = await createServer((_req, res) => {
+      embedHits += 1;
+      res.statusCode = 500;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ error: "embed failed" }));
+    });
+    const rerankServer = await createServer((_req, res, body) => {
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          results: (body.documents as string[]).map(
+            (_: string, index: number) => ({
+              index,
+              relevance_score: 0.9 - index * 0.1,
+            }),
+          ),
+        }),
+      );
+    });
+    serversToClose.push(embedServer.server, rerankServer.server);
+
+    const remote = new RemoteLLM({
+      embedUrl: embedServer.baseUrl,
+      rerankUrl: rerankServer.baseUrl,
+      breakerCooldownMs: 50,
+    });
+
+    await expect(remote.embed("first")).rejects.toThrow("HTTP 500");
+    await expect(remote.embed("second")).rejects.toThrow("HTTP 500");
+    await expect(remote.embed("third")).rejects.toThrow(
+      "circuit-breaker cooldown",
+    );
+    expect(embedHits).toBe(2);
+
+    const rerank = await remote.rerank("query", [
+      { file: "a.md", text: "doc-a" },
+    ]);
+    expect(rerank.results[0]?.file).toBe("a.md");
+  });
+
+  test("retries after cooldown in half-open state", async () => {
+    let callCount = 0;
+    const embedServer = await createServer((_req, res) => {
+      callCount += 1;
+      res.setHeader("content-type", "application/json");
+      if (callCount <= 2) {
+        res.statusCode = 500;
+        res.end(JSON.stringify({ error: "boom" }));
+        return;
+      }
+      res.end(
+        JSON.stringify({
+          data: [{ index: 0, embedding: [0.1, 0.2, 0.3] }],
+        }),
+      );
+    });
+    const rerankServer = await createServer((_req, res) => {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ results: [] }));
+    });
+    serversToClose.push(embedServer.server, rerankServer.server);
+
+    const remote = new RemoteLLM({
+      embedUrl: embedServer.baseUrl,
+      rerankUrl: rerankServer.baseUrl,
+      breakerCooldownMs: 20,
+    });
+
+    await expect(remote.embed("first")).rejects.toThrow();
+    await expect(remote.embed("second")).rejects.toThrow();
+    await expect(remote.embed("third")).rejects.toThrow(
+      "circuit-breaker cooldown",
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    const result = await remote.embed("fourth");
+    expect(result?.embedding).toHaveLength(3);
+    expect(callCount).toBe(3);
+  });
+
+  test("uses Authorization header when api key is configured", async () => {
+    const embedServer = await createServer((_req, res, body) => {
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          data: (body.input as string[]).map((_: string, index: number) => ({
+            index,
+            embedding: [0.1, 0.2, 0.3],
+          })),
+        }),
+      );
+    });
+    const rerankServer = await createServer((_req, res) => {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ results: [] }));
+    });
+    serversToClose.push(embedServer.server, rerankServer.server);
+
+    const remote = new RemoteLLM({
+      embedUrl: embedServer.baseUrl,
+      rerankUrl: rerankServer.baseUrl,
+      apiKey: "secret-token",
+    });
+
+    await remote.embed("hello");
+    expect(embedServer.requests[0]?.headers.authorization).toBe(
+      "Bearer secret-token",
+    );
+  });
+
+  test("enforces connect timeout", async () => {
+    const fetchStub = vi.fn(async (_url: string, init?: RequestInit) => {
+      const signal = init?.signal as AbortSignal | undefined;
+      return await new Promise<Response>((resolve, reject) => {
+        signal?.addEventListener("abort", () => reject(signal.reason));
+        void resolve;
+      });
+    });
+    vi.stubGlobal("fetch", fetchStub);
+
+    const remote = new RemoteLLM({
+      embedUrl: "http://example.com",
+      rerankUrl: "http://example.com",
+      connectTimeoutMs: 20,
+      readTimeoutMs: 100,
+    });
+
+    await expect(remote.embed("hello")).rejects.toThrow(
+      "connect timeout after 20ms",
+    );
+  });
+
+  test("enforces read timeout", async () => {
+    const fetchStub = vi.fn(
+      async () =>
+        new Response(null, {
+          status: 200,
+        }),
+    );
+
+    const responseTextSpy = vi
+      .spyOn(Response.prototype, "text")
+      .mockImplementation(async () => {
+        return await new Promise<string>(() => {});
+      });
+
+    vi.stubGlobal("fetch", fetchStub);
+
+    const remote = new RemoteLLM({
+      embedUrl: "http://example.com",
+      rerankUrl: "http://example.com",
+      connectTimeoutMs: 50,
+      readTimeoutMs: 20,
+    });
+
+    await expect(remote.embed("hello")).rejects.toThrow(
+      "read timeout after 20ms",
+    );
+    responseTextSpy.mockRestore();
+  });
+
+  test("generate calls chat completions and returns text", async () => {
+    const chatServer = await createServer((_req, res) => {
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          model: "gpt-5.4-mini",
+          choices: [{ message: { content: "Generated response text" } }],
+        }),
+      );
+    });
+    serversToClose.push(chatServer.server);
+
+    const remote = new RemoteLLM({
+      embedUrl: chatServer.baseUrl,
+      rerankUrl: chatServer.baseUrl,
+    });
+
+    const result = await remote.generate("What is 2+2?");
+    expect(result?.text).toBe("Generated response text");
+    expect(result?.model).toBe("gpt-5.4-mini");
+    expect(result?.done).toBe(true);
+  });
+
+  test("generate and expandQuery use genUrl when set, not embedUrl", async () => {
+    const embedRequests: string[] = [];
+    const genRequests: string[] = [];
+
+    const embedServer = await createServer((req, res) => {
+      embedRequests.push(req.url ?? "");
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ data: [{ embedding: [0.1] }], model: "m" }));
+    });
+    const genServer = await createServer((req, res) => {
+      genRequests.push(req.url ?? "");
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          choices: [{ message: { content: "vec: test query" } }],
+        }),
+      );
+    });
+    serversToClose.push(embedServer.server, genServer.server);
+
+    const remote = new RemoteLLM({
+      embedUrl: embedServer.baseUrl,
+      rerankUrl: embedServer.baseUrl,
+      genUrl: genServer.baseUrl,
+    });
+
+    await remote.embed("hello");
+    await remote.expandQuery("my query");
+
+    expect(embedRequests.some((u) => u.includes("/v1/embeddings"))).toBe(true);
+    expect(genRequests.some((u) => u.includes("/v1/chat/completions"))).toBe(
+      true,
+    );
+    // embedServer must NOT have received a chat completions request
+    expect(embedRequests.some((u) => u.includes("/v1/chat/completions"))).toBe(
+      false,
+    );
+  });
+
+  test("generate defaults to embedUrl when genUrl not set (backward compat)", async () => {
+    const requests: string[] = [];
+    const server = await createServer((req, res) => {
+      requests.push(req.url ?? "");
+      res.setHeader("content-type", "application/json");
+      if (req.url?.includes("/v1/chat/completions")) {
+        res.end(
+          JSON.stringify({
+            choices: [{ message: { content: "ok" } }],
+          }),
+        );
+      } else {
+        res.end(JSON.stringify({ data: [{ embedding: [0.1] }], model: "m" }));
+      }
+    });
+    serversToClose.push(server.server);
+
+    const remote = new RemoteLLM({
+      embedUrl: server.baseUrl,
+      rerankUrl: server.baseUrl,
+      // no genUrl — should default to embedUrl
+    });
+
+    await remote.embed("hello");
+    await remote.generate("hi");
+
+    // Both embed and chat go to the same server
+    expect(requests.some((u) => u.includes("/v1/embeddings"))).toBe(true);
+    expect(requests.some((u) => u.includes("/v1/chat/completions"))).toBe(true);
+  });
+
+  test("modelExists logs a warning when /v1/models is unreachable", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    const remote = new RemoteLLM({
+      embedUrl: "http://127.0.0.1:1", // unreachable
+      rerankUrl: "http://127.0.0.1:1",
+      connectTimeoutMs: 50,
+      readTimeoutMs: 50,
+    });
+
+    const result = await remote.modelExists("some-model");
+    expect(result.exists).toBe(true); // fail-open
+    const logged = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+    expect(logged).toMatch(/modelExists.*fail-open|assuming available/);
+    stderrSpy.mockRestore();
+  });
+
+  test("legacy prefix stripping logs at debug level", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    const embedServer = await createServer((_req, res) => {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ data: [{ embedding: [0.1] }], model: "m" }));
+    });
+    serversToClose.push(embedServer.server);
+
+    const remote = new RemoteLLM({
+      embedUrl: embedServer.baseUrl,
+      rerankUrl: embedServer.baseUrl,
+      embedModel: "Qwen3-Embedding-8B",
+    });
+
+    // Send text that has a Qwen query prefix (simulating migration scenario)
+    await remote.embed(
+      "Instruct: Retrieve relevant documents for the given query\nQuery: test",
+      { isQuery: true },
+    );
+
+    const logged = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+    expect(logged).toMatch(/\[debug\].*stripped.*prefix/i);
+    stderrSpy.mockRestore();
+  });
+
+  test("expandQuery parses typed lines from chat completions", async () => {
+    const chatServer = await createServer((_req, res) => {
+      res.setHeader("content-type", "application/json");
+      res.end(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                content:
+                  "lex: machine learning search\nvec: neural network retrieval\nhyde: A document about deep learning algorithms",
+              },
+            },
+          ],
+        }),
+      );
+    });
+    serversToClose.push(chatServer.server);
+
+    const remote = new RemoteLLM({
+      embedUrl: chatServer.baseUrl,
+      rerankUrl: chatServer.baseUrl,
+    });
+
+    const results = await remote.expandQuery("deep learning");
+    expect(results).toHaveLength(3);
+    expect(results[0]).toEqual({
+      type: "lex",
+      text: "machine learning search",
+    });
+    expect(results[1]).toEqual({
+      type: "vec",
+      text: "neural network retrieval",
+    });
+    expect(results[2]).toEqual({
+      type: "hyde",
+      text: "A document about deep learning algorithms",
+    });
+  });
+
+  test("expandQuery falls back to lex+vec+hyde when chat fails", async () => {
+    const chatServer = await createServer((_req, res) => {
+      res.statusCode = 500;
+      res.end("{}");
+    });
+    serversToClose.push(chatServer.server);
+
+    const remote = new RemoteLLM({
+      embedUrl: chatServer.baseUrl,
+      rerankUrl: chatServer.baseUrl,
+    });
+
+    const results = await remote.expandQuery("search term");
+    expect(results.some((q) => q.type === "hyde")).toBe(true);
+    expect(results.some((q) => q.type === "vec")).toBe(true);
+    expect(results.some((q) => q.type === "lex")).toBe(true);
+  });
+
+  test("tokenize and countTokens use ~4 chars/token approximation", async () => {
+    const remote = new RemoteLLM({
+      embedUrl: "http://localhost:1",
+      rerankUrl: "http://localhost:1",
+    });
+
+    const text = "hello world test"; // 16 chars → 4 tokens
+    const tokens = await remote.tokenize(text);
+    expect(tokens).toHaveLength(4);
+    expect(await remote.countTokens(text)).toBe(4);
+    // detokenize returns a character-length approximation, not empty string
+    const detoken = await remote.detokenize(tokens);
+    expect(detoken.length).toBe(tokens.length * 4); // CHARS_PER_TOKEN = 4
+    expect(detoken.length).toBeGreaterThan(0);
+  });
+
+  test("chat circuit breaker is independent of embed circuit", async () => {
+    let chatHits = 0;
+    // One server that succeeds for /v1/embeddings but fails for /v1/chat/completions
+    const mixedServer = await createServer((req, res) => {
+      if (req.url?.includes("/v1/chat/completions")) {
+        chatHits += 1;
+        res.statusCode = 500;
+        res.end("{}");
+      } else {
+        res.setHeader("content-type", "application/json");
+        res.end(
+          JSON.stringify({
+            data: [{ embedding: [0.1, 0.2, 0.3] }],
+            model: "m",
+          }),
+        );
+      }
+    });
+    serversToClose.push(mixedServer.server);
+
+    const remote = new RemoteLLM({
+      embedUrl: mixedServer.baseUrl,
+      rerankUrl: mixedServer.baseUrl,
+      breakerCooldownMs: 60_000,
+    });
+
+    // Trip the chat circuit via two failures
+    await expect(remote.generate("p1")).rejects.toThrow();
+    await expect(remote.generate("p2")).rejects.toThrow();
+    await expect(remote.generate("p3")).rejects.toThrow(
+      "circuit-breaker cooldown",
+    );
+    expect(chatHits).toBe(2);
+
+    // Embed circuit is still closed — embeddings work fine
+    const result = await remote.embed("hello");
+    expect(result?.embedding).toHaveLength(3);
+  });
+});
+
+describe("HybridLLM", () => {
+  test("routes all operations to remote — embed, rerank, generate, and expansion", async () => {
+    const calls = {
+      remoteEmbed: 0,
+      remoteRerank: 0,
+      remoteGenerate: 0,
+      remoteExpand: 0,
+    };
+
+    const local = createLocalLLM({});
+
+    const remote = createLocalLLM({
+      isRemote: true,
+      embed: async () => {
+        calls.remoteEmbed += 1;
+        return { embedding: [1, 2, 3], model: "remote-embed" };
+      },
+      embedBatch: async (texts) => {
+        calls.remoteEmbed += texts.length;
+        return texts.map(() => ({
+          embedding: [1, 2, 3],
+          model: "remote-embed",
+        }));
+      },
+      rerank: async (_query, documents) => {
+        calls.remoteRerank += 1;
+        return {
+          results: documents.map((document, index) => ({
+            file: document.file,
+            score: 1 - index * 0.1,
+            index,
+          })),
+          model: "remote-rerank",
+        };
+      },
+      generate: async () => {
+        calls.remoteGenerate += 1;
+        return { text: "remote-generated", model: "remote", done: true };
+      },
+      expandQuery: async () => {
+        calls.remoteExpand += 1;
+        return [{ type: "vec", text: "expanded-remote" }];
+      },
+    });
+
+    const hybrid = new HybridLLM(local, remote);
+
+    expect((await hybrid.embed("hello"))?.model).toBe("remote-embed");
+    expect((await hybrid.generate("prompt"))?.text).toBe("remote-generated");
+    expect((await hybrid.expandQuery("query"))[0]?.text).toBe(
+      "expanded-remote",
+    );
+    expect(
+      (await hybrid.rerank("query", [{ file: "a.md", text: "doc-a" }])).model,
+    ).toBe("remote-rerank");
+
+    expect(calls.remoteEmbed).toBe(1);
+    expect(calls.remoteRerank).toBe(1);
+    expect(calls.remoteGenerate).toBe(1);
+    expect(calls.remoteExpand).toBe(1);
+  });
+
+  test("tokenize/detokenize delegate to remote without as-any casts", async () => {
+    const remote = createLocalLLM({
+      isRemote: true,
+      tokenize: async (text: string) =>
+        Array.from({ length: Math.ceil(text.length / 4) }, (_, i) => i),
+      countTokens: async (text: string) => Math.ceil(text.length / 4),
+      detokenize: async (tokens: readonly unknown[]) =>
+        "x".repeat((tokens as number[]).length * 4),
+    });
+
+    const hybrid = new HybridLLM(createLocalLLM({}), remote);
+
+    const tokens = await hybrid.tokenize("hello world"); // 11 chars → 3 tokens
+    expect(tokens).toHaveLength(3);
+    expect(await hybrid.countTokens("hello world")).toBe(3);
+    const detoken = await hybrid.detokenize(tokens);
+    expect(detoken.length).toBe(12); // 3 * 4
+    expect(detoken.length).toBeGreaterThan(0);
+  });
+});

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -938,6 +938,9 @@ describe("embed", () => {
     const embedBatchCalls: string[][] = [];
     return {
       embedBatchCalls,
+      async tokenize(text: string) {
+        return new Array(Math.max(1, Math.ceil(text.length / 16))).fill(1);
+      },
       async embed(_text: string) {
         return { embedding: [0.1, 0.2, 0.3], model: "fake-embed" };
       },

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -49,6 +49,7 @@ import {
   STRONG_SIGNAL_MIN_SCORE,
   STRONG_SIGNAL_MIN_GAP,
   generateEmbeddings,
+  _resetProductionModeForTesting,
   type Store,
   type DocumentResult,
   type SearchResult,
@@ -280,6 +281,7 @@ describe("Store Creation", () => {
     // In test mode, createStore without path should throw to prevent accidental writes
     const originalIndexPath = process.env.INDEX_PATH;
     delete process.env.INDEX_PATH;
+    _resetProductionModeForTesting();
 
     expect(() => createStore()).toThrow("Database path not set");
 
@@ -2699,6 +2701,9 @@ describe("Embedding batching", () => {
       embedBatchCalls,
       embedCalls,
       embedBatchModelCalls,
+      async tokenize(text: string) {
+        return new Array(Math.max(1, Math.ceil(text.length / 16))).fill(1);
+      },
       async embed(text: string, options?: { model?: string }) {
         embedCalls.push({ text, options });
         return { embedding: [0.1, 0.2, 0.3], model: "fake-embed" };

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -291,6 +291,7 @@ describe("Store Creation", () => {
     _resetProductionModeForTesting();
     const originalIndexPath = process.env.INDEX_PATH;
     delete process.env.INDEX_PATH;
+    _resetProductionModeForTesting();
 
     expect(() => createStore()).toThrow("Database path not set");
 
@@ -2924,6 +2925,9 @@ describe("Embedding batching", () => {
       embedBatchCalls,
       embedCalls,
       embedBatchModelCalls,
+      async tokenize(text: string) {
+        return new Array(Math.max(1, Math.ceil(text.length / 16))).fill(1);
+      },
       async embed(text: string, options?: { model?: string }) {
         embedCalls.push({ text, options });
         return { embedding: [0.1, 0.2, 0.3], model: "fake-embed" };


### PR DESCRIPTION
## Problem

QMD is designed as an on-device tool, but its value — BM25 + vector search + query expansion + LLM reranking in a single pipeline — makes it equally useful in cloud and multi-agent environments. The current hard dependency on local GGUF models via node-llama-cpp creates two problems in those settings:

1. **Performance.** Embedding 300M–0.6B GGUF models on CPU is slow; in cloud environments there is often no GPU at all.
2. **Concurrency.** node-llama-cpp serialises all inference calls through a single context. Running multiple agents or workers against the same index causes queuing and timeouts — each waits for the previous embed/rerank call to finish before starting.

Both problems go away when the embedding and reranking workload moves to a dedicated remote server (vLLM, TEI, Ollama, LiteLLM, or any OpenAI-compatible endpoint).

This closes #521 and addresses the use case in #229.

---

## What this adds

Two new classes, plus the plumbing to activate them via environment variables.

### `RemoteLLM`

A drop-in `LLM` implementation that calls an OpenAI-compatible HTTP server:

| Capability | Endpoint |
|---|---|
| Embedding | `POST /v1/embeddings` |
| Reranking | `POST /v1/rerank` (cross-encoder format) |
| Query expansion / generation | `POST /v1/chat/completions` |

Features:
- Independent circuit breakers per endpoint (`embed`, `rerank`, `chat`) — an embed outage does not affect reranking or chat
- Configurable connect/read timeouts and breaker thresholds
- Bearer auth via `QMD_REMOTE_API_KEY`
- `qmd status` shows the remote server URLs instead of local model paths
- `RemoteLLM.modelExists()` logs a warning before returning the optimistic fail-open result when the server can't be reached, so operators know the check was skipped
- Character-based token approximation (~4 chars/token) keeps chunking and overflow protection working without a local tokenizer

### `HybridLLM`

A thin composite that delegates all operations to `RemoteLLM`. Designed for future extension (e.g. local generate + remote embed), but in the current implementation runs fully remote when the local backend is `null`.

### Changes to existing code

**`src/llm.ts`**
- `LLM` interface: adds `embedBatch()`, `tokenize()`, `countTokens()`, `detokenize()`, `isRemote?`, `embedModelName?`
- `LLMSessionManager` and `withLLMSessionForLlm` accept `LLM` instead of `LlamaCpp` only
- New exports: `getDefaultLLM()` / `setDefaultLLM()` — sit alongside `getDefaultLlamaCpp()` / `setDefaultLlamaCpp()` for backward compatibility
- `LlamaCpp.tokenize` / `detokenize` use `unknown[]` to satisfy the interface while still casting internally to `LlamaToken[]`

**`src/store.ts`** (~45 lines changed)
- `getLlm()` returns `LLM` and falls back to `getDefaultLLM()`
- `generateEmbeddings`: uses `formatDoc()` — skips the Qwen3 task-prefix for remote backends, which don't need it
- `chunkDocumentByTokens`: accepts an optional `llm?` parameter so internal callers pass the store-scoped LLM rather than always pulling from the global singleton

**`src/cli/qmd.ts`** (~52 lines changed)
- Reads `QMD_REMOTE_EMBED_URL` / `QMD_REMOTE_RERANK_URL` / `QMD_REMOTE_GEN_URL` at startup and builds a `HybridLLM` if set
- Guards the YAML `models:` override in `getStore()` — skips `setDefaultLlamaCpp` when remote mode is already active, so a `models:` block in the config cannot silently revert to local

**`src/index.ts`** (~46 lines changed)
- `StoreOptions.llm?` — inject a backend directly (useful for testing or custom integrations)
- `createStore()` checks `QMD_REMOTE_*` env vars automatically when no `llm` option is provided, so SDK users get the same remote mode as the CLI

---

## Usage

```sh
# Minimal: TEI for embeddings and reranking
export QMD_REMOTE_EMBED_URL=http://localhost:8080
export QMD_REMOTE_RERANK_URL=http://localhost:8081
qmd embed && qmd query "how does auth work?"

# Separate chat server for query expansion
export QMD_REMOTE_GEN_URL=http://localhost:8082

# Authentication (sent as Bearer token to all endpoints)
export QMD_REMOTE_API_KEY=sk-...
```

All `QMD_REMOTE_*` variables are optional — when unset, qmd falls back to the existing local GGUF behaviour with no behavioural change.

| Variable | Default |
|---|---|
| `QMD_REMOTE_EMBED_URL` | — (required to enable remote mode) |
| `QMD_REMOTE_RERANK_URL` | — (required to enable remote mode) |
| `QMD_REMOTE_GEN_URL` | `QMD_REMOTE_EMBED_URL` |
| `QMD_REMOTE_API_KEY` | — |
| `QMD_REMOTE_EMBED_MODEL` | `remote-embedding` |
| `QMD_REMOTE_RERANK_MODEL` | `remote-reranker` |
| `QMD_REMOTE_GEN_MODEL` | `gpt-4o-mini` |
| `QMD_REMOTE_CONNECT_TIMEOUT` | `5000` ms |
| `QMD_REMOTE_READ_TIMEOUT` | `30000` ms |

---

## Testing

`test/remote-llm.test.ts` — 19 tests, all in-process with real HTTP servers (no mocks):

- Embed and rerank routing to separate URLs
- Qwen3 instruct prefix added for query embeddings; legacy `title: | text:` prefixes stripped on receipt
- Embedding dimension lock and error on mismatch
- Circuit breaker opens after N failures; `embed`, `rerank`, and `chat` circuits are independent
- Half-open state retries after cooldown
- Bearer auth header
- Connect and read timeouts
- `generate` calls chat completions and returns text
- `expandQuery` parses typed lines; falls back to lex+vec+hyde on error
- `tokenize` / `countTokens` / `detokenize` character-approximation
- `HybridLLM` routes all operations to remote without `as any` casts

---

## Backward compatibility

No breaking changes. All new behaviour is opt-in via environment variables. Existing local-only setups are unaffected.