### PR TITLE
Handle unreliable Vulkan memory budgets

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -488,6 +488,7 @@ export class LlamaCpp implements LLM {
 
   // Ensure we don't load the same model/context concurrently (which can allocate duplicate VRAM).
   private embedModelLoadPromise: Promise<LlamaModel> | null = null;
+  private unreliableVulkanMemoryBudget: boolean | null = null;
   private generateModelLoadPromise: Promise<LlamaModel> | null = null;
   private rerankModelLoadPromise: Promise<LlamaModel> | null = null;
 
@@ -696,6 +697,40 @@ export class LlamaCpp implements LLM {
   }
 
   /**
+   * Some Vulkan drivers do not expose VK_EXT_memory_budget. node-llama-cpp can
+   * still return a heap size in that case, but live allocation accounting is not
+   * useful: `used` remains 0 and `free === total` even after loading a model.
+   * Treat that as unreliable instead of deriving concurrency from it.
+   */
+  private async hasUnreliableVulkanMemoryBudget(llama: Llama | null = this.llama): Promise<boolean> {
+    if (this.unreliableVulkanMemoryBudget != null) {
+      return this.unreliableVulkanMemoryBudget;
+    }
+
+    // Do not initialize llama just to probe this. Callers that need a fresh
+    // decision first initialize llama through their normal load path, which also
+    // keeps mocked unit tests from accidentally loading native bindings.
+    if (!llama || llama.gpu !== "vulkan") {
+      return false;
+    }
+
+    try {
+      const vram = await llama.getVramState();
+      const unifiedSize = (vram as { unifiedSize?: number }).unifiedSize ?? 0;
+      this.unreliableVulkanMemoryBudget = (
+        vram.total > 0 &&
+        vram.used === 0 &&
+        vram.free === vram.total &&
+        unifiedSize === 0
+      );
+    } catch {
+      this.unreliableVulkanMemoryBudget = true;
+    }
+
+    return this.unreliableVulkanMemoryBudget;
+  }
+
+  /**
    * Compute how many parallel contexts to create.
    *
    * GPU: constrained by VRAM (25% of free, capped at 8).
@@ -707,6 +742,10 @@ export class LlamaCpp implements LLM {
     const llama = await this.ensureLlama();
 
     if (llama.gpu) {
+      if (await this.hasUnreliableVulkanMemoryBudget(llama)) {
+        return 1;
+      }
+
       try {
         const vram = await llama.getVramState();
         const freeMB = vram.free / (1024 * 1024);
@@ -972,9 +1011,50 @@ export class LlamaCpp implements LLM {
     return { text: truncatedText, truncated: true, limit: maxTokens };
   }
 
+  private async embedWithFreshContext(
+    text: string,
+    options: EmbedOptions,
+    errorLabel: string,
+  ): Promise<EmbeddingResult | null> {
+    let context: LlamaEmbeddingContext | null = null;
+
+    try {
+      const model = await this.ensureEmbedModel();
+      context = await model.createEmbeddingContext({
+        contextSize: LlamaCpp.EMBED_CONTEXT_SIZE,
+      });
+
+      // Guard: truncate text that exceeds model context window to prevent GGML crash
+      const { text: safeText, truncated, limit } = await this.truncateToContextSize(text);
+      if (truncated) {
+        console.warn(`⚠ Text truncated to fit embedding context (${limit} tokens)`);
+      }
+
+      const embedding = await context.getEmbeddingFor(safeText);
+      this.touchActivity();
+
+      return {
+        embedding: Array.from(embedding.vector),
+        model: options.model ?? this.embedModelUri,
+      };
+    } catch (error) {
+      console.error(errorLabel, error);
+      return null;
+    } finally {
+      await context?.dispose();
+    }
+  }
+
   async embed(text: string, options: EmbedOptions = {}): Promise<EmbeddingResult | null> {
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();
+
+    if (await this.hasUnreliableVulkanMemoryBudget()) {
+      // Some Vulkan drivers without memory-budget reporting fail when an
+      // embedding context is reused for later inputs. Keep the model loaded but
+      // use a fresh context per embedding on those drivers.
+      return await this.embedWithFreshContext(text, options, "Embedding error:");
+    }
 
     try {
       const context = await this.ensureEmbedContext();
@@ -1008,8 +1088,24 @@ export class LlamaCpp implements LLM {
 
     if (texts.length === 0) return [];
 
+    if (await this.hasUnreliableVulkanMemoryBudget()) {
+      const embeddings: (EmbeddingResult | null)[] = [];
+      for (const text of texts) {
+        embeddings.push(await this.embedWithFreshContext(text, options, "Embedding error for text:"));
+      }
+      return embeddings;
+    }
+
     try {
       const contexts = await this.ensureEmbedContexts();
+      if (await this.hasUnreliableVulkanMemoryBudget()) {
+        const embeddings: (EmbeddingResult | null)[] = [];
+        for (const text of texts) {
+          embeddings.push(await this.embedWithFreshContext(text, options, "Embedding error for text:"));
+        }
+        return embeddings;
+      }
+
       const n = contexts.length;
 
       if (n === 1) {

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -220,6 +220,99 @@ describe("LlamaCpp embedding truncation", () => {
   });
 });
 
+describe("LlamaCpp Vulkan memory budget fallback", () => {
+  function mockUnreliableVulkan(llm: any) {
+    const fakeLlama = {
+      gpu: "vulkan",
+      cpuMathCores: 8,
+      getVramState: vi.fn().mockResolvedValue({
+        total: 24 * 1024 * 1024 * 1024,
+        used: 0,
+        free: 24 * 1024 * 1024 * 1024,
+        unifiedSize: 0,
+      }),
+    };
+    llm.llama = fakeLlama;
+    llm.ensureLlama = vi.fn().mockResolvedValue(fakeLlama);
+  }
+
+  test("caps context parallelism when Vulkan memory budget is unreliable", async () => {
+    const llm = new LlamaCpp({}) as any;
+    mockUnreliableVulkan(llm);
+
+    await expect(llm.computeParallelism(150)).resolves.toBe(1);
+  });
+
+  test("uses pooled contexts when Vulkan memory budget is reliable", async () => {
+    const llm = new LlamaCpp({}) as any;
+    const fakeLlama = {
+      gpu: "vulkan",
+      cpuMathCores: 8,
+      getVramState: vi.fn().mockResolvedValue({
+        total: 24 * 1024 * 1024 * 1024,
+        used: 4 * 1024 * 1024 * 1024,
+        free: 20 * 1024 * 1024 * 1024,
+        unifiedSize: 0,
+      }),
+    };
+    llm.llama = fakeLlama;
+    llm.ensureLlama = vi.fn().mockResolvedValue(fakeLlama);
+
+    await expect(llm.computeParallelism(150)).resolves.toBe(8);
+  });
+
+  test("uses a fresh embedding context per embed when Vulkan memory budget is unreliable", async () => {
+    const llm = new LlamaCpp({}) as any;
+    mockUnreliableVulkan(llm);
+
+    const dispose = vi.fn(async () => {});
+    const getEmbeddingFor = vi.fn(async () => ({
+      vector: new Float32Array([0.25, 0.5]),
+    }));
+    const createEmbeddingContext = vi.fn(async () => ({
+      getEmbeddingFor,
+      dispose,
+    }));
+
+    llm.touchActivity = vi.fn();
+    llm.ensureEmbedContext = vi.fn();
+    llm.ensureEmbedModel = vi.fn().mockResolvedValue({ createEmbeddingContext });
+
+    await llm.embed("first");
+    await llm.embed("second");
+
+    expect(llm.ensureEmbedContext).not.toHaveBeenCalled();
+    expect(createEmbeddingContext).toHaveBeenCalledTimes(2);
+    expect(getEmbeddingFor).toHaveBeenCalledTimes(2);
+    expect(dispose).toHaveBeenCalledTimes(2);
+  });
+
+  test("runs embedBatch sequentially with fresh contexts when Vulkan memory budget is unreliable", async () => {
+    const llm = new LlamaCpp({}) as any;
+    mockUnreliableVulkan(llm);
+    llm._ciMode = false;
+
+    const dispose = vi.fn(async () => {});
+    const createEmbeddingContext = vi.fn(async () => ({
+      getEmbeddingFor: vi.fn(async (text: string) => ({
+        vector: new Float32Array([text.length]),
+      })),
+      dispose,
+    }));
+
+    llm.touchActivity = vi.fn();
+    llm.ensureEmbedContexts = vi.fn();
+    llm.ensureEmbedModel = vi.fn().mockResolvedValue({ createEmbeddingContext });
+
+    const results = await llm.embedBatch(["one", "two"]);
+
+    expect(llm.ensureEmbedContexts).not.toHaveBeenCalled();
+    expect(createEmbeddingContext).toHaveBeenCalledTimes(2);
+    expect(dispose).toHaveBeenCalledTimes(2);
+    expect(results.map((result: any) => result?.embedding[0])).toEqual([3, 3]);
+  });
+});
+
 describe("LlamaCpp rerank deduping", () => {
   test("deduplicates identical document texts before scoring", async () => {
     const llm = new LlamaCpp({}) as any;


### PR DESCRIPTION
## Summary

Some Vulkan drivers do not expose `VK_EXT_memory_budget`. In that case, `node-llama-cpp` can still return heap-size values via `getVramState()`, but live allocation accounting is not useful: `used` remains `0` and `free === total` even after loading a GPU-offloaded model.

QMD currently treats that state as reliable VRAM availability and derives embedding/rerank context parallelism from it. On PanVK/Mali-G610 this causes QMD to create too many embedding contexts, which reproduces as:

```text
vk::CommandBuffer::end: ErrorOutOfDeviceMemory
```

It can also crash the process when multiple embedding contexts evaluate concurrently.

This PR adds a conservative fallback for unreliable Vulkan memory-budget reporting:

- detect the unreliable Vulkan budget shape (`used === 0`, `free === total`, no unified budget)
- cap context parallelism to `1` for that case
- use a fresh embedding context per embedding on that path while keeping the model loaded
- run `embedBatch()` sequentially with fresh contexts on that path
- add unit coverage for the fallback behavior

## Motivation / repro notes

Observed on `aarch64-linux` with Mali-G610/PanVK:

- Vulkan backend loads successfully
- model offloading works
- `getVramState()` reports roughly the full device heap as free before and after model loading
- QMD creates its maximum embedding context pool from that bogus free-memory estimate
- 8 embedding contexts fail with `VK_ERROR_OUT_OF_DEVICE_MEMORY`
- reusing one embedding context for a second medium-sized input can also fail
- creating a fresh embedding context per input succeeds reliably

So the issue is not “no GPU”; it is unsafe concurrency/context reuse decisions caused by unreliable Vulkan memory accounting.

## Tests

```sh
CI=true bun test test/llm.test.ts
```

Result: passes.

I also attempted broader local validation, but there are unrelated local environment failures in this checkout:

- `bun run build` fails on current main with:

  ```text
  src/store.ts(2142,22): error TS2339: Property 'transaction' does not exist on type 'Database'.
  ```

- full `CI=true bun test` could not complete locally because CLI tests need `better-sqlite3` native bindings, which were not built in this checkout on my `aarch64-linux` machine.
