### PR TITLE
Forward candidateLimit through search APIs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -159,6 +159,8 @@ export interface SearchOptions {
   collections?: string[];
   /** Max results (default: 10) */
   limit?: number;
+  /** Max candidates to rerank (default: 40) */
+  candidateLimit?: number;
   /** Minimum score threshold */
   minScore?: number;
   /** Include explain traces */
@@ -402,6 +404,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
           minScore: opts.minScore,
           explain: opts.explain,
           intent: opts.intent,
+          candidateLimit: opts.candidateLimit,
           skipRerank,
           chunkStrategy: opts.chunkStrategy,
         });
@@ -414,6 +417,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
         minScore: opts.minScore,
         explain: opts.explain,
         intent: opts.intent,
+        candidateLimit: opts.candidateLimit,
         skipRerank,
         chunkStrategy: opts.chunkStrategy,
       });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -331,6 +331,7 @@ Intent-aware lex (C++ performance, not sports):
         collections: effectiveCollections.length > 0 ? effectiveCollections : undefined,
         limit,
         minScore,
+        candidateLimit,
         rerank,
         intent,
       });
@@ -692,6 +693,7 @@ export async function startMcpHttpServer(
           collections: effectiveCollections.length > 0 ? effectiveCollections : undefined,
           limit: params.limit ?? 10,
           minScore: params.minScore ?? 0,
+          candidateLimit: params.candidateLimit,
           intent: params.intent,
           rerank: params.rerank,
         });

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -614,6 +614,20 @@ describe("search (unified API)", () => {
     expect(results.length).toBeGreaterThan(0);
   });
 
+  test("search() forwards candidateLimit to structured search", async () => {
+    const results = await store.search({
+      queries: [
+        { type: "lex", query: "authentication" },
+        { type: "lex", query: "meeting" },
+      ],
+      limit: 5,
+      candidateLimit: 1,
+      rerank: false,
+    });
+
+    expect(results).toHaveLength(1);
+  });
+
   // Tests below use search({ query: ... }) which triggers LLM query expansion
   describe.skipIf(!!process.env.CI)("with LLM query expansion", () => {
     test("search() with query and rerank:false returns results", async () => {


### PR DESCRIPTION
## Summary
- add candidateLimit to the SDK SearchOptions surface
- forward candidateLimit from SDK search() into structuredSearch()/hybridQuery()
- forward MCP stdio and HTTP query candidateLimit into store.search()
- add a CI-safe SDK regression test

## Tests
- npm run build
- CI=1 TMPDIR=/Users/woodenriver/AI_Work/comfy/_worktrees/qmd-upstream/.tmp/vitest-tmp npx vitest run --reporter=verbose test/sdk.test.ts
- CI=1 TMPDIR=/Users/woodenriver/AI_Work/comfy/_worktrees/qmd-upstream/.tmp/vitest-tmp npm test