### PR TITLE
fix(db): declare transaction() on local Database interface

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -69,6 +69,7 @@ export interface Database {
   exec(sql: string): void;
   prepare(sql: string): Statement;
   loadExtension(path: string): void;
+  transaction<T extends (...args: any[]) => any>(fn: T): T;
   close(): void;
 }
 


### PR DESCRIPTION
## Summary

The cross-runtime `Database` interface in `src/db.ts` declares the subset of
`better-sqlite3` / `bun:sqlite` methods QMD uses. Commit fee576b ("fix: migrate
legacy lowercase paths on reindex") introduced a `db.transaction(...)` call in
`src/store.ts:2142` but didn't extend the interface, so `tsc -p tsconfig.build.json`
fails on main:

```
src/store.ts(2142,22): error TS2339: Property 'transaction' does not exist on type 'Database'.
```

Both underlying engines expose `transaction(fn)`, so this one-line addition just
makes the type reflect reality.

## Change

```diff
 export interface Database {
   exec(sql: string): void;
   prepare(sql: string): Statement;
   loadExtension(path: string): void;
+  transaction<T extends (...args: any[]) => any>(fn: T): T;
   close(): void;
 }
```

## Validation

- `npm run build` is green with this change, red without it (reproduced on current `main` at `cfd640e`).
- No runtime behavior change — pure type declaration on an interface that already matched both engines in practice.
- Codex Cloud separately reproduced the same `TS2339` on `main` and flagged it as a build-blocker.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — no new failures vs. `main` baseline
