### PR TITLE
feat(Add OpenAI-compatible backend support)

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -78,7 +78,7 @@ import {
   type ReindexResult,
   type ChunkStrategy,
 } from "../store.js";
-import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, setDefaultLlamaCpp, LlamaCpp, withLLMSession, pullModels, DEFAULT_EMBED_MODEL_URI, DEFAULT_GENERATE_MODEL_URI, DEFAULT_RERANK_MODEL_URI, DEFAULT_MODEL_CACHE_DIR } from "../llm.js";
+import { createLLM, disposeDefaultLlamaCpp, getDefaultLLM, setDefaultLLM, withLLMSession, pullModels, DEFAULT_EMBED_MODEL_URI, DEFAULT_GENERATE_MODEL_URI, DEFAULT_RERANK_MODEL_URI, DEFAULT_MODEL_CACHE_DIR } from "../llm.js";
 import {
   formatSearchResults,
   formatDocuments,
@@ -120,11 +120,14 @@ function getStore(): ReturnType<typeof createStore> {
     try {
       const config = loadConfig();
       syncConfigToDb(store.db, config);
-      if (config.models) {
-        setDefaultLlamaCpp(new LlamaCpp({
-          embedModel: config.models.embed,
-          generateModel: config.models.generate,
-          rerankModel: config.models.rerank,
+      if (config.models || config.llm) {
+        setDefaultLLM(createLLM({
+          embedModel: config.models?.embed,
+          generateModel: config.models?.generate,
+          rerankModel: config.models?.rerank,
+          provider: config.llm?.provider,
+          baseUrl: config.llm?.baseUrl,
+          apiKey: config.llm?.apiKey,
         }));
       }
     } catch {
@@ -205,6 +208,28 @@ const cursor = {
   hide() { process.stderr.write('\x1b[?25l'); },
   show() { process.stderr.write('\x1b[?25h'); },
 };
+
+function getActiveLlmConfig(): {
+  embedModel: string;
+  rerankModel: string;
+  generateModel: string;
+  provider?: "llama-cpp" | "openai-compatible";
+  baseUrl?: string;
+} {
+  const config = loadConfig();
+  return {
+    embedModel: config.models?.embed || DEFAULT_EMBED_MODEL_URI,
+    rerankModel: config.models?.rerank || DEFAULT_RERANK_MODEL_URI,
+    generateModel: config.models?.generate || DEFAULT_GENERATE_MODEL_URI,
+    provider: config.llm?.provider,
+    baseUrl: config.llm?.baseUrl,
+  };
+}
+
+function formatConfiguredModel(uri: string): string {
+  const match = uri.match(/^hf:([^/]+\/[^/]+)\//);
+  return match ? `https://huggingface.co/${match[1]}` : uri;
+}
 
 // Ensure cursor is restored on exit
 process.on('SIGINT', () => { cursor.show(); process.exit(130); });
@@ -456,15 +481,11 @@ async function showStatus(): Promise<void> {
 
   // Models
   {
-    // hf:org/repo/file.gguf → https://huggingface.co/org/repo
-    const hfLink = (uri: string) => {
-      const match = uri.match(/^hf:([^/]+\/[^/]+)\//);
-      return match ? `https://huggingface.co/${match[1]}` : uri;
-    };
+    const { embedModel, rerankModel, generateModel } = getActiveLlmConfig();
     console.log(`\n${c.bold}Models${c.reset}`);
-    console.log(`  Embedding:   ${hfLink(DEFAULT_EMBED_MODEL_URI)}`);
-    console.log(`  Reranking:   ${hfLink(DEFAULT_RERANK_MODEL_URI)}`);
-    console.log(`  Generation:  ${hfLink(DEFAULT_GENERATE_MODEL_URI)}`);
+    console.log(`  Embedding:   ${formatConfiguredModel(embedModel)}`);
+    console.log(`  Reranking:   ${formatConfiguredModel(rerankModel)}`);
+    console.log(`  Generation:  ${formatConfiguredModel(generateModel)}`);
   }
 
   // Device / GPU info
@@ -474,9 +495,16 @@ async function showStatus(): Promise<void> {
   if (process.env.QMD_STATUS_DEVICE_PROBE === "1") {
     console.log(`\n${c.bold}Device${c.reset}`);
     try {
-      const llm = getDefaultLlamaCpp();
-      const device = await llm.getDeviceInfo({ allowBuild: false });
-      if (device.gpu) {
+      const llm = getDefaultLLM();
+      const device = await llm.getDeviceInfo?.({ allowBuild: false });
+      if (!device) {
+        console.log(`  Backend:  unavailable`);
+      } else if (device.backend === "openai-compatible") {
+        console.log(`  Backend:  ${c.green}openai-compatible${c.reset}`);
+        if (device.endpoint) {
+          console.log(`  Endpoint: ${device.endpoint}`);
+        }
+      } else if (device.gpu) {
         console.log(`  GPU:      ${c.green}${device.gpu}${c.reset} (offloading: ${device.gpuOffloading ? 'yes' : 'no'})`);
         if (device.gpuDevices.length > 0) {
           // Deduplicate and count GPUs
@@ -496,7 +524,9 @@ async function showStatus(): Promise<void> {
         console.log(`  GPU:      ${c.yellow}none${c.reset} (running on CPU — models will be slow)`);
         console.log(`  ${c.dim}Tip: Install CUDA, Vulkan, or Metal support for GPU acceleration.${c.reset}`);
       }
-      console.log(`  CPU:      ${device.cpuCores} math cores`);
+      if (device && device.backend !== "openai-compatible") {
+        console.log(`  CPU:      ${device.cpuCores} math cores`);
+      }
     } catch (error) {
       console.log(`  Status:   ${c.dim}probe failed${c.reset}`);
       if (error instanceof Error && error.message) {
@@ -1679,12 +1709,13 @@ function parseChunkStrategy(value: unknown): ChunkStrategy | undefined {
 }
 
 async function vectorIndex(
-  model: string = DEFAULT_EMBED_MODEL_URI,
+  model: string | undefined = undefined,
   force: boolean = false,
   batchOptions?: { maxDocsPerBatch?: number; maxBatchBytes?: number; chunkStrategy?: ChunkStrategy },
 ): Promise<void> {
   const storeInstance = getStore();
   const db = storeInstance.db;
+  const embedModel = model ?? getDefaultLLM().embedModelName;
 
   if (force) {
     console.log(`${c.yellow}Force re-indexing: clearing all vectors...${c.reset}`);
@@ -1698,7 +1729,7 @@ async function vectorIndex(
     return;
   }
 
-  console.log(`${c.dim}Model: ${model}${c.reset}\n`);
+  console.log(`${c.dim}Model: ${embedModel}${c.reset}\n`);
   if (batchOptions?.maxDocsPerBatch !== undefined || batchOptions?.maxBatchBytes !== undefined) {
     const maxDocsPerBatch = batchOptions.maxDocsPerBatch ?? DEFAULT_EMBED_MAX_DOCS_PER_BATCH;
     const maxBatchBytes = batchOptions.maxBatchBytes ?? DEFAULT_EMBED_MAX_BATCH_BYTES;
@@ -1711,7 +1742,7 @@ async function vectorIndex(
 
   const result = await generateEmbeddings(storeInstance, {
     force,
-    model,
+    model: embedModel,
     maxDocsPerBatch: batchOptions?.maxDocsPerBatch,
     maxBatchBytes: batchOptions?.maxBatchBytes,
     chunkStrategy: batchOptions?.chunkStrategy,
@@ -2700,6 +2731,7 @@ async function installSkill(globalInstall: boolean, force: boolean, autoYes: boo
 }
 
 function showHelp(): void {
+  const { embedModel, rerankModel, generateModel, provider, baseUrl } = getActiveLlmConfig();
   console.log("qmd — Quick Markdown Search");
   console.log("");
   console.log("Usage:");
@@ -2724,10 +2756,21 @@ function showHelp(): void {
   console.log("Maintenance:");
   console.log("  qmd status                    - View index + collection health");
   console.log("  qmd update [--pull]           - Re-index collections (optionally git pull first)");
-  console.log("  qmd embed [-f]                - Generate/refresh vector embeddings");
+  console.log(`  qmd embed [-f]                - Generate/refresh vector embeddings (current: ${embedModel})`);
   console.log("    --max-docs-per-batch <n>    - Cap docs loaded into memory per embedding batch");
   console.log("    --max-batch-mb <n>          - Cap UTF-8 MB loaded into memory per embedding batch");
   console.log("  qmd cleanup                   - Clear caches, vacuum DB");
+  console.log("");
+  console.log("Active config:");
+  console.log(`  Embedding model:   ${formatConfiguredModel(embedModel)}`);
+  console.log(`  Reranking model:   ${formatConfiguredModel(rerankModel)}`);
+  console.log(`  Generation model:  ${formatConfiguredModel(generateModel)}`);
+  if (provider) {
+    console.log(`  Backend:           ${provider}`);
+  }
+  if (provider === "openai-compatible" && baseUrl) {
+    console.log(`  Endpoint:          ${baseUrl}`);
+  }
   console.log("");
   console.log("Query syntax (qmd query):");
   console.log("  QMD queries are either a single expand query (no prefix) or a multi-line");
@@ -3112,7 +3155,7 @@ if (isMain) {
         const maxDocsPerBatch = parseEmbedBatchOption("maxDocsPerBatch", cli.values["max-docs-per-batch"]);
         const maxBatchMb = parseEmbedBatchOption("maxBatchBytes", cli.values["max-batch-mb"]);
         const embedChunkStrategy = parseChunkStrategy(cli.values["chunk-strategy"]);
-        await vectorIndex(DEFAULT_EMBED_MODEL_URI, !!cli.values.force, {
+        await vectorIndex(undefined, !!cli.values.force, {
           maxDocsPerBatch,
           maxBatchBytes: maxBatchMb === undefined ? undefined : maxBatchMb * 1024 * 1024,
           chunkStrategy: embedChunkStrategy,

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -42,6 +42,12 @@ export interface ModelsConfig {
   generate?: string;
 }
 
+export interface LLMBackendConfig {
+  provider?: "llama-cpp" | "openai-compatible";
+  baseUrl?: string;
+  apiKey?: string;
+}
+
 /**
  * The complete configuration file structure
  */
@@ -51,6 +57,7 @@ export interface CollectionConfig {
   editor_uri_template?: string;               // Alias for editor_uri
   collections: Record<string, Collection>;    // Collection name -> config
   models?: ModelsConfig;
+  llm?: LLMBackendConfig;
 }
 
 /**

--- a/src/db.ts
+++ b/src/db.ts
@@ -68,6 +68,7 @@ export function openDatabase(path: string): Database {
 export interface Database {
   exec(sql: string): void;
   prepare(sql: string): Statement;
+  transaction<T extends (...args: any[]) => any>(fn: T): T;
   loadExtension(path: string): void;
   close(): void;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ import {
   type ChunkStrategy,
 } from "./store.js";
 import {
-  LlamaCpp,
+  createLLM,
 } from "./llm.js";
 import {
   setConfigSource,
@@ -210,7 +210,7 @@ export interface StoreOptions {
  * The QMD SDK store — provides search, retrieval, collection management,
  * context management, and indexing operations.
  *
- * All methods are async. The store manages its own LlamaCpp instance
+ * All methods are async. The store manages its own LLM instance
  * (lazy-loaded, auto-unloaded after inactivity) — no global singletons.
  */
 export interface QMDStore {
@@ -365,12 +365,15 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
   }
   // else: DB-only mode — no external config, use existing store_collections
 
-  // Create a per-store LlamaCpp instance — lazy-loads models on first use,
+  // Create a per-store LLM instance — lazy-loads models on first use,
   // auto-unloads after 5 min inactivity to free VRAM.
-  const llm = new LlamaCpp({
+  const llm = createLLM({
     embedModel: config?.models?.embed,
     generateModel: config?.models?.generate,
     rerankModel: config?.models?.rerank,
+    provider: config?.llm?.provider,
+    baseUrl: config?.llm?.baseUrl,
+    apiKey: config?.llm?.apiKey,
     inactivityTimeoutMs: 5 * 60 * 1000,
     disposeModelsOnInactivity: true,
   });
@@ -417,7 +420,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
       });
     },
     searchLex: async (q, opts) => internal.searchFTS(q, opts?.limit, opts?.collection),
-    searchVector: async (q, opts) => internal.searchVec(q, DEFAULT_EMBED_MODEL, opts?.limit, opts?.collection),
+    searchVector: async (q, opts) => internal.searchVec(q, llm.embedModelName, opts?.limit, opts?.collection),
     expandQuery: async (q, opts) => internal.expandQuery(q, undefined, opts?.intent),
     get: async (pathOrDocid, opts) => internal.findDocument(pathOrDocid, opts),
     getDocumentBody: async (pathOrDocid, opts) => {

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -113,6 +113,20 @@ export type ModelInfo = {
   path?: string;
 };
 
+export type LLMProvider = "llama-cpp" | "openai-compatible";
+
+export type LLMTokenLike = LlamaToken | string | number;
+
+export type LLMDeviceInfo = {
+  gpu: string | false;
+  gpuOffloading: boolean;
+  gpuDevices: string[];
+  vram?: { total: number; used: number; free: number };
+  cpuCores: number;
+  backend?: LLMProvider;
+  endpoint?: string;
+};
+
 /**
  * Options for embedding
  */
@@ -156,7 +170,7 @@ export type LLMSessionOptions = {
 export interface ILLMSession {
   embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null>;
   embedBatch(texts: string[], options?: EmbedOptions): Promise<(EmbeddingResult | null)[]>;
-  expandQuery(query: string, options?: { context?: string; includeLexical?: boolean }): Promise<Queryable[]>;
+  expandQuery(query: string, options?: { context?: string; includeLexical?: boolean; intent?: string }): Promise<Queryable[]>;
   rerank(query: string, documents: RerankDocument[], options?: RerankOptions): Promise<RerankResult>;
   /** Whether this session is still valid (not released or aborted) */
   readonly isValid: boolean;
@@ -367,15 +381,36 @@ export async function pullModels(
  * Abstract LLM interface - implement this for different backends
  */
 export interface LLM {
+  /** Active embedding model name or alias */
+  readonly embedModelName: string;
+
+  /** Active rerank model name or alias */
+  readonly rerankModelName: string;
+
   /**
    * Get embeddings for text
    */
   embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null>;
 
   /**
+   * Batch embedding helper for vector indexing and query expansion.
+   */
+  embedBatch(texts: string[], options?: EmbedOptions): Promise<(EmbeddingResult | null)[]>;
+
+  /**
    * Generate text completion
    */
   generate(prompt: string, options?: GenerateOptions): Promise<GenerateResult | null>;
+
+  /**
+   * Tokenize text for chunking heuristics.
+   */
+  tokenize(text: string): Promise<readonly LLMTokenLike[]>;
+
+  /**
+   * Reconstruct text from tokens.
+   */
+  detokenize(tokens: readonly LLMTokenLike[]): Promise<string>;
 
   /**
    * Check if a model exists/is available
@@ -386,13 +421,18 @@ export interface LLM {
    * Expand a search query into multiple variations for different backends.
    * Returns a list of Queryable objects.
    */
-  expandQuery(query: string, options?: { context?: string, includeLexical?: boolean }): Promise<Queryable[]>;
+  expandQuery(query: string, options?: { context?: string, includeLexical?: boolean, intent?: string }): Promise<Queryable[]>;
 
   /**
    * Rerank documents by relevance to a query
    * Returns list of documents with relevance scores (higher = more relevant)
    */
   rerank(query: string, documents: RerankDocument[], options?: RerankOptions): Promise<RerankResult>;
+
+  /**
+   * Return backend/device info for status probes when available.
+   */
+  getDeviceInfo?(options?: { allowBuild?: boolean }): Promise<LLMDeviceInfo>;
 
   /**
    * Dispose of resources
@@ -430,6 +470,17 @@ export type LlamaCppConfig = {
    */
   disposeModelsOnInactivity?: boolean;
 };
+
+export type OpenAICompatibleConfig = {
+  provider?: LLMProvider;
+  baseUrl?: string;
+  apiKey?: string;
+  embedModel?: string;
+  generateModel?: string;
+  rerankModel?: string;
+};
+
+export type LLMConfig = LlamaCppConfig & OpenAICompatibleConfig;
 
 /**
  * LLM implementation using node-llama-cpp
@@ -469,6 +520,72 @@ function resolveExpandContextSize(configValue?: number): number {
     return DEFAULT_EXPAND_CONTEXT_SIZE;
   }
   return parsed;
+}
+
+export function resolveLlmProvider(
+  envValue = process.env.QMD_LLM_PROVIDER,
+  openAIBaseUrl = process.env.QMD_OPENAI_BASE_URL
+): LLMProvider {
+  const normalized = envValue?.trim().toLowerCase() ?? "";
+  const fallback = openAIBaseUrl ? "openai-compatible" : "llama-cpp";
+  if (!normalized) return fallback;
+  if (["llama-cpp", "llamacpp", "local"].includes(normalized)) return "llama-cpp";
+  if (["openai-compatible", "openai", "openai_compatible"].includes(normalized)) {
+    return "openai-compatible";
+  }
+
+  process.stderr.write(`QMD Warning: invalid QMD_LLM_PROVIDER="${envValue}", using ${fallback}.\n`);
+  return fallback;
+}
+
+function buildExpandPrompt(query: string, intent?: string): string {
+  return intent
+    ? `/no_think Expand this search query: ${query}\nQuery intent: ${intent}`
+    : `/no_think Expand this search query: ${query}`;
+}
+
+function fallbackExpandedQueries(query: string, includeLexical: boolean): Queryable[] {
+  const fallback: Queryable[] = [
+    { type: "hyde", text: `Information about ${query}` },
+    { type: "lex", text: query },
+    { type: "vec", text: query },
+  ];
+  return includeLexical ? fallback : fallback.filter((item) => item.type !== "lex");
+}
+
+function parseExpandedQueryText(raw: string, query: string, includeLexical: boolean): Queryable[] {
+  const lines = raw.trim().split("\n");
+  const queryLower = query.toLowerCase();
+  const queryTerms = queryLower.replace(/[^a-z0-9\s]/g, " ").split(/\s+/).filter(Boolean);
+
+  const hasQueryTerm = (text: string): boolean => {
+    const lower = text.toLowerCase();
+    if (queryTerms.length === 0) return true;
+    return queryTerms.some((term) => lower.includes(term));
+  };
+
+  const queryables: Queryable[] = lines
+    .map((line) => {
+      const colonIdx = line.indexOf(":");
+      if (colonIdx === -1) return null;
+      const type = line.slice(0, colonIdx).trim();
+      if (type !== "lex" && type !== "vec" && type !== "hyde") return null;
+      const text = line.slice(colonIdx + 1).trim();
+      if (!text || !hasQueryTerm(text)) return null;
+      return { type: type as QueryType, text };
+    })
+    .filter((item): item is Queryable => item !== null);
+
+  const filtered = includeLexical ? queryables : queryables.filter((item) => item.type !== "lex");
+  if (filtered.length > 0) {
+    return filtered;
+  }
+
+  return fallbackExpandedQueries(query, includeLexical);
+}
+
+function normalizeOpenAIBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, "");
 }
 
 export class LlamaCpp implements LLM {
@@ -512,6 +629,10 @@ export class LlamaCpp implements LLM {
 
   get embedModelName(): string {
     return this.embedModelUri;
+  }
+
+  get rerankModelName(): string {
+    return this.rerankModelUri;
   }
 
   /**
@@ -1148,10 +1269,7 @@ export class LlamaCpp implements LLM {
       `
     });
 
-    const intent = options.intent;
-    const prompt = intent
-      ? `/no_think Expand this search query: ${query}\nQuery intent: ${intent}`
-      : `/no_think Expand this search query: ${query}`;
+    const prompt = buildExpandPrompt(query, options.intent);
 
     // Create a bounded context for expansion to prevent large default VRAM allocations.
     const genContext = await this.generateModel!.createContext({
@@ -1176,42 +1294,11 @@ export class LlamaCpp implements LLM {
         },
       });
 
-      const lines = result.trim().split("\n");
-      const queryLower = query.toLowerCase();
-      const queryTerms = queryLower.replace(/[^a-z0-9\s]/g, " ").split(/\s+/).filter(Boolean);
-
-      const hasQueryTerm = (text: string): boolean => {
-        const lower = text.toLowerCase();
-        if (queryTerms.length === 0) return true;
-        return queryTerms.some(term => lower.includes(term));
-      };
-
-      const queryables: Queryable[] = lines.map(line => {
-        const colonIdx = line.indexOf(":");
-        if (colonIdx === -1) return null;
-        const type = line.slice(0, colonIdx).trim();
-        if (type !== 'lex' && type !== 'vec' && type !== 'hyde') return null;
-        const text = line.slice(colonIdx + 1).trim();
-        if (!hasQueryTerm(text)) return null;
-        return { type: type as QueryType, text };
-      }).filter((q): q is Queryable => q !== null);
-
-      // Filter out lex entries if not requested
-      const filtered = includeLexical ? queryables : queryables.filter(q => q.type !== 'lex');
-      if (filtered.length > 0) return filtered;
-
-      const fallback: Queryable[] = [
-        { type: 'hyde', text: `Information about ${query}` },
-        { type: 'lex', text: query },
-        { type: 'vec', text: query },
-      ];
-      return includeLexical ? fallback : fallback.filter(q => q.type !== 'lex');
+      return parseExpandedQueryText(result, query, includeLexical);
     } catch (error) {
       console.error("Structured query expansion failed:", error);
       // Fallback to original query
-      const fallback: Queryable[] = [{ type: 'vec', text: query }];
-      if (includeLexical) fallback.unshift({ type: 'lex', text: query });
-      return fallback;
+      return fallbackExpandedQueries(query, includeLexical);
     } finally {
       await genContext.dispose();
     }
@@ -1322,13 +1409,7 @@ export class LlamaCpp implements LLM {
    * Get device/GPU info for status display.
    * Initializes llama if not already done.
    */
-  async getDeviceInfo(options: { allowBuild?: boolean } = {}): Promise<{
-    gpu: string | false;
-    gpuOffloading: boolean;
-    gpuDevices: string[];
-    vram?: { total: number; used: number; free: number };
-    cpuCores: number;
-  }> {
+  async getDeviceInfo(options: { allowBuild?: boolean } = {}): Promise<LLMDeviceInfo> {
     const llama = await this.ensureLlama(options.allowBuild ?? true);
     const gpuDevices = await llama.getGpuDeviceNames();
     let vram: { total: number; used: number; free: number } | undefined;
@@ -1344,6 +1425,7 @@ export class LlamaCpp implements LLM {
       gpuDevices,
       vram,
       cpuCores: llama.cpuMathCores,
+      backend: "llama-cpp",
     };
   }
 
@@ -1385,6 +1467,313 @@ export class LlamaCpp implements LLM {
   }
 }
 
+export class OpenAICompatibleLLM implements LLM {
+  private readonly baseUrl: string;
+  private readonly apiKey?: string;
+  private readonly embedModelUri: string;
+  private readonly generateModelUri: string;
+  private readonly rerankModelUri: string;
+
+  constructor(config: OpenAICompatibleConfig = {}) {
+    this.baseUrl = normalizeOpenAIBaseUrl(config.baseUrl || process.env.QMD_OPENAI_BASE_URL || "");
+    if (!this.baseUrl) {
+      throw new Error("OpenAI-compatible backend requires llm.baseUrl or QMD_OPENAI_BASE_URL.");
+    }
+
+    this.apiKey = config.apiKey || process.env.QMD_OPENAI_API_KEY || process.env.OPENAI_API_KEY;
+    this.embedModelUri = config.embedModel || process.env.QMD_EMBED_MODEL || DEFAULT_EMBED_MODEL;
+    this.generateModelUri = config.generateModel || process.env.QMD_GENERATE_MODEL || DEFAULT_GENERATE_MODEL;
+    this.rerankModelUri = config.rerankModel || process.env.QMD_RERANK_MODEL || DEFAULT_RERANK_MODEL;
+  }
+
+  get embedModelName(): string {
+    return this.embedModelUri;
+  }
+
+  get rerankModelName(): string {
+    return this.rerankModelUri;
+  }
+
+  private buildEndpoint(path: string): string {
+    const suffix = path.replace(/^\/+/, "");
+    if (/\/v1$/i.test(this.baseUrl)) {
+      return `${this.baseUrl}/${suffix}`;
+    }
+    return `${this.baseUrl}/v1/${suffix}`;
+  }
+
+  private buildHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+    };
+    if (this.apiKey) {
+      headers.authorization = `Bearer ${this.apiKey}`;
+    }
+    return headers;
+  }
+
+  private async requestJson(path: string, init: RequestInit = {}): Promise<any> {
+    const response = await fetch(this.buildEndpoint(path), {
+      ...init,
+      headers: {
+        ...this.buildHeaders(),
+        ...(init.headers as Record<string, string> | undefined),
+      },
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(
+        `OpenAI-compatible request failed (${response.status} ${response.statusText})${body ? `: ${body}` : ""}`
+      );
+    }
+
+    return await response.json();
+  }
+
+  private static extractChatText(payload: any): string {
+    const content = payload?.choices?.[0]?.message?.content;
+    if (typeof content === "string") return content;
+    if (Array.isArray(content)) {
+      return content
+        .map((part) => {
+          if (typeof part === "string") return part;
+          if (typeof part?.text === "string") return part.text;
+          return "";
+        })
+        .join("");
+    }
+    return "";
+  }
+
+  async embed(text: string, options: EmbedOptions = {}): Promise<EmbeddingResult | null> {
+    const [result] = await this.embedBatch([text], options);
+    return result ?? null;
+  }
+
+  async embedBatch(texts: string[], options: EmbedOptions = {}): Promise<(EmbeddingResult | null)[]> {
+    if (texts.length === 0) return [];
+
+    try {
+      const model = options.model ?? this.embedModelUri;
+      const payload = await this.requestJson("embeddings", {
+        method: "POST",
+        body: JSON.stringify({
+          model,
+          input: texts,
+        }),
+      });
+
+      const items = Array.isArray(payload?.data) ? payload.data : [];
+      const byIndex = new Map<number, number[]>();
+      for (const item of items) {
+        if (typeof item?.index !== "number" || !Array.isArray(item?.embedding)) continue;
+        byIndex.set(item.index, item.embedding.map((value: unknown) => Number(value)));
+      }
+
+      return texts.map((_, index) => {
+        const embedding = byIndex.get(index);
+        if (!embedding) return null;
+        return { embedding, model };
+      });
+    } catch (error) {
+      console.error("Embedding error:", error);
+      return texts.map(() => null);
+    }
+  }
+
+  async generate(prompt: string, options: GenerateOptions = {}): Promise<GenerateResult | null> {
+    try {
+      const model = options.model ?? this.generateModelUri;
+      const payload = await this.requestJson("chat/completions", {
+        method: "POST",
+        body: JSON.stringify({
+          model,
+          messages: [{ role: "user", content: prompt }],
+          max_tokens: options.maxTokens ?? 150,
+          temperature: options.temperature ?? 0.7,
+        }),
+      });
+
+      return {
+        text: OpenAICompatibleLLM.extractChatText(payload),
+        model,
+        done: true,
+      };
+    } catch (error) {
+      console.error("Generation error:", error);
+      return null;
+    }
+  }
+
+  async tokenize(text: string): Promise<readonly LLMTokenLike[]> {
+    return text.match(/\s+|[^\s]+/g) ?? [];
+  }
+
+  async detokenize(tokens: readonly LLMTokenLike[]): Promise<string> {
+    return tokens.map((token) => typeof token === "string" ? token : String(token)).join("");
+  }
+
+  async modelExists(model: string): Promise<ModelInfo> {
+    try {
+      const payload = await this.requestJson("models", { method: "GET" });
+      const ids = new Set(
+        Array.isArray(payload?.data)
+          ? payload.data
+              .map((item: any) => item?.id)
+              .filter((id: unknown): id is string => typeof id === "string")
+          : []
+      );
+      return { name: model, exists: ids.size === 0 ? true : ids.has(model) };
+    } catch {
+      return { name: model, exists: true };
+    }
+  }
+
+  async expandQuery(
+    query: string,
+    options: { context?: string; includeLexical?: boolean; intent?: string } = {}
+  ): Promise<Queryable[]> {
+    const includeLexical = options.includeLexical ?? true;
+
+    try {
+      const payload = await this.requestJson("chat/completions", {
+        method: "POST",
+        body: JSON.stringify({
+          model: this.generateModelUri,
+          messages: [
+            {
+              role: "system",
+              content:
+                "Return newline-separated search expansions only. Each line must use exactly one of these prefixes: lex:, vec:, hyde:.",
+            },
+            { role: "user", content: buildExpandPrompt(query, options.intent) },
+          ],
+          temperature: 0.2,
+          max_tokens: 400,
+        }),
+      });
+
+      return parseExpandedQueryText(OpenAICompatibleLLM.extractChatText(payload), query, includeLexical);
+    } catch (error) {
+      console.error("Structured query expansion failed:", error);
+      return fallbackExpandedQueries(query, includeLexical);
+    }
+  }
+
+  async rerank(
+    query: string,
+    documents: RerankDocument[],
+    options: RerankOptions = {}
+  ): Promise<RerankResult> {
+    if (documents.length === 0) {
+      return { results: [], model: options.model ?? this.rerankModelUri };
+    }
+
+    try {
+      const model = options.model ?? this.rerankModelUri;
+      const rerankBatch = async (
+        batch: RerankDocument[],
+        start: number
+      ): Promise<RerankDocumentResult[]> => {
+        const payload = await this.requestJson("rerank", {
+          method: "POST",
+          body: JSON.stringify({
+            model,
+            query,
+            documents: batch.map((doc) => doc.text),
+            top_n: batch.length,
+          }),
+        });
+
+        return (Array.isArray(payload?.results) ? payload.results : [])
+          .map((item: any, rank: number) => {
+            const localIndex = typeof item?.index === "number" ? item.index : rank;
+            const score = typeof item?.relevance_score === "number"
+              ? item.relevance_score
+              : typeof item?.score === "number"
+                ? item.score
+                : 0;
+            const documentIndex = start + localIndex;
+            const file = documents[documentIndex]?.file;
+            if (!file) return null;
+            return { file, score, index: documentIndex };
+          })
+          .filter((item): item is RerankDocumentResult => item !== null);
+      };
+
+      const scoreBatches = async (
+        batch: RerankDocument[],
+        start: number
+      ): Promise<RerankDocumentResult[]> => {
+        try {
+          return await rerankBatch(batch, start);
+        } catch (error) {
+          const oversized = error instanceof Error
+            && error.message.includes("too large to process");
+          if (!oversized || batch.length <= 1) {
+            if (!oversized || batch.length === 0) {
+              throw error;
+            }
+
+            const [doc] = batch;
+            if (!doc || doc.text.length <= 32) {
+              throw error;
+            }
+
+            const nextLength = Math.max(32, Math.floor(doc.text.length / 2));
+            if (nextLength >= doc.text.length) {
+              throw error;
+            }
+
+            return await scoreBatches([{ ...doc, text: doc.text.slice(0, nextLength) }], start);
+          }
+
+          const midpoint = Math.ceil(batch.length / 2);
+          const left = await scoreBatches(batch.slice(0, midpoint), start);
+          const right = await scoreBatches(batch.slice(midpoint), start + midpoint);
+          return [...left, ...right];
+        }
+      };
+
+      const results = await scoreBatches(documents, 0);
+
+      results.sort((left, right) => right.score - left.score);
+
+      return { results, model };
+    } catch (error) {
+      console.error("Rerank error:", error);
+      return {
+        results: documents.map((doc, index) => ({ file: doc.file, score: 0, index })),
+        model: options.model ?? this.rerankModelUri,
+      };
+    }
+  }
+
+  async getDeviceInfo(): Promise<LLMDeviceInfo> {
+    return {
+      gpu: false,
+      gpuOffloading: false,
+      gpuDevices: [],
+      cpuCores: 0,
+      backend: "openai-compatible",
+      endpoint: this.baseUrl,
+    };
+  }
+
+  async dispose(): Promise<void> {
+    // No local resources to dispose for remote inference.
+  }
+}
+
+export function createLLM(config: LLMConfig = {}): LLM {
+  const provider = resolveLlmProvider(config.provider, config.baseUrl || process.env.QMD_OPENAI_BASE_URL);
+  if (provider === "openai-compatible") {
+    return new OpenAICompatibleLLM(config);
+  }
+  return new LlamaCpp(config);
+}
+
 // =============================================================================
 // Session Management Layer
 // =============================================================================
@@ -1394,11 +1783,11 @@ export class LlamaCpp implements LLM {
  * Coordinates with LlamaCpp idle timeout to prevent disposal during active sessions.
  */
 class LLMSessionManager {
-  private llm: LlamaCpp;
+  private llm: LLM;
   private _activeSessionCount = 0;
   private _inFlightOperations = 0;
 
-  constructor(llm: LlamaCpp) {
+  constructor(llm: LLM) {
     this.llm = llm;
   }
 
@@ -1434,7 +1823,7 @@ class LLMSessionManager {
     this._inFlightOperations = Math.max(0, this._inFlightOperations - 1);
   }
 
-  getLlamaCpp(): LlamaCpp {
+  getLlm(): LLM {
     return this.llm;
   }
 }
@@ -1537,18 +1926,18 @@ class LLMSession implements ILLMSession {
   }
 
   async embed(text: string, options?: EmbedOptions): Promise<EmbeddingResult | null> {
-    return this.withOperation(() => this.manager.getLlamaCpp().embed(text, options));
+    return this.withOperation(() => this.manager.getLlm().embed(text, options));
   }
 
   async embedBatch(texts: string[], options?: EmbedOptions): Promise<(EmbeddingResult | null)[]> {
-    return this.withOperation(() => this.manager.getLlamaCpp().embedBatch(texts, options));
+    return this.withOperation(() => this.manager.getLlm().embedBatch(texts, options));
   }
 
   async expandQuery(
     query: string,
-    options?: { context?: string; includeLexical?: boolean }
+    options?: { context?: string; includeLexical?: boolean; intent?: string }
   ): Promise<Queryable[]> {
-    return this.withOperation(() => this.manager.getLlamaCpp().expandQuery(query, options));
+    return this.withOperation(() => this.manager.getLlm().expandQuery(query, options));
   }
 
   async rerank(
@@ -1556,7 +1945,7 @@ class LLMSession implements ILLMSession {
     documents: RerankDocument[],
     options?: RerankOptions
   ): Promise<RerankResult> {
-    return this.withOperation(() => this.manager.getLlamaCpp().rerank(query, documents, options));
+    return this.withOperation(() => this.manager.getLlm().rerank(query, documents, options));
   }
 }
 
@@ -1567,8 +1956,8 @@ let defaultSessionManager: LLMSessionManager | null = null;
  * Get the session manager for the default LlamaCpp instance.
  */
 function getSessionManager(): LLMSessionManager {
-  const llm = getDefaultLlamaCpp();
-  if (!defaultSessionManager || defaultSessionManager.getLlamaCpp() !== llm) {
+  const llm = getDefaultLLM();
+  if (!defaultSessionManager || defaultSessionManager.getLlm() !== llm) {
     defaultSessionManager = new LLMSessionManager(llm);
   }
   return defaultSessionManager;
@@ -1607,7 +1996,7 @@ export async function withLLMSession<T>(
  * Unlike withLLMSession, this does not use the global singleton.
  */
 export async function withLLMSessionForLlm<T>(
-  llm: LlamaCpp,
+  llm: LLM,
   fn: (session: ILLMSession) => Promise<T>,
   options?: LLMSessionOptions
 ): Promise<T> {
@@ -1634,23 +2023,36 @@ export function canUnloadLLM(): boolean {
 // Singleton for default LlamaCpp instance
 // =============================================================================
 
-let defaultLlamaCpp: LlamaCpp | null = null;
+let defaultLLM: LLM | null = null;
+
+export function getDefaultLLM(): LLM {
+  if (!defaultLLM) {
+    defaultLLM = createLLM();
+  }
+  return defaultLLM;
+}
+
+export function setDefaultLLM(llm: LLM | null): void {
+  defaultLLM = llm;
+  defaultSessionManager = null;
+}
 
 /**
  * Get the default LlamaCpp instance (creates one if needed)
  */
 export function getDefaultLlamaCpp(): LlamaCpp {
-  if (!defaultLlamaCpp) {
-    defaultLlamaCpp = new LlamaCpp();
+  const llm = getDefaultLLM();
+  if (!(llm instanceof LlamaCpp)) {
+    throw new Error("Default LLM backend is not LlamaCpp.");
   }
-  return defaultLlamaCpp;
+  return llm;
 }
 
 /**
  * Set a custom default LlamaCpp instance (useful for testing)
  */
-export function setDefaultLlamaCpp(llm: LlamaCpp | null): void {
-  defaultLlamaCpp = llm;
+export function setDefaultLlamaCpp(llm: LLM | null): void {
+  setDefaultLLM(llm);
 }
 
 /**
@@ -1658,8 +2060,9 @@ export function setDefaultLlamaCpp(llm: LlamaCpp | null): void {
  * Call this before process exit to prevent NAPI crashes.
  */
 export async function disposeDefaultLlamaCpp(): Promise<void> {
-  if (defaultLlamaCpp) {
-    await defaultLlamaCpp.dispose();
-    defaultLlamaCpp = null;
+  if (defaultLLM) {
+    await defaultLLM.dispose();
+    defaultLLM = null;
+    defaultSessionManager = null;
   }
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -19,13 +19,13 @@ import { readFileSync, realpathSync, statSync, mkdirSync } from "node:fs";
 // Note: node:path resolve is not imported — we export our own cross-platform resolve()
 import fastGlob from "fast-glob";
 import {
-  LlamaCpp,
-  getDefaultLlamaCpp,
+  getDefaultLLM,
   formatQueryForEmbedding,
   formatDocForEmbedding,
   withLLMSessionForLlm,
   type RerankDocument,
   type ILLMSession,
+  type LLM,
 } from "./llm.js";
 import type {
   NamedCollection,
@@ -59,11 +59,11 @@ export const CHUNK_WINDOW_TOKENS = 200;
 export const CHUNK_WINDOW_CHARS = CHUNK_WINDOW_TOKENS * 4;  // 800 chars
 
 /**
- * Get the LlamaCpp instance for a store — prefers the store's own instance,
+ * Get the configured LLM instance for a store — prefers the store's own instance,
  * falls back to the global singleton.
  */
-function getLlm(store: Store): LlamaCpp {
-  return store.llm ?? getDefaultLlamaCpp();
+function getLlm(store: Store): LLM {
+  return store.llm ?? getDefaultLLM();
 }
 
 // =============================================================================
@@ -1087,8 +1087,8 @@ function ensureVecTableInternal(db: Database, dimensions: number): void {
 export type Store = {
   db: Database;
   dbPath: string;
-  /** Optional LlamaCpp instance for this store (overrides the global singleton) */
-  llm?: LlamaCpp;
+  /** Optional LLM instance for this store (overrides the global singleton) */
+  llm?: LLM;
   close: () => void;
   ensureVecTable: (dimensions: number) => void;
 
@@ -1411,7 +1411,6 @@ export async function generateEmbeddings(
   options?: EmbedOptions
 ): Promise<EmbedResult> {
   const db = store.db;
-  const model = options?.model ?? DEFAULT_EMBED_MODEL;
   const now = new Date().toISOString();
   const { maxDocsPerBatch, maxBatchBytes } = resolveEmbedOptions(options);
   const encoder = new TextEncoder();
@@ -1429,8 +1428,9 @@ export async function generateEmbeddings(
   const totalDocs = docsToEmbed.length;
   const startTime = Date.now();
 
-  // Use store's LlamaCpp or global singleton, wrapped in a session
+  // Use store's configured LLM or global singleton, wrapped in a session
   const llm = getLlm(store);
+  const model = options?.model ?? llm.embedModelName;
   const embedModelUri = llm.embedModelName;
 
   // Create a session manager for this llm instance
@@ -2276,7 +2276,7 @@ export async function chunkDocumentByTokens(
   chunkStrategy: ChunkStrategy = "regex",
   signal?: AbortSignal
 ): Promise<{ text: string; pos: number; tokens: number }[]> {
-  const llm = getDefaultLlamaCpp();
+  const llm = getDefaultLLM();
 
   // Use moderate chars/token estimate (prose ~4, code ~2, mixed ~3)
   // If chunks exceed limit, they'll be re-split with actual ratio
@@ -3186,12 +3186,12 @@ export async function searchVec(db: Database, query: string, model: string, limi
 // Embeddings
 // =============================================================================
 
-async function getEmbedding(text: string, model: string, isQuery: boolean, session?: ILLMSession, llmOverride?: LlamaCpp): Promise<number[] | null> {
+async function getEmbedding(text: string, model: string, isQuery: boolean, session?: ILLMSession, llmOverride?: LLM): Promise<number[] | null> {
   // Format text using the appropriate prompt template
   const formattedText = isQuery ? formatQueryForEmbedding(text, model) : formatDocForEmbedding(text, undefined, model);
   const result = session
     ? await session.embed(formattedText, { model, isQuery })
-    : await (llmOverride ?? getDefaultLlamaCpp()).embed(formattedText, { model, isQuery });
+    : await (llmOverride ?? getDefaultLLM()).embed(formattedText, { model, isQuery });
   return result?.embedding || null;
 }
 
@@ -3255,7 +3255,7 @@ export function insertEmbedding(
 // Query expansion
 // =============================================================================
 
-export async function expandQuery(query: string, model: string = DEFAULT_QUERY_MODEL, db: Database, intent?: string, llmOverride?: LlamaCpp): Promise<ExpandedQuery[]> {
+export async function expandQuery(query: string, model: string = DEFAULT_QUERY_MODEL, db: Database, intent?: string, llmOverride?: LLM): Promise<ExpandedQuery[]> {
   // Check cache first — stored as JSON preserving types
   const cacheKey = getCacheKey("expandQuery", { query, model, ...(intent && { intent }) });
   const cached = getCachedResult(db, cacheKey);
@@ -3273,7 +3273,7 @@ export async function expandQuery(query: string, model: string = DEFAULT_QUERY_M
     }
   }
 
-  const llm = llmOverride ?? getDefaultLlamaCpp();
+  const llm = llmOverride ?? getDefaultLLM();
   // Note: LlamaCpp uses hardcoded model, model parameter is ignored
   const results = await llm.expandQuery(query, { intent });
 
@@ -3294,9 +3294,11 @@ export async function expandQuery(query: string, model: string = DEFAULT_QUERY_M
 // Reranking
 // =============================================================================
 
-export async function rerank(query: string, documents: { file: string; text: string }[], model: string = DEFAULT_RERANK_MODEL, db: Database, intent?: string, llmOverride?: LlamaCpp): Promise<{ file: string; score: number }[]> {
+export async function rerank(query: string, documents: { file: string; text: string }[], model: string | undefined, db: Database, intent?: string, llmOverride?: LLM): Promise<{ file: string; score: number }[]> {
   // Prepend intent to rerank query so the reranker scores with domain context
   const rerankQuery = intent ? `${intent}\n\n${query}` : query;
+  const llm = llmOverride ?? getDefaultLLM();
+  const resolvedModel = model ?? llm.rerankModelName;
 
   const cachedResults: Map<string, number> = new Map();
   const uncachedDocsByChunk: Map<string, RerankDocument> = new Map();
@@ -3307,8 +3309,8 @@ export async function rerank(query: string, documents: { file: string; text: str
   // File path is excluded from the new cache key because the reranker score
   // depends on the chunk content, not where it came from.
   for (const doc of documents) {
-    const cacheKey = getCacheKey("rerank", { query: rerankQuery, model, chunk: doc.text });
-    const legacyCacheKey = getCacheKey("rerank", { query, file: doc.file, model, chunk: doc.text });
+    const cacheKey = getCacheKey("rerank", { query: rerankQuery, model: resolvedModel, chunk: doc.text });
+    const legacyCacheKey = getCacheKey("rerank", { query, file: doc.file, model: resolvedModel, chunk: doc.text });
     const cached = getCachedResult(db, cacheKey) ?? getCachedResult(db, legacyCacheKey);
     if (cached !== null) {
       cachedResults.set(doc.text, parseFloat(cached));
@@ -3319,15 +3321,14 @@ export async function rerank(query: string, documents: { file: string; text: str
 
   // Rerank uncached documents using LlamaCpp
   if (uncachedDocsByChunk.size > 0) {
-    const llm = llmOverride ?? getDefaultLlamaCpp();
     const uncachedDocs = [...uncachedDocsByChunk.values()];
-    const rerankResult = await llm.rerank(rerankQuery, uncachedDocs, { model });
+    const rerankResult = await llm.rerank(rerankQuery, uncachedDocs, { model: resolvedModel });
 
     // Cache results by chunk text so identical chunks across files are scored once.
     const textByFile = new Map(uncachedDocs.map(d => [d.file, d.text]));
     for (const result of rerankResult.results) {
       const chunk = textByFile.get(result.file) || "";
-      const cacheKey = getCacheKey("rerank", { query: rerankQuery, model, chunk });
+      const cacheKey = getCacheKey("rerank", { query: rerankQuery, model: resolvedModel, chunk });
       setCachedResult(db, cacheKey, result.score.toString());
       cachedResults.set(chunk, result.score);
     }
@@ -4100,7 +4101,7 @@ export async function hybridQuery(
       if (!embedding) continue;
 
       const vecResults = await store.searchVec(
-        vecQueries[i]!.text, DEFAULT_EMBED_MODEL, 20, collection,
+        vecQueries[i]!.text, llm.embedModelName, 20, collection,
         undefined, embedding
       );
       if (vecResults.length > 0) {
@@ -4332,8 +4333,9 @@ export async function vectorSearchQuery(
   // Run original + vec/hyde expanded through vector, sequentially — concurrent embed() hangs
   const queryTexts = [query, ...vecExpanded.map(q => q.query)];
   const allResults = new Map<string, VectorSearchResult>();
+  const llm = getLlm(store);
   for (const q of queryTexts) {
-    const vecResults = await store.searchVec(q, DEFAULT_EMBED_MODEL, limit, collection);
+    const vecResults = await store.searchVec(q, llm.embedModelName, limit, collection);
     for (const r of vecResults) {
       const existing = allResults.get(r.filepath);
       if (!existing || r.score > existing.score) {
@@ -4483,7 +4485,7 @@ export async function structuredSearch(
 
         for (const coll of collectionList) {
           const vecResults = await store.searchVec(
-            vecSearches[i]!.query, DEFAULT_EMBED_MODEL, 20, coll,
+            vecSearches[i]!.query, llm.embedModelName, 20, coll,
             undefined, embedding
           );
           if (vecResults.length > 0) {

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -7,12 +7,15 @@
  * rerank functions first to trigger model downloads.
  */
 
-import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
+import { describe, test, expect, beforeAll, afterAll, afterEach, vi } from "vitest";
 import {
   LlamaCpp,
+  OpenAICompatibleLLM,
+  createLLM,
   getDefaultLlamaCpp,
   disposeDefaultLlamaCpp,
   resolveLlamaGpuMode,
+  resolveLlmProvider,
   withLLMSession,
   canUnloadLLM,
   SessionReleasedError,
@@ -194,6 +197,157 @@ describe("LlamaCpp model resolution (config > env > default)", () => {
   });
 });
 
+describe("OpenAI-compatible backend", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("auto-selects the OpenAI-compatible backend when a base URL is configured", () => {
+    expect(resolveLlmProvider(undefined, "http://127.0.0.1:8080/v1")).toBe("openai-compatible");
+    expect(createLLM({ baseUrl: "http://127.0.0.1:8080/v1" })).toBeInstanceOf(OpenAICompatibleLLM);
+  });
+
+  test("embedBatch maps embeddings by response index", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { index: 1, embedding: [0.2, 0.3] },
+          { index: 0, embedding: [0.1] },
+        ],
+      }),
+    } as any);
+
+    const llm = new OpenAICompatibleLLM({
+      baseUrl: "http://127.0.0.1:8080/v1",
+      embedModel: "qmd-embed",
+    });
+
+    const results = await llm.embedBatch(["first", "second"]);
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://127.0.0.1:8080/v1/embeddings",
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(results).toEqual([
+      { embedding: [0.1], model: "qmd-embed" },
+      { embedding: [0.2, 0.3], model: "qmd-embed" },
+    ]);
+  });
+
+  test("expandQuery parses newline-prefixed completions", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [
+          {
+            message: {
+              content: "lex: bof3 docs\nvec: bof3 battle system\nhyde: Information about bof3 docs",
+            },
+          },
+        ],
+      }),
+    } as any);
+
+    const llm = new OpenAICompatibleLLM({
+      baseUrl: "http://127.0.0.1:8080/v1",
+      generateModel: "qmd-query",
+    });
+
+    const results = await llm.expandQuery("bof3 docs");
+
+    expect(results).toEqual([
+      { type: "lex", text: "bof3 docs" },
+      { type: "vec", text: "bof3 battle system" },
+      { type: "hyde", text: "Information about bof3 docs" },
+    ]);
+  });
+
+  test("rerank maps remote indices back to source files", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [
+          { index: 1, relevance_score: 0.9 },
+          { index: 0, relevance_score: 0.4 },
+        ],
+      }),
+    } as any);
+
+    const llm = new OpenAICompatibleLLM({
+      baseUrl: "http://127.0.0.1:8080/v1",
+      rerankModel: "qmd-rerank",
+    });
+
+    const result = await llm.rerank("capital", [
+      { file: "a.md", text: "alpha" },
+      { file: "b.md", text: "beta" },
+    ]);
+
+    expect(result).toEqual({
+      model: "qmd-rerank",
+      results: [
+        { file: "b.md", score: 0.9, index: 1 },
+        { file: "a.md", score: 0.4, index: 0 },
+      ],
+    });
+  });
+
+  test("recovers from oversized rerank requests by splitting and truncating", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      const documents = Array.isArray(body.documents) ? body.documents : [];
+      const tooManyDocs = documents.length > 1;
+      const oversizedSingle = documents.some((doc: string) => typeof doc === "string" && doc.length > 64);
+
+      if (tooManyDocs || oversizedSingle) {
+        return {
+          ok: false,
+          status: 500,
+          statusText: "Internal Server Error",
+          text: async () => JSON.stringify({
+            error: {
+              code: 500,
+              message: "input is too large to process",
+              type: "server_error",
+            },
+          }),
+        } as any;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({
+          results: documents.map((_: unknown, index: number) => ({
+            index,
+            relevance_score: 1 - index * 0.1,
+          })),
+        }),
+      } as any;
+    });
+
+    const llm = new OpenAICompatibleLLM({
+      baseUrl: "http://127.0.0.1:8080/v1",
+      rerankModel: "qmd-rerank",
+    });
+
+    const documents = [
+      { file: "a.md", text: "a".repeat(6000) },
+      { file: "b.md", text: "b".repeat(6000) },
+      { file: "c.md", text: "c".repeat(6000) },
+    ];
+
+    const result = await llm.rerank("capital", documents);
+
+    expect(fetchSpy).toHaveBeenCalled();
+    const requestBodies = fetchSpy.mock.calls.map(([, init]) => JSON.parse(String(init?.body ?? "{}")));
+    expect(requestBodies[0]?.documents.length).toBe(documents.length);
+    expect(requestBodies.some((body) => body.documents.length === 1)).toBe(true);
+    expect(requestBodies.some((body) => body.documents[0]?.length < documents[0]!.text.length)).toBe(true);
+    expect(result.results).toHaveLength(documents.length);
+  });
+});
+
 describe("LlamaCpp embedding truncation", () => {
   test("truncates against the active embedding context limit, not the model train context", async () => {
     const llm = new LlamaCpp({}) as any;
@@ -274,6 +428,7 @@ describe("LlamaCpp.getDeviceInfo", () => {
       gpuDevices: ["Apple GPU"],
       vram: { total: 1024, used: 256, free: 768 },
       cpuCores: 8,
+      backend: "llama-cpp",
     });
   });
 });


### PR DESCRIPTION
# Problem

QMD currently assumes a local `llama.cpp` style setup for generation, embeddings, and reranking which is baked in.  This prevents any and all user customization to llama cpp (such as for example, using TheTom's turboquant fork...) and doesn't integrate well with existing homelab servers as it tries to run it all locally on the machine.

That makes it harder to use QMD with a local OpenAI-compatible server setup, such as `llama-swap` which is what I tested this PR with.  Even when the server already exposes the same models through `/v1/chat/completions`, `/v1/embeddings`, and `/v1/rerank`, why can't we?  Now we can!

# Solution

This PR adds an **OpenAI-compatible backend** alongside the existing llama cpp one that lets QMD talk to a local compatible server instead of requiring direct local model access.  Meaning now you can run this on your laptop while your homelab does the tensor crunching!

It also makes the CLI and store paths respect configured model aliases, so users can route QMD generation, embedding, and reranking through named server-side models (ex: `qmd-generate`, `qmd-embed`, and `qmd-rerank`) which I set my server up with for testing this PR.

# What's Changed?

- Added config support for:
  - `llm.provider`
  - `llm.baseUrl`
  - `llm.apiKey`
- Updated QMD to select the backend when configured.
- Routed query expansion, embedding, and reranking through the configured remote model aliases.
- Updated vector search and rerank paths to use the configured embed and rerank model names instead of hardcoded defaults.
- Updated `qmd embed` so it uses the configured embedding alias instead of forcing the built-in default model name.
- Updated help and status output to show the active configured models and backend more clearly.
- Added rerank handling that recovers from oversized rerank requests by splitting batches and truncating oversized single documents when needed.
- Added and updated tests for the new backend behavior.

# Testing

## Automated

1. Run the focused LLM test for the new rerank recovery path:

```bash
npx vitest run test/llm.test.ts -t "recovers from oversized rerank requests by splitting and truncating"
```

2. Run the existing adjacent OpenAI-compatible rerank mapping test:

```bash
npx vitest run test/llm.test.ts -t "rerank maps remote indices back to source files"
```

## Manual

You can test this with `llama-swap` or any server that exposes OpenAI-compatible chat, embedding, and rerank endpoints.

### Option A: Use llama-swap

1. Start or prepare a local OpenAI-compatible server.
2. Expose three model IDs, for example:
   - `qmd-generate`
   - `qmd-embed`
   - `qmd-rerank`
3. Make sure the server exposes these routes:
   - `POST /v1/chat/completions`
   - `POST /v1/embeddings`
   - `POST /v1/rerank`

### Option B: Roll your own compatible server

1. Use any local server that follows the same OpenAI-compatible route layout.
2. Configure one model for generation, one for embeddings, and one for reranking.
3. Point QMD at that server with the config below.

### QMD config example

Create or update your QMD config:

```yaml
models:
  generate: qmd-generate
  embed: qmd-embed
  rerank: qmd-rerank

llm:
  provider: openai-compatible
  baseUrl: http://127.0.0.1:8080/v1
  apiKey: your-local-api-key
```

### Verify the flow

1. Check help and status:

```bash
qmd --index my-index --help
qmd --index my-index status
```

2. Build embeddings:

```bash
qmd --index my-index embed
```

3. Run a query:

```bash
qmd --index my-index query "How do I unpack EMI archives?" -n 3 --json
```

4. Confirm the server receives requests for:
   - chat completions
   - embeddings
   - rerank

5. If your reranker has tighter request limits, verify the query still succeeds and that rerank requests continue after the first oversized split when needed.
