### PR TITLE
fix: allow mid-term hyphens in vec/hyde queries (DEC-0054, ui-kit)

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -3003,8 +3003,10 @@ function buildFTS5Query(query: string): string | null {
  * Returns error message if invalid, null if valid.
  */
 export function validateSemanticQuery(query: string): string | null {
-  // Check for negation syntax
-  if (/-\w/.test(query) || /-"/.test(query)) {
+  // Check for negation syntax. Match -word or -"phrase" only at the start of the
+  // query or after whitespace so that mid-term hyphens (e.g. DEC-0054, ui-kit) do
+  // not trigger false positives.
+  if (/(?:^|\s)-[\w"]/.test(query)) {
     return 'Negation (-term) is not supported in vec/hyde queries. Use lex for exclusions.';
   }
   return null;

--- a/test/structured-search.test.ts
+++ b/test/structured-search.test.ts
@@ -364,8 +364,17 @@ describe("lex query syntax", () => {
     test("rejects negation syntax", () => {
       expect(validateSemanticQuery("performance -sports")).toContain("Negation");
       expect(validateSemanticQuery('-"exact phrase"')).toContain("Negation");
+      expect(validateSemanticQuery("foo -bar baz")).toContain("Negation");
     });
 
+    test("accepts mid-term hyphens without false-positive negation", () => {
+      // Identifiers with embedded hyphens are common (doc ids, npm scopes,
+      // hyphenated compounds). They must not be flagged as negation syntax.
+      expect(validateSemanticQuery("DEC-0054 architecture decision")).toBeNull();
+      expect(validateSemanticQuery("how does @scope/ui-kit work")).toBeNull();
+      expect(validateSemanticQuery("state-of-the-art retrieval")).toBeNull();
+      expect(validateSemanticQuery("token-based chunking")).toBeNull();
+    });
 
     test("accepts hyde-style hypothetical answers", () => {
       expect(validateSemanticQuery(


### PR DESCRIPTION
## Problem

`validateSemanticQuery()` rejects semantic (`vec` / `hyde`) queries that contain mid-term hyphens inside compound words or identifiers, with a misleading error message:

```
qmd query 'vec: how does DEC-0054 work'
# Error: Negation (-term) is not supported in vec/hyde queries. Use lex for exclusions.
```

The regex `/-\w/` matches **any** hyphen-followed-by-word-char, so perfectly reasonable tokens trigger false positives:

- Document / decision / CVE identifiers — `DEC-0054`, `RFC-0011`, `CVE-2024-1234`
- Scoped npm packages and component names — `@scope/ui-kit`, `material-ui`
- Compound adjectives — `state-of-the-art`, `role-based`, `multi-agent`, `chain-of-thought`
- Hyphenated technical terms — `token-based`, `context-aware`, `fine-tuned`

Users see a confusing "Negation is not supported" error for queries that contain no intentional negation at all.

## Root Cause

The regex does not distinguish between **true negation** (`-word` at the start of a query or after whitespace — i.e. syntax borrowed from lex) and **internal hyphens** in compound words (`multi-agent`, `DEC-0054`). Both match `/-\w/`.

## Fix

One-line change in `validateSemanticQuery()` — anchor the negation regex to the start of the query or a whitespace boundary:

```diff
- if (/-\w/.test(query) || /-"/.test(query)) {
+ if (/(?:^|\s)-[\w"]/.test(query)) {
```

Now only true negation tokens (`-word` or `-"phrase"` at the start of a word) match. Mid-term hyphens pass through unchanged.

## Testing

Added four new test cases in `test/structured-search.test.ts` covering common identifier patterns:

| Query | Before | After |
|-------|--------|-------|
| `"DEC-0054 architecture decision"` | ❌ Negation error | ✅ Accepted |
| `"how does @scope/ui-kit work"` | ❌ Negation error | ✅ Accepted |
| `"state-of-the-art retrieval"` | ❌ Negation error | ✅ Accepted |
| `"token-based chunking"` | ❌ Negation error | ✅ Accepted |
| `"performance -sports"` (true negation) | ✅ Rejected | ✅ Rejected |
| `"foo -bar baz"` (true negation) | ✅ Rejected | ✅ Rejected |
| `'-"exact phrase"'` (true negation) | ✅ Rejected | ✅ Rejected |

Also verified manually against a 7,665 document production index — `vec: "multi-agent orchestration"` returns results (88% top hit) instead of the negation error.

## Relationship to #418

This is a scope-reduced follow-up to #418, which you closed on 2026-04-05 with:

> Closing — the underscore handling landed in #404. The remaining hyphen + validateSemanticQuery changes conflict with main and would need a rebase. Happy to revisit if you want to open a focused follow-up PR. Thanks!

#418 bundled two independent changes:

1. **FTS5 hyphen handling** in `sanitizeFTS5Term()` — preserve hyphens so the `unicode61` tokenizer splits symmetrically at query time.
2. **`validateSemanticQuery()` negation regex fix** — this PR.

Since #418 was closed you took a different (and arguably cleaner) approach for (1) — `sanitizeHyphenatedTerm()` which splits on `-` into separate tokens. That change landed on `main` and already addresses the lex-side hyphen problem.

Piece (2) — the `validateSemanticQuery()` false positive — is an independent bug still present on current `main` and is unaffected by `sanitizeHyphenatedTerm()`. This PR isolates only that fix, with no overlap with your hyphenated-term work.

Fixes #414

## Environment

- QMD: `main` (post-rebase, includes `sanitizeHyphenatedTerm` and the new `rerank` parameter)
- Platform: macOS (Apple Silicon), Linux (container)
- Node: v24.14.0