### PR TITLE
feat(embed): make session max duration configurable via QMD_EMBED_MAX_DURATION_MS

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,22 @@ Supported model families:
 - **Qwen3-Embedding** — Multilingual (119 languages including CJK), MTEB top-ranked
 
 > **Note:** When switching embedding models, you must re-index with `qmd embed -f`
+
+### Embedding Session Duration
+
+`qmd embed` aborts after 30 minutes by default to bound long-running sessions.
+On a large backlog this leaves chunks unprocessed (look for `Session expired —
+skipping N remaining chunks` in the output). Override with
+`QMD_EMBED_MAX_DURATION_MS` (in milliseconds), or set it to `0` to disable the
+timeout entirely:
+
+```sh
+# Allow up to 4 hours per embed run
+export QMD_EMBED_MAX_DURATION_MS=14400000
+
+# Disable the timeout entirely
+export QMD_EMBED_MAX_DURATION_MS=0
+```
 > since vectors are not cross-compatible between models. The prompt format is
 > automatically adjusted for each model family.
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -1401,6 +1401,24 @@ function getEmbeddingDocsForBatch(db: Database, batch: PendingEmbeddingDoc[]): E
   }));
 }
 
+const DEFAULT_EMBED_MAX_DURATION_MS = 30 * 60 * 1000;
+
+/**
+ * Resolve the max duration for an embedding session.
+ * Override with QMD_EMBED_MAX_DURATION_MS (milliseconds) — useful for large
+ * backlogs that can't finish inside the 30-minute default. Set to 0 to disable
+ * the timeout entirely.
+ */
+export function getEmbedMaxDurationMs(): number {
+  const raw = process.env.QMD_EMBED_MAX_DURATION_MS;
+  if (raw === undefined || raw === "") return DEFAULT_EMBED_MAX_DURATION_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_EMBED_MAX_DURATION_MS;
+  }
+  return parsed;
+}
+
 /**
  * Generate vector embeddings for documents that need them.
  * Pure function — no console output, no db lifecycle management.
@@ -1578,7 +1596,7 @@ export async function generateEmbeddings(
     }
 
     return { chunksEmbedded, errors };
-  }, { maxDuration: 30 * 60 * 1000, name: 'generateEmbeddings' });
+  }, { maxDuration: getEmbedMaxDurationMs(), name: 'generateEmbeddings' });
 
   return {
     docsProcessed: totalDocs,

--- a/test/store.helpers.unit.test.ts
+++ b/test/store.helpers.unit.test.ts
@@ -18,6 +18,7 @@ import {
   handelize,
   cleanupOrphanedVectors,
   sanitizeFTS5Term,
+  getEmbedMaxDurationMs,
 } from "../src/store";
 
 // =============================================================================
@@ -285,5 +286,62 @@ describe("sanitizeFTS5Term", () => {
   test("handles unicode letters and numbers", () => {
     expect(sanitizeFTS5Term("café")).toBe("café");
     expect(sanitizeFTS5Term("日本語")).toBe("日本語");
+  });
+});
+
+// =============================================================================
+// Embedding session duration override
+// =============================================================================
+
+describe("getEmbedMaxDurationMs", () => {
+  const DEFAULT = 30 * 60 * 1000;
+  const ENV = "QMD_EMBED_MAX_DURATION_MS";
+
+  function withEnv(value: string | undefined, fn: () => void) {
+    const prior = process.env[ENV];
+    if (value === undefined) delete process.env[ENV];
+    else process.env[ENV] = value;
+    try {
+      fn();
+    } finally {
+      if (prior === undefined) delete process.env[ENV];
+      else process.env[ENV] = prior;
+    }
+  }
+
+  test("returns 30 minutes when env var is unset", () => {
+    withEnv(undefined, () => {
+      expect(getEmbedMaxDurationMs()).toBe(DEFAULT);
+    });
+  });
+
+  test("returns 30 minutes when env var is empty", () => {
+    withEnv("", () => {
+      expect(getEmbedMaxDurationMs()).toBe(DEFAULT);
+    });
+  });
+
+  test("respects a numeric override", () => {
+    withEnv(String(4 * 60 * 60 * 1000), () => {
+      expect(getEmbedMaxDurationMs()).toBe(4 * 60 * 60 * 1000);
+    });
+  });
+
+  test("allows 0 to disable the timeout", () => {
+    withEnv("0", () => {
+      expect(getEmbedMaxDurationMs()).toBe(0);
+    });
+  });
+
+  test("falls back to default for non-numeric values", () => {
+    withEnv("forever", () => {
+      expect(getEmbedMaxDurationMs()).toBe(DEFAULT);
+    });
+  });
+
+  test("falls back to default for negative values", () => {
+    withEnv("-1", () => {
+      expect(getEmbedMaxDurationMs()).toBe(DEFAULT);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- `generateEmbeddings` is wrapped in an LLM session with a hardcoded 30-minute `maxDuration` (`src/store.ts`). On large backlogs the session aborts mid-run, logging `Session expired — skipping N remaining chunks` and leaving thousands of chunks unembedded until the user re-runs `qmd embed`.
- Add a new `QMD_EMBED_MAX_DURATION_MS` env var that overrides the cap. `0` disables the timeout entirely. Default behavior is unchanged.
- Helper is exported and unit-tested; README gets a short section under the embedding model docs.

## Repro
On a corpus with ~80k chunks pending:
```
$ qmd embed
…
⚠ Session expired — skipping 76900 remaining chunks
✓ Done! Embedded 35671 chunks from 5800 documents in 30m 2s
⚠ 76900 chunks failed
```
Re-running picks up the next batch but caps again at 30 min, so it takes 3+ runs to drain.

## After
```
$ QMD_EMBED_MAX_DURATION_MS=0 qmd embed     # no timeout
$ QMD_EMBED_MAX_DURATION_MS=14400000 qmd embed  # 4 hours
```

## Test plan
- [x] `bunx vitest run test/store.helpers.unit.test.ts -t getEmbedMaxDurationMs` — 6 new tests cover unset, empty, numeric override, `0`, non-numeric, and negative inputs.
- [x] Default (env unset) returns `30 * 60 * 1000` — preserves current behavior.
- [ ] Manual: run `QMD_EMBED_MAX_DURATION_MS=0 qmd embed` against a large backlog and confirm it runs past 30 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)