### PR TITLE
fix: lazy load node-llama-cpp for no-op embed

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -4,19 +4,24 @@
  * Provides embeddings, text generation, and reranking using local GGUF models.
  */
 
-import {
-  getLlama,
-  resolveModelFile,
-  LlamaChatSession,
-  LlamaLogLevel,
-  type Llama,
-  type LlamaModel,
-  type LlamaEmbeddingContext,
-  type Token as LlamaToken,
+import type {
+  Llama,
+  LlamaModel,
+  LlamaEmbeddingContext,
+  Token as LlamaToken,
 } from "node-llama-cpp";
 import { homedir } from "os";
 import { join } from "path";
 import { existsSync, mkdirSync, statSync, unlinkSync, readdirSync, readFileSync, writeFileSync, openSync, readSync, closeSync } from "fs";
+
+type NodeLlamaCppModule = typeof import("node-llama-cpp");
+
+let nodeLlamaCppModulePromise: Promise<NodeLlamaCppModule> | null = null;
+
+function loadNodeLlamaCpp(): Promise<NodeLlamaCppModule> {
+  nodeLlamaCppModulePromise ??= import("node-llama-cpp");
+  return nodeLlamaCppModulePromise;
+}
 
 // =============================================================================
 // Embedding Formatting Functions
@@ -344,6 +349,7 @@ export async function pullModels(
       }
     }
 
+    const { resolveModelFile } = await loadNodeLlamaCpp();
     const path = await resolveModelFile(model, cacheDir);
     validateGgufFile(path, model);
     const sizeBytes = existsSync(path) ? statSync(path).size : 0;
@@ -619,6 +625,7 @@ export class LlamaCpp implements LLM {
     if (!this.llama) {
       const gpuMode = resolveLlamaGpuMode();
 
+      const { getLlama, LlamaLogLevel } = await loadNodeLlamaCpp();
       const loadLlama = async (gpu: LlamaGpuMode) =>
         await getLlama({
           build: allowBuild ? "autoAttempt" : "never",
@@ -661,6 +668,7 @@ export class LlamaCpp implements LLM {
   private async resolveModel(modelUri: string): Promise<string> {
     this.ensureModelCacheDir();
     // resolveModelFile handles HF URIs and downloads to the cache dir
+    const { resolveModelFile } = await loadNodeLlamaCpp();
     const modelPath = await resolveModelFile(modelUri, this.modelCacheDir);
     validateGgufFile(modelPath, modelUri);
     return modelPath;
@@ -1079,6 +1087,7 @@ export class LlamaCpp implements LLM {
     // Create fresh context -> sequence -> session for each call
     const context = await this.generateModel!.createContext();
     const sequence = context.getSequence();
+    const { LlamaChatSession } = await loadNodeLlamaCpp();
     const session = new LlamaChatSession({ contextSequence: sequence });
 
     const maxTokens = options.maxTokens ?? 150;
@@ -1158,6 +1167,7 @@ export class LlamaCpp implements LLM {
       contextSize: this.expandContextSize,
     });
     const sequence = genContext.getSequence();
+    const { LlamaChatSession } = await loadNodeLlamaCpp();
     const session = new LlamaChatSession({ contextSequence: sequence });
 
     try {

--- a/test/llm-lazy-load.test.ts
+++ b/test/llm-lazy-load.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const state = vi.hoisted(() => ({ nodeLlamaImported: false }));
+
+vi.mock("node-llama-cpp", () => {
+  state.nodeLlamaImported = true;
+  return {
+    LlamaLogLevel: { error: "error" },
+    LlamaChatSession: vi.fn(),
+    getLlama: vi.fn(async () => {
+      throw new Error("node-llama-cpp should not be initialized for no-op embed");
+    }),
+    resolveModelFile: vi.fn(async () => {
+      throw new Error("node-llama-cpp should not resolve models for no-op embed");
+    }),
+  };
+});
+
+describe("lazy node-llama-cpp loading", () => {
+  test("no-op embed does not import node-llama-cpp", async () => {
+    const { createStore } = await import("../src/index.js");
+    const dir = mkdtempSync(join(tmpdir(), "qmd-lazy-"));
+
+    try {
+      const store = await createStore({
+        dbPath: join(dir, "index.sqlite"),
+        config: { collections: {} },
+      });
+
+      const result = await store.embed();
+      await store.close();
+
+      expect(result).toEqual({ docsProcessed: 0, chunksEmbedded: 0, errors: 0, durationMs: 0 });
+      expect(state.nodeLlamaImported).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Avoid importing `node-llama-cpp` until QMD actually needs a local LLM/model operation.

This keeps no-op embed/status-style paths lightweight. In particular, `store.embed()` already checks for pending documents before calling into the LLM, but the previous static import meant the native `node-llama-cpp` module was still loaded as soon as `llm.ts` was imported.

This matters for OpenClaw multi-agent gateways where boot/update cycles may call `qmd embed` frequently and most runs often have no missing embeddings.

## Changes

- Convert `node-llama-cpp` value imports to type-only imports.
- Add a memoized dynamic loader for `node-llama-cpp`.
- Load `getLlama`, `resolveModelFile`, `LlamaLogLevel`, and `LlamaChatSession` only from code paths that actually need them.
- Add a regression test proving a no-op embed does not import `node-llama-cpp`.

## Related

This addresses part of openclaw/openclaw#72144: avoiding heavy native/LLM initialization when all content hashes already have embeddings.

## Tests

Passed:

```bash
corepack pnpm exec vitest run test/llm-lazy-load.test.ts test/sdk.test.ts -t "lazy node-llama-cpp loading|store.embed rejects invalid batch limits|store.embed forwards batch limit options" --reporter=verbose
```

Also checked:

```bash
corepack pnpm exec tsc -p tsconfig.build.json --noEmit
```

That currently fails on main with an unrelated existing error:

```text
src/store.ts(2142,22): error TS2339: Property 'transaction' does not exist on type 'Database'.
```
