### PR TITLE
feat: configurable FTS5 tokenizer via QMD_FTS_TOKENIZER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Changes
+
+- `QMD_FTS_TOKENIZER` env var lets you swap the FTS5 tokenizer used for
+  `documents_fts`. Defaults to the existing `porter unicode61`. Set to
+  `trigram` to make BM25 usable on CJK / mixed-language corpora —
+  `unicode61` splits on whitespace and indexes whole CJK sentences as a
+  single token, so substring queries return zero hits. Allowed values:
+  `porter unicode61`, `porter ascii`, `unicode61`, `ascii`, `trigram`.
+  Only affects newly created indexes; existing databases need a rebuild.
+
 ### Fixes
 
 - GPU: respect explicit `QMD_LLAMA_GPU=metal|vulkan|cuda` backend overrides instead of always using auto GPU selection. #529

--- a/README.md
+++ b/README.md
@@ -797,6 +797,7 @@ llm_cache       -- Cached LLM responses (query expansion, rerank scores)
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `XDG_CACHE_HOME` | `~/.cache` | Cache directory location |
+| `QMD_FTS_TOKENIZER` | `porter unicode61` | FTS5 tokenizer for `documents_fts`. Set to `trigram` for usable BM25 on CJK / mixed-language corpora — `unicode61` splits on whitespace and indexes whole CJK sentences as a single token, so substring queries return zero hits. Allowed values: `porter unicode61`, `porter ascii`, `unicode61`, `ascii`, `trigram`. Only affects newly created indexes — existing databases need a rebuild (delete `~/.cache/qmd/index.sqlite`, then re-index) for the change to take effect. |
 
 ## How It Works
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -703,6 +703,43 @@ export function toVirtualPath(db: Database, absolutePath: string): string | null
 // Database initialization
 // =============================================================================
 
