### PR TITLE
feat: add --no-expand flag to qmd query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Changes
+
+- `--no-expand` flag on `qmd query` skips LLM query expansion and
+  searches the original query verbatim. Mirrors the existing
+  `--no-rerank` flag and is also exposed as `expand: false` on the
+  SDK `search()` method. Useful for non-English corpora where the
+  expansion model translates the query into English and degrades
+  vector recall, and as a faster path when you trust your query
+  wording.
+
 ### Fixes
 
 - GPU: respect explicit `QMD_LLAMA_GPU=metal|vulkan|cuda` backend overrides instead of always using auto GPU selection. #529

--- a/README.md
+++ b/README.md
@@ -222,6 +222,10 @@ const results3 = await store.search({
 
 // Skip reranking for faster results
 const fast = await store.search({ query: "auth", rerank: false })
+
+// Skip LLM query expansion — useful for non-English corpora where the
+// expansion model translates the query into English and tanks recall
+const verbatim = await store.search({ query: "テレグラム 設定", expand: false })
 ```
 
 For direct backend access:

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -1811,6 +1811,7 @@ type OutputOptions = {
   candidateLimit?: number;  // Max candidates to rerank (default: 40)
   intent?: string;       // Domain intent for disambiguation
   skipRerank?: boolean;  // Skip LLM reranking, use RRF scores only
+  skipExpansion?: boolean;  // Skip LLM query expansion, search verbatim
   chunkStrategy?: ChunkStrategy;  // "auto" (default) or "regex"
 };
 
@@ -2404,6 +2405,7 @@ async function querySearch(query: string, opts: OutputOptions, _embedModel: stri
         minScore: opts.minScore || 0,
         candidateLimit: opts.candidateLimit,
         skipRerank: opts.skipRerank,
+        skipExpansion: opts.skipExpansion,
         explain: !!opts.explain,
         intent,
         chunkStrategy: opts.chunkStrategy,
@@ -2415,6 +2417,10 @@ async function querySearch(query: string, opts: OutputOptions, _embedModel: stri
             process.stderr.write(`${c.dim}Expanding query...${c.reset}`);
           },
           onExpand: (original, expanded, ms) => {
+            if (opts.skipExpansion) {
+              process.stderr.write(`${c.dim}Expansion disabled (--no-expand) — searching original query only${c.reset}\n`);
+              return;
+            }
             process.stderr.write(`${c.dim} (${formatMs(ms)})${c.reset}\n`);
             logExpansionTree(original, expanded);
             process.stderr.write(`${c.dim}Searching ${expanded.length + 1} queries...${c.reset}\n`);
@@ -2520,6 +2526,7 @@ function parseCLI() {
       // Query options
       "candidate-limit": { type: "string", short: "C" },
       "no-rerank": { type: "boolean", default: false },
+      "no-expand": { type: "boolean", default: false },
       intent: { type: "string" },
       // Chunking options
       "chunk-strategy": { type: "string" },  // "regex" (default) or "auto" (AST for code files)
@@ -2562,6 +2569,7 @@ function parseCLI() {
     lineNumbers: !!values["line-numbers"],
     candidateLimit: values["candidate-limit"] ? parseInt(String(values["candidate-limit"]), 10) : undefined,
     skipRerank: !!values["no-rerank"],
+    skipExpansion: !!values["no-expand"],
     explain: !!values.explain,
     intent: values.intent as string | undefined,
     chunkStrategy: parseChunkStrategy(values["chunk-strategy"]),
@@ -2784,6 +2792,7 @@ function showHelp(): void {
   console.log("  --full                     - Output full document instead of snippet");
   console.log("  -C, --candidate-limit <n>  - Max candidates to rerank (default 40, lower = faster)");
   console.log("  --no-rerank                - Skip LLM reranking (use RRF scores only, much faster on CPU)");
+  console.log("  --no-expand                - Skip LLM query expansion (search original query verbatim; useful for non-English corpora)");
   console.log("  --line-numbers             - Include line numbers in output");
   console.log("  --explain                  - Include retrieval score traces (query --json/CLI)");
   console.log("  --files | --json | --csv | --md | --xml  - Output format");

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,6 +153,13 @@ export interface SearchOptions {
   intent?: string;
   /** Rerank results using LLM (default: true) */
   rerank?: boolean;
+  /**
+   * Run LLM query expansion before search (default: true). Set to false to
+   * search the original query verbatim — useful for non-English corpora
+   * where the expansion model translates the query into English and
+   * degrades vector recall.
+   */
+  expand?: boolean;
   /** Filter to a specific collection */
   collection?: string;
   /** Filter to specific collections */
@@ -391,6 +398,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
         ...(opts.collections ?? []),
       ];
       const skipRerank = opts.rerank === false;
+      const skipExpansion = opts.expand === false;
 
       if (opts.queries) {
         // Pre-expanded queries — use structuredSearch
@@ -413,6 +421,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
         explain: opts.explain,
         intent: opts.intent,
         skipRerank,
+        skipExpansion,
         chunkStrategy: opts.chunkStrategy,
       });
     },

--- a/src/store.ts
+++ b/src/store.ts
@@ -3965,6 +3965,7 @@ export interface HybridQueryOptions {
   explain?: boolean;        // include backend/RRF/rerank score traces
   intent?: string;          // domain intent hint for disambiguation
   skipRerank?: boolean;     // skip LLM reranking, use only RRF scores
+  skipExpansion?: boolean;  // skip LLM query expansion (preserve original wording)
   chunkStrategy?: ChunkStrategy;
   hooks?: SearchHooks;
 }
@@ -4013,6 +4014,7 @@ export async function hybridQuery(
   const explain = options?.explain ?? false;
   const intent = options?.intent;
   const skipRerank = options?.skipRerank ?? false;
+  const skipExpansion = options?.skipExpansion ?? false;
   const hooks = options?.hooks;
 
   const rankedLists: RankedResult[][] = [];
@@ -4036,14 +4038,20 @@ export async function hybridQuery(
 
   if (hasStrongSignal) hooks?.onStrongSignal?.(topScore);
 
-  // Step 2: Expand query (or skip if strong signal)
-  hooks?.onExpandStart?.();
-  const expandStart = Date.now();
-  const expanded = hasStrongSignal
-    ? []
-    : await store.expandQuery(query, undefined, intent);
-
-  hooks?.onExpand?.(query, expanded, Date.now() - expandStart);
+  // Step 2: Expand query. Skipped entirely on caller request (preserves
+  // non-English wording), or short-circuited when a strong BM25 signal
+  // makes LLM expansion not worth the latency.
+  let expanded: ExpandedQuery[] = [];
+  let expandElapsed = 0;
+  if (!skipExpansion) {
+    hooks?.onExpandStart?.();
+    const expandStart = Date.now();
+    expanded = hasStrongSignal
+      ? []
+      : await store.expandQuery(query, undefined, intent);
+    expandElapsed = Date.now() - expandStart;
+  }
+  hooks?.onExpand?.(query, expanded, expandElapsed);
 
   // Seed with initial FTS results (avoid re-running original query FTS)
   if (initialFts.length > 0) {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -233,6 +233,8 @@ describe("CLI Help", () => {
     expect(stdout).toContain("qmd collection add");
     expect(stdout).toContain("qmd search");
     expect(stdout).toContain("qmd skill show/install");
+    expect(stdout).toContain("--no-rerank");
+    expect(stdout).toContain("--no-expand");
   });
 
   test("shows help with no arguments", async () => {


### PR DESCRIPTION
#454

## Summary

Add a `--no-expand` flag to `qmd query` that skips LLM query expansion and searches the original query verbatim.

## Motivation

The built-in query expansion model (`qmd-query-expansion-1.7B`) is trained primarily on English. Given a non-English query — Chinese, Japanese, Korean — it translates the query into English before generating lex/vec/hyde variants. The vector search downstream then runs against English-translated text, and on a non-English corpus recall drops sharply.

A typed-query path (`{ type: 'lex', query: ... }` via SDK or MCP) bypasses expansion already, but for the simple ergonomic `qmd query "..."` CLI path there was no escape hatch. This PR adds one.

## Changes

- `qmd query --no-expand` skips expansion entirely and searches the original query verbatim. Mirrors `--no-rerank`.
- SDK: `search({ query, expand: false })` — analogous to the existing `rerank: false`.
- `HybridQueryOptions.skipExpansion` plumbs through to `hybridQuery()`. When set, `expandQuery()` is not called and the lex/vec/hyde fan-out is empty — only the original query runs against BM25 and the vector index.
- CLI hook output emits a single `Expansion disabled (--no-expand)` line on stderr so users see the flag took effect, instead of the misleading "Expanding query..." line.
- MCP `query` tool already takes pre-expanded `searches`, so expansion is structurally absent there. No MCP changes needed.

## Usage

```sh
# Skip expansion for non-English queries
qmd query "テレグラム 設定" --no-expand

# Same effect via SDK
const results = await store.search({ query: "テレグラム 設定", expand: false })
```

## Notes

- Default behavior is unchanged when `--no-expand` is absent (or `expand` is unset / `true`).
- Strong-BM25-signal short-circuit still works on the default path; `--no-expand` just makes the bypass unconditional.
- Pairs naturally with `--no-rerank` for the lowest-latency CPU path: `qmd query "..." --no-expand --no-rerank` runs only BM25 + vector + RRF, no LLM calls.
