### PR TITLE
fix: add transaction() to Database interface

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -68,6 +68,7 @@ export function openDatabase(path: string): Database {
 export interface Database {
   exec(sql: string): void;
   prepare(sql: string): Statement;
+  transaction<T extends (...args: any[]) => any>(fn: T): T;
   loadExtension(path: string): void;
   close(): void;
 }


### PR DESCRIPTION
## Problem

The custom `Database` interface in `src/db.ts` is missing the `transaction()` method. This causes a TypeScript compilation error when building from source:

```
src/store.ts(2142,22): error TS2339: Property 'transaction' does not exist on type 'Database'.
```

The published npm package works because it ships pre-built `dist/` files. But building from a fresh git clone fails.

## Fix

Add `transaction()` to the `Database` interface:

```ts
export interface Database {
  exec(sql: string): void;
  prepare(sql: string): Statement;
  transaction<T extends (...args: any[]) => any>(fn: T): T;  // added
  loadExtension(path: string): void;
  close(): void;
}
```

Both `better-sqlite3` and `bun:sqlite` support `transaction()`, so this is simply an omission in the interface definition.

## Verified

```bash
npm install && npm run build  # ✅ compiles successfully
```