### PR TITLE
feat(mcp): add update and embed tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- MCP tools `update` and `embed` for re-indexing and embedding via the MCP server.
+  - `update` accepts optional `collection` and `runUpdateCommand` parameters.
+  - `embed` accepts optional `force` parameter for full re-embedding.
+
 ### Fixes
 
 - GPU: respect explicit `QMD_LLAMA_GPU=metal|vulkan|cuda` backend overrides instead of always using auto GPU selection. #529

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ qmd query <query>                 # Search with query expansion + reranking (rec
 qmd search <query>                # Full-text keyword search (BM25, no LLM)
 qmd vsearch <query>               # Vector similarity search (no reranking)
 qmd mcp                           # Start MCP server (stdio transport)
+                                  # MCP tools: query, get, multi_get, status, update, embed
 qmd mcp --http [--port N]         # Start MCP server (HTTP, default port 8181)
 qmd mcp --http --daemon           # Start as background daemon
 qmd mcp stop                      # Stop background MCP daemon

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -984,6 +984,10 @@ export async function startMcpHttpServer(port: number, options?: { quiet?: boole
  * Run a shell command in `cwd`. Resolves on exit code 0; rejects otherwise.
  * Used by the MCP `update` tool when the caller opts into running the
  * configured update_command (e.g. `git pull`).
+ *
+ * Security: `cmd` originates from the user-owned YAML config
+ * (`collections[].update`). It is treated as trusted input. Never pass
+ * untrusted strings here — they would execute as shell commands via `sh -c`.
  */
 function runShellCommand(cmd: string, cwd: string): Promise<void> {
   return new Promise((resolve, reject) => {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -644,8 +644,27 @@ Intent-aware lex (C++ performance, not sports):
         ),
       },
     },
-    async () => {
-      throw new Error("embed: not implemented");
+    async ({ force }) => {
+      const useForce = force === true;
+      const result = await generateEmbeddings(store.internal, { force: useForce });
+
+      const summary = [
+        `Embed: ${result.chunksEmbedded} chunks across ${result.docsProcessed} doc(s)`,
+        result.errors > 0 ? `  errors: ${result.errors}` : null,
+        `  durationMs: ${result.durationMs}`,
+        useForce ? `  (force: regenerated all embeddings)` : null,
+      ].filter(Boolean).join("\n");
+
+      return {
+        content: [{ type: "text", text: summary }],
+        structuredContent: {
+          chunksEmbedded: result.chunksEmbedded,
+          docsEmbedded: result.docsProcessed,
+          errors: result.errors,
+          durationMs: result.durationMs,
+          force: useForce,
+        },
+      };
     }
   );
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -29,8 +29,9 @@ import {
   type ExpandedQuery,
   type IndexStatus,
 } from "../index.js";
-import { getConfigPath } from "../collections.js";
-import { enableProductionMode } from "../store.js";
+import { getConfigPath, getCollection as getCollectionFromYaml } from "../collections.js";
+import { enableProductionMode, reindexCollection, generateEmbeddings, listCollections } from "../store.js";
+import { spawn } from "node:child_process";
 
 // =============================================================================
 // Types for structured content
@@ -528,6 +529,53 @@ Intent-aware lex (C++ performance, not sports):
         content: [{ type: "text", text: summary.join('\n') }],
         structuredContent: status,
       };
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Tool: update (Re-index collection(s))
+  // ---------------------------------------------------------------------------
+
+  server.registerTool(
+    "update",
+    {
+      title: "Update Index",
+      description:
+        "Re-index markdown files in one or all collections. Updates the FTS5 index, document table, and cleans up orphaned content. Returns counts per collection.",
+      annotations: { readOnlyHint: false, idempotentHint: true, openWorldHint: false },
+      inputSchema: {
+        collection: z.string().optional().describe(
+          "Collection name to re-index. Omit to re-index all collections."
+        ),
+        runUpdateCommand: z.boolean().optional().describe(
+          "Run the configured update_command (e.g. 'git pull') before indexing each collection. Default: false."
+        ),
+      },
+    },
+    async () => {
+      throw new Error("update: not implemented");
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Tool: embed (Generate vector embeddings)
+  // ---------------------------------------------------------------------------
+
+  server.registerTool(
+    "embed",
+    {
+      title: "Generate Embeddings",
+      description:
+        "Generate vector embeddings for documents that don't yet have them. Default: incremental. Set force=true to wipe and regenerate all embeddings (long-running).",
+      annotations: { readOnlyHint: false, idempotentHint: true, openWorldHint: false },
+      inputSchema: {
+        force: z.boolean().optional().describe(
+          "Wipe all existing embeddings and regenerate from scratch. Long-running. Default: false."
+        ),
+      },
+    },
+    async () => {
+      throw new Error("embed: not implemented");
     }
   );
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -130,10 +130,10 @@ async function buildInstructions(store: QMDStore): Promise<string> {
   // --- Capability gaps ---
   if (!status.hasVectorIndex) {
     lines.push("");
-    lines.push("Note: No vector embeddings yet. Run `qmd embed` to enable semantic search (vec/hyde).");
+    lines.push("Note: No vector embeddings yet. Call the `embed` tool to enable semantic search (vec/hyde).");
   } else if (status.needsEmbedding > 0) {
     lines.push("");
-    lines.push(`Note: ${status.needsEmbedding} documents need embedding. Run \`qmd embed\` to update.`);
+    lines.push(`Note: ${status.needsEmbedding} documents need embedding. Call the \`embed\` tool to update.`);
   }
 
   // --- Search tool ---
@@ -156,6 +156,11 @@ async function buildInstructions(store: QMDStore): Promise<string> {
   lines.push("Retrieval:");
   lines.push("  - `get` — single document by path or docid (#abc123). Supports line offset (`file.md:100`).");
   lines.push("  - `multi_get` — batch retrieve by glob (`journals/2025-05*.md`) or comma-separated list.");
+
+  lines.push("");
+  lines.push("Maintenance:");
+  lines.push("  - `update` — re-index collection(s) (optionally per-collection via `collection` param)");
+  lines.push("  - `embed`  — generate vector embeddings for documents that need them");
 
   // --- Non-obvious things that prevent mistakes ---
   lines.push("");

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -552,8 +552,78 @@ Intent-aware lex (C++ performance, not sports):
         ),
       },
     },
-    async () => {
-      throw new Error("update: not implemented");
+    async ({ collection, runUpdateCommand }) => {
+      const allCols = listCollections(store.internal.db);
+      const targets = collection
+        ? allCols.filter(c => c.name === collection)
+        : allCols;
+
+      if (collection && targets.length === 0) {
+        throw new Error(`Collection not found: ${collection}`);
+      }
+
+      type UpdateRow = {
+        name: string;
+        indexed: number;
+        updated: number;
+        unchanged: number;
+        removed: number;
+        orphanedCleaned: number;
+        durationMs: number;
+        skipped?: { reason: string; error: string };
+      };
+
+      const results: UpdateRow[] = [];
+
+      for (const col of targets) {
+        const start = Date.now();
+        const yamlCol = getCollectionFromYaml(col.name);
+
+        if (runUpdateCommand && yamlCol?.update) {
+          try {
+            await runShellCommand(yamlCol.update, col.pwd);
+          } catch (err) {
+            results.push({
+              name: col.name,
+              indexed: 0, updated: 0, unchanged: 0, removed: 0, orphanedCleaned: 0,
+              durationMs: Date.now() - start,
+              skipped: { reason: "update-command-failed", error: String(err) },
+            });
+            continue;
+          }
+        }
+
+        const r = await reindexCollection(store.internal, col.pwd, col.glob_pattern, col.name, {
+          ignorePatterns: yamlCol?.ignore,
+        });
+
+        results.push({
+          name: col.name,
+          indexed: r.indexed,
+          updated: r.updated,
+          unchanged: r.unchanged,
+          removed: r.removed,
+          orphanedCleaned: r.orphanedCleaned,
+          durationMs: Date.now() - start,
+        });
+      }
+
+      const status = await store.getStatus();
+
+      const summary = [
+        `Updated ${results.length} collection(s):`,
+        ...results.map(r =>
+          r.skipped
+            ? `  - ${r.name}: skipped (${r.skipped.reason})`
+            : `  - ${r.name}: ${r.indexed} new, ${r.updated} updated, ${r.unchanged} unchanged, ${r.removed} removed`
+        ),
+        `Needs embedding: ${status.needsEmbedding}`,
+      ].join("\n");
+
+      return {
+        content: [{ type: "text", text: summary }],
+        structuredContent: { collections: results, needsEmbedding: status.needsEmbedding },
+      };
     }
   );
 
@@ -884,6 +954,22 @@ export async function startMcpHttpServer(port: number, options?: { quiet?: boole
 
   log(`QMD MCP server listening on http://localhost:${actualPort}/mcp`);
   return { httpServer, port: actualPort, stop };
+}
+
+/**
+ * Run a shell command in `cwd`. Resolves on exit code 0; rejects otherwise.
+ * Used by the MCP `update` tool when the caller opts into running the
+ * configured update_command (e.g. `git pull`).
+ */
+function runShellCommand(cmd: string, cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("sh", ["-c", cmd], { cwd, stdio: "ignore" });
+    child.on("error", reject);
+    child.on("exit", code => {
+      if (code === 0) resolve();
+      else reject(new Error(`command exited with code ${code}`));
+    });
+  });
 }
 
 // Run if this is the main module

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1039,6 +1039,8 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
     expect(toolNames).toContain("query");
     expect(toolNames).toContain("get");
     expect(toolNames).toContain("status");
+    expect(toolNames).toContain("update");
+    expect(toolNames).toContain("embed");
   });
 
   test("POST /mcp tools/call query returns results", async () => {

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1377,5 +1377,35 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport — update/embed", () => {
     expect(sc.force).toBe(false);
   }, 60000);
 
