### PR TITLE
feat: improve CJK keyword recall with n-gram FTS

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -13,7 +13,7 @@ import {
   homedir,
   resolve,
   enableProductionMode,
-  searchFTS,
+  searchKeyword,
   extractSnippet,
   getContextForFile,
   getContextForPath,
@@ -2241,7 +2241,7 @@ function search(query: string, opts: OutputOptions): void {
   // Use large limit for --all, otherwise fetch more than needed and let outputResults filter
   const fetchLimit = opts.all ? 100000 : Math.max(50, opts.limit * 2);
   const results = filterByCollections(
-    searchFTS(db, query, fetchLimit, singleCollection),
+    searchKeyword(db, query, fetchLimit, singleCollection),
     collectionNames
   );
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -68,6 +68,7 @@ export function openDatabase(path: string): Database {
 export interface Database {
   exec(sql: string): void;
   prepare(sql: string): Statement;
+  transaction<T extends (...args: any[]) => any>(fn: T): T;
   loadExtension(path: string): void;
   close(): void;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -416,7 +416,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
         chunkStrategy: opts.chunkStrategy,
       });
     },
-    searchLex: async (q, opts) => internal.searchFTS(q, opts?.limit, opts?.collection),
+    searchLex: async (q, opts) => internal.searchKeyword(q, opts?.limit, opts?.collection),
     searchVector: async (q, opts) => internal.searchVec(q, DEFAULT_EMBED_MODEL, opts?.limit, opts?.collection),
     expandQuery: async (q, opts) => internal.expandQuery(q, undefined, opts?.intent),
     get: async (pathOrDocid, opts) => internal.findDocument(pathOrDocid, opts),

--- a/src/store.ts
+++ b/src/store.ts
@@ -733,6 +733,41 @@ export function verifySqliteVecLoaded(db: Database): void {
 
 let _sqliteVecAvailable: boolean | null = null;
 
+const CJK_RUN_PATTERN = /\p{Script=Han}+/gu;
+
+export function hasCjk(text: string): boolean {
+  return /\p{Script=Han}/u.test(text);
+}
+
+export function extractCjkRuns(text: string): string[] {
+  return text.match(CJK_RUN_PATTERN) ?? [];
+}
+
+export function cjkNgrams(text: string, sizes: number[] = [2, 3]): string {
+  const grams: string[] = [];
+  for (const run of extractCjkRuns(text)) {
+    const chars = Array.from(run);
+    for (const size of sizes) {
+      if (size < 1 || chars.length < size) continue;
+      for (let i = 0; i <= chars.length - size; i++) {
+        grams.push(chars.slice(i, i + size).join(""));
+      }
+    }
+  }
+  return grams.join(" ");
+}
+
+function registerCjkNgramsFunction(db: Database): boolean {
+  const register = (db as unknown as { function?: (name: string, fn: (value: unknown) => string) => void }).function;
+  if (typeof register !== "function") return false;
+  try {
+    register.call(db, "qmd_cjk_ngrams", (value: unknown) => cjkNgrams(String(value ?? "")));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function initializeDatabase(db: Database): void {
   try {
     loadSqliteVec(db);
@@ -747,6 +782,7 @@ function initializeDatabase(db: Database): void {
   }
   db.exec("PRAGMA journal_mode = WAL");
   db.exec("PRAGMA foreign_keys = ON");
+  const cjkNgramsRegistered = registerCjkNgramsFunction(db);
 
   // Drop legacy tables that are now managed in YAML
   db.exec(`DROP TABLE IF EXISTS path_contexts`);
@@ -838,6 +874,16 @@ function initializeDatabase(db: Database): void {
     )
   `);
 
+  const hadCjkFts = !!db.prepare(`
+    SELECT name FROM sqlite_master WHERE type='table' AND name='documents_fts_cjk'
+  `).get();
+  db.exec(`
+    CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts_cjk USING fts5(
+      filepath, title, body,
+      tokenize='unicode61'
+    )
+  `);
+
   // Triggers to keep FTS in sync
   db.exec(`
     CREATE TRIGGER IF NOT EXISTS documents_ai AFTER INSERT ON documents
@@ -853,11 +899,39 @@ function initializeDatabase(db: Database): void {
     END
   `);
 
+  if (cjkNgramsRegistered) {
+    db.exec(`
+      CREATE TRIGGER IF NOT EXISTS documents_cjk_ai AFTER INSERT ON documents
+      WHEN new.active = 1
+      BEGIN
+        INSERT INTO documents_fts_cjk(rowid, filepath, title, body)
+        SELECT
+          new.id,
+          qmd_cjk_ngrams(new.collection || '/' || new.path),
+          qmd_cjk_ngrams(new.title),
+          qmd_cjk_ngrams((SELECT doc FROM content WHERE hash = new.hash))
+        WHERE new.active = 1;
+      END
+    `);
+  } else {
+    db.exec(`DROP TRIGGER IF EXISTS documents_cjk_ai`);
+  }
+
   db.exec(`
     CREATE TRIGGER IF NOT EXISTS documents_ad AFTER DELETE ON documents BEGIN
       DELETE FROM documents_fts WHERE rowid = old.id;
     END
   `);
+
+  if (cjkNgramsRegistered) {
+    db.exec(`
+      CREATE TRIGGER IF NOT EXISTS documents_cjk_ad AFTER DELETE ON documents BEGIN
+        DELETE FROM documents_fts_cjk WHERE rowid = old.id;
+      END
+    `);
+  } else {
+    db.exec(`DROP TRIGGER IF EXISTS documents_cjk_ad`);
+  }
 
   db.exec(`
     CREATE TRIGGER IF NOT EXISTS documents_au AFTER UPDATE ON documents
@@ -875,6 +949,40 @@ function initializeDatabase(db: Database): void {
       WHERE new.active = 1;
     END
   `);
+
+  if (cjkNgramsRegistered) {
+    db.exec(`
+      CREATE TRIGGER IF NOT EXISTS documents_cjk_au AFTER UPDATE ON documents
+      BEGIN
+        DELETE FROM documents_fts_cjk WHERE rowid = old.id AND new.active = 0;
+
+        INSERT OR REPLACE INTO documents_fts_cjk(rowid, filepath, title, body)
+        SELECT
+          new.id,
+          qmd_cjk_ngrams(new.collection || '/' || new.path),
+          qmd_cjk_ngrams(new.title),
+          qmd_cjk_ngrams((SELECT doc FROM content WHERE hash = new.hash))
+        WHERE new.active = 1;
+      END
+    `);
+
+    const cjkRows = (db.prepare(`SELECT COUNT(*) AS c FROM documents_fts_cjk`).get() as { c: number }).c;
+    if (!hadCjkFts || cjkRows === 0) {
+      db.exec(`
+        INSERT OR REPLACE INTO documents_fts_cjk(rowid, filepath, title, body)
+        SELECT
+          d.id,
+          qmd_cjk_ngrams(d.collection || '/' || d.path),
+          qmd_cjk_ngrams(d.title),
+          qmd_cjk_ngrams(content.doc)
+        FROM documents d
+        JOIN content ON content.hash = d.hash
+        WHERE d.active = 1
+      `);
+    }
+  } else {
+    db.exec(`DROP TRIGGER IF EXISTS documents_cjk_au`);
+  }
 }
 
 // =============================================================================
@@ -1126,6 +1234,8 @@ export type Store = {
 
   // Search
   searchFTS: (query: string, limit?: number, collectionName?: string) => SearchResult[];
+  searchCjkFTS: (query: string, limit?: number, collectionName?: string) => SearchResult[];
+  searchKeyword: (query: string, limit?: number, collectionName?: string) => SearchResult[];
   searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => Promise<SearchResult[]>;
 
   // Query expansion & reranking
@@ -1640,6 +1750,8 @@ export function createStore(dbPath?: string): Store {
 
     // Search
     searchFTS: (query: string, limit?: number, collectionName?: string) => searchFTS(db, query, limit, collectionName),
+    searchCjkFTS: (query: string, limit?: number, collectionName?: string) => searchCjkFTS(db, query, limit, collectionName),
+    searchKeyword: (query: string, limit?: number, collectionName?: string) => searchKeyword(db, query, limit, collectionName),
     searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => searchVec(db, query, model, limit, collectionName, session, precomputedEmbedding),
 
     // Query expansion & reranking
@@ -1796,7 +1908,7 @@ export type RankedResult = {
 export type RRFContributionTrace = {
   listIndex: number;
   source: "fts" | "vec";
-  queryType: "original" | "lex" | "vec" | "hyde";
+  queryType: "original" | "lex" | "cjk" | "vec" | "hyde";
   query: string;
   rank: number;            // 1-indexed rank within list
   weight: number;
@@ -2157,6 +2269,24 @@ export function findOrMigrateLegacyDocument(
              (SELECT doc FROM content WHERE hash = documents.hash)
       FROM documents WHERE id = ?
     `).run(legacy.id);
+
+    const cjkRow = db.prepare(`
+      SELECT id, collection || '/' || path as filepath, title,
+             (SELECT doc FROM content WHERE hash = documents.hash) as body
+      FROM documents WHERE id = ?
+    `).get(legacy.id) as { id: number; filepath: string; title: string; body: string } | null;
+    if (cjkRow) {
+      db.prepare(`DELETE FROM documents_fts_cjk WHERE rowid = ?`).run(legacy.id);
+      db.prepare(`
+        INSERT INTO documents_fts_cjk(rowid, filepath, title, body)
+        VALUES (?, ?, ?, ?)
+      `).run(
+        cjkRow.id,
+        cjkNgrams(cjkRow.filepath),
+        cjkNgrams(cjkRow.title),
+        cjkNgrams(cjkRow.body),
+      );
+    }
 
     return true;
   });
@@ -2998,6 +3128,14 @@ function buildFTS5Query(query: string): string | null {
   return result;
 }
 
+function buildCjkFTS5Query(query: string): string | null {
+  if (!hasCjk(query)) return null;
+  const grams = cjkNgrams(query).split(/\s+/).filter(Boolean);
+  if (grams.length === 0) return null;
+  const uniqueGrams = Array.from(new Set(grams)).slice(0, 96);
+  return uniqueGrams.map(gram => `"${gram.replace(/"/g, '""')}"`).join(" AND ");
+}
+
 /**
  * Validate that a vec/hyde query doesn't use lex-only syntax.
  * Returns error message if invalid, null if valid.
@@ -3088,6 +3226,101 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
       context: getContextForFile(db, row.filepath),
       score,
       source: "fts" as const,
+    };
+  });
+}
+
+export function searchCjkFTS(db: Database, query: string, limit: number = 20, collectionName?: string): SearchResult[] {
+  const ftsQuery = buildCjkFTS5Query(query);
+  if (!ftsQuery) return [];
+
+  const tableExists = db.prepare(`
+    SELECT name FROM sqlite_master WHERE type='table' AND name='documents_fts_cjk'
+  `).get();
+  if (!tableExists) return [];
+
+  const params: (string | number)[] = [ftsQuery];
+  const ftsLimit = collectionName ? limit * 10 : limit;
+
+  let sql = `
+    WITH fts_matches AS (
+      SELECT rowid, bm25(documents_fts_cjk, 1.2, 4.0, 1.0) as bm25_score
+      FROM documents_fts_cjk
+      WHERE documents_fts_cjk MATCH ?
+      ORDER BY bm25_score ASC
+      LIMIT ${ftsLimit}
+    )
+    SELECT
+      'qmd://' || d.collection || '/' || d.path as filepath,
+      d.collection || '/' || d.path as display_path,
+      d.title,
+      content.doc as body,
+      d.hash,
+      fm.bm25_score
+    FROM fts_matches fm
+    JOIN documents d ON d.id = fm.rowid
+    JOIN content ON content.hash = d.hash
+    WHERE d.active = 1
+  `;
+
+  if (collectionName) {
+    sql += ` AND d.collection = ?`;
+    params.push(String(collectionName));
+  }
+
+  sql += ` ORDER BY fm.bm25_score ASC LIMIT ?`;
+  params.push(limit);
+
+  const rows = db.prepare(sql).all(...params) as { filepath: string; display_path: string; title: string; body: string; hash: string; bm25_score: number }[];
+  return rows.map(row => {
+    const collectionName = row.filepath.split('//')[1]?.split('/')[0] || "";
+    const score = Math.abs(row.bm25_score) / (1 + Math.abs(row.bm25_score));
+    return {
+      filepath: row.filepath,
+      displayPath: row.display_path,
+      title: row.title,
+      hash: row.hash,
+      docid: getDocid(row.hash),
+      collectionName,
+      modifiedAt: "",
+      bodyLength: row.body.length,
+      body: row.body,
+      context: getContextForFile(db, row.filepath),
+      score,
+      source: "fts" as const,
+    };
+  });
+}
+
+export function searchKeyword(db: Database, query: string, limit: number = 20, collectionName?: string): SearchResult[] {
+  const ftsResults = searchFTS(db, query, limit, collectionName);
+  const cjkResults = searchCjkFTS(db, query, limit, collectionName);
+  if (cjkResults.length === 0) return ftsResults;
+  if (ftsResults.length === 0) return cjkResults;
+
+  const resultByFile = new Map<string, SearchResult>();
+  for (const result of [...ftsResults, ...cjkResults]) {
+    const existing = resultByFile.get(result.filepath);
+    if (!existing || result.score > existing.score) {
+      resultByFile.set(result.filepath, result);
+    }
+  }
+
+  const rankedLists = [ftsResults, cjkResults].map(list => list.map(r => ({
+    file: r.filepath,
+    displayPath: r.displayPath,
+    title: r.title,
+    body: r.body || "",
+    score: r.score,
+  })));
+  const fused = reciprocalRankFusion(rankedLists, [2.0, 0.8]);
+  const topScore = fused[0]?.score || 1;
+
+  return fused.slice(0, limit).map(result => {
+    const original = resultByFile.get(result.file)!;
+    return {
+      ...original,
+      score: Math.min(1, result.score / topScore),
     };
   });
 }
@@ -3983,9 +4216,30 @@ export interface HybridQueryResult {
 
 export type RankedListMeta = {
   source: "fts" | "vec";
-  queryType: "original" | "lex" | "vec" | "hyde";
+  queryType: "original" | "lex" | "cjk" | "vec" | "hyde";
   query: string;
 };
+
+function rankedResultsFromSearch(results: SearchResult[]): RankedResult[] {
+  return results.map(r => ({
+    file: r.filepath,
+    displayPath: r.displayPath,
+    title: r.title,
+    body: r.body || "",
+    score: r.score,
+  }));
+}
+
+function hybridRrfWeight(meta: RankedListMeta): number {
+  if (meta.queryType === "cjk") return 0.8;
+  if (meta.queryType === "original") return 2.0;
+  return 1.0;
+}
+
+function structuredRrfWeight(meta: RankedListMeta, index: number): number {
+  if (meta.queryType === "cjk") return 0.8;
+  return index === 0 ? 2.0 : 1.0;
+}
 
 /**
  * Hybrid search: BM25 + vector + query expansion + RRF + chunked reranking.
@@ -4047,11 +4301,14 @@ export async function hybridQuery(
   // Seed with initial FTS results (avoid re-running original query FTS)
   if (initialFts.length > 0) {
     for (const r of initialFts) docidMap.set(r.filepath, r.docid);
-    rankedLists.push(initialFts.map(r => ({
-      file: r.filepath, displayPath: r.displayPath,
-      title: r.title, body: r.body || "", score: r.score,
-    })));
+    rankedLists.push(rankedResultsFromSearch(initialFts));
     rankedListMeta.push({ source: "fts", queryType: "original", query });
+  }
+  const initialCjkFts = store.searchCjkFTS(query, 20, collection);
+  if (initialCjkFts.length > 0) {
+    for (const r of initialCjkFts) docidMap.set(r.filepath, r.docid);
+    rankedLists.push(rankedResultsFromSearch(initialCjkFts));
+    rankedListMeta.push({ source: "fts", queryType: "cjk", query });
   }
 
   // Step 3: Route searches by query type
@@ -4066,11 +4323,14 @@ export async function hybridQuery(
       const ftsResults = store.searchFTS(q.query, 20, collection);
       if (ftsResults.length > 0) {
         for (const r of ftsResults) docidMap.set(r.filepath, r.docid);
-        rankedLists.push(ftsResults.map(r => ({
-          file: r.filepath, displayPath: r.displayPath,
-          title: r.title, body: r.body || "", score: r.score,
-        })));
+        rankedLists.push(rankedResultsFromSearch(ftsResults));
         rankedListMeta.push({ source: "fts", queryType: "lex", query: q.query });
+      }
+      const cjkResults = store.searchCjkFTS(q.query, 20, collection);
+      if (cjkResults.length > 0) {
+        for (const r of cjkResults) docidMap.set(r.filepath, r.docid);
+        rankedLists.push(rankedResultsFromSearch(cjkResults));
+        rankedListMeta.push({ source: "fts", queryType: "cjk", query: q.query });
       }
     }
   }
@@ -4118,8 +4378,9 @@ export async function hybridQuery(
     }
   }
 
-  // Step 4: RRF fusion — first 2 lists (original FTS + first vec) get 2x weight
-  const weights = rankedLists.map((_, i) => i < 2 ? 2.0 : 1.0);
+  // Step 4: RRF fusion — original lexical/vector queries get 2x weight;
+  // CJK n-gram lists are auxiliary recall signals.
+  const weights = rankedListMeta.map(hybridRrfWeight);
   const fused = reciprocalRankFusion(rankedLists, weights);
   const rrfTraceByFile = explain ? buildRrfTrace(rankedLists, weights, rankedListMeta) : null;
   const candidates = fused.slice(0, candidateLimit);
@@ -4449,13 +4710,20 @@ export async function structuredSearch(
         const ftsResults = store.searchFTS(search.query, 20, coll);
         if (ftsResults.length > 0) {
           for (const r of ftsResults) docidMap.set(r.filepath, r.docid);
-          rankedLists.push(ftsResults.map(r => ({
-            file: r.filepath, displayPath: r.displayPath,
-            title: r.title, body: r.body || "", score: r.score,
-          })));
+          rankedLists.push(rankedResultsFromSearch(ftsResults));
           rankedListMeta.push({
             source: "fts",
             queryType: "lex",
+            query: search.query,
+          });
+        }
+        const cjkResults = store.searchCjkFTS(search.query, 20, coll);
+        if (cjkResults.length > 0) {
+          for (const r of cjkResults) docidMap.set(r.filepath, r.docid);
+          rankedLists.push(rankedResultsFromSearch(cjkResults));
+          rankedListMeta.push({
+            source: "fts",
+            queryType: "cjk",
             query: search.query,
           });
         }
@@ -4505,8 +4773,8 @@ export async function structuredSearch(
 
   if (rankedLists.length === 0) return [];
 
-  // Step 3: RRF fusion — first list gets 2x weight (assume caller ordered by importance)
-  const weights = rankedLists.map((_, i) => i === 0 ? 2.0 : 1.0);
+  // Step 3: RRF fusion — first non-auxiliary list gets 2x weight.
+  const weights = rankedListMeta.map(structuredRrfWeight);
   const fused = reciprocalRankFusion(rankedLists, weights);
   const rrfTraceByFile = explain ? buildRrfTrace(rankedLists, weights, rankedListMeta) : null;
   const candidates = fused.slice(0, candidateLimit);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -187,6 +187,14 @@ Index new documents.
 `
   );
 
+  await writeFile(
+    join(fixturesDir, "docs", "chinese.md"),
+    `# 中文检索
+
+中文关键词召回效果不好。
+`
+  );
+
   // Create test files for path normalization tests
   await writeFile(
     join(fixturesDir, "test1.md"),
@@ -400,6 +408,13 @@ describe("CLI Search Command", () => {
     expect(exitCode).toBe(0);
     // Should find meeting.md
     expect(stdout.toLowerCase()).toContain("meeting");
+  });
+
+  test("searches continuous Chinese text through CJK n-gram recall", async () => {
+    const { stdout, exitCode } = await runQmd(["search", "召回", "--json"]);
+    expect(exitCode).toBe(0);
+    const results = JSON.parse(stdout) as Array<{ file: string; snippet?: string }>;
+    expect(results.some(r => r.file.includes("chinese.md"))).toBe(true);
   });
 
   test("searches with limit option", async () => {

--- a/test/store.helpers.unit.test.ts
+++ b/test/store.helpers.unit.test.ts
@@ -18,6 +18,8 @@ import {
   handelize,
   cleanupOrphanedVectors,
   sanitizeFTS5Term,
+  hasCjk,
+  cjkNgrams,
 } from "../src/store";
 
 // =============================================================================
@@ -285,5 +287,35 @@ describe("sanitizeFTS5Term", () => {
   test("handles unicode letters and numbers", () => {
     expect(sanitizeFTS5Term("café")).toBe("café");
     expect(sanitizeFTS5Term("日本語")).toBe("日本語");
+  });
+});
+
+// =============================================================================
+// CJK n-gram Tests
+// =============================================================================
+
+describe("CJK n-gram helpers", () => {
+  test("detects Han text", () => {
+    expect(hasCjk("中文关键词")).toBe(true);
+    expect(hasCjk("API keyword recall")).toBe(false);
+  });
+
+  test("generates 2-gram and 3-gram tokens for continuous Chinese text", () => {
+    const grams = cjkNgrams("中文关键词召回").split(/\s+/);
+    expect(grams).toContain("中文");
+    expect(grams).toContain("关键");
+    expect(grams).toContain("键词");
+    expect(grams).toContain("召回");
+    expect(grams).toContain("中文关");
+    expect(grams).toContain("关键词");
+    expect(grams).toContain("词召回");
+  });
+
+  test("only tokenizes Chinese runs in mixed text", () => {
+    const grams = cjkNgrams("API关键词召回v2").split(/\s+/);
+    expect(grams).toContain("关键");
+    expect(grams).toContain("召回");
+    expect(grams).not.toContain("API");
+    expect(grams).not.toContain("v2");
   });
 });

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1267,6 +1267,72 @@ describe("FTS Search", () => {
     await cleanupTestDb(store);
   });
 
+  test("searchCjkFTS finds two-character words inside continuous Chinese text", async () => {
+    const store = await createTestStore();
+    const collectionName = await createTestCollection();
+    await insertTestDocument(store.db, collectionName, {
+      name: "cjk",
+      title: "中文检索",
+      body: "中文关键词召回效果不好",
+      displayPath: "docs/cjk.md",
+    });
+
+    expect(store.searchFTS("召回", 10)).toHaveLength(0);
+
+    const cjkResults = store.searchCjkFTS("召回", 10);
+    expect(cjkResults.length).toBeGreaterThan(0);
+    expect(cjkResults[0]!.displayPath).toBe(`${collectionName}/docs/cjk.md`);
+
+    const keywordResults = store.searchKeyword("召回", 10);
+    expect(keywordResults.length).toBeGreaterThan(0);
+    expect(keywordResults[0]!.displayPath).toBe(`${collectionName}/docs/cjk.md`);
+
+    await cleanupTestDb(store);
+  });
+
+  test("searchCjkFTS finds three-character Chinese keywords", async () => {
+    const store = await createTestStore();
+    const collectionName = await createTestCollection();
+    await insertTestDocument(store.db, collectionName, {
+      name: "cjk-keyword",
+      title: "召回链路",
+      body: "这个文档记录中文关键词召回链路的行为。",
+      displayPath: "docs/cjk-keyword.md",
+    });
+
+    const results = store.searchCjkFTS("关键词", 10);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]!.displayPath).toBe(`${collectionName}/docs/cjk-keyword.md`);
+
+    await cleanupTestDb(store);
+  });
+
+  test("CJK FTS updates and deactivates with documents", async () => {
+    const store = await createTestStore();
+    const collectionName = await createTestCollection();
+    const now = new Date().toISOString();
+    const oldBody = "旧的中文召回问题";
+    const oldHash = await hashContent(oldBody);
+    store.insertContent(oldHash, oldBody, now);
+    store.insertDocument(collectionName, "docs/cjk-update.md", "中文文档", oldHash, now, now);
+
+    expect(store.searchCjkFTS("召回", 10)).toHaveLength(1);
+
+    const newBody = "新的中文索引内容";
+    const newHash = await hashContent(newBody);
+    store.insertContent(newHash, newBody, now);
+    const doc = store.findActiveDocument(collectionName, "docs/cjk-update.md")!;
+    store.updateDocument(doc.id, "中文文档", newHash, now);
+
+    expect(store.searchCjkFTS("召回", 10)).toHaveLength(0);
+    expect(store.searchCjkFTS("索引", 10)).toHaveLength(1);
+
+    store.deactivateDocument(collectionName, "docs/cjk-update.md");
+    expect(store.searchCjkFTS("索引", 10)).toHaveLength(0);
+
+    await cleanupTestDb(store);
+  });
+
   // BM25 IDF requires corpus depth — helper adds non-matching docs so term frequency
   // differentiation produces meaningful scores (2-doc corpus has near-zero IDF).
   async function addNoiseDocuments(db: Database, collectionName: string, count = 8) {

--- a/test/structured-search.test.ts
+++ b/test/structured-search.test.ts
@@ -345,6 +345,21 @@ describe("structuredSearch", () => {
       { type: "lex", query: "\"unfinished phrase", line: 2 }
     ])).rejects.toThrow(/unmatched double quote/);
   });
+
+  test("lex queries use CJK n-gram recall for continuous Chinese text", async () => {
+    const now = new Date().toISOString();
+    const body = "# 中文检索\n\n中文关键词召回效果不好";
+    const hash = "structured-cjk-recall";
+    store.insertContent(hash, body, now);
+    store.insertDocument("docs", "cjk.md", "中文检索", hash, now, now);
+
+    const results = await structuredSearch(store, [
+      { type: "lex", query: "召回" }
+    ], { limit: 5, skipRerank: true });
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]!.displayPath).toBe("docs/cjk.md");
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
## Problem

Chinese keyword search currently depends on SQLite FTS5 with `porter unicode61`, which does not segment continuous CJK text. A document containing `中文关键词召回效果不好` can be indexed as one long token, so searching for middle terms like `召回` or `关键词` may fail to recall the document.

This mainly affects the lexical/BM25 path:
- `qmd search`
- SDK `searchLex()`
- `lex` queries in hybrid/structured search
- MCP query calls that rely on lexical subqueries

The vector path can help when embeddings are available, but it does not fix exact keyword recall.

## Fix

Add a CJK n-gram auxiliary FTS index while keeping the existing BM25 index unchanged.

- add CJK 2/3-gram generation for continuous Han text
- add `documents_fts_cjk` as an auxiliary FTS5 table
- sync the CJK FTS table through document insert/update/delete triggers
- add CJK lexical search and fuse it with existing FTS results
- wire the fused keyword path into `qmd search`, SDK `searchLex()`, `hybridQuery()`, and `structuredSearch()`

This lets queries like `召回`, `关键词`, and `关键词召回` match continuous Chinese content without changing the existing English/code tokenizer behavior.

## Test Plan
- `pnpm build`
- `pnpm exec vitest run test/store.helpers.unit.test.ts test/store.test.ts test/structured-search.test.ts test/cli.test.ts`
- `pnpm exec vitest run test/`