### PR TITLE
fix(ls): handle collections whose names are absolute paths

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -1303,15 +1303,22 @@ function listFiles(pathArg?: string): void {
     const match = allColls
       .filter(c => normalized === c.name || normalized.startsWith(c.name + '/'))
       .sort((a, b) => b.name.length - a.name.length)[0];
-    if (!match) {
-      console.error(`Collection not found for path: ${pathArg}`);
-      console.error(`Run 'qmd ls' to see available collections.`);
-      closeDb();
-      process.exit(1);
+    if (match) {
+      collectionName = match.name;
+      const rest = normalized.slice(match.name.length).replace(/^\//, '');
+      pathPrefix = rest || null;
+    } else {
+      // Preserve the historical qmd:////collection/path alias behavior for normal
+      // collections when no absolute-path collection matches.
+      const parsed = parseVirtualPath(pathArg);
+      if (!parsed) {
+        console.error(`Invalid virtual path: ${pathArg}`);
+        closeDb();
+        process.exit(1);
+      }
+      collectionName = parsed.collectionName;
+      pathPrefix = parsed.path;
     }
-    collectionName = match.name;
-    const rest = normalized.slice(match.name.length).replace(/^\//, '');
-    pathPrefix = rest || null;
   } else if (afterScheme !== null) {
     // Normal virtual path: qmd://collection-name/path
     const parsed = parseVirtualPath(pathArg);

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -1294,8 +1294,26 @@ function listFiles(pathArg?: string): void {
   let collectionName: string;
   let pathPrefix: string | null = null;
 
-  if (pathArg.startsWith('qmd://')) {
-    // Virtual path format: qmd://collection/path
+  const afterScheme = pathArg.startsWith('qmd://') ? pathArg.slice('qmd://'.length) : null;
+  if (afterScheme !== null && afterScheme.startsWith('/')) {
+    // Absolute-path collection: qmd:///Users/foo/bar — normalizeVirtualPath would corrupt
+    // this by stripping all leading slashes, so bypass parseVirtualPath entirely.
+    const normalized = afterScheme.replace(/\/$/, '');
+    const allColls = yamlListCollections();
+    const match = allColls
+      .filter(c => normalized === c.name || normalized.startsWith(c.name + '/'))
+      .sort((a, b) => b.name.length - a.name.length)[0];
+    if (!match) {
+      console.error(`Collection not found for path: ${pathArg}`);
+      console.error(`Run 'qmd ls' to see available collections.`);
+      closeDb();
+      process.exit(1);
+    }
+    collectionName = match.name;
+    const rest = normalized.slice(match.name.length).replace(/^\//, '');
+    pathPrefix = rest || null;
+  } else if (afterScheme !== null) {
+    // Normal virtual path: qmd://collection-name/path
     const parsed = parseVirtualPath(pathArg);
     if (!parsed) {
       console.error(`Invalid virtual path: ${pathArg}`);
@@ -1304,8 +1322,22 @@ function listFiles(pathArg?: string): void {
     }
     collectionName = parsed.collectionName;
     pathPrefix = parsed.path;
+  } else if (pathArg.startsWith('/')) {
+    // Raw absolute filesystem path — longest-prefix match against collection names
+    const normalized = pathArg.replace(/\/$/, '');
+    const allColls = yamlListCollections();
+    const match = allColls
+      .filter(c => normalized === c.name || normalized.startsWith(c.name + '/'))
+      .sort((a, b) => b.name.length - a.name.length)[0];
+    if (match) {
+      collectionName = match.name;
+      const rest = normalized.slice(match.name.length).replace(/^\//, '');
+      pathPrefix = rest || null;
+    } else {
+      collectionName = normalized;
+    }
   } else {
-    // Just collection name or collection/path
+    // Short collection name or name/path
     const parts = pathArg.split('/');
     collectionName = parts[0] || '';
     if (parts.length > 1) {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -863,6 +863,71 @@ describe("CLI ls Command", () => {
     expect(stdout).toContain("qmd://fixtures/docs/api.md");
   });
 
+  test("continues to normalize extra slashes for normal collection virtual paths", async () => {
+    const { stdout, stderr, exitCode } = await runQmd(["ls", "qmd:///fixtures/docs"], { dbPath: localDbPath });
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("qmd://fixtures/docs/api.md");
+  });
+
+  test("lists an absolute-path collection from a qmd:/// virtual path", async () => {
+    const env = await createIsolatedTestEnv("absolute-qmd-path");
+    const absoluteDir = await mkdtemp(join(tmpdir(), "qmd-absolute-collection-"));
+    await writeFile(join(absoluteDir, "root.md"), "# Absolute collection\n");
+    await writeFile(
+      join(env.configDir, "index.yml"),
+      `collections:\n  "${absoluteDir}":\n    path: "${absoluteDir}"\n    pattern: "**/*.md"\n`
+    );
+
+    const update = await runQmd(["update"], {
+      cwd: absoluteDir,
+      dbPath: env.dbPath,
+      configDir: env.configDir,
+    });
+    expect(update.exitCode).toBe(0);
+
+    const { stdout, stderr, exitCode } = await runQmd(["ls", `qmd://${absoluteDir}/`], {
+      cwd: absoluteDir,
+      dbPath: env.dbPath,
+      configDir: env.configDir,
+    });
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain(`qmd://${absoluteDir}/root.md`);
+  });
+
+  test("lists an absolute-path collection from a raw path using the longest prefix match", async () => {
+    const env = await createIsolatedTestEnv("absolute-raw-path");
+    const parentCollectionName = await mkdtemp(join(tmpdir(), "qmd-absolute-parent-name-"));
+    const childCollectionName = join(parentCollectionName, "nested");
+    const parentDataDir = await mkdtemp(join(tmpdir(), "qmd-absolute-parent-data-"));
+    const childDataDir = await mkdtemp(join(tmpdir(), "qmd-absolute-child-data-"));
+    await writeFile(join(parentDataDir, "parent.md"), "# Parent collection\n");
+    await writeFile(join(childDataDir, "child.md"), "# Child collection\n");
+    await writeFile(
+      join(env.configDir, "index.yml"),
+      `collections:\n  "${parentCollectionName}":\n    path: "${parentDataDir}"\n    pattern: "**/*.md"\n  "${childCollectionName}":\n    path: "${childDataDir}"\n    pattern: "**/*.md"\n`
+    );
+
+    const update = await runQmd(["update"], {
+      cwd: parentDataDir,
+      dbPath: env.dbPath,
+      configDir: env.configDir,
+    });
+    expect(update.exitCode).toBe(0);
+
+    const { stdout, stderr, exitCode } = await runQmd(["ls", `${childCollectionName}/`], {
+      cwd: childDataDir,
+      dbPath: env.dbPath,
+      configDir: env.configDir,
+    });
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain(`qmd://${childCollectionName}/child.md`);
+    expect(stdout).not.toContain("No files found");
+    expect(stdout).not.toContain(`qmd://${parentCollectionName}/parent.md`);
+  });
+
   test("handles non-existent collection", async () => {
     const { stderr, exitCode } = await runQmd(["ls", "nonexistent"], { dbPath: localDbPath });
     expect(exitCode).toBe(1);


### PR DESCRIPTION
## Problem

`qmd ls` fails when a collection's name is an absolute filesystem path (e.g. `/Users/foo/bar`). These collections are created when `qmd collection add <path>` is run without `--name` by an older code path that stored the full path as the collection name.

`qmd ls` (no args) displays them correctly as `qmd:///Users/foo/bar/` (3 slashes), but passing that URI back to `qmd ls <uri>` produces `Collection not found: Users`.

## Root cause

`normalizeVirtualPath` strips **all** leading slashes after `qmd:` and re-adds exactly two:

```
qmd:///Users/foo/bar  →  qmd://Users/foo/bar
```

So `parseVirtualPath` extracts `Users` as the collection name instead of `/Users/foo/bar`.

## Fix

In `listFiles`, detect the absolute-path case **before** calling `parseVirtualPath` by checking whether the portion after `qmd://` starts with `/`. If so, bypass `parseVirtualPath` entirely and resolve the collection via a longest-prefix match against known collection names.

Also added the same matching logic for raw absolute paths passed without the `qmd://` scheme (e.g. `qmd ls /Users/foo/bar/`).

## Test

```sh
# Before: "Collection not found: Users"
# After: lists files correctly
qmd ls "qmd:///Users/foo/bar/"
qmd ls /Users/foo/bar/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)