+  test("tools/call embed with force=true regenerates all embeddings", async () => {
+    await initSession();
+
+    // Index documents first so there is something to embed
+    await mcpRequest({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "update", arguments: {} },
+    });
+
+    // Ensure baseline is fully embedded
+    await mcpRequest({
+      jsonrpc: "2.0", id: 3, method: "tools/call",
+      params: { name: "embed", arguments: {} },
+    });
+
+    // Force: clears all vectors and regenerates
+    const { status, json } = await mcpRequest({
+      jsonrpc: "2.0", id: 4, method: "tools/call",
+      params: { name: "embed", arguments: { force: true } },
+    });
+
+    expect(status).toBe(200);
+    expect(json.result.isError).toBeFalsy();
+
+    const sc = json.result.structuredContent;
+    expect(sc.force).toBe(true);
+    expect(sc.chunksEmbedded).toBeGreaterThan(0); // re-embedded everything
+    expect(sc.docsEmbedded).toBeGreaterThan(0);
+  }, 120000);
+
   // tests go here in subsequent tasks
 });

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1212,5 +1212,19 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport — update/embed", () => {
     expect(json.result.structuredContent.collections[0].name).toBe("notes");
   });
 
+  test("tools/call update with unknown collection returns isError", async () => {
+    await initSession();
+
+    const { status, json } = await mcpRequest({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "update", arguments: { collection: "doesnotexist" } },
+    });
+
+    expect(status).toBe(200);
+    // McpServer wraps thrown errors into result.isError = true with content[0].text
+    expect(json.result.isError).toBe(true);
+    expect(json.result.content[0].text).toContain("Collection not found: doesnotexist");
+  });
+
   // tests go here in subsequent tasks
 });

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1226,5 +1226,37 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport — update/embed", () => {
     expect(json.result.content[0].text).toContain("Collection not found: doesnotexist");
   });
 
