### PR TITLE
fix: use case-insensitive matching for context path prefix lookup

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -2504,12 +2504,12 @@ export function getContextForPath(db: Database, collectionName: string, path: st
 
   // Add all matching path contexts (from most general to most specific)
   if (coll.context) {
-    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+    const normalizedPath = (path.startsWith("/") ? path : `/${path}`).toLowerCase();
 
-    // Collect all matching prefixes
+    // Collect all matching prefixes (case-insensitive)
     const matchingContexts: { prefix: string; context: string }[] = [];
     for (const [prefix, context] of Object.entries(coll.context)) {
-      const normalizedPrefix = prefix.startsWith("/") ? prefix : `/${prefix}`;
+      const normalizedPrefix = (prefix.startsWith("/") ? prefix : `/${prefix}`).toLowerCase();
       if (normalizedPath.startsWith(normalizedPrefix)) {
         matchingContexts.push({ prefix: normalizedPrefix, context });
       }
@@ -2591,12 +2591,12 @@ export function getContextForFile(db: Database, filepath: string): string | null
 
   // Add all matching path contexts (from most general to most specific)
   if (coll.context) {
-    const normalizedPath = relativePath.startsWith("/") ? relativePath : `/${relativePath}`;
+    const normalizedPath = (relativePath.startsWith("/") ? relativePath : `/${relativePath}`).toLowerCase();
 
-    // Collect all matching prefixes
+    // Collect all matching prefixes (case-insensitive)
     const matchingContexts: { prefix: string; context: string }[] = [];
     for (const [prefix, context] of Object.entries(coll.context)) {
-      const normalizedPrefix = prefix.startsWith("/") ? prefix : `/${prefix}`;
+      const normalizedPrefix = (prefix.startsWith("/") ? prefix : `/${prefix}`).toLowerCase();
       if (normalizedPath.startsWith(normalizedPrefix)) {
         matchingContexts.push({ prefix: normalizedPrefix, context });
       }

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1090,6 +1090,39 @@ describe("Path Context", () => {
 
     await cleanupTestDb(store);
   });
+
+  test("getContextForFile matches context with different case in path prefix", async () => {
+    const store = await createTestStore();
+    const collectionName = await createTestCollection({ pwd: "/test/collection", glob: "**/*.md" });
+
+    // Context key uses mixed case (as typed by user)
+    await addPathContext(collectionName, "/L3/CacheService.md", "File-level context for CacheService");
+
+    // Document path stored in lowercase (as resolved from filesystem)
+    await insertTestDocument(store.db, collectionName, {
+      name: "cacheservice",
+      displayPath: "l3/cacheservice.md",
+    });
+
+    // Should match despite case difference
+    const context = store.getContextForFile("/test/collection/l3/cacheservice.md");
+    expect(context).toBe("File-level context for CacheService");
+
+    await cleanupTestDb(store);
+  });
+
+  test("getContextForPath matches context with different case", async () => {
+    const store = await createTestStore();
+    const collectionName = await createTestCollection({ pwd: "/test/collection", glob: "**/*.md" });
+
+    await addPathContext(collectionName, "/Docs/API", "API docs context");
+
+    // Path in different case
+    const context = store.getContextForPath(collectionName, "docs/api/reference.md");
+    expect(context).toBe("API docs context");
+
+    await cleanupTestDb(store);
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
## Problem

File-level context set via `qmd context add` is not returned in search results — all results fall back to root-level context only.

### Root Cause

`getContextForPath()` and `getContextForFile()` in `src/store.ts` use `startsWith` for path prefix matching, which is **case-sensitive**. The `documents` table stores paths as resolved from the filesystem (e.g. `l3/cacheservice.md`), while `store_collections.context` preserves the original casing from the `qmd context add` command (e.g. `L3/CacheService.md`). This mismatch causes `startsWith` to fail silently.

### Reproduction

1. `qmd collection add wiki/ --name wiki`
2. `qmd context add "qmd://wiki" "Root context"`
3. `qmd context add "qmd://wiki/L3/CacheService.md" "File-level context"`
4. `qmd search "cache"` — hits CacheService.md
5. Result only shows root context; file-level context is missing

## Fix

Apply `.toLowerCase()` to both the normalized path and context key prefix before comparison in both `getContextForPath()` and `getContextForFile()`.

## Tests

Added two test cases covering mixed-case path prefix matching:
- `getContextForFile` matches context with different case in path prefix
- `getContextForPath` matches context with different case

All 200 tests pass.