### PR TITLE
fix: return text blocks instead of resource blocks from tool results

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -412,16 +412,7 @@ Intent-aware lex (C++ performance, not sports):
       }
 
       return {
-        content: [{
-          type: "resource",
-          resource: {
-            uri: `qmd://${encodeQmdPath(result.displayPath)}`,
-            name: result.displayPath,
-            title: result.title,
-            mimeType: "text/markdown",
-            text,
-          },
-        }],
+        content: [{ type: "text", text }],
       };
     }
   );
@@ -453,7 +444,7 @@ Intent-aware lex (C++ performance, not sports):
         };
       }
 
-      const content: ({ type: "text"; text: string } | { type: "resource"; resource: { uri: string; name: string; title?: string; mimeType: string; text: string } })[] = [];
+      const content: { type: "text"; text: string }[] = [];
 
       if (errors.length > 0) {
         content.push({ type: "text", text: `Errors:\n${errors.join('\n')}` });
@@ -483,16 +474,7 @@ Intent-aware lex (C++ performance, not sports):
           text = `<!-- Context: ${result.doc.context} -->\n\n` + text;
         }
 
-        content.push({
-          type: "resource",
-          resource: {
-            uri: `qmd://${encodeQmdPath(result.doc.displayPath)}`,
-            name: result.doc.displayPath,
-            title: result.doc.title,
-            mimeType: "text/markdown",
-            text,
-          },
-        });
+        content.push({ type: "text", text });
       }
 
       return { content };


### PR DESCRIPTION
## Problem

The `get` and `multi_get` MCP tools return content blocks with `type: "resource"`, wrapping text inside a `resource` object. This causes MCP clients that only extract `.text` from content blocks (e.g., Hermes agent) to receive empty content.

## Root Cause

MCP tool call results should use `type: "text"` content blocks. The `type: "resource"` format is intended for the `resources/read` endpoint, not tool responses.

Per the MCP spec, `CallToolResult.content` should contain text/image/audio content blocks. Resource embedding blocks in tool results are not widely supported by MCP clients.

## Fix

Changed both `get` and `multi_get` tools to return `{ type: "text", text }` blocks instead of `{ type: "resource", resource: { uri, name, title, mimeType, text } }`.

Document metadata (uri, name, title, mimeType) remains available through:
- The existing `qmd://{path}` resource template (via `resources/read`)
- The `structuredContent` field on search results

## Testing

- Verified QMD 2.1.0 with this patch returns text blocks via direct MCP HTTP calls
- Hermes agent correctly receives content after the fix
- `resources/read` endpoint still works independently for document retrieval

3 insertions, 21 deletions. Clean simplification.