+  test("tools/call update with runUpdateCommand omitted does NOT execute the configured command", async () => {
+    await initSession();
+
+    const sentinelPath = join(collectionDir, "sentinel-no-run.txt");
+
+    // Configure update_command for "notes" via the YAML config that the running
+    // server is reading. We write a fresh YAML that includes an update command
+    // creating the sentinel, then call update.
+    const cfg: CollectionConfig = {
+      collections: {
+        notes: {
+          path: collectionDir,
+          pattern: "**/*.md",
+          update: `touch ${sentinelPath}`,
+        },
+      },
+    };
+    await writeFile(join(testConfigDir, "index.yml"), YAML.stringify(cfg));
+
+    const { status, json } = await mcpRequest({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "update", arguments: {} }, // no runUpdateCommand
+    });
+
+    expect(status).toBe(200);
+    expect(json.result.isError).toBeFalsy();
+
+    // Sentinel should NOT exist
+    const fs = await import("node:fs");
+    expect(fs.existsSync(sentinelPath)).toBe(false);
+  });
+
   // tests go here in subsequent tasks
 });

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1290,5 +1290,34 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport — update/embed", () => {
     fs.unlinkSync(sentinelPath);
   });
 
+  test("tools/call update with failing update_command marks collection skipped", async () => {
+    await initSession();
+
+    const cfg: CollectionConfig = {
+      collections: {
+        notes: {
+          path: collectionDir,
+          pattern: "**/*.md",
+          update: `false`, // exits with code 1
+        },
+      },
+    };
+    await writeFile(join(testConfigDir, "index.yml"), YAML.stringify(cfg));
+
+    const { status, json } = await mcpRequest({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "update", arguments: { runUpdateCommand: true } },
+    });
+
+    expect(status).toBe(200);
+    expect(json.result.isError).toBeFalsy();
+
+    const sc = json.result.structuredContent;
+    expect(sc.collections).toHaveLength(1);
+    expect(sc.collections[0].name).toBe("notes");
+    expect(sc.collections[0].skipped).toBeDefined();
+    expect(sc.collections[0].skipped.reason).toBe("update-command-failed");
+  });
+
   // tests go here in subsequent tasks
 });

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1319,5 +1319,38 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport — update/embed", () => {
     expect(sc.collections[0].skipped.reason).toBe("update-command-failed");
   });
 
