### PR TITLE
fix: resolve embed model from config in CLI commands

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -463,7 +463,8 @@ async function showStatus(): Promise<void> {
       return match ? `https://huggingface.co/${match[1]}` : uri;
     };
     console.log(`\n${c.bold}Models${c.reset}`);
-    console.log(`  Embedding:   ${hfLink(DEFAULT_EMBED_MODEL_URI)}`);
+    const activeEmbedModel = resolveEmbedModelForCli();
+    console.log(`  Embedding:   ${hfLink(activeEmbedModel)}${activeEmbedModel !== DEFAULT_EMBED_MODEL_URI ? ' (config)' : ''}`);
     console.log(`  Reranking:   ${hfLink(DEFAULT_RERANK_MODEL_URI)}`);
     console.log(`  Generation:  ${hfLink(DEFAULT_GENERATE_MODEL_URI)}`);
   }
@@ -1680,6 +1681,11 @@ function parseChunkStrategy(value: unknown): ChunkStrategy | undefined {
 }
 
 export function resolveEmbedModelForCli(): string {
+  // Resolution order: config > env > default
+  try {
+    const config = loadConfig();
+    if (config.models?.embed) return config.models.embed;
+  } catch { /* config may not exist */ }
   return process.env.QMD_EMBED_MODEL ?? DEFAULT_EMBED_MODEL_URI;
 }
 


### PR DESCRIPTION
## Summary

- `resolveEmbedModelForCli()` only checked the `QMD_EMBED_MODEL` env var before falling back to the hardcoded default (`embeddinggemma-300M`). Setting `models.embed` in `~/.config/qmd/index.yml` had no effect on `qmd embed` or `qmd status`.
- Added config lookup to `resolveEmbedModelForCli()` so the resolution order is: **config > env > default** — matching the priority already implemented in the `LlamaCpp` constructor.
- Updated `showStatus()` to display the resolved model instead of the hardcoded default, with a `(config)` tag when overridden.

## Reproduction

```yaml
# ~/.config/qmd/index.yml
models:
  embed: "hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf"
```

```bash
qmd embed -f
# Before fix: Model: hf:ggml-org/embeddinggemma-300M-GGUF/...
# After fix:  Model: hf:Qwen/Qwen3-Embedding-0.6B-GGUF/...

qmd status
# Before fix: Embedding: https://huggingface.co/ggml-org/embeddinggemma-300M-GGUF
# After fix:  Embedding: https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF (config)
```

## Changes

- `src/cli/qmd.ts`: 7 lines added, 1 line changed
- `resolveEmbedModelForCli()`: added `loadConfig().models?.embed` lookup before env/default fallback
- `showStatus()`: use `resolveEmbedModelForCli()` instead of `DEFAULT_EMBED_MODEL_URI`