+const DEFAULT_FTS_TOKENIZER = "porter unicode61";
+
+// FTS5 tokenizer values that are safe to interpolate into the CREATE VIRTUAL
+// TABLE statement. Built-in SQLite FTS5 tokenizers only — extension-loaded
+// tokenizers (e.g. via QMD_FTS_EXTENSION) are not validated here.
+const ALLOWED_FTS_TOKENIZERS: ReadonlySet<string> = new Set([
+  "porter unicode61",
+  "porter ascii",
+  "unicode61",
+  "ascii",
+  "trigram",
+]);
+
+/**
+ * Resolve the FTS5 tokenizer to use for documents_fts.
+ *
+ * Defaults to "porter unicode61" (English-tuned). Set QMD_FTS_TOKENIZER to
+ * "trigram" for usable BM25 on CJK / mixed-language corpora — unicode61
+ * splits on Unicode whitespace, which leaves CJK content as a single token
+ * per sentence.
+ *
+ * Changing this value only affects newly created documents_fts tables.
+ * Existing indexes must be rebuilt (drop the database file or run
+ * `qmd embed -f` after deleting the FTS table) for the change to take
+ * effect.
+ */
+export function getFtsTokenizer(): string {
+  const value = process.env.QMD_FTS_TOKENIZER?.trim();
+  if (!value) return DEFAULT_FTS_TOKENIZER;
+  if (!ALLOWED_FTS_TOKENIZERS.has(value)) {
+    throw new Error(
+      `Invalid QMD_FTS_TOKENIZER value: "${value}". ` +
+      `Allowed: ${[...ALLOWED_FTS_TOKENIZERS].map(t => `"${t}"`).join(", ")}.`
+    );
+  }
+  return value;
+}
 
 function createSqliteVecUnavailableError(reason: string): Error {
   return new Error(
@@ -831,12 +868,15 @@ function initializeDatabase(db: Database): void {
   `);
 
   // FTS - index filepath (collection/path), title, and content
-  db.exec(`
+  // tokenize is interpolated from a strict whitelist (see getFtsTokenizer)
+  const tokenizer = getFtsTokenizer();
+  const createFtsSql = `
     CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(
       filepath, title, body,
-      tokenize='porter unicode61'
+      tokenize='${tokenizer}'
     )
-  `);
+  `;
+  db.exec(createFtsSql);
 
   // Triggers to keep FTS in sync
   db.exec(`

--- a/test/store.helpers.unit.test.ts
+++ b/test/store.helpers.unit.test.ts
@@ -18,6 +18,7 @@ import {
   handelize,
   cleanupOrphanedVectors,
   sanitizeFTS5Term,
+  getFtsTokenizer,
 } from "../src/store";
 
 // =============================================================================
@@ -285,5 +286,69 @@ describe("sanitizeFTS5Term", () => {
   test("handles unicode letters and numbers", () => {
     expect(sanitizeFTS5Term("café")).toBe("café");
     expect(sanitizeFTS5Term("日本語")).toBe("日本語");
+  });
+});
+
+// =============================================================================
+// FTS Tokenizer Selection
+// =============================================================================
+
+describe("getFtsTokenizer", () => {
+  const ENV_KEY = "QMD_FTS_TOKENIZER";
+
+  function withEnv(value: string | undefined, fn: () => void): void {
+    const prev = process.env[ENV_KEY];
+    if (value === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = value;
+    }
+    try {
+      fn();
+    } finally {
+      if (prev === undefined) {
+        delete process.env[ENV_KEY];
+      } else {
+        process.env[ENV_KEY] = prev;
+      }
+    }
+  }
+
+  test("returns the porter unicode61 default when the env var is unset", () => {
+    withEnv(undefined, () => {
+      expect(getFtsTokenizer()).toBe("porter unicode61");
+    });
+  });
+
+  test("returns the porter unicode61 default when the env var is empty", () => {
+    withEnv("", () => {
+      expect(getFtsTokenizer()).toBe("porter unicode61");
+    });
+  });
+
+  test("trims surrounding whitespace before validating", () => {
+    withEnv("  trigram  ", () => {
+      expect(getFtsTokenizer()).toBe("trigram");
+    });
+  });
+
+  test("accepts each whitelisted tokenizer", () => {
+    for (const tokenizer of ["porter unicode61", "porter ascii", "unicode61", "ascii", "trigram"]) {
+      withEnv(tokenizer, () => {
+        expect(getFtsTokenizer()).toBe(tokenizer);
+      });
+    }
+  });
+
+  test("rejects unknown values", () => {
+    withEnv("icu", () => {
+      expect(() => getFtsTokenizer()).toThrow(/Invalid QMD_FTS_TOKENIZER/);
+    });
+  });
+
+  test("rejects values that try to inject extra SQL", () => {
+    withEnv("trigram') --", () => {
+      expect(() => getFtsTokenizer()).toThrow(/Invalid QMD_FTS_TOKENIZER/);
+    });
   });
 });


### PR DESCRIPTION
#617

## Summary

Add a `QMD_FTS_TOKENIZER` env var that lets users swap the FTS5 tokenizer used for `documents_fts`.

The default (`porter unicode61`) is English-tuned. On CJK / mixed-language corpora `unicode61` only splits on Unicode whitespace, so a whole CJK sentence becomes one token and substring queries return zero hits. That silently degrades hybrid retrieval (BM25 ⊕ vector ⊕ rerank) to vector-only — and Reciprocal Rank Fusion still mixes in the useless BM25 ranking, which can actively hurt the final ordering.

## Changes

- `getFtsTokenizer()` resolves `QMD_FTS_TOKENIZER` against a whitelist of FTS5 built-in tokenizers and returns the value to interpolate.
- `documents_fts` is created using that resolved tokenizer instead of the hardcoded literal.
- Whitelist: `porter unicode61` (default), `porter ascii`, `unicode61`, `ascii`, `trigram`. Anything else throws — keeps the env var safe to interpolate into the CREATE VIRTUAL TABLE statement.
- Documented in README env var table and CHANGELOG.

## Recommended setup for CJK / multilingual users

```sh
export QMD_FTS_TOKENIZER=trigram
# delete the existing index and re-run qmd update / qmd embed
rm ~/.cache/qmd/index.sqlite
```

`trigram` generates 3-char overlapping ngrams, which works for CJK *and* Latin queries ≥ 3 chars. Trade-offs: loses Porter stemming, minimum query length 3 chars, ~2-3× index growth.

## Notes

- `CREATE VIRTUAL TABLE IF NOT EXISTS` means the env var only affects newly created indexes — existing DBs need a rebuild for the new tokenizer to take effect. README and CHANGELOG call this out.
- `sanitizeFTS5Term` in `src/store.ts` is already Unicode-aware (`\p{L}\p{N}'_`), so CJK content survives the sanitizer end-to-end. No query-builder changes needed.
- Default behavior is unchanged when `QMD_FTS_TOKENIZER` is unset — fully backward-compatible.
