### PR TITLE
fix(store): preserve inactive document references in cleanupOrphanedContent

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -1949,13 +1949,20 @@ export function deleteInactiveDocuments(db: Database): number {
 }
 
 /**
- * Remove orphaned content hashes that are not referenced by any active document.
+ * Remove orphaned content hashes that are not referenced by any document.
+ *
+ * Inactive (soft-deleted) documents still count as references — otherwise the
+ * `documents.hash ON DELETE CASCADE` foreign key would cascade-delete rows that
+ * `reindexCollection` has just marked `active = 0`, turning soft deletes into
+ * hard deletes and breaking the reactivation path in `insertDocument`.
+ * `deleteInactiveDocuments()` exists as the explicit hard-delete entry point.
+ *
  * Returns the number of orphaned content hashes deleted.
  */
 export function cleanupOrphanedContent(db: Database): number {
   const result = db.prepare(`
     DELETE FROM content
-    WHERE hash NOT IN (SELECT DISTINCT hash FROM documents WHERE active = 1)
+    WHERE hash NOT IN (SELECT DISTINCT hash FROM documents)
   `).run();
   return result.changes;
 }

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -3059,6 +3059,11 @@ describe("Content-Addressable Storage", () => {
         .prepare(`SELECT COUNT(*) AS c FROM documents WHERE collection = ? AND active = 0`)
         .get(collectionName) as { c: number }).c,
     ).toBe(3);
+    // And the content rows the tombstones reference must still exist —
+    // otherwise `documents.hash ON DELETE CASCADE` would have removed them.
+    expect(
+      (store.db.prepare(`SELECT COUNT(*) AS c FROM content`).get() as { c: number }).c,
+    ).toBe(5);
 
     await rm(collectionDir, { recursive: true, force: true });
     await cleanupTestDb(store);

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -9,7 +9,7 @@
 import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
 import { openDatabase, loadSqliteVec } from "../src/db.js";
 import type { Database } from "../src/db.js";
-import { unlink, mkdtemp, rmdir, writeFile } from "node:fs/promises";
+import { unlink, mkdtemp, rmdir, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import YAML from "yaml";
@@ -53,6 +53,7 @@ import {
   type DocumentResult,
   type SearchResult,
   type RankedResult,
+  reindexCollection,
 } from "../src/store.js";
 import type { CollectionConfig } from "../src/collections.js";
 
@@ -3016,6 +3017,50 @@ describe("Content-Addressable Storage", () => {
     const contentCount = store.db.prepare(`SELECT COUNT(*) as count FROM content`).get() as { count: number };
     expect(contentCount.count).toBe(2);
 
+    await cleanupTestDb(store);
+  });
+
+  test("reindexCollection soft-deletes orphaned docs and cleanupOrphanedContent preserves their content rows (#585)", async () => {
+    const store = await createTestStore();
+    const collectionDir = await mkdtemp(join(testDir, "qmd-585-"));
+    const collectionName = "testcoll-585";
+
+    const filenames = ["a.md", "b.md", "c.md", "d.md", "e.md"];
+    for (const name of filenames) {
+      await writeFile(join(collectionDir, name), `# ${name}\n\nbody ${name}`);
+    }
+
+    const first = await reindexCollection(store, collectionDir, "*.md", collectionName);
+    expect(first.indexed).toBe(5);
+    expect(first.removed).toBe(0);
+    expect(
+      (store.db
+        .prepare(`SELECT COUNT(*) AS c FROM documents WHERE collection = ? AND active = 1`)
+        .get(collectionName) as { c: number }).c,
+    ).toBe(5);
+
+    await unlink(join(collectionDir, "a.md"));
+    await unlink(join(collectionDir, "b.md"));
+    await unlink(join(collectionDir, "c.md"));
+
+    const second = await reindexCollection(store, collectionDir, "*.md", collectionName);
+
+    expect(second.removed).toBe(3);
+    expect(
+      (store.db
+        .prepare(`SELECT COUNT(*) AS c FROM documents WHERE collection = ? AND active = 1`)
+        .get(collectionName) as { c: number }).c,
+    ).toBe(2);
+    // Soft-deleted tombstones must survive the cleanupOrphanedContent pass so
+    // that `insertDocument`'s ON CONFLICT reactivation path still works when a
+    // file comes back.
+    expect(
+      (store.db
+        .prepare(`SELECT COUNT(*) AS c FROM documents WHERE collection = ? AND active = 0`)
+        .get(collectionName) as { c: number }).c,
+    ).toBe(3);
+
+    await rm(collectionDir, { recursive: true, force: true });
     await cleanupTestDb(store);
   });
 


### PR DESCRIPTION
Refs #585

## Problem

`cleanupOrphanedContent` deletes `content` rows not referenced by any **active** document:

```sql
DELETE FROM content
WHERE hash NOT IN (SELECT DISTINCT hash FROM documents WHERE active = 1)
```

Combined with `documents.hash` `ON DELETE CASCADE` (schema at `src/store.ts:776`), this cascade-deletes rows that `reindexCollection` just marked `active=0` a few lines earlier. The soft-delete pattern is silently turned into a hard delete, which also breaks the reactivation path in `insertDocument` (`ON CONFLICT ... DO UPDATE SET ... active = 1`) because the row is gone when a file comes back.

### Reproduction (on `main`)

The new test at `test/store.test.ts` (`reindexCollection soft-deletes orphaned docs and cleanupOrphanedContent preserves their content rows (#585)`) fails on `main`:

- Index 5 files in a collection
- Delete 3, re-index
- `result.removed === 3` (correct, the deactivation loop fires)
- But `SELECT COUNT(*) FROM documents WHERE active = 0` returns **0** (should be 3) and `SELECT COUNT(*) FROM content` returns **2** (should be 5). The 3 tombstones got cascade-deleted.

## Fix

Drop `WHERE active = 1` from the subquery so that inactive documents still count as references. Explicit hard-deletion stays available via `deleteInactiveDocuments()` (which the cascade then handles correctly).

```diff
 export function cleanupOrphanedContent(db: Database): number {
   const result = db.prepare(`
     DELETE FROM content
-    WHERE hash NOT IN (SELECT DISTINCT hash FROM documents WHERE active = 1)
+    WHERE hash NOT IN (SELECT DISTINCT hash FROM documents)
   `).run();
   return result.changes;
 }
```

## Relationship to the original report

The reporter in #585 observes ghost rows with `active = 1` and output showing `0 removed`. That suggests their specific scenario may involve an additional path I couldn't reproduce locally (possibly a legacy path-format mismatch between stored rows and `handelize()`, or a dist/source divergence in the npm-published `v2.0.1`). This PR fixes one concrete, reproducible bug on the same code path, but may not be the complete picture for what they're seeing. Happy to investigate further if you have pointers.

## Follow-up worth noting (not in this PR)

`removeCollection` at `src/store.ts:2675` uses the same `WHERE active = 1` pattern for its inline content cleanup. The semantics are slightly different (it runs after a hard `DELETE FROM documents WHERE collection = ?`), but a cross-collection soft-delete could be affected similarly. Happy to file a separate issue or PR if useful.

## Test plan

- [x] New regression test `reindexCollection soft-deletes orphaned docs and cleanupOrphanedContent preserves their content rows (#585)` in `test/store.test.ts`. Fails on `main`, passes after this fix.
- [x] Full `test/store.test.ts` passes (197/199. The 2 `LlamaCpp Integration > rerank` failures are pre-existing on `main`, unrelated to this diff.)
- [x] `tsc --noEmit` shows no new errors (two pre-existing type errors on `main` are unchanged)
