### PR TITLE
fix(embed): use config.models.embed from index.yml when set

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -3120,7 +3120,8 @@ if (isMain) {
         const maxDocsPerBatch = parseEmbedBatchOption("maxDocsPerBatch", cli.values["max-docs-per-batch"]);
         const maxBatchMb = parseEmbedBatchOption("maxBatchBytes", cli.values["max-batch-mb"]);
         const embedChunkStrategy = parseChunkStrategy(cli.values["chunk-strategy"]);
-        await vectorIndex(DEFAULT_EMBED_MODEL_URI, !!cli.values.force, {
+        const embedConfig = (() => { try { return loadConfig(); } catch { return {}; } })();
+        await vectorIndex(embedConfig?.models?.embed ?? DEFAULT_EMBED_MODEL_URI, !!cli.values.force, {
           maxDocsPerBatch,
           maxBatchBytes: maxBatchMb === undefined ? undefined : maxBatchMb * 1024 * 1024,
           chunkStrategy: embedChunkStrategy,

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -464,10 +464,14 @@ async function showStatus(): Promise<void> {
       const match = uri.match(/^hf:([^/]+\/[^/]+)\//);
       return match ? `https://huggingface.co/${match[1]}` : uri;
     };
+    const statusConfig = (() => { try { return loadConfig(); } catch { return {}; } })();
+    const activeEmbedModel = statusConfig?.models?.embed ?? DEFAULT_EMBED_MODEL_URI;
+    const activeRerankModel = statusConfig?.models?.rerank ?? DEFAULT_RERANK_MODEL_URI;
+    const activeGenerateModel = statusConfig?.models?.generate ?? DEFAULT_GENERATE_MODEL_URI;
     console.log(`\n${c.bold}Models${c.reset}`);
-    console.log(`  Embedding:   ${hfLink(DEFAULT_EMBED_MODEL_URI)}`);
-    console.log(`  Reranking:   ${hfLink(DEFAULT_RERANK_MODEL_URI)}`);
-    console.log(`  Generation:  ${hfLink(DEFAULT_GENERATE_MODEL_URI)}`);
+    console.log(`  Embedding:   ${hfLink(activeEmbedModel)}`);
+    console.log(`  Reranking:   ${hfLink(activeRerankModel)}`);
+    console.log(`  Generation:  ${hfLink(activeGenerateModel)}`);
   }
 
   // Device / GPU info


### PR DESCRIPTION
## Problem
`qmd embed` hardcodes `DEFAULT_EMBED_MODEL_URI` instead of reading
the configured embed model from `index.yml`. The same issue affects
reranking and generation — `DEFAULT_RERANK_MODEL_URI` and
`DEFAULT_GENERATE_MODEL_URI` are always used regardless of what is
configured via `models.rerank` and `models.generate` in `index.yml`.
Users who configure custom models see them silently ignored.

## Fix
Load config and prefer the configured model over the default when set,
falling back gracefully if config can't be loaded. Applied to `embed`,
`rerank`, and `generate`.

## Testing
Configured local models in `index.yml`:

```yaml
models:
  embed: "/path/to/bge-m3-FP16.gguf"
  rerank: "/path/to/qwen3-reranker.gguf"
  generate: "/path/to/qmd-query-expansion.gguf"
```

Before fix: `qmd embed` used embeddinggemma regardless.
After fix: `qmd embed` correctly uses the configured model.

## Also fixes
`qmd status` was hardcoding `DEFAULT_EMBED_MODEL_URI`, `DEFAULT_RERANK_MODEL_URI`,
and `DEFAULT_GENERATE_MODEL_URI` in the Models section regardless of what was
configured in `index.yml`. Status now shows the actual active models from config
for embed, rerank, and generate, falling back to defaults when not set.