+  test("tools/call embed embeds pending documents", async () => {
+    await initSession();
+
+    // Make sure documents are indexed first (creates rows that need embeddings)
+    await mcpRequest({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "update", arguments: {} },
+    });
+
+    // Reset YAML to plain (no update_command) for cleanliness in subsequent tests
+    const cfg: CollectionConfig = {
+      collections: {
+        notes: { path: collectionDir, pattern: "**/*.md" },
+      },
+    };
+    await writeFile(join(testConfigDir, "index.yml"), YAML.stringify(cfg));
+
+    const { status, json } = await mcpRequest({
+      jsonrpc: "2.0", id: 3, method: "tools/call",
+      params: { name: "embed", arguments: {} },
+    });
+
+    expect(status).toBe(200);
+    expect(json.result.isError).toBeFalsy();
+
+    const sc = json.result.structuredContent;
+    expect(sc.chunksEmbedded).toBeGreaterThan(0);
+    expect(sc.docsEmbedded).toBeGreaterThan(0);
+    expect(sc.errors).toBe(0);
+    expect(typeof sc.durationMs).toBe("number");
+    expect(sc.force).toBe(false);
+  }, 60000); // longer timeout — real llamacpp embed
+
   // tests go here in subsequent tasks
 });

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1192,5 +1192,25 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport — update/embed", () => {
     expect(typeof sc.needsEmbedding).toBe("number");
   });
 
+  test("tools/call update with collection arg only re-indexes that collection", async () => {
+    await initSession();
+
+    // First, ensure all collections are indexed (no-op for already-indexed)
+    await mcpRequest({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "update", arguments: {} },
+    });
+
+    // Now call update for the single existing collection — should report exactly that one
+    const { status, json } = await mcpRequest({
+      jsonrpc: "2.0", id: 3, method: "tools/call",
+      params: { name: "update", arguments: { collection: "notes" } },
+    });
+
+    expect(status).toBe(200);
+    expect(json.result.structuredContent.collections).toHaveLength(1);
+    expect(json.result.structuredContent.collections[0].name).toBe("notes");
+  });
+
   // tests go here in subsequent tasks
 });

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1077,3 +1077,99 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
     expect(json.result.content.length).toBeGreaterThan(0);
   });
 });
