### PR TITLE
Wire `--context` flag through to query expansion

### DIFF
--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -2340,6 +2340,7 @@ function parseCLI() {
     all: isAll,
     collection: values.collection as string | undefined,
     lineNumbers: !!values["line-numbers"],
+    context: values.context as string | undefined,
   };
 
   return {


### PR DESCRIPTION
The `--context` flag is parsed by `parseCLI()` (declared in the `parseArgs` options block) but never assigned to the `opts` object passed downstream. As a result, `qmd query --context "..."` accepts the flag silently and has zero effect on query expansion or the HyDE prompt — `expandQueryStructured(query, true, opts.context)` always receives `undefined`.

This patch adds the missing one-line wiring inside the `opts` literal in `parseCLI()`:

```ts
context: values.context as string | undefined,
```

### Verification

Smoke-tested on Bun 1.3.13 against a local collection:

- **Without `--context`**: HyDE expansion is generic ("psychological description of fear and anxiety…").
- **With** `--context "in the Joe Hudson AoA podcast, fear and anxiety often refer to vulnerability, what wants to be felt, or unprocessed grief"`: HyDE expansion is corpus-aware ("In the Joe Hudson AoA podcast, fear and anxiety are often discussed in the context of…"), top result shifts, downstream rerank ordering changes meaningfully.

### Notes

- No behavior change when `--context` is omitted (`values.context` is `undefined`, threads through as `undefined`, no-op in `expandQueryStructured`).
- Adjacent recent work on the query path (`intent` parameter, `--no-expand` PR #622) suggested the maintainer is iterating in this area — happy to rebase if needed.