### PR TITLE
fix(mcp): do not enable production mode at module import time

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -101,9 +101,12 @@ import {
 } from "../collections.js";
 import { getEmbeddedQmdSkillContent, getEmbeddedQmdSkillFiles } from "../embedded-skills.js";
 
-// Enable production mode - allows using default database path
-// Tests must set INDEX_PATH or use createStore() with explicit path
-enableProductionMode();
+// NOTE: enableProductionMode() is intentionally NOT called at module scope here.
+// Importing this module for its exports (e.g. buildEditorUri, termLink from
+// test/cli.test.ts) must not flip the global production flag, as that leaks
+// into unrelated tests that rely on the default (development) database path
+// resolution. The flag is flipped inside the CLI's main-module guard below so
+// it only fires when qmd is actually invoked as a script.
 
 // =============================================================================
 // Store/DB lifecycle (no legacy singletons in store.ts)
@@ -2821,6 +2824,11 @@ const isMain = argv1 === __filename
   || argv1?.endsWith("/qmd.js")
   || (argv1 != null && realpathSync(argv1) === __filename);
 if (isMain) {
+  // Flip to production mode only when this module is executed as the CLI
+  // entrypoint, not when imported for its exports. Tests must set INDEX_PATH
+  // or use createStore() with an explicit path.
+  enableProductionMode();
+
   const cli = parseCLI();
 
   if (cli.values.version) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -32,8 +32,6 @@ import {
 import { getConfigPath } from "../collections.js";
 import { enableProductionMode } from "../store.js";
 
-enableProductionMode();
-
 // =============================================================================
 // Types for structured content
 // =============================================================================
@@ -541,6 +539,12 @@ Intent-aware lex (C++ performance, not sports):
 // =============================================================================
 
 export async function startMcpServer(): Promise<void> {
+  // Opt into production mode when the MCP server is actually started, not
+  // when this module is merely imported for its exports. Importing the module
+  // at the top level flipped the global production flag and broke test
+  // isolation for downstream suites that expect the default (development)
+  // database path behaviour.
+  enableProductionMode();
   const configPath = getConfigPath();
   const store = await createStore({
     dbPath: getDefaultDbPath(),
@@ -566,6 +570,10 @@ export type HttpServerHandle = {
  * Binds to localhost only. Returns a handle for shutdown and port discovery.
  */
 export async function startMcpHttpServer(port: number, options?: { quiet?: boolean }): Promise<HttpServerHandle> {
+  // See startMcpServer() for the rationale — flip production mode here so the
+  // HTTP transport resolves the real database path, without leaking state into
+  // callers that only import this module for its exports (e.g. tests).
+  enableProductionMode();
   const configPath = getConfigPath();
   const store = await createStore({
     dbPath: getDefaultDbPath(),


### PR DESCRIPTION
## Problem

Upstream CI on `main` has been failing on `Bun (ubuntu-latest)` since 2026-04-09 — 14+ consecutive runs — with a single test failure:

```
(fail) Store Creation > createStore throws without explicit path in test mode
Expected substring: "Database path not set"
Received function did not throw
```

## Root Cause

#537 fixed a real bug — the MCP server was resolving the wrong database path at startup — by adding `enableProductionMode()` at module scope in `src/mcp/server.ts`:

```ts
import { enableProductionMode } from "../store.js";

enableProductionMode();  // ← runs on every import
```

This flips the global `_productionMode` flag as a **side effect of importing the module**. `test/mcp.test.ts` imports `startMcpHttpServer` from this module, and while the HTTP Transport `describe` block is `skipIf(!!process.env.CI)`, the import happens regardless of skip status. So `_productionMode` flips to `true` in CI, which later makes `store.test.ts` fail:

```ts
test("createStore throws without explicit path in test mode", () => {
  delete process.env.INDEX_PATH;
  expect(() => createStore()).toThrow("Database path not set");
});
```

In production mode, `getDefaultDbPath()` resolves a cache path instead of throwing — so the assertion fails.

## Fix

Move `enableProductionMode()` from module scope into the two server entry points — `startMcpServer()` (stdio) and `startMcpHttpServer()` (HTTP). Both entry points still flip the flag **before** `getDefaultDbPath()` runs, so #537's original fix is preserved. Merely importing the module for its exports no longer mutates global state.

## Testing

Verified against current `main`:

- Reproduced the CI failure on unmodified `main` (as expected — every main run since #537 has failed).
- With this change applied, the failing test passes.
- `qmd mcp` and `qmd mcp --http` still enter production mode before path resolution — behaviour identical to before for end users.

## Notes

This is a module-scope vs function-scope question rather than a conceptual disagreement with #537. If you'd prefer a different approach (e.g. explicit `getDefaultDbPath({ production: true })` parameter, or moving the whole path-resolution logic), happy to adjust.

## Relationship to #411 and #537

- [#411](https://github.com/tobi/qmd/issues/411) originally reported that `qmd mcp` crashed on startup because `enableProductionMode()` was never called before `getDefaultDbPath()`.
- [#537](https://github.com/tobi/qmd/pull/537) fixed that by adding the call at module top level in `src/mcp/server.ts`.
- This PR keeps #537's fix working — both `startMcpServer` (stdio) and `startMcpHttpServer` (HTTP) still enable production mode before resolving the database path — but moves the call out of module scope so importing the module for its exports (e.g. from `test/mcp.test.ts`) does not leak the flag into unrelated tests.

Net effect on #411's original symptom: unchanged (still fixed). Net effect on CI: `Bun (ubuntu-latest)` goes green again.