+
+// =============================================================================
+// HTTP Transport — update/embed Tools
+// =============================================================================
+
+describe.skipIf(!!process.env.CI)("MCP HTTP Transport — update/embed", () => {
+  let handle: HttpServerHandle;
+  let baseUrl: string;
+  let testDbPath: string;
+  let testConfigDir: string;
+  let collectionDir: string;
+  const origIndexPath = process.env.INDEX_PATH;
+  const origConfigDir = process.env.QMD_CONFIG_DIR;
+
+  /** Fresh session ID per test — initialize() always runs first. */
+  let sessionId: string | null = null;
+
+  async function mcpRequest(body: object): Promise<{ status: number; json: any }> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "Accept": "application/json, text/event-stream",
+    };
+    if (sessionId) headers["mcp-session-id"] = sessionId;
+
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+    const sid = res.headers.get("mcp-session-id");
+    if (sid) sessionId = sid;
+    const json = await res.json();
+    return { status: res.status, json };
+  }
+
+  async function initSession(): Promise<void> {
+    sessionId = null;
+    await mcpRequest({
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "test", version: "1.0" } },
+    });
+  }
+
+  beforeAll(async () => {
+    // Real on-disk collection directory with markdown files
+    collectionDir = await mkdtemp(join(tmpdir(), `qmd-mcp-update-coll-`));
+    await writeFile(join(collectionDir, "alpha.md"), "# Alpha\n\nFirst test document.\n");
+    await writeFile(join(collectionDir, "beta.md"), "# Beta\n\nSecond test document.\n");
+
+    // Empty database (we re-index from the collection dir, not seed data)
+    testDbPath = `/tmp/qmd-mcp-update-test-${Date.now()}.sqlite`;
+    const db = openDatabase(testDbPath);
+    initTestDatabase(db);
+
+    const config: CollectionConfig = {
+      collections: {
+        notes: {
+          path: collectionDir,
+          pattern: "**/*.md",
+        },
+      },
+    };
+    syncConfigToDb(db, config);
+    db.close();
+
+    testConfigDir = await mkdtemp(join(tmpdir(), `qmd-mcp-update-config-`));
+    await writeFile(join(testConfigDir, "index.yml"), YAML.stringify(config));
+
+    process.env.INDEX_PATH = testDbPath;
+    process.env.QMD_CONFIG_DIR = testConfigDir;
+
+    handle = await startMcpHttpServer(0, { quiet: true });
+    baseUrl = `http://localhost:${handle.port}`;
+  });
+
+  afterAll(async () => {
+    await handle.stop();
+
+    if (origIndexPath !== undefined) process.env.INDEX_PATH = origIndexPath;
+    else delete process.env.INDEX_PATH;
+    if (origConfigDir !== undefined) process.env.QMD_CONFIG_DIR = origConfigDir;
+    else delete process.env.QMD_CONFIG_DIR;
+
+    try { unlinkSync(testDbPath); } catch {}
+    for (const dir of [testConfigDir, collectionDir]) {
+      try {
+        const files = await readdir(dir);
+        for (const f of files) await unlink(join(dir, f));
+        await rmdir(dir);
+      } catch {}
+    }
+  });
+
+  // tests go here in subsequent tasks
+  test.todo("update/embed tests — implemented in subsequent tasks");
+});

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1258,5 +1258,37 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport — update/embed", () => {
     expect(fs.existsSync(sentinelPath)).toBe(false);
   });
 
+  test("tools/call update with runUpdateCommand=true executes configured command", async () => {
+    await initSession();
+
+    const sentinelPath = join(collectionDir, "sentinel-with-run.txt");
+
+    const cfg: CollectionConfig = {
+      collections: {
+        notes: {
+          path: collectionDir,
+          pattern: "**/*.md",
+          update: `touch ${sentinelPath}`,
+        },
+      },
+    };
+    await writeFile(join(testConfigDir, "index.yml"), YAML.stringify(cfg));
+
+    const { status, json } = await mcpRequest({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "update", arguments: { runUpdateCommand: true } },
+    });
+
+    expect(status).toBe(200);
+    expect(json.result.isError).toBeFalsy();
+    expect(json.result.structuredContent.collections[0].skipped).toBeUndefined();
+
+    const fs = await import("node:fs");
+    expect(fs.existsSync(sentinelPath)).toBe(true);
+
+    // Cleanup so it doesn't pollute the next test
+    fs.unlinkSync(sentinelPath);
+  });
+
   // tests go here in subsequent tasks
 });

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1126,10 +1126,9 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport — update/embed", () => {
     await writeFile(join(collectionDir, "alpha.md"), "# Alpha\n\nFirst test document.\n");
     await writeFile(join(collectionDir, "beta.md"), "# Beta\n\nSecond test document.\n");
 
-    // Empty database (we re-index from the collection dir, not seed data)
+    // Write YAML config — startMcpHttpServer will create the DB with the correct
+    // schema via createStore({ configPath }) and sync the collection from YAML.
     testDbPath = `/tmp/qmd-mcp-update-test-${Date.now()}.sqlite`;
-    const db = openDatabase(testDbPath);
-    initTestDatabase(db);
 
     const config: CollectionConfig = {
       collections: {
@@ -1139,8 +1138,6 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport — update/embed", () => {
         },
       },
     };
