### PR TITLE
fix(bin): rewrite launcher as cross-platform Node.js script (fixes Windows global install)

### DIFF
--- a/bin/qmd
+++ b/bin/qmd
@@ -1,32 +1,66 @@
-#!/bin/sh
-# Resolve symlinks so global installs (npm link / npm install -g) can find the
-# actual package directory instead of the global bin directory.
-SOURCE="$0"
-while [ -L "$SOURCE" ]; do
-  SOURCE_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
-  TARGET="$(readlink "$SOURCE")"
-  case "$TARGET" in
-    /*) SOURCE="$TARGET" ;;
-    *) SOURCE="$SOURCE_DIR/$TARGET" ;;
-  esac
-done
+#!/usr/bin/env node
+// Cross-platform launcher for qmd.
+//
+// Previously this was a POSIX shell script with `#!/bin/sh`, which meant npm
+// on Windows generated shims that tried to route through `/bin/sh` — a path
+// that doesn't exist on Windows, so `qmd` failed immediately after a global
+// install. Rewriting the launcher in Node.js lets npm generate native
+// cmd/ps1/sh shims that invoke `node` directly on every platform.
 
-# Detect the runtime used to install this package and use the matching one
-# to avoid native module ABI mismatches (e.g., better-sqlite3 compiled for bun vs node)
-DIR="$(cd -P "$(dirname "$SOURCE")/.." && pwd)"
+import { spawn } from "node:child_process";
+import { existsSync, realpathSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-# Detect the package manager that installed dependencies by checking lockfiles.
-# $BUN_INSTALL is intentionally NOT checked — it only indicates that bun exists
-# on the system, not that it was used to install this package (see #361).
-#
-# package-lock.json takes priority: if it exists, npm installed the native
-# modules for Node.  The repo ships bun.lock, so without this check, source
-# builds that use npm would be incorrectly routed to bun, causing ABI
-# mismatches with better-sqlite3 / sqlite-vec (see #381).
-if [ -f "$DIR/package-lock.json" ]; then
-  exec node "$DIR/dist/cli/qmd.js" "$@"
-elif [ -f "$DIR/bun.lock" ] || [ -f "$DIR/bun.lockb" ]; then
-  exec bun "$DIR/dist/cli/qmd.js" "$@"
-else
-  exec node "$DIR/dist/cli/qmd.js" "$@"
-fi
+// Resolve symlinks so global installs (npm link / npm install -g) can find
+// the actual package directory instead of the global bin directory.
+const self = realpathSync(fileURLToPath(import.meta.url));
+const pkgDir = resolve(dirname(self), "..");
+const entry = resolve(pkgDir, "dist/cli/qmd.js");
+
+// Detect the runtime used to install this package and use the matching one
+// to avoid native module ABI mismatches (e.g., better-sqlite3 compiled for
+// bun vs node).
+//
+// Detect the package manager that installed dependencies by checking
+// lockfiles. $BUN_INSTALL is intentionally NOT checked — it only indicates
+// that bun exists on the system, not that it was used to install this
+// package (see #361).
+//
+// package-lock.json takes priority: if it exists, npm installed the native
+// modules for Node. The repo ships bun.lock, so without this check, source
+// builds that use npm would be incorrectly routed to bun, causing ABI
+// mismatches with better-sqlite3 / sqlite-vec (see #381).
+function detectRunner(dir) {
+  if (existsSync(resolve(dir, "package-lock.json"))) return "node";
+  if (
+    existsSync(resolve(dir, "bun.lock")) ||
+    existsSync(resolve(dir, "bun.lockb"))
+  ) {
+    return "bun";
+  }
+  return "node";
+}
+
+const runnerName = detectRunner(pkgDir);
+// For Node, use process.execPath — guaranteed to exist and avoids relying on
+// PATH resolution. For bun, we have to look it up on PATH, which on Windows
+// requires shell: true so PATHEXT (.exe, .cmd) is honored.
+const runnerCmd = runnerName === "node" ? process.execPath : "bun";
+const needsShell = runnerName === "bun" && process.platform === "win32";
+
+const child = spawn(runnerCmd, [entry, ...process.argv.slice(2)], {
+  stdio: "inherit",
+  shell: needsShell,
+});
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+  } else {
+    process.exit(code ?? 0);
+  }
+});
+child.on("error", (err) => {
+  console.error(`qmd: failed to launch ${runnerName}: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Problem

`npm install -g @tobilu/qmd` on Windows installs successfully but produces a `qmd` command that fails in every shell (cmd, PowerShell, Git Bash).

Root cause: `bin/qmd` has a `#!/bin/sh` shebang. When npm generates its cmd/ps1/sh shims on Windows, it reads that shebang and routes them through `/bin/sh` — a path that doesn't exist on Windows:

```cmd
IF EXIST "%dp0%/bin/sh.exe" (
SET "_prog=%dp0%/bin/sh.exe"
) ELSE (
SET "_prog=/bin/sh"
```

So the shim dies before any qmd code runs.

## Fix

Rewrite `bin/qmd` as a Node.js script with a `#!/usr/bin/env node` shebang. npm then generates native shims that invoke `node` directly on every platform. The runtime-detection logic is preserved verbatim:

- `package-lock.json` present → `node` (npm install)
- `bun.lock` / `bun.lockb` present → `bun`
- no lockfile → `node`

Implementation notes:
- Node is launched via `process.execPath` (guaranteed to exist, skips PATH resolution, avoids the `child_process` `shell: true` deprecation warning).
- Bun is launched by name; on Windows this requires `shell: true` so `PATHEXT` resolves `bun.exe` / `bun.cmd`.
- Symlink resolution still happens via `fs.realpathSync`, matching the old shell `readlink` loop, so `npm link` keeps working.
- Signals from the parent are re-raised after the child exits, so Ctrl-C behaves the same as before.

## Testing

- Verified locally on Windows 11: `qmd --help` works from cmd, PowerShell, and Git Bash after `npm install -g`.
- `test/launcher-detection.test.sh` still documents the intended detection behavior; its `detect_runtime` helper mirrors the JS implementation. A platform-agnostic vitest version can follow in a separate PR (would also let Windows CI catch regressions — currently CI only runs Linux + macOS).

## Alternative considered

Pointing `bin.qmd` in `package.json` directly at `dist/cli/qmd.js` (which already has a Node shebang). That's simpler but drops the bun-vs-node lockfile detection, so I kept the launcher.