### PR TITLE
fix(mcp): instructions say singular `collection` but schema is plural

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -116,7 +116,7 @@ async function buildInstructions(store: QMDStore): Promise<string> {
   // --- What's searchable? ---
   if (status.collections.length > 0) {
     lines.push("");
-    lines.push("Collections (scope with `collection` parameter):");
+    lines.push("Collections (scope with `collections` parameter — array of names):");
     for (const col of status.collections) {
       // Find root context for this collection
       const rootCtx = contexts.find(c => c.collection === col.name && (c.path === "" || c.path === "/"));


### PR DESCRIPTION
## Summary

The MCP `query` tool's input schema accepts `collections: z.array(z.string())` ([`src/mcp/server.ts:309`](https://github.com/tobi/qmd/blob/main/src/mcp/server.ts#L309)) but the auto-generated instructions string handed to clients on initialize says:

> Collections (scope with `collection` parameter):

So agents that follow the instructions verbatim pass `collection: "obsidian"`, the schema ignores it, and the search silently widens across every collection. The cost is recall degradation, not an error — easy to miss without instrumentation.

This PR changes one word and adds the shape hint:

> Collections (scope with `collections` parameter — array of names):

Verified `collections` is the only schema field accepting collection scope (no other singular `collection` parameter exists in `src/mcp/`).

## Test plan

- [ ] Local rebuild: `bun run build`
- [ ] `qmd mcp --http --port 9471` → connect a client → confirm `instructions` carries the new wording