-    syncConfigToDb(db, config);
-    db.close();
 
     testConfigDir = await mkdtemp(join(tmpdir(), `qmd-mcp-update-config-`));
     await writeFile(join(testConfigDir, "index.yml"), YAML.stringify(config));
@@ -1170,6 +1167,30 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport — update/embed", () => {
     }
   });
 
+  test("tools/call update with no args re-indexes all collections", async () => {
+    await initSession();
+
+    const { status, json } = await mcpRequest({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "update", arguments: {} },
+    });
+
+    expect(status).toBe(200);
+    expect(json.result).toBeDefined();
+    expect(json.result.isError).toBeFalsy();
+    expect(json.result.structuredContent).toBeDefined();
+
+    const sc = json.result.structuredContent;
+    expect(Array.isArray(sc.collections)).toBe(true);
+    expect(sc.collections).toHaveLength(1);
+    expect(sc.collections[0].name).toBe("notes");
+    expect(sc.collections[0].indexed).toBe(2); // alpha.md + beta.md
+    expect(sc.collections[0].updated).toBe(0);
+    expect(sc.collections[0].unchanged).toBe(0);
+    expect(sc.collections[0].removed).toBe(0);
+    expect(typeof sc.collections[0].durationMs).toBe("number");
+    expect(typeof sc.needsEmbedding).toBe("number");
+  });
+
   // tests go here in subsequent tasks
-  test.todo("update/embed tests — implemented in subsequent tasks");
 });

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1352,5 +1352,30 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport — update/embed", () => {
     expect(sc.force).toBe(false);
   }, 60000); // longer timeout — real llamacpp embed
 
+  test("tools/call embed with nothing pending returns zero counts", async () => {
+    await initSession();
+
+    // Run embed once to make sure everything is embedded
+    await mcpRequest({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "embed", arguments: {} },
+    });
+
+    // Second call — nothing pending now
+    const { status, json } = await mcpRequest({
+      jsonrpc: "2.0", id: 3, method: "tools/call",
+      params: { name: "embed", arguments: {} },
+    });
+
+    expect(status).toBe(200);
+    expect(json.result.isError).toBeFalsy();
+
+    const sc = json.result.structuredContent;
+    expect(sc.chunksEmbedded).toBe(0);
+    expect(sc.docsEmbedded).toBe(0);
+    expect(sc.errors).toBe(0);
+    expect(sc.force).toBe(false);
+  }, 60000);
+
   // tests go here in subsequent tasks
 });


### PR DESCRIPTION
## Summary

- New MCP tools `update` and `embed` so an agent can re-index collections and generate vector embeddings without shelling out to the CLI.
- `update` accepts optional `collection` (scope to one) and `runUpdateCommand` (opt-in `git pull` etc.); failing update_command marks that collection skipped and continues.
- `embed` is incremental by default; opt-in `force: true` wipes and regenerates all vectors.
- `buildInstructions` updated: existing `qmd embed` CLI hints replaced with tool-style `Call the \`embed\` tool` plus a new "Maintenance:" tool list.

## Implementation notes

- Both handlers reuse the existing pure-logic functions `reindexCollection` and `generateEmbeddings` from `src/store.ts` via `store.internal`.
- Synchronous return only, no MCP `progressNotification` — the agent flow is short by design.
- `EmbedResult.docsProcessed` is mapped to `docsEmbedded` at the tool boundary so the public MCP shape is stable independent of the internal field name.
- `runShellCommand` (private helper) executes the YAML-configured update_command via `sh -c`. Documented as trusted-source-only.

## Test plan

- [x] `npx vitest run test/mcp.test.ts` — 65/65 passing.
- [x] Manual end-to-end through Claude Code (`qmd-feat` MCP server registered locally):
  - [x] `tools/list` shows `update` and `embed` alongside existing tools.
  - [x] `update` with no args re-indexed `myrag` (2 new, 5 updated, 454 unchanged, 5 orphaned cleaned, 133ms; surfaced `needsEmbedding: 7`).
  - [x] `embed` with no args embedded the 7 pending docs (120 chunks, 0 errors, 14.2s, force=false).
- [ ] Reviewer: spot-check `runShellCommand` security note (`src/mcp/server.ts`, JSDoc above the helper) — confirm the trusted-source-only wording is acceptable.
- [ ] Reviewer: confirm field-name mapping `docsProcessed` → `docsEmbedded` is acceptable as the public MCP shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)