### PR TITLE
Add remote LLM backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An on-device search engine for everything you need to remember. Index your markdown notes, meeting transcripts, documentation, and knowledge bases. Search with keywords or natural language. Ideal for your agentic flows.
 
-QMD combines BM25 full-text search, vector semantic search, and LLM re-ranking—all running locally via node-llama-cpp with GGUF models.
+QMD combines BM25 full-text search, vector semantic search, and LLM re-ranking. By default it runs locally via node-llama-cpp with GGUF models, and it can also use remotely deployed OpenAI-compatible LLM services.
 
 ![QMD Architecture](assets/qmd-architecture.png)
 
@@ -515,6 +515,39 @@ Supported model families:
 > since vectors are not cross-compatible between models. The prompt format is
 > automatically adjusted for each model family.
 
+### Remote LLM Backend
+
+Use a remotely deployed OpenAI-compatible service for embeddings, query expansion, and reranking:
+
+```sh
+export QMD_LLM_BACKEND=remote
+export QMD_REMOTE_BASE_URL="https://llm.example.com/v1"
+export QMD_REMOTE_API_KEY="..."   # optional
+export QMD_REMOTE_EMBED_MODEL="text-embedding-3-small"
+export QMD_REMOTE_GENERATE_MODEL="gpt-4o-mini"
+export QMD_REMOTE_RERANK_MODEL="gpt-4o-mini"
+
+qmd embed -f
+qmd query "authentication flow"
+```
+
+For a native reranker endpoint, set `QMD_REMOTE_RERANK_URL=/rerank` (or an absolute URL). Without it, QMD falls back to chat-based scoring via `/chat/completions`.
+
+YAML config is also supported (`provider: remote` is explicit; `baseUrl` also selects the remote backend):
+
+```yaml
+models:
+  provider: remote
+  baseUrl: https://llm.example.com/v1
+  apiKeyEnv: QMD_REMOTE_API_KEY
+  embed: text-embedding-3-small
+  generate: gpt-4o-mini
+  rerank: gpt-4o-mini
+  # rerankUrl: /rerank
+```
+
+Remote embedding models default to raw input formatting. Set `QMD_EMBED_FORMAT=raw|nomic|qwen3` if your remote model needs a specific prompt format.
+
 ## Installation
 
 ```sh
@@ -820,8 +853,8 @@ Collection ──► Glob Pattern ──► Markdown Files ──► Parse Title
 Documents are chunked into ~900-token pieces with 15% overlap using smart boundary detection:
 
 ```
-Document ──► Smart Chunk (~900 tokens) ──► Format each chunk ──► node-llama-cpp ──► Store Vectors
-                │                           "title | text"        embedBatch()
+Document ──► Smart Chunk (~900 tokens) ──► Format each chunk ──► LLM backend ──► Store Vectors
+                │                           "title | text"        local or remote embedBatch()
                 │
                 └─► Chunks stored with:
                     - hash: document hash
@@ -913,7 +946,7 @@ Query ──► LLM Expansion ──► [Original, Variant 1, Variant 2]
 
 ## Model Configuration
 
-Models are configured in `src/llm.ts` as HuggingFace URIs:
+Local models are configured in `src/llm.ts` as HuggingFace URIs:
 
 ```typescript
 const DEFAULT_EMBED_MODEL = "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";

--- a/docs/LLM_USAGE.md
+++ b/docs/LLM_USAGE.md
@@ -1,0 +1,219 @@
+# LLM Usage in QMD
+
+QMD uses model inference to improve retrieval quality. It does **not** use an LLM to write final answers. The main output of QMD is ranked search results and retrieved markdown content; any answer synthesis is handled by the calling agent or application.
+
+By default, QMD runs local GGUF models loaded in-process through `node-llama-cpp` and cached under `~/.cache/qmd/models/` (or `$XDG_CACHE_HOME/qmd/models/`). The same embedding, query-expansion, and reranking paths can also run against a remotely deployed OpenAI-compatible LLM service.
+
+## Summary
+
+| Function | Used by | Local default model | Remote behavior | Purpose |
+|---|---|---|---|---|
+| Document embeddings | `qmd embed`, SDK `store.embed()` | `embeddinggemma-300M-Q8_0` | `POST /embeddings` | Converts indexed document chunks into vectors for semantic search. |
+| Query embeddings | `qmd query`, `qmd vsearch`, SDK vector/structured search | `embeddinggemma-300M-Q8_0` | `POST /embeddings` | Converts natural-language, `vec`, and `hyde` queries into vectors for sqlite-vec lookup. |
+| Query expansion | Plain `qmd query`, CLI `qmd vsearch`, SDK `store.search({ query })`, SDK `store.expandQuery()` | `qmd-query-expansion-1.7B-q4_k_m` | `POST /chat/completions` | Expands a raw query into typed `lex`, `vec`, and `hyde` sub-queries. |
+| HyDE generation | Query expansion | `qmd-query-expansion-1.7B-q4_k_m` | `POST /chat/completions` | Generates a hypothetical answer/document passage for vector retrieval. |
+| Reranking | `qmd query`, MCP `query`, SDK `store.search()` by default | `qwen3-reranker-0.6b-q8_0` | rerank endpoint or chat scoring fallback | Scores candidate chunks for relevance after BM25/vector retrieval. |
+
+## Model configuration
+
+Defaults are defined in `src/llm.ts`:
+
+```ts
+const DEFAULT_EMBED_MODEL = "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";
+const DEFAULT_RERANK_MODEL = "hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf";
+const DEFAULT_GENERATE_MODEL = "hf:tobil/qmd-query-expansion-1.7B-gguf/qmd-query-expansion-1.7B-q4_k_m.gguf";
+```
+
+The embedding model can be overridden with `QMD_EMBED_MODEL`. Rerank, generation, and backend selection can be overridden through environment variables or the `models:` section in the QMD collections config.
+
+### Remote LLM backend
+
+Set `QMD_LLM_BACKEND=remote` (or define `QMD_REMOTE_BASE_URL`) to use a remotely deployed OpenAI-compatible service instead of loading local GGUF models:
+
+```sh
+export QMD_LLM_BACKEND=remote
+export QMD_REMOTE_BASE_URL="https://llm.example.com/v1"
+export QMD_REMOTE_API_KEY="..."            # optional for trusted/internal endpoints
+export QMD_REMOTE_EMBED_MODEL="text-embedding-3-small"
+export QMD_REMOTE_GENERATE_MODEL="gpt-4o-mini"
+export QMD_REMOTE_RERANK_MODEL="gpt-4o-mini"
+```
+
+Remote endpoints used by QMD:
+
+- `POST {baseUrl}/embeddings` with `{ model, input }` for document/query embeddings.
+- `POST {baseUrl}/chat/completions` for query expansion and, if needed, chat-based reranking.
+- Optional `QMD_REMOTE_RERANK_URL` for native reranker services. The endpoint may be absolute or relative to `QMD_REMOTE_BASE_URL`; QMD sends `{ model, query, documents, top_n, return_documents }` and accepts common `results[{ index, relevance_score|score }]` or `scores[]` responses.
+
+Remote backend configuration can also live in the QMD YAML config. `provider: remote` is explicit; a `models.baseUrl` also selects the remote backend:
+
+```yaml
+models:
+  provider: remote
+  baseUrl: https://llm.example.com/v1
+  apiKeyEnv: QMD_REMOTE_API_KEY
+  embed: text-embedding-3-small
+  generate: gpt-4o-mini
+  rerank: gpt-4o-mini
+  # Optional native reranker endpoint:
+  # rerankUrl: /rerank
+```
+
+When the remote backend is selected, `OPENAI_API_KEY` and `OPENAI_BASE_URL` are also recognized. If `OPENAI_API_KEY` is set and no base URL is provided, QMD defaults to `https://api.openai.com/v1`.
+
+Remote embedding model names default to raw text formatting. Local GGUF/HuggingFace model names keep QMD’s historical embeddinggemma format. Override with `QMD_EMBED_FORMAT=raw|nomic|qwen3` if your remote embedding model expects a different prompt format.
+
+## Where LLMs are used
+
+### 1. Embedding documents
+
+Command/API:
+
+```sh
+qmd embed
+```
+
+```ts
+await store.embed()
+```
+
+What happens:
+
+1. QMD finds active documents that do not have vectors yet.
+2. Each document is chunked.
+3. Each chunk is formatted for the active embedding model.
+4. The embedding model converts each chunk to a vector, either locally or through the remote `/embeddings` endpoint.
+5. Vectors are stored in `content_vectors` and `vectors_vec`.
+
+This enables semantic search. `qmd update` indexes file contents and metadata, but `qmd embed` is the step that calls the embedding model.
+
+### 2. Embedding queries for vector search
+
+Vector search needs a vector for the user query or each semantic sub-query.
+
+Used by:
+
+- `qmd query` when vector embeddings exist
+- `qmd vsearch`
+- Structured queries containing `vec:` or `hyde:` lines
+- SDK `store.searchVector()`
+- SDK `store.search({ queries: [...] })` when queries include `vec` or `hyde`
+
+`lex:` queries are routed to BM25 and do not require embeddings. `vec:` and `hyde:` queries are embedded and searched against `vectors_vec`.
+
+### 3. Query expansion
+
+Plain queries are expanded by the configured generation backend: the local generation model by default, or the remote `/chat/completions` endpoint when the remote backend is selected.
+
+Examples:
+
+```sh
+qmd query "authentication flow"
+qmd vsearch "how do users log in"
+```
+
+```ts
+await store.search({ query: "authentication flow" })
+await store.expandQuery("authentication flow")
+```
+
+The expansion model emits typed sub-queries such as:
+
+```text
+lex: authentication login flow
+vec: how does user authentication work
+hyde: The authentication flow validates user credentials, creates a session, and redirects the user after login.
+```
+
+Routing:
+
+- `lex` -> BM25 full-text search
+- `vec` -> vector semantic search
+- `hyde` -> vector semantic search using a hypothetical document passage
+
+A structured query skips this internal expansion step because the caller supplies the typed sub-queries directly:
+
+```sh
+qmd query $'lex: "connection pool" timeout\nvec: why database connections time out under load'
+```
+
+```ts
+await store.search({
+  queries: [
+    { type: "lex", query: "\"connection pool\" timeout" },
+    { type: "vec", query: "why database connections time out under load" },
+  ],
+})
+```
+
+### 4. HyDE
+
+HyDE means “Hypothetical Document Embeddings.” A `hyde:` query is written as a short passage that looks like the answer or relevant document. QMD embeds that passage and searches for documents with similar meaning.
+
+HyDE can be generated automatically during query expansion or provided manually:
+
+```sh
+qmd query $'hyde: The API uses a token bucket rate limiter. Requests over the burst capacity return HTTP 429 until tokens refill.'
+```
+
+HyDE is useful when the exact vocabulary in the corpus is unknown or when the user query is conceptual.
+
+### 5. Reranking candidates
+
+`qmd query` gathers candidates from BM25 and vector search, combines them with Reciprocal Rank Fusion (RRF), selects the best chunk per candidate, and sends those chunks to the reranker model.
+
+The reranker returns relevance scores. QMD blends those scores with the retrieval/RRF rank so strong exact matches are not discarded too aggressively.
+
+With a remote backend, QMD first uses `QMD_REMOTE_RERANK_URL`/`models.rerankUrl` if configured. Without a native reranker endpoint, QMD falls back to chat-based scoring through `/chat/completions`, asking the remote model to return JSON scores for small batches of candidate chunks.
+
+Reranking is enabled by default for full query search and MCP `query`. Disable it when speed matters more than quality:
+
+```sh
+qmd query "authentication flow" --no-rerank
+```
+
+```ts
+await store.search({ query: "authentication flow", rerank: false })
+```
+
+## Where LLMs are not used
+
+These operations do not require an LLM:
+
+- `qmd search` / SDK `store.searchLex()` — BM25 keyword search only.
+- `qmd get` and `qmd multi-get` — direct document retrieval.
+- `qmd collection ...` — collection metadata management.
+- `qmd update` — filesystem scanning and SQLite indexing.
+- `qmd ls`, `qmd status`, context management, and cleanup operations.
+
+Some full-query paths may also avoid specific LLM steps:
+
+- Structured queries skip internal query expansion.
+- `--no-rerank` / `rerank: false` skips reranking.
+- `lex:`-only structured queries do not need query embeddings, unless reranking is enabled afterward.
+- If no vector index exists, vector search is skipped.
+- A strong BM25 signal can skip query expansion, though later embedding/reranking may still run depending on query options and index state.
+
+## MCP behavior
+
+The MCP `query` tool expects typed sub-queries (`lex`, `vec`, `hyde`). In that path, the calling LLM or agent usually creates the query document, so QMD skips its own query-expansion model and executes the provided searches.
+
+By default, MCP `query` still uses QMD’s configured LLM backend for:
+
+- embeddings for `vec`/`hyde` searches
+- reranking, unless `rerank: false` is passed
+
+If `QMD_LLM_BACKEND=remote` or `models.provider: remote` is configured for the MCP server process, MCP searches use the remote embedding/reranking backend too.
+
+## Caching and lifecycle
+
+QMD caches LLM-derived results in the `llm_cache` table:
+
+- query expansion results
+- rerank scores
+
+Embeddings are stored separately in `content_vectors` and `vectors_vec`.
+
+Local models are lazy-loaded on first use. Contexts are released after inactivity, while models are kept warm by default to avoid repeated load overhead.
+
+Remote backends do not keep local model state; QMD only maintains the SQLite index/cache and sends HTTP requests on demand.

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -78,7 +78,7 @@ import {
   type ReindexResult,
   type ChunkStrategy,
 } from "../store.js";
