### PR TITLE
Make generateEmbeddings session timeout configurable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -294,6 +294,9 @@ export interface QMDStore {
     maxBatchBytes?: number;
     chunkStrategy?: ChunkStrategy;
     onProgress?: (info: EmbedProgress) => void;
+    /** Maximum wall-clock duration for the embedding session in milliseconds.
+     *  0 (default) disables the timeout entirely. */
+    maxDuration?: number;
   }): Promise<EmbedResult>;
 
   // ── Index Health ────────────────────────────────────────────────────
@@ -520,6 +523,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
         maxBatchBytes: embedOpts?.maxBatchBytes,
         chunkStrategy: embedOpts?.chunkStrategy,
         onProgress: embedOpts?.onProgress,
+        maxDuration: embedOpts?.maxDuration,
       });
     },
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -1304,6 +1304,9 @@ export type EmbedOptions = {
   maxBatchBytes?: number;
   chunkStrategy?: ChunkStrategy;
   onProgress?: (info: EmbedProgress) => void;
+  /** Maximum wall-clock duration for the embedding session in milliseconds.
+   *  0 (default) disables the timeout entirely. */
+  maxDuration?: number;
 };
 
 type PendingEmbeddingDoc = {
@@ -1578,7 +1581,7 @@ export async function generateEmbeddings(
     }
 
     return { chunksEmbedded, errors };
-  }, { maxDuration: 30 * 60 * 1000, name: 'generateEmbeddings' });
+  }, { maxDuration: options?.maxDuration ?? 0, name: 'generateEmbeddings' });
 
   return {
     docsProcessed: totalDocs,


### PR DESCRIPTION
Make generateEmbeddings session timeout configurable (default: no timeout)

generateEmbeddings currently uses a hardcoded 30-minute maxDuration for its LLM session. On slower hardware — CPU-only embedding on a Raspberry Pi with 500+ documents, for example — this wall-clock limit is easily exceeded, causing the session to abort mid-run with:

```
⚠ Session expired — skipping 60 remaining chunks
⚠ Session expired — skipping remaining document batches
```

The timeout fires regardless of whether the session is actively doing work. Since embedding duration scales with corpus size and hardware speed, a fixed cap is the wrong constraint here.

This PR adds a maxDuration field to EmbedOptions (and the public QMDStore.embed() API), defaulting to 0 which disables the timer. Callers that want a safety timeout can pass one explicitly.

The session timeout machinery in LLMSession already handles maxDuration: 0 correctly (skips the setTimeout), so no changes to the session layer are needed.