-import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, setDefaultLlamaCpp, LlamaCpp, withLLMSession, pullModels, DEFAULT_EMBED_MODEL_URI, DEFAULT_GENERATE_MODEL_URI, DEFAULT_RERANK_MODEL_URI, DEFAULT_MODEL_CACHE_DIR } from "../llm.js";
+import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, getDefaultLLM, setDefaultLLM, createLLM, withLLMSession, pullModels, DEFAULT_EMBED_MODEL_URI, DEFAULT_GENERATE_MODEL_URI, DEFAULT_RERANK_MODEL_URI, DEFAULT_MODEL_CACHE_DIR, resolveLLMProvider } from "../llm.js";
 import {
   formatSearchResults,
   formatDocuments,
@@ -117,18 +117,25 @@ function getStore(): ReturnType<typeof createStore> {
   if (!store) {
     store = createStore(storeDbPathOverride);
     // Sync YAML config into SQLite store_collections so store.ts reads from DB
+    let config: ReturnType<typeof loadConfig> | undefined;
     try {
-      const config = loadConfig();
+      config = loadConfig();
       syncConfigToDb(store.db, config);
-      if (config.models) {
-        setDefaultLlamaCpp(new LlamaCpp({
-          embedModel: config.models.embed,
-          generateModel: config.models.generate,
-          rerankModel: config.models.rerank,
-        }));
-      }
     } catch {
       // Config may not exist yet — that's fine, DB works without it
+    }
+    if (config?.models) {
+      setDefaultLLM(createLLM({
+        provider: config.models.provider,
+        backend: config.models.backend,
+        baseUrl: config.models.baseUrl,
+        apiKeyEnv: config.models.apiKeyEnv,
+        embedModel: config.models.embed,
+        generateModel: config.models.generate,
+        rerankModel: config.models.rerank,
+        rerankUrl: config.models.rerankUrl,
+        timeoutMs: config.models.timeoutMs,
+      }));
     }
   }
   return store;
@@ -461,10 +468,26 @@ async function showStatus(): Promise<void> {
       const match = uri.match(/^hf:([^/]+\/[^/]+)\//);
       return match ? `https://huggingface.co/${match[1]}` : uri;
     };
+    let modelConfig: ReturnType<typeof loadConfig>["models"] | undefined;
+    try { modelConfig = loadConfig().models; } catch { /* config optional */ }
+    const provider = modelConfig?.provider || modelConfig?.backend
+      ? resolveLLMProvider(modelConfig.provider ?? modelConfig.backend)
+      : modelConfig?.baseUrl
+        ? "remote"
+        : resolveLLMProvider();
     console.log(`\n${c.bold}Models${c.reset}`);
-    console.log(`  Embedding:   ${hfLink(DEFAULT_EMBED_MODEL_URI)}`);
-    console.log(`  Reranking:   ${hfLink(DEFAULT_RERANK_MODEL_URI)}`);
-    console.log(`  Generation:  ${hfLink(DEFAULT_GENERATE_MODEL_URI)}`);
+    if (provider === "remote") {
+      const llm = getDefaultLLM();
+      console.log(`  Backend:     remote OpenAI-compatible`);
+      console.log(`  Embedding:   ${modelConfig?.embed || llm.embedModelName}`);
+      console.log(`  Reranking:   ${modelConfig?.rerank || llm.rerankModelName || process.env.QMD_REMOTE_RERANK_MODEL || process.env.QMD_RERANK_MODEL || "remote default"}`);
+      console.log(`  Generation:  ${modelConfig?.generate || llm.generateModelName || process.env.QMD_REMOTE_GENERATE_MODEL || process.env.QMD_GENERATE_MODEL || "remote default"}`);
+    } else {
+      console.log(`  Backend:     local node-llama-cpp`);
+      console.log(`  Embedding:   ${hfLink(DEFAULT_EMBED_MODEL_URI)}`);
+      console.log(`  Reranking:   ${hfLink(DEFAULT_RERANK_MODEL_URI)}`);
+      console.log(`  Generation:  ${hfLink(DEFAULT_GENERATE_MODEL_URI)}`);
+    }
   }
 
   // Device / GPU info
@@ -1679,12 +1702,13 @@ function parseChunkStrategy(value: unknown): ChunkStrategy | undefined {
 }
 
 async function vectorIndex(
-  model: string = DEFAULT_EMBED_MODEL_URI,
+  model: string | undefined = undefined,
   force: boolean = false,
   batchOptions?: { maxDocsPerBatch?: number; maxBatchBytes?: number; chunkStrategy?: ChunkStrategy },
 ): Promise<void> {
   const storeInstance = getStore();
   const db = storeInstance.db;
+  const activeModel = model ?? (storeInstance.llm?.embedModelName ?? getDefaultLLM().embedModelName);
 
   if (force) {
     console.log(`${c.yellow}Force re-indexing: clearing all vectors...${c.reset}`);
@@ -1698,7 +1722,7 @@ async function vectorIndex(
     return;
   }
 
-  console.log(`${c.dim}Model: ${model}${c.reset}\n`);
+  console.log(`${c.dim}Model: ${activeModel}${c.reset}\n`);
   if (batchOptions?.maxDocsPerBatch !== undefined || batchOptions?.maxBatchBytes !== undefined) {
     const maxDocsPerBatch = batchOptions.maxDocsPerBatch ?? DEFAULT_EMBED_MAX_DOCS_PER_BATCH;
     const maxBatchBytes = batchOptions.maxBatchBytes ?? DEFAULT_EMBED_MAX_BATCH_BYTES;
@@ -1711,7 +1735,7 @@ async function vectorIndex(
 
   const result = await generateEmbeddings(storeInstance, {
     force,
-    model,
+    model: activeModel,
     maxDocsPerBatch: batchOptions?.maxDocsPerBatch,
     maxBatchBytes: batchOptions?.maxBatchBytes,
     chunkStrategy: batchOptions?.chunkStrategy,
@@ -3112,7 +3136,7 @@ if (isMain) {
         const maxDocsPerBatch = parseEmbedBatchOption("maxDocsPerBatch", cli.values["max-docs-per-batch"]);
         const maxBatchMb = parseEmbedBatchOption("maxBatchBytes", cli.values["max-batch-mb"]);
         const embedChunkStrategy = parseChunkStrategy(cli.values["chunk-strategy"]);
-        await vectorIndex(DEFAULT_EMBED_MODEL_URI, !!cli.values.force, {
+        await vectorIndex(undefined, !!cli.values.force, {
           maxDocsPerBatch,
           maxBatchBytes: maxBatchMb === undefined ? undefined : maxBatchMb * 1024 * 1024,
           chunkStrategy: embedChunkStrategy,

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -34,9 +34,18 @@ export interface Collection {
 }
 
 /**
- * Model configuration for embedding, reranking, and generation
+ * Model/backend configuration for embedding, reranking, and generation.
+ *
+ * Defaults to the local node-llama-cpp GGUF backend. Set provider/backend to
+ * "remote" plus baseUrl for an OpenAI-compatible remote deployment.
  */
 export interface ModelsConfig {
+  provider?: "local" | "remote" | string;
+  backend?: "local" | "remote" | string;
+  baseUrl?: string;
+  apiKeyEnv?: string;
+  timeoutMs?: number;
+  rerankUrl?: string;
   embed?: string;
   rerank?: string;
   generate?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ import {
   type ChunkStrategy,
 } from "./store.js";
 import {
-  LlamaCpp,
+  createLLM as createLLMBackend,
 } from "./llm.js";
 import {
   setConfigSource,
@@ -112,6 +112,10 @@ export type { InternalStore };
 // Re-export utility functions and types used by frontends
 export { extractSnippet, addLineNumbers, DEFAULT_MULTI_GET_MAX_BYTES };
 export type { ChunkStrategy } from "./store.js";
+
+// Re-export LLM backend helpers for advanced SDK consumers
+export { createLLM, LlamaCpp, RemoteLLM, resolveLLMProvider } from "./llm.js";
+export type { LLM, LLMConfig, LLMProvider, RemoteLLMConfig } from "./llm.js";
 
 // Re-export getDefaultDbPath for CLI/MCP that need the default database location
 export { getDefaultDbPath } from "./store.js";
@@ -210,8 +214,8 @@ export interface StoreOptions {
  * The QMD SDK store — provides search, retrieval, collection management,
  * context management, and indexing operations.
  *
- * All methods are async. The store manages its own LlamaCpp instance
- * (lazy-loaded, auto-unloaded after inactivity) — no global singletons.
+ * All methods are async. The store manages its own LLM instance
+ * (local LlamaCpp by default, or a configured remote backend) — no global singletons.
  */
 export interface QMDStore {
   /** The underlying internal store (for advanced use) */
@@ -306,7 +310,7 @@ export interface QMDStore {
 
   // ── Lifecycle ───────────────────────────────────────────────────────
 
-  /** Close the store and release all resources (LLM models, DB connection) */
+  /** Close the store and release all resources (LLM backend, DB connection) */
   close(): Promise<void>;
 }
 
@@ -365,12 +369,18 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
   }
   // else: DB-only mode — no external config, use existing store_collections
 
-  // Create a per-store LlamaCpp instance — lazy-loads models on first use,
-  // auto-unloads after 5 min inactivity to free VRAM.
-  const llm = new LlamaCpp({
+  // Create a per-store LLM instance — local node-llama-cpp by default, or a
+  // remote OpenAI-compatible backend when configured via models.provider/env.
+  const llm = createLLMBackend({
+    provider: config?.models?.provider,
+    backend: config?.models?.backend,
+    baseUrl: config?.models?.baseUrl,
+    apiKeyEnv: config?.models?.apiKeyEnv,
     embedModel: config?.models?.embed,
     generateModel: config?.models?.generate,
     rerankModel: config?.models?.rerank,
+    rerankUrl: config?.models?.rerankUrl,
+    timeoutMs: config?.models?.timeoutMs,
     inactivityTimeoutMs: 5 * 60 * 1000,
     disposeModelsOnInactivity: true,
   });

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -1,7 +1,8 @@
 /**
- * llm.ts - LLM abstraction layer for QMD using node-llama-cpp
+ * llm.ts - LLM abstraction layer for QMD.
  *
- * Provides embeddings, text generation, and reranking using local GGUF models.
+ * Provides embeddings, text generation, and reranking using local GGUF models
+ * (node-llama-cpp) or remotely deployed OpenAI-compatible services.
  */
 
 import {
@@ -30,28 +31,62 @@ export function isQwen3EmbeddingModel(modelUri: string): boolean {
   return /qwen.*embed/i.test(modelUri) || /embed.*qwen/i.test(modelUri);
 }
 
+export type EmbeddingFormat = "nomic" | "qwen3" | "raw";
+
+function parseEmbeddingFormat(value?: string): EmbeddingFormat | null {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return null;
+  if (["nomic", "embeddinggemma", "task"].includes(normalized)) return "nomic";
+  if (["qwen", "qwen3", "instruct"].includes(normalized)) return "qwen3";
+  if (["raw", "none", "plain"].includes(normalized)) return "raw";
+  process.stderr.write(`QMD Warning: invalid QMD_EMBED_FORMAT="${value}", inferring embedding format from model name.\n`);
+  return null;
+}
+
+/**
+ * Resolve the text formatting convention for an embedding model.
+ *
+ * Local GGUF defaults keep QMD's historical embeddinggemma/nomic-style prompts.
+ * Remotely deployed OpenAI-compatible embedding models usually expect raw input,
+ * so non-GGUF model names default to raw unless QMD_EMBED_FORMAT overrides it.
+ */
+export function resolveEmbeddingFormat(modelUri: string): EmbeddingFormat {
+  const explicit = parseEmbeddingFormat(process.env.QMD_EMBED_FORMAT);
+  if (explicit) return explicit;
+  if (isQwen3EmbeddingModel(modelUri)) return "qwen3";
+
+  const lower = modelUri.toLowerCase();
+  const looksLocalGguf = lower.startsWith("hf:") || lower.endsWith(".gguf") || lower.includes("embeddinggemma");
+  return looksLocalGguf ? "nomic" : "raw";
+}
+
 /**
  * Format a query for embedding.
- * Uses nomic-style task prefix format for embeddinggemma (default).
+ * Uses nomic-style task prefix format for local embeddinggemma (default).
  * Uses Qwen3-Embedding instruct format when a Qwen embedding model is active.
+ * Uses raw text for remote/OpenAI-compatible embedding model names by default.
  */
 export function formatQueryForEmbedding(query: string, modelUri?: string): string {
   const uri = modelUri ?? process.env.QMD_EMBED_MODEL ?? DEFAULT_EMBED_MODEL;
-  if (isQwen3EmbeddingModel(uri)) {
+  const format = resolveEmbeddingFormat(uri);
+  if (format === "qwen3") {
     return `Instruct: Retrieve relevant documents for the given query\nQuery: ${query}`;
+  }
+  if (format === "raw") {
+    return query;
   }
   return `task: search result | query: ${query}`;
 }
 
 /**
  * Format a document for embedding.
- * Uses nomic-style format with title and text fields (default).
- * Qwen3-Embedding encodes documents as raw text without special prefixes.
+ * Uses nomic-style format with title and text fields for local embeddinggemma.
+ * Qwen3 and remote/OpenAI-compatible embedding models encode documents as raw text.
  */
 export function formatDocForEmbedding(text: string, title?: string, modelUri?: string): string {
   const uri = modelUri ?? process.env.QMD_EMBED_MODEL ?? DEFAULT_EMBED_MODEL;
-  if (isQwen3EmbeddingModel(uri)) {
-    // Qwen3-Embedding: documents are raw text, no task prefix
+  const format = resolveEmbeddingFormat(uri);
+  if (format === "qwen3" || format === "raw") {
     return title ? `${title}\n${text}` : text;
   }
   return `title: ${title || "none"} | text: ${text}`;
@@ -156,7 +191,7 @@ export type LLMSessionOptions = {
 export interface ILLMSession {
   embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null>;
   embedBatch(texts: string[], options?: EmbedOptions): Promise<(EmbeddingResult | null)[]>;
-  expandQuery(query: string, options?: { context?: string; includeLexical?: boolean }): Promise<Queryable[]>;
+  expandQuery(query: string, options?: { context?: string; includeLexical?: boolean; intent?: string }): Promise<Queryable[]>;
   rerank(query: string, documents: RerankDocument[], options?: RerankOptions): Promise<RerankResult>;
   /** Whether this session is still valid (not released or aborted) */
   readonly isValid: boolean;
@@ -367,10 +402,22 @@ export async function pullModels(
  * Abstract LLM interface - implement this for different backends
  */
 export interface LLM {
+  /** Active embedding model name/identifier. Used for formatting and index metadata. */
+  readonly embedModelName: string;
+  /** Active generation model name/identifier. Used for cache keys and status output. */
+  readonly generateModelName?: string;
+  /** Active rerank model name/identifier. Used for cache keys and status output. */
+  readonly rerankModelName?: string;
+
   /**
    * Get embeddings for text
    */
   embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null>;
+
+  /**
+   * Get embeddings for multiple texts.
+   */
+  embedBatch(texts: string[], options?: EmbedOptions): Promise<(EmbeddingResult | null)[]>;
 
   /**
    * Generate text completion
@@ -386,13 +433,20 @@ export interface LLM {
    * Expand a search query into multiple variations for different backends.
    * Returns a list of Queryable objects.
    */
-  expandQuery(query: string, options?: { context?: string, includeLexical?: boolean }): Promise<Queryable[]>;
+  expandQuery(query: string, options?: { context?: string; includeLexical?: boolean; intent?: string }): Promise<Queryable[]>;
 
   /**
    * Rerank documents by relevance to a query
    * Returns list of documents with relevance scores (higher = more relevant)
    */
   rerank(query: string, documents: RerankDocument[], options?: RerankOptions): Promise<RerankResult>;
+
+  /**
+   * Optional tokenizer hooks. Local LlamaCpp provides exact tokenization;
+   * remote implementations may provide approximations for chunk sizing.
+   */
+  tokenize?(text: string): Promise<readonly unknown[]>;
+  detokenize?(tokens: readonly unknown[]): Promise<string>;
 
   /**
    * Dispose of resources
@@ -512,6 +566,14 @@ export class LlamaCpp implements LLM {
 
   get embedModelName(): string {
     return this.embedModelUri;
+  }
+
+  get generateModelName(): string {
+    return this.generateModelUri;
+  }
+
+  get rerankModelName(): string {
+    return this.rerankModelUri;
   }
 
   /**
@@ -928,12 +990,12 @@ export class LlamaCpp implements LLM {
   /**
    * Detokenize token IDs back to text
    */
-  async detokenize(tokens: readonly LlamaToken[]): Promise<string> {
+  async detokenize(tokens: readonly LlamaToken[] | readonly unknown[]): Promise<string> {
     await this.ensureEmbedContext();
     if (!this.embedModel) {
       throw new Error("Embed model not loaded");
     }
-    return this.embedModel.detokenize(tokens);
+    return this.embedModel.detokenize(tokens as readonly LlamaToken[]);
   }
 
   // ==========================================================================
@@ -1386,19 +1448,544 @@ export class LlamaCpp implements LLM {
 }
 
 // =============================================================================
+// Remote OpenAI-compatible implementation
+// =============================================================================
+
+export type LLMProvider = "local" | "remote";
+
+export type RemoteLLMConfig = {
+  /** OpenAI-compatible base URL, e.g. https://llm.example.com/v1 */
+  baseUrl?: string;
+  /** API key value. Prefer apiKeyEnv/env vars for configuration files. */
+  apiKey?: string;
+  /** Environment variable name that contains the API key. */
+  apiKeyEnv?: string;
+  /** OpenAI-compatible embedding model name. */
+  embedModel?: string;
+  /** OpenAI-compatible chat/completion model name for query expansion. */
+  generateModel?: string;
+  /** Rerank endpoint model name, or chat model name when no rerank endpoint is configured. */
+  rerankModel?: string;
+  /** Optional rerank endpoint. Absolute URL or path relative to baseUrl. */
+  rerankUrl?: string;
+  /** Request timeout in milliseconds. */
+  timeoutMs?: number;
+  /** Documents per chat-scored rerank batch when no rerank endpoint is configured. */
+  maxRerankBatchSize?: number;
+  /** Extra HTTP headers for all remote requests. */
+  headers?: Record<string, string>;
+};
+
+export type LLMConfig = LlamaCppConfig & RemoteLLMConfig & {
+  /** Backend selector. "local" keeps node-llama-cpp; "remote" uses OpenAI-compatible HTTP. */
+  provider?: LLMProvider | string;
+  /** Alias for provider. */
+  backend?: LLMProvider | string;
+};
+
+const DEFAULT_REMOTE_EMBED_MODEL = "text-embedding-3-small";
+const DEFAULT_REMOTE_GENERATE_MODEL = "gpt-4o-mini";
+const DEFAULT_REMOTE_RERANK_MODEL = "gpt-4o-mini";
+const DEFAULT_REMOTE_TIMEOUT_MS = 60_000;
+const DEFAULT_REMOTE_RERANK_BATCH_SIZE = 6;
+
+function isProbablyLocalModelName(model?: string): boolean {
+  if (!model) return false;
+  const lower = model.toLowerCase();
+  return lower.startsWith("hf:") || lower.endsWith(".gguf") || lower.includes("gguf/");
+}
+
+function shouldUseRemoteModelOverride(model: string | undefined, logicalAliases: string[] = []): model is string {
+  return !!model && !isProbablyLocalModelName(model) && !logicalAliases.includes(model);
+}
+
+function resolveRemoteModel(
+  configValue: string | undefined,
+  remoteEnvName: string,
+  legacyEnvName: string,
+  fallback: string,
+): string {
+  if (configValue) return configValue;
+  const remoteEnvValue = process.env[remoteEnvName];
+  if (remoteEnvValue) return remoteEnvValue;
+  const legacyEnvValue = process.env[legacyEnvName];
+  if (legacyEnvValue && !isProbablyLocalModelName(legacyEnvValue)) return legacyEnvValue;
+  return fallback;
+}
+
+function resolveRemoteApiKey(config: RemoteLLMConfig): string | undefined {
+  const envName = config.apiKeyEnv ?? process.env.QMD_REMOTE_API_KEY_ENV;
+  return config.apiKey
+    ?? (envName ? process.env[envName] : undefined)
+    ?? process.env.QMD_REMOTE_API_KEY
+    ?? process.env.OPENAI_API_KEY;
+}
+
+function resolveRemoteBaseUrl(config: RemoteLLMConfig, apiKey?: string): string {
+  const baseUrl = config.baseUrl
+    ?? process.env.QMD_REMOTE_BASE_URL
+    ?? process.env.QMD_REMOTE_URL
+    ?? process.env.OPENAI_BASE_URL
+    ?? process.env.OPENAI_API_BASE
+    ?? (apiKey ? "https://api.openai.com/v1" : undefined);
+
+  if (!baseUrl) {
+    throw new Error(
+      "Remote LLM backend selected but no base URL is configured. " +
+      "Set QMD_REMOTE_BASE_URL (for example, https://llm.example.com/v1) " +
+      "or OPENAI_BASE_URL."
+    );
+  }
+
+  return baseUrl.replace(/\/+$/, "");
+}
+
+function clampScore(score: unknown): number {
+  const n = typeof score === "number" ? score : Number(score);
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(1, n));
+}
+
+function stripCodeFence(text: string): string {
+  const trimmed = text.trim();
+  const match = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return match ? match[1]!.trim() : trimmed;
+}
+
+function parseScoreArray(text: string, expectedLength: number): number[] | null {
+  const cleaned = stripCodeFence(text);
+  const arrayMatch = cleaned.match(/\[[\s\S]*\]/);
+  const jsonText = arrayMatch?.[0] ?? cleaned;
+
+  try {
+    const parsed = JSON.parse(jsonText) as unknown;
+    const rawScores = Array.isArray(parsed)
+      ? parsed
+      : (parsed && typeof parsed === "object" && Array.isArray((parsed as any).scores))
+        ? (parsed as any).scores
+        : null;
+    if (!rawScores) return null;
+
+    const scores = rawScores.map((item: unknown) => {
+      if (typeof item === "number" || typeof item === "string") return clampScore(item);
+      if (item && typeof item === "object") return clampScore((item as any).score ?? (item as any).relevance_score);
+      return 0;
+    });
+
+    if (scores.length < expectedLength) {
+      return [...scores, ...Array(expectedLength - scores.length).fill(0)];
+    }
+    return scores.slice(0, expectedLength);
+  } catch {
+    return null;
+  }
+}
+
+function parseQueryExpansionText(query: string, text: string, includeLexical: boolean): Queryable[] {
+  const queryables: Queryable[] = [];
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim().replace(/^[-*]\s*/, "").replace(/^\d+[.)]\s*/, "");
+    const match = line.match(/^(lex|vec|hyde)\s*:\s*(.+)$/i);
+    if (!match) continue;
+    const type = match[1]!.toLowerCase() as QueryType;
+    const content = match[2]!.trim();
+    if (!content) continue;
+    if (!includeLexical && type === "lex") continue;
+    queryables.push({ type, text: content });
+  }
+
+  if (queryables.length > 0) return queryables;
+
+  const fallback: Queryable[] = [
+    { type: "hyde", text: `Information about ${query}` },
+    { type: "lex", text: query },
+    { type: "vec", text: query },
+  ];
+  return includeLexical ? fallback : fallback.filter(q => q.type !== "lex");
+}
+
+function approximateTokenize(text: string): string[] {
+  // A conservative, dependency-free tokenizer approximation used only for chunk sizing
+  // with remote backends. Four characters per token mirrors QMD's existing fallback.
+  const tokens: string[] = [];
+  for (let i = 0; i < text.length; i += 4) {
+    tokens.push(text.slice(i, i + 4));
+  }
+  return tokens;
+}
+
+export class RemoteLLM implements LLM {
+  private readonly baseUrl: string;
+  private readonly apiKey?: string;
+  private readonly embedModel: string;
+  private readonly generateModel: string;
+  private readonly rerankModel: string;
+  private readonly rerankUrl?: string;
+  private readonly timeoutMs: number;
+  private readonly maxRerankBatchSize: number;
+  private readonly extraHeaders: Record<string, string>;
+
+  constructor(config: RemoteLLMConfig = {}) {
+    this.apiKey = resolveRemoteApiKey(config);
+    this.baseUrl = resolveRemoteBaseUrl(config, this.apiKey);
+    this.embedModel = resolveRemoteModel(config.embedModel, "QMD_REMOTE_EMBED_MODEL", "QMD_EMBED_MODEL", DEFAULT_REMOTE_EMBED_MODEL);
+    this.generateModel = resolveRemoteModel(config.generateModel, "QMD_REMOTE_GENERATE_MODEL", "QMD_GENERATE_MODEL", DEFAULT_REMOTE_GENERATE_MODEL);
+    this.rerankModel = resolveRemoteModel(config.rerankModel, "QMD_REMOTE_RERANK_MODEL", "QMD_RERANK_MODEL", DEFAULT_REMOTE_RERANK_MODEL);
+    this.rerankUrl = config.rerankUrl ?? process.env.QMD_REMOTE_RERANK_URL;
+    const envTimeoutMs = Number.parseInt(process.env.QMD_REMOTE_TIMEOUT_MS ?? "", 10);
+    this.timeoutMs = config.timeoutMs ?? (Number.isFinite(envTimeoutMs) && envTimeoutMs > 0 ? envTimeoutMs : DEFAULT_REMOTE_TIMEOUT_MS);
+    this.maxRerankBatchSize = config.maxRerankBatchSize ?? DEFAULT_REMOTE_RERANK_BATCH_SIZE;
+    this.extraHeaders = config.headers ?? {};
+  }
+
+  get embedModelName(): string {
+    return this.embedModel;
+  }
+
+  get generateModelName(): string {
+    return this.generateModel;
+  }
+
+  get rerankModelName(): string {
+    return this.rerankModel;
+  }
+
+  private endpoint(pathOrUrl: string): string {
+    if (/^https?:\/\//i.test(pathOrUrl)) return pathOrUrl;
+    return `${this.baseUrl}/${pathOrUrl.replace(/^\/+/, "")}`;
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      "content-type": "application/json",
+      "accept": "application/json",
+      ...(this.apiKey ? { authorization: `Bearer ${this.apiKey}` } : {}),
+      ...this.extraHeaders,
+    };
+  }
+
+  private async postJson<T>(pathOrUrl: string, body: unknown): Promise<T> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(new Error(`Remote LLM request timed out after ${this.timeoutMs}ms`)), this.timeoutMs);
+    (timer as any).unref?.();
+
+    let response: Response;
+    try {
+      response = await fetch(this.endpoint(pathOrUrl), {
+        method: "POST",
+        headers: this.headers(),
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    const responseText = await response.text();
+    if (!response.ok) {
+      const snippet = responseText.slice(0, 500);
+      throw new Error(`Remote LLM request failed (${response.status} ${response.statusText}): ${snippet}`);
+    }
+
+    if (!responseText.trim()) return {} as T;
+    try {
+      return JSON.parse(responseText) as T;
+    } catch (error) {
+      throw new Error(`Remote LLM returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  async embed(text: string, options: EmbedOptions = {}): Promise<EmbeddingResult | null> {
+    const [result] = await this.embedBatch([text], options);
+    return result ?? null;
+  }
+
+  async embedBatch(texts: string[], options: EmbedOptions = {}): Promise<(EmbeddingResult | null)[]> {
+    if (texts.length === 0) return [];
+    const model = shouldUseRemoteModelOverride(options.model, ["embeddinggemma"])
+      ? options.model
+      : this.embedModel;
+
+    try {
+      const response = await this.postJson<any>("/embeddings", {
+        model,
+        input: texts,
+      });
+
+      if (Array.isArray(response.embeddings)) {
+        return texts.map((_, i) => {
+          const embedding = response.embeddings[i];
+          return Array.isArray(embedding)
+            ? { embedding: embedding.map(Number), model: response.model ?? model }
+            : null;
+        });
+      }
+
+      const data = Array.isArray(response.data) ? response.data : [];
+      const byIndex = new Map<number, number[]>();
+      for (let i = 0; i < data.length; i++) {
+        const item = data[i];
+        const index = typeof item?.index === "number" ? item.index : i;
+        if (Array.isArray(item?.embedding)) {
+          byIndex.set(index, item.embedding.map(Number));
+        }
+      }
+
+      return texts.map((_, i) => {
+        const embedding = byIndex.get(i);
+        return embedding ? { embedding, model: response.model ?? model } : null;
+      });
+    } catch (error) {
+      console.error("Remote embedding error:", error);
+      return texts.map(() => null);
+    }
+  }
+
+  private async chat(prompt: string, options: GenerateOptions = {}, system?: string): Promise<GenerateResult | null> {
+    const model = shouldUseRemoteModelOverride(options.model, ["Qwen/Qwen3-1.7B"])
+      ? options.model
+      : this.generateModel;
+    const messages = [
+      ...(system ? [{ role: "system", content: system }] : []),
+      { role: "user", content: prompt },
+    ];
+
+    const response = await this.postJson<any>("/chat/completions", {
+      model,
+      messages,
+      temperature: options.temperature ?? 0.2,
+      max_tokens: options.maxTokens ?? 150,
+      stream: false,
+    });
+
+    const text = response.choices?.[0]?.message?.content
+      ?? response.choices?.[0]?.text
+      ?? response.output_text
+      ?? "";
+
+    return {
+      text: String(text),
+      model: response.model ?? model,
+      done: true,
+    };
+  }
+
+  async generate(prompt: string, options: GenerateOptions = {}): Promise<GenerateResult | null> {
+    return this.chat(prompt, options);
+  }
+
+  async modelExists(model: string): Promise<ModelInfo> {
+    // OpenAI-compatible servers do not consistently expose /models, and custom
+    // deployments may hide it. Treat configured remote model names as available
+    // and let the first actual request surface provider errors.
+    return { name: model, exists: true };
+  }
+
+  async expandQuery(
+    query: string,
+    options: { context?: string; includeLexical?: boolean; intent?: string } = {}
+  ): Promise<Queryable[]> {
+    const includeLexical = options.includeLexical ?? true;
+    const prompt = [
+      "Expand the user search query for a hybrid markdown search engine.",
+      "Return only newline-separated typed search lines in this exact format:",
+      includeLexical ? "lex: concise keyword query" : undefined,
+      "vec: semantic query in natural language",
+      "hyde: short hypothetical passage that would appear in a relevant document",
+      "",
+      "Rules:",
+      "- Do not write explanations, bullets, JSON, or markdown fences.",
+      "- Keep each line on one line.",
+      "- Use terms from the original query where possible.",
+      options.context ? `Corpus context: ${options.context}` : undefined,
+      options.intent ? `Query intent: ${options.intent}` : undefined,
+      `User query: ${query}`,
+    ].filter(Boolean).join("\n");
+
+    try {
+      const result = await this.chat(prompt, { model: this.generateModel, maxTokens: 600, temperature: 0.2 }, "You expand search queries for retrieval.");
+      return parseQueryExpansionText(query, result?.text ?? "", includeLexical);
+    } catch (error) {
+      console.error("Remote query expansion failed:", error);
+      return parseQueryExpansionText(query, "", includeLexical);
+    }
+  }
+
+  private parseRerankResponse(response: any, documents: RerankDocument[], model: string): RerankResult | null {
+    if (Array.isArray(response.scores)) {
+      return {
+        model: response.model ?? model,
+        results: response.scores.map((score: unknown, index: number) => ({
+          file: documents[index]?.file ?? String(index),
+          index,
+          score: clampScore(score),
+        })).sort((a: RerankDocumentResult, b: RerankDocumentResult) => b.score - a.score),
+      };
+    }
+
+    const items = Array.isArray(response.results)
+      ? response.results
+      : Array.isArray(response.data)
+        ? response.data
+        : Array.isArray(response)
+          ? response
+          : null;
+    if (!items) return null;
+
+    const seen = new Set<number>();
+    const results: RerankDocumentResult[] = [];
+    for (let fallbackIndex = 0; fallbackIndex < items.length; fallbackIndex++) {
+      const item = items[fallbackIndex];
+      const index = typeof item?.index === "number"
+        ? item.index
+        : typeof item?.document?.index === "number"
+          ? item.document.index
+          : fallbackIndex;
+      if (index < 0 || index >= documents.length) continue;
+      seen.add(index);
+      results.push({
+        file: documents[index]!.file,
+        index,
+        score: clampScore(item?.relevance_score ?? item?.score ?? item?.document?.score),
+      });
+    }
+
+    for (let index = 0; index < documents.length; index++) {
+      if (!seen.has(index)) {
+        results.push({ file: documents[index]!.file, index, score: 0 });
+      }
+    }
+
+    return { model: response.model ?? model, results: results.sort((a, b) => b.score - a.score) };
+  }
+
+  private async rerankViaEndpoint(query: string, documents: RerankDocument[], model: string): Promise<RerankResult | null> {
+    if (!this.rerankUrl) return null;
+    const response = await this.postJson<any>(this.rerankUrl, {
+      model,
+      query,
+      documents: documents.map(doc => doc.text),
+      top_n: documents.length,
+      return_documents: false,
+    });
+    return this.parseRerankResponse(response, documents, model);
+  }
+
+  private async scoreRerankBatch(query: string, documents: RerankDocument[], model: string): Promise<number[]> {
+    const prompt = [
+      "Score each document for relevance to the query.",
+      "Return only a JSON array of numbers between 0 and 1, in the same order as the documents.",
+      "Use 1 for directly answering/relevant documents and 0 for unrelated documents.",
+      "",
+      `Query: ${query}`,
+      "",
+      "Documents:",
+      JSON.stringify(documents.map((doc, index) => ({
+        index,
+        title: doc.title ?? doc.file,
+        text: doc.text.slice(0, 4000),
+      }))),
+    ].join("\n");
+
+    const result = await this.chat(prompt, {
+      model,
+      temperature: 0,
+      maxTokens: Math.max(100, documents.length * 12 + 50),
+    }, "You are a strict search relevance scorer.");
+
+    return parseScoreArray(result?.text ?? "", documents.length) ?? documents.map(() => 0);
+  }
+
+  async rerank(
+    query: string,
+    documents: RerankDocument[],
+    options: RerankOptions = {}
+  ): Promise<RerankResult> {
+    if (documents.length === 0) return { results: [], model: options.model ?? this.rerankModel };
+    const model = shouldUseRemoteModelOverride(options.model, ["ExpedientFalcon/qwen3-reranker:0.6b-q8_0"])
+      ? options.model
+      : this.rerankModel;
+
+    try {
+      const endpointResult = await this.rerankViaEndpoint(query, documents, model);
+      if (endpointResult) return endpointResult;
+    } catch (error) {
+      console.error("Remote rerank endpoint failed; falling back to chat scoring:", error);
+    }
+
+    const results: RerankDocumentResult[] = [];
+    for (let start = 0; start < documents.length; start += this.maxRerankBatchSize) {
+      const batch = documents.slice(start, start + this.maxRerankBatchSize);
+      try {
+        const scores = await this.scoreRerankBatch(query, batch, model);
+        for (let i = 0; i < batch.length; i++) {
+          results.push({
+            file: batch[i]!.file,
+            index: start + i,
+            score: clampScore(scores[i]),
+          });
+        }
+      } catch (error) {
+        console.error("Remote chat rerank failed for batch:", error);
+        for (let i = 0; i < batch.length; i++) {
+          results.push({ file: batch[i]!.file, index: start + i, score: 0 });
+        }
+      }
+    }
+
+    return { model, results: results.sort((a, b) => b.score - a.score) };
+  }
+
+  async tokenize(text: string): Promise<readonly string[]> {
+    return approximateTokenize(text);
+  }
+
+  async detokenize(tokens: readonly unknown[]): Promise<string> {
+    return tokens.map(token => String(token)).join("");
+  }
+
+  async dispose(): Promise<void> {
+    // Remote backend has no local resources to dispose.
+  }
+}
+
+export function resolveLLMProvider(configValue?: string): LLMProvider {
+  const raw = configValue ?? process.env.QMD_LLM_BACKEND ?? process.env.QMD_LLM_PROVIDER;
+  const normalized = raw?.trim().toLowerCase();
+  if (normalized) {
+    if (["remote", "openai", "http", "https"].includes(normalized)) return "remote";
+    if (["local", "llama", "llamacpp", "node-llama-cpp"].includes(normalized)) return "local";
+    process.stderr.write(`QMD Warning: invalid LLM backend "${raw}", using local node-llama-cpp.\n`);
+    return "local";
+  }
+
+  if (process.env.QMD_REMOTE_BASE_URL || process.env.QMD_REMOTE_URL) return "remote";
+  return "local";
+}
+
+export function createLLM(config: LLMConfig = {}): LLM {
+  const provider = config.provider || config.backend
+    ? resolveLLMProvider(config.provider ?? config.backend)
+    : config.baseUrl
+      ? "remote"
+      : resolveLLMProvider();
+  return provider === "remote" ? new RemoteLLM(config) : new LlamaCpp(config);
+}
+
+// =============================================================================
 // Session Management Layer
 // =============================================================================
 
 /**
  * Manages LLM session lifecycle with reference counting.
- * Coordinates with LlamaCpp idle timeout to prevent disposal during active sessions.
+ * Coordinates with local LlamaCpp idle timeout to prevent disposal during active sessions.
  */
 class LLMSessionManager {
-  private llm: LlamaCpp;
+  private llm: LLM;
   private _activeSessionCount = 0;
   private _inFlightOperations = 0;
 
-  constructor(llm: LlamaCpp) {
+  constructor(llm: LLM) {
     this.llm = llm;
   }
 
@@ -1434,7 +2021,7 @@ class LLMSessionManager {
     this._inFlightOperations = Math.max(0, this._inFlightOperations - 1);
   }
 
-  getLlamaCpp(): LlamaCpp {
+  getLLM(): LLM {
     return this.llm;
   }
 }
@@ -1451,7 +2038,7 @@ export class SessionReleasedError extends Error {
 
 /**
  * Scoped LLM session with automatic lifecycle management.
- * Wraps LlamaCpp methods with operation tracking and abort handling.
+ * Wraps LLM methods with operation tracking and abort handling.
  */
 class LLMSession implements ILLMSession {
   private manager: LLMSessionManager;
@@ -1537,18 +2124,18 @@ class LLMSession implements ILLMSession {
   }
 
   async embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null> {
-    return this.withOperation(() => this.manager.getLlamaCpp().embed(text, options));
+    return this.withOperation(() => this.manager.getLLM().embed(text, options));
   }
 
   async embedBatch(texts: string[], options?: EmbedOptions): Promise<(EmbeddingResult | null)[]> {
-    return this.withOperation(() => this.manager.getLlamaCpp().embedBatch(texts, options));
+    return this.withOperation(() => this.manager.getLLM().embedBatch(texts, options));
   }
 
   async expandQuery(
     query: string,
-    options?: { context?: string; includeLexical?: boolean }
+    options?: { context?: string; includeLexical?: boolean; intent?: string }
   ): Promise<Queryable[]> {
-    return this.withOperation(() => this.manager.getLlamaCpp().expandQuery(query, options));
+    return this.withOperation(() => this.manager.getLLM().expandQuery(query, options));
   }
 
   async rerank(
@@ -1556,19 +2143,19 @@ class LLMSession implements ILLMSession {
     documents: RerankDocument[],
     options?: RerankOptions
   ): Promise<RerankResult> {
-    return this.withOperation(() => this.manager.getLlamaCpp().rerank(query, documents, options));
+    return this.withOperation(() => this.manager.getLLM().rerank(query, documents, options));
   }
 }
 
-// Session manager for the default LlamaCpp instance
+// Session manager for the configured default LLM instance
 let defaultSessionManager: LLMSessionManager | null = null;
 
 /**
- * Get the session manager for the default LlamaCpp instance.
+ * Get the session manager for the configured default LLM instance.
  */
 function getSessionManager(): LLMSessionManager {
-  const llm = getDefaultLlamaCpp();
-  if (!defaultSessionManager || defaultSessionManager.getLlamaCpp() !== llm) {
+  const llm = getDefaultLLM();
+  if (!defaultSessionManager || defaultSessionManager.getLLM() !== llm) {
     defaultSessionManager = new LLMSessionManager(llm);
   }
   return defaultSessionManager;
@@ -1603,11 +2190,11 @@ export async function withLLMSession<T>(
 }
 
 /**
- * Execute a function with a scoped LLM session using a specific LlamaCpp instance.
+ * Execute a function with a scoped LLM session using a specific LLM instance.
  * Unlike withLLMSession, this does not use the global singleton.
  */
 export async function withLLMSessionForLlm<T>(
-  llm: LlamaCpp,
+  llm: LLM,
   fn: (session: ILLMSession) => Promise<T>,
   options?: LLMSessionOptions
 ): Promise<T> {
@@ -1631,26 +2218,72 @@ export function canUnloadLLM(): boolean {
 }
 
 // =============================================================================
-// Singleton for default LlamaCpp instance
+// Singleton for configured default LLM instances
 // =============================================================================
 
+let defaultLLM: LLM | null = null;
 let defaultLlamaCpp: LlamaCpp | null = null;
 
 /**
- * Get the default LlamaCpp instance (creates one if needed)
+ * Get the configured default LLM instance (local LlamaCpp or remote HTTP).
+ */
+export function getDefaultLLM(): LLM {
+  if (!defaultLLM) {
+    defaultLLM = createLLM();
+    if (defaultLLM instanceof LlamaCpp) {
+      defaultLlamaCpp = defaultLLM;
+    }
+  }
+  return defaultLLM;
+}
+
+/**
+ * Set a custom default LLM instance (useful for tests and config-driven CLI setup).
+ */
+export function setDefaultLLM(llm: LLM | null): void {
+  defaultLLM = llm;
+  defaultSessionManager = null;
+  defaultLlamaCpp = llm instanceof LlamaCpp ? llm : null;
+}
+
+/**
+ * Get the default local LlamaCpp instance (creates one if needed).
+ * Prefer getDefaultLLM() for search/indexing code that should honor remote config.
  */
 export function getDefaultLlamaCpp(): LlamaCpp {
   if (!defaultLlamaCpp) {
     defaultLlamaCpp = new LlamaCpp();
   }
+  if (!defaultLLM && resolveLLMProvider() === "local") {
+    defaultLLM = defaultLlamaCpp;
+  }
   return defaultLlamaCpp;
 }
 
 /**
- * Set a custom default LlamaCpp instance (useful for testing)
+ * Set a custom default LlamaCpp instance (useful for testing).
  */
 export function setDefaultLlamaCpp(llm: LlamaCpp | null): void {
   defaultLlamaCpp = llm;
+  defaultLLM = llm;
+  defaultSessionManager = null;
+}
+
+/**
+ * Dispose the configured default LLM instance if it exists.
+ */
+export async function disposeDefaultLLM(): Promise<void> {
+  if (defaultLLM) {
+    await defaultLLM.dispose();
+    if (defaultLLM === defaultLlamaCpp) {
+      defaultLlamaCpp = null;
+    }
+    defaultLLM = null;
+  } else if (defaultLlamaCpp) {
+    await defaultLlamaCpp.dispose();
+    defaultLlamaCpp = null;
+  }
+  defaultSessionManager = null;
 }
 
 /**
@@ -1658,8 +2291,5 @@ export function setDefaultLlamaCpp(llm: LlamaCpp | null): void {
  * Call this before process exit to prevent NAPI crashes.
  */
 export async function disposeDefaultLlamaCpp(): Promise<void> {
-  if (defaultLlamaCpp) {
-    await defaultLlamaCpp.dispose();
-    defaultLlamaCpp = null;
-  }
+  await disposeDefaultLLM();
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -19,11 +19,11 @@ import { readFileSync, realpathSync, statSync, mkdirSync } from "node:fs";
 // Note: node:path resolve is not imported — we export our own cross-platform resolve()
 import fastGlob from "fast-glob";
 import {
-  LlamaCpp,
-  getDefaultLlamaCpp,
+  getDefaultLLM,
   formatQueryForEmbedding,
   formatDocForEmbedding,
   withLLMSessionForLlm,
+  type LLM,
   type RerankDocument,
   type ILLMSession,
 } from "./llm.js";
@@ -59,11 +59,11 @@ export const CHUNK_WINDOW_TOKENS = 200;
 export const CHUNK_WINDOW_CHARS = CHUNK_WINDOW_TOKENS * 4;  // 800 chars
 
 /**
- * Get the LlamaCpp instance for a store — prefers the store's own instance,
- * falls back to the global singleton.
+ * Get the LLM instance for a store — prefers the store's own instance,
+ * falls back to the configured global singleton.
  */
-function getLlm(store: Store): LlamaCpp {
-  return store.llm ?? getDefaultLlamaCpp();
+function getLlm(store: Store): LLM {
+  return store.llm ?? getDefaultLLM();
 }
 
 // =============================================================================
@@ -1087,8 +1087,8 @@ function ensureVecTableInternal(db: Database, dimensions: number): void {
 export type Store = {
   db: Database;
   dbPath: string;
-  /** Optional LlamaCpp instance for this store (overrides the global singleton) */
-  llm?: LlamaCpp;
+  /** Optional LLM instance for this store (overrides the global singleton) */
+  llm?: LLM;
   close: () => void;
   ensureVecTable: (dimensions: number) => void;
 
@@ -1404,14 +1404,15 @@ function getEmbeddingDocsForBatch(db: Database, batch: PendingEmbeddingDoc[]): E
 /**
  * Generate vector embeddings for documents that need them.
  * Pure function — no console output, no db lifecycle management.
- * Uses the store's LlamaCpp instance if set, otherwise the global singleton.
+ * Uses the store's configured LLM instance if set, otherwise the global singleton.
  */
 export async function generateEmbeddings(
   store: Store,
   options?: EmbedOptions
 ): Promise<EmbedResult> {
   const db = store.db;
-  const model = options?.model ?? DEFAULT_EMBED_MODEL;
+  const llm = getLlm(store);
+  const model = options?.model ?? llm.embedModelName ?? DEFAULT_EMBED_MODEL;
   const now = new Date().toISOString();
   const { maxDocsPerBatch, maxBatchBytes } = resolveEmbedOptions(options);
   const encoder = new TextEncoder();
@@ -1429,9 +1430,8 @@ export async function generateEmbeddings(
   const totalDocs = docsToEmbed.length;
   const startTime = Date.now();
 
-  // Use store's LlamaCpp or global singleton, wrapped in a session
-  const llm = getLlm(store);
-  const embedModelUri = llm.embedModelName;
+  // Use store's configured LLM or global singleton, wrapped in a session
+  const embedModelUri = llm.embedModelName ?? model;
 
   // Create a session manager for this llm instance
   const result = await withLLMSessionForLlm(llm, async (session) => {
@@ -1464,6 +1464,7 @@ export async function generateEmbeddings(
           doc.path,
           options?.chunkStrategy,
           session.signal,
+          llm,
         );
 
         for (let seq = 0; seq < chunks.length; seq++) {
@@ -1640,7 +1641,7 @@ export function createStore(dbPath?: string): Store {
 
     // Search
     searchFTS: (query: string, limit?: number, collectionName?: string) => searchFTS(db, query, limit, collectionName),
-    searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => searchVec(db, query, model, limit, collectionName, session, precomputedEmbedding),
+    searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => searchVec(db, query, model, limit, collectionName, session, precomputedEmbedding, store.llm),
 
     // Query expansion & reranking
     expandQuery: (query: string, model?: string, intent?: string) => expandQuery(query, model, db, intent, store.llm),
@@ -2274,9 +2275,21 @@ export async function chunkDocumentByTokens(
   windowTokens: number = CHUNK_WINDOW_TOKENS,
   filepath?: string,
   chunkStrategy: ChunkStrategy = "regex",
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  llmOverride?: LLM,
 ): Promise<{ text: string; pos: number; tokens: number }[]> {
-  const llm = getDefaultLlamaCpp();
+  const llm = llmOverride ?? getDefaultLLM();
+  const approximateTokenize = (text: string): string[] => {
+    const tokens: string[] = [];
+    for (let i = 0; i < text.length; i += 4) tokens.push(text.slice(i, i + 4));
+    return tokens;
+  };
+  const tokenize = async (text: string): Promise<readonly unknown[]> => llm.tokenize
+    ? await llm.tokenize(text)
+    : approximateTokenize(text);
+  const detokenize = async (tokens: readonly unknown[]): Promise<string> => llm.detokenize
+    ? await llm.detokenize(tokens)
+    : tokens.map(token => String(token)).join("");
 
   // Use moderate chars/token estimate (prose ~4, code ~2, mixed ~3)
   // If chunks exceed limit, they'll be re-split with actual ratio
@@ -2299,7 +2312,7 @@ export async function chunkDocumentByTokens(
   const pushChunkWithinTokenLimit = async (text: string, pos: number): Promise<void> => {
     if (signal?.aborted) return;
 
-    const tokens = await llm.tokenize(text);
+    const tokens = await tokenize(text);
     if (tokens.length <= maxTokens || text.length <= 1) {
       results.push({ text, pos, tokens: tokens.length });
       return;
@@ -2336,7 +2349,7 @@ export async function chunkDocumentByTokens(
       || subChunks[0]?.text.length === text.length
     ) {
       const fallbackTokens = tokens.slice(0, Math.max(1, maxTokens));
-      const truncatedText = await llm.detokenize(fallbackTokens);
+      const truncatedText = await detokenize(fallbackTokens);
       results.push({
         text: truncatedText,
         pos,
@@ -3096,11 +3109,11 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
 // Vector Search
 // =============================================================================
 
-export async function searchVec(db: Database, query: string, model: string, limit: number = 20, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]): Promise<SearchResult[]> {
+export async function searchVec(db: Database, query: string, model: string, limit: number = 20, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[], llmOverride?: LLM): Promise<SearchResult[]> {
   const tableExists = db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'`).get();
   if (!tableExists) return [];
 
-  const embedding = precomputedEmbedding ?? await getEmbedding(query, model, true, session);
+  const embedding = precomputedEmbedding ?? await getEmbedding(query, model, true, session, llmOverride);
   if (!embedding) return [];
 
   // IMPORTANT: We use a two-step query approach here because sqlite-vec virtual tables
@@ -3186,12 +3199,15 @@ export async function searchVec(db: Database, query: string, model: string, limi
 // Embeddings
 // =============================================================================
 
-async function getEmbedding(text: string, model: string, isQuery: boolean, session?: ILLMSession, llmOverride?: LlamaCpp): Promise<number[] | null> {
-  // Format text using the appropriate prompt template
-  const formattedText = isQuery ? formatQueryForEmbedding(text, model) : formatDocForEmbedding(text, undefined, model);
+async function getEmbedding(text: string, model: string, isQuery: boolean, session?: ILLMSession, llmOverride?: LLM): Promise<number[] | null> {
+  const llm = llmOverride ?? getDefaultLLM();
+  const activeEmbedModel = llm.embedModelName ?? DEFAULT_EMBED_MODEL;
+  const modelName = model === DEFAULT_EMBED_MODEL ? activeEmbedModel : model;
+  // Format text using the appropriate prompt template for the active embedding model
+  const formattedText = isQuery ? formatQueryForEmbedding(text, modelName) : formatDocForEmbedding(text, undefined, modelName);
   const result = session
-    ? await session.embed(formattedText, { model, isQuery })
-    : await (llmOverride ?? getDefaultLlamaCpp()).embed(formattedText, { model, isQuery });
+    ? await session.embed(formattedText, { model: modelName, isQuery })
+    : await llm.embed(formattedText, { model: modelName, isQuery });
   return result?.embedding || null;
 }
 
@@ -3255,9 +3271,11 @@ export function insertEmbedding(
 // Query expansion
 // =============================================================================
 
-export async function expandQuery(query: string, model: string = DEFAULT_QUERY_MODEL, db: Database, intent?: string, llmOverride?: LlamaCpp): Promise<ExpandedQuery[]> {
+export async function expandQuery(query: string, model: string = DEFAULT_QUERY_MODEL, db: Database, intent?: string, llmOverride?: LLM): Promise<ExpandedQuery[]> {
+  const llm = llmOverride ?? getDefaultLLM();
+  const cacheModel = model === DEFAULT_QUERY_MODEL ? (llm.generateModelName ?? model) : model;
   // Check cache first — stored as JSON preserving types
-  const cacheKey = getCacheKey("expandQuery", { query, model, ...(intent && { intent }) });
+  const cacheKey = getCacheKey("expandQuery", { query, model: cacheModel, ...(intent && { intent }) });
   const cached = getCachedResult(db, cacheKey);
   if (cached) {
     try {
@@ -3273,8 +3291,7 @@ export async function expandQuery(query: string, model: string = DEFAULT_QUERY_M
     }
   }
 
-  const llm = llmOverride ?? getDefaultLlamaCpp();
-  // Note: LlamaCpp uses hardcoded model, model parameter is ignored
+  // Local and remote providers resolve their configured generation model internally.
   const results = await llm.expandQuery(query, { intent });
 
   // Map Queryable[] → ExpandedQuery[] (same shape, decoupled from llm.ts internals).
@@ -3294,7 +3311,9 @@ export async function expandQuery(query: string, model: string = DEFAULT_QUERY_M
 // Reranking
 // =============================================================================
 
-export async function rerank(query: string, documents: { file: string; text: string }[], model: string = DEFAULT_RERANK_MODEL, db: Database, intent?: string, llmOverride?: LlamaCpp): Promise<{ file: string; score: number }[]> {
+export async function rerank(query: string, documents: { file: string; text: string }[], model: string = DEFAULT_RERANK_MODEL, db: Database, intent?: string, llmOverride?: LLM): Promise<{ file: string; score: number }[]> {
+  const llm = llmOverride ?? getDefaultLLM();
+  const cacheModel = model === DEFAULT_RERANK_MODEL ? (llm.rerankModelName ?? model) : model;
   // Prepend intent to rerank query so the reranker scores with domain context
   const rerankQuery = intent ? `${intent}\n\n${query}` : query;
 
@@ -3307,7 +3326,7 @@ export async function rerank(query: string, documents: { file: string; text: str
   // File path is excluded from the new cache key because the reranker score
   // depends on the chunk content, not where it came from.
   for (const doc of documents) {
-    const cacheKey = getCacheKey("rerank", { query: rerankQuery, model, chunk: doc.text });
+    const cacheKey = getCacheKey("rerank", { query: rerankQuery, model: cacheModel, chunk: doc.text });
     const legacyCacheKey = getCacheKey("rerank", { query, file: doc.file, model, chunk: doc.text });
     const cached = getCachedResult(db, cacheKey) ?? getCachedResult(db, legacyCacheKey);
     if (cached !== null) {
@@ -3317,9 +3336,8 @@ export async function rerank(query: string, documents: { file: string; text: str
     }
   }
 
-  // Rerank uncached documents using LlamaCpp
+  // Rerank uncached documents using the configured LLM provider
   if (uncachedDocsByChunk.size > 0) {
-    const llm = llmOverride ?? getDefaultLlamaCpp();
     const uncachedDocs = [...uncachedDocsByChunk.values()];
     const rerankResult = await llm.rerank(rerankQuery, uncachedDocs, { model });
 
@@ -3327,7 +3345,7 @@ export async function rerank(query: string, documents: { file: string; text: str
     const textByFile = new Map(uncachedDocs.map(d => [d.file, d.text]));
     for (const result of rerankResult.results) {
       const chunk = textByFile.get(result.file) || "";
-      const cacheKey = getCacheKey("rerank", { query: rerankQuery, model, chunk });
+      const cacheKey = getCacheKey("rerank", { query: rerankQuery, model: cacheModel, chunk });
       setCachedResult(db, cacheKey, result.score.toString());
       cachedResults.set(chunk, result.score);
     }
@@ -4304,7 +4322,7 @@ export interface VectorSearchResult {
  *
  * Pipeline:
  * 1. expandQuery() → typed variants, filter to vec/hyde only (lex irrelevant here)
- * 2. searchVec() for original + vec/hyde variants (sequential — node-llama-cpp embed limitation)
+ * 2. searchVec() for original + vec/hyde variants (sequential for provider compatibility)
  * 3. Dedup by filepath (keep max score)
  * 4. Sort by score descending, filter by minScore, slice to limit
  */
@@ -4329,7 +4347,7 @@ export async function vectorSearchQuery(
   const vecExpanded = allExpanded.filter(q => q.type !== 'lex');
   options?.hooks?.onExpand?.(query, vecExpanded, Date.now() - expandStart);
 
-  // Run original + vec/hyde expanded through vector, sequentially — concurrent embed() hangs
+  // Run original + vec/hyde expanded through vector sequentially for provider compatibility
   const queryTexts = [query, ...vecExpanded.map(q => q.query)];
   const allResults = new Map<string, VectorSearchResult>();
   for (const q of queryTexts) {
@@ -4392,9 +4410,9 @@ export interface StructuredSearchOptions {
  * 5. Position-aware score blending
  * 6. Dedup, filter, slice
  *
- * This is the recommended endpoint for capable LLMs — they can generate
- * better query variations than our small local model, especially for
- * domain-specific or nuanced queries.
+ * This is the recommended endpoint for capable callers — they can generate
+ * tailored query variations themselves and skip QMD's internal expansion step,
+ * especially for domain-specific or nuanced queries.
  */
 export async function structuredSearch(
   store: Store,

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -7,12 +7,17 @@
  * rerank functions first to trigger model downloads.
  */
 
-import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
+import { describe, test, expect, beforeAll, afterAll, afterEach, vi } from "vitest";
 import {
   LlamaCpp,
+  RemoteLLM,
+  createLLM,
   getDefaultLlamaCpp,
   disposeDefaultLlamaCpp,
   resolveLlamaGpuMode,
+  resolveLLMProvider,
+  formatQueryForEmbedding,
+  formatDocForEmbedding,
   withLLMSession,
   canUnloadLLM,
   SessionReleasedError,
@@ -217,6 +222,103 @@ describe("LlamaCpp embedding truncation", () => {
       embedding: [0.25, 0.5],
       model: llm.embedModelUri,
     });
+  });
+});
+
+describe("Remote LLM backend", () => {
+  const originalFetch = globalThis.fetch;
+  const originalRemoteBaseUrl = process.env.QMD_REMOTE_BASE_URL;
+
+  afterEach(() => {
+    (globalThis as any).fetch = originalFetch;
+    if (originalRemoteBaseUrl === undefined) delete process.env.QMD_REMOTE_BASE_URL;
+    else process.env.QMD_REMOTE_BASE_URL = originalRemoteBaseUrl;
+    vi.restoreAllMocks();
+  });
+
+  test("raw embedding formatting is used for OpenAI-style model names", () => {
+    expect(formatQueryForEmbedding("auth flow", "text-embedding-3-small")).toBe("auth flow");
+    expect(formatDocForEmbedding("body", "Title", "text-embedding-3-small")).toBe("Title\nbody");
+  });
+
+  test("provider selection supports remote env and explicit local override", () => {
+    process.env.QMD_REMOTE_BASE_URL = "https://llm.example.com/v1";
+    expect(resolveLLMProvider()).toBe("remote");
+    expect(resolveLLMProvider("local")).toBe("local");
+  });
+
+  test("createLLM returns RemoteLLM for remote provider or configured baseUrl", () => {
+    const explicit = createLLM({ provider: "remote", baseUrl: "https://llm.example.com/v1" });
+    const inferred = createLLM({ baseUrl: "https://llm.example.com/v1" });
+    expect(explicit).toBeInstanceOf(RemoteLLM);
+    expect(inferred).toBeInstanceOf(RemoteLLM);
+  });
+
+  test("RemoteLLM embeds batches via OpenAI-compatible /embeddings", async () => {
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body));
+      expect(body).toEqual({ model: "remote-embed", input: ["one", "two"] });
+      return new Response(JSON.stringify({
+        model: "remote-embed",
+        data: [
+          { index: 0, embedding: [0.1, 0.2] },
+          { index: 1, embedding: [0.3, 0.4] },
+        ],
+      }));
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const llm = new RemoteLLM({ baseUrl: "https://llm.example.com/v1", embedModel: "remote-embed" });
+    const embeddings = await llm.embedBatch(["one", "two"]);
+
+    expect(fetchMock).toHaveBeenCalledWith("https://llm.example.com/v1/embeddings", expect.any(Object));
+    expect(embeddings.map(item => item?.embedding)).toEqual([[0.1, 0.2], [0.3, 0.4]]);
+  });
+
+  test("RemoteLLM expands queries from chat completions", async () => {
+    (globalThis as any).fetch = vi.fn(async () => new Response(JSON.stringify({
+      model: "remote-chat",
+      choices: [{ message: { content: "lex: auth login\nvec: how users authenticate\nhyde: Users sign in with credentials and receive a session token." } }],
+    })));
+
+    const llm = new RemoteLLM({ baseUrl: "https://llm.example.com/v1", generateModel: "remote-chat" });
+    const expanded = await llm.expandQuery("auth flow");
+
+    expect(expanded).toEqual([
+      { type: "lex", text: "auth login" },
+      { type: "vec", text: "how users authenticate" },
+      { type: "hyde", text: "Users sign in with credentials and receive a session token." },
+    ]);
+  });
+
+  test("RemoteLLM parses rerank endpoint responses", async () => {
+    (globalThis as any).fetch = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body));
+      expect(body.query).toBe("capital of France");
+      expect(body.documents).toEqual(["Paris is the capital.", "Butterflies fly."]);
+      return new Response(JSON.stringify({
+        model: "remote-rerank",
+        results: [
+          { index: 1, relevance_score: 0.1 },
+          { index: 0, relevance_score: 0.95 },
+        ],
+      }));
+    });
+
+    const llm = new RemoteLLM({
+      baseUrl: "https://llm.example.com/v1",
+      rerankUrl: "/rerank",
+      rerankModel: "remote-rerank",
+    });
+    const reranked = await llm.rerank("capital of France", [
+      { file: "france.md", text: "Paris is the capital." },
+      { file: "bugs.md", text: "Butterflies fly." },
+    ]);
+
+    expect(reranked.results.map(r => [r.file, r.score])).toEqual([
+      ["france.md", 0.95],
+      ["bugs.md", 0.1],
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add a configurable remote OpenAI-compatible LLM backend for embeddings, query expansion, and reranking
- Wire backend selection through env vars, YAML model config, CLI, SDK store creation, and MCP via createStore
- Document remote backend usage and add unit tests for remote embedding, expansion, rerank, and backend selection

## Testing
- CI=true bun test test/llm.test.ts
- CI=true bun test test/sdk.test.ts -t "store.embed forwards batch limit options|CollectionConfig type is usable"

## Notes
- bunx tsc -p tsconfig.build.json --noEmit still reports the existing unrelated typing issue: src/store.ts(2143,22): Property 'transaction' does not exist on type 'Database'.