### PR TITLE
feat(update): add --watch mode for periodic re-indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Features
+
+- `qmd update --watch`: re-index collections on a fixed interval without an external scheduler. Configure with `--interval 30s|5m|1h` (default 5m). Combine with `--embed` to also generate vector embeddings whenever new hashes appear. Designed for "drop into mcp.json and forget" workflows where the MCP server is paired with a sibling watcher process. Quiet by default: ticks only log when documents actually change, and a 3-strike circuit breaker exits non-zero if reindexing fails repeatedly.
+
 ### Fixes
 
 - Embedding: `qmd embed -c <collection>` now scopes pending-doc selection

--- a/README.md
+++ b/README.md
@@ -135,6 +135,20 @@ LLM models stay loaded in VRAM across requests. Embedding/reranking contexts are
 
 Point any MCP client at `http://localhost:8181/mcp` to connect.
 
+#### Keeping the Index Fresh
+
+When QMD is running as an MCP server, pair it with `qmd update --watch` so the index stays current as your notes change:
+
+```sh
+# Terminal 1 — MCP server
+qmd mcp --http --daemon
+
+# Terminal 2 — sibling watcher (re-index every 5 minutes, auto-embed new hashes)
+qmd update --watch --embed
+```
+
+For a more permanent setup, run `qmd update --watch --embed` from a launchd job (macOS), systemd user unit (Linux), or scheduled task (Windows).
+
 ### SDK / Library Usage
 
 Use QMD as a library in your own Node.js or Bun applications.
@@ -750,6 +764,15 @@ qmd update
 
 # Re-index with git pull first (for remote repos)
 qmd update --pull
+
+# Watch mode: re-index periodically (default every 5 minutes)
+qmd update --watch
+
+# Watch with a custom interval (units: ms, s, m, h)
+qmd update --watch --interval 30s
+
+# Watch and auto-embed new hashes after each tick
+qmd update --watch --interval 5m --embed
 
 # Get document by filepath (with fuzzy matching suggestions)
 qmd get notes/meeting.md

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -100,6 +100,7 @@ import {
   loadConfig,
 } from "../collections.js";
 import { getEmbeddedQmdSkillContent, getEmbeddedQmdSkillFiles } from "../embedded-skills.js";
+import { parseDurationMs, runWatchLoop } from "../watch.js";
 
 // NOTE: enableProductionMode() is intentionally NOT called at module scope here.
 // Importing this module for its exports (e.g. buildEditorUri, termLink from
@@ -544,7 +545,29 @@ async function showStatus(): Promise<void> {
   closeDb();
 }
 
-async function updateCollections(): Promise<void> {
+interface UpdateOptions {
+  /** Suppress informational logging; still surface errors and meaningful changes. */
+  quiet?: boolean;
+  /** Skip closeDb() at end (caller owns DB lifecycle, e.g. watch loop). */
+  keepDbOpen?: boolean;
+}
+
+interface UpdateSummary {
+  /** Number of newly indexed docs across all collections. */
+  indexed: number;
+  /** Number of docs whose content changed. */
+  updated: number;
+  /** Number of docs removed from the filesystem. */
+  removed: number;
+  /** True if at least one collection had any change. */
+  anyChange: boolean;
+  /** Number of unique content hashes that still need embeddings. */
+  needsEmbedding: number;
+}
+
+async function updateCollections(updateOpts: UpdateOptions = {}): Promise<UpdateSummary> {
+  const quiet = !!updateOpts.quiet;
+  const logInfo = (msg: string) => { if (!quiet) console.log(msg); };
   const db = getDb();
   const storeInstance = getStore();
   // Collections are defined in YAML; no duplicate cleanup needed.
@@ -554,23 +577,31 @@ async function updateCollections(): Promise<void> {
 
   const collections = listCollections(db);
 
+  const summary: UpdateSummary = {
+    indexed: 0,
+    updated: 0,
+    removed: 0,
+    anyChange: false,
+    needsEmbedding: 0,
+  };
+
   if (collections.length === 0) {
-    console.log(`${c.dim}No collections found. Run 'qmd collection add .' to index markdown files.${c.reset}`);
-    closeDb();
-    return;
+    logInfo(`${c.dim}No collections found. Run 'qmd collection add .' to index markdown files.${c.reset}`);
+    if (!updateOpts.keepDbOpen) closeDb();
+    return summary;
   }
 
-  console.log(`${c.bold}Updating ${collections.length} collection(s)...${c.reset}\n`);
+  logInfo(`${c.bold}Updating ${collections.length} collection(s)...${c.reset}\n`);
 
   for (let i = 0; i < collections.length; i++) {
     const col = collections[i];
     if (!col) continue;
-    console.log(`${c.cyan}[${i + 1}/${collections.length}]${c.reset} ${c.bold}${col.name}${c.reset} ${c.dim}(${col.glob_pattern})${c.reset}`);
+    logInfo(`${c.cyan}[${i + 1}/${collections.length}]${c.reset} ${c.bold}${col.name}${c.reset} ${c.dim}(${col.glob_pattern})${c.reset}`);
 
     // Execute custom update command if specified in YAML
     const yamlCol = getCollectionFromYaml(col.name);
     if (yamlCol?.update) {
-      console.log(`${c.dim}    Running update command: ${yamlCol.update}${c.reset}`);
+      logInfo(`${c.dim}    Running update command: ${yamlCol.update}${c.reset}`);
       try {
         const proc = nodeSpawn("bash", ["-c", yamlCol.update], {
           cwd: col.pwd,
@@ -587,29 +618,37 @@ async function updateCollections(): Promise<void> {
         });
 
         if (output.trim()) {
-          console.log(output.trim().split('\n').map(l => `    ${l}`).join('\n'));
+          logInfo(output.trim().split('\n').map(l => `    ${l}`).join('\n'));
         }
         if (errorOutput.trim()) {
-          console.log(errorOutput.trim().split('\n').map(l => `    ${l}`).join('\n'));
+          // Custom update command stderr is always shown — it's a likely error signal.
+          console.error(errorOutput.trim().split('\n').map(l => `    ${l}`).join('\n'));
         }
 
         if (exitCode !== 0) {
-          console.log(`${c.yellow}✗ Update command failed with exit code ${exitCode}${c.reset}`);
+          console.error(`${c.yellow}✗ Update command failed with exit code ${exitCode}${c.reset}`);
+          if (quiet) {
+            // In watch mode, surface the error but don't kill the process — the
+            // watch loop's circuit breaker handles repeated failures.
+            throw new Error(`Update command for collection '${col.name}' exited ${exitCode}`);
+          }
           process.exit(exitCode);
         }
       } catch (err) {
-        console.log(`${c.yellow}✗ Update command failed: ${err}${c.reset}`);
+        console.error(`${c.yellow}✗ Update command failed: ${err}${c.reset}`);
+        if (quiet) throw err;
         process.exit(1);
       }
     }
 
     const startTime = Date.now();
-    console.log(`Collection: ${col.pwd} (${col.glob_pattern})`);
-    progress.indeterminate();
+    logInfo(`Collection: ${col.pwd} (${col.glob_pattern})`);
+    if (!quiet) progress.indeterminate();
 
     const result = await reindexCollection(storeInstance, col.pwd, col.glob_pattern, col.name, {
       ignorePatterns: yamlCol?.ignore,
       onProgress: (info) => {
+        if (quiet) return;
         progress.set((info.current / info.total) * 100);
         const elapsed = (Date.now() - startTime) / 1000;
         const rate = info.current / elapsed;
@@ -619,22 +658,39 @@ async function updateCollections(): Promise<void> {
       },
     });
 
-    progress.clear();
-    console.log(`\nIndexed: ${result.indexed} new, ${result.updated} updated, ${result.unchanged} unchanged, ${result.removed} removed`);
-    if (result.orphanedCleaned > 0) {
-      console.log(`Cleaned up ${result.orphanedCleaned} orphaned content hash(es)`);
+    if (!quiet) progress.clear();
+    summary.indexed += result.indexed;
+    summary.updated += result.updated;
+    summary.removed += result.removed;
+    if (result.indexed > 0 || result.updated > 0 || result.removed > 0) {
+      summary.anyChange = true;
+      // In quiet mode, surface changes so watch logs are actionable.
+      if (quiet) {
+        console.log(
+          `[${new Date().toISOString()}] ${col.name}: ${result.indexed} new, ${result.updated} updated, ${result.removed} removed`,
+        );
+      }
     }
-    console.log("");
+    if (!quiet) {
+      console.log(`\nIndexed: ${result.indexed} new, ${result.updated} updated, ${result.unchanged} unchanged, ${result.removed} removed`);
+      if (result.orphanedCleaned > 0) {
+        console.log(`Cleaned up ${result.orphanedCleaned} orphaned content hash(es)`);
+      }
+      console.log("");
+    }
   }
 
   // Check if any documents need embedding (show once at end)
   const needsEmbedding = getHashesNeedingEmbedding(db);
-  closeDb();
+  summary.needsEmbedding = needsEmbedding;
+  if (!updateOpts.keepDbOpen) closeDb();
 
-  console.log(`${c.green}✓ All collections updated.${c.reset}`);
+  logInfo(`${c.green}✓ All collections updated.${c.reset}`);
   if (needsEmbedding > 0) {
-    console.log(`\nRun 'qmd embed' to update embeddings (${needsEmbedding} unique hashes need vectors)`);
+    logInfo(`\nRun 'qmd embed' to update embeddings (${needsEmbedding} unique hashes need vectors)`);
   }
+
+  return summary;
 }
 
 /**
@@ -2515,6 +2571,10 @@ function parseCLI() {
       // Update options
       pull: { type: "boolean" },  // git pull before update
       refresh: { type: "boolean" },
+      // Watch options (update --watch)
+      watch: { type: "boolean" },
+      interval: { type: "string" },  // e.g. "30s", "5m", "1h"
+      embed: { type: "boolean" },    // auto-embed after each update tick
       // Get options
       l: { type: "string" },  // max lines
       from: { type: "string" },  // start line
@@ -2730,6 +2790,8 @@ function showHelp(): void {
   console.log("Maintenance:");
   console.log("  qmd status                    - View index + collection health");
   console.log("  qmd update [--pull]           - Re-index collections (optionally git pull first)");
+  console.log("    --watch [--interval <dur>]  - Re-index periodically (default 5m). Use 30s, 5m, 1h.");
+  console.log("    --watch --embed             - Also auto-embed after each tick if new hashes appear");
   console.log("  qmd embed [-f] [-c <name>]    - Generate/refresh vector embeddings");
   console.log("    --max-docs-per-batch <n>    - Cap docs loaded into memory per embedding batch");
   console.log("    --max-batch-mb <n>          - Cap UTF-8 MB loaded into memory per embedding batch");
@@ -3114,9 +3176,42 @@ if (isMain) {
       await showStatus();
       break;
 
-    case "update":
+    case "update": {
+      if (cli.values.watch) {
+        const intervalRaw = (cli.values.interval as string | undefined) ?? "5m";
+        let intervalMs: number;
+        try {
+          intervalMs = parseDurationMs(intervalRaw);
+        } catch (err) {
+          console.error(err instanceof Error ? err.message : String(err));
+          process.exit(1);
+        }
+        const runEmbed = !!cli.values.embed;
+        const embedModel = runEmbed ? resolveEmbedModelForCli() : undefined;
+        // Remove the top-level cursor-restoring signal handlers so the watch
+        // loop can install its own and exit cleanly between ticks.
+        process.removeAllListeners("SIGINT");
+        process.removeAllListeners("SIGTERM");
+        console.error(
+          `${c.bold}qmd watch:${c.reset} re-indexing every ${intervalRaw}${runEmbed ? " (auto-embed enabled)" : ""}. Ctrl-C to stop.`,
+        );
+        const result = await runWatchLoop({
+          intervalMs,
+          tick: async () => {
+            const summary = await updateCollections({ quiet: true });
+            if (runEmbed && summary.needsEmbedding > 0) {
+              console.log(
+                `[${new Date().toISOString()}] embedding ${summary.needsEmbedding} new hash(es)...`,
+              );
+              await vectorIndex(embedModel!, false, {});
+            }
+          },
+        });
+        process.exit(result.stoppedBy === "max-failures" ? 1 : 0);
+      }
       await updateCollections();
       break;
+    }
 
     case "embed":
       try {

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,0 +1,164 @@
+/**
+ * Watch mode for `qmd update` — periodic re-indexing.
+ *
+ * Polls collections on a fixed interval. Cheap because reindexCollection()
+ * hashes files and skips unchanged ones. Optionally re-embeds after each tick.
+ *
+ * Cross-platform: uses setInterval rather than fs.watch so behavior is
+ * consistent on Linux, macOS, and Windows without an extra dependency.
+ */
+
+const DURATION_RE = /^(\d+(?:\.\d+)?)(ms|s|m|h)?$/i;
+
+/**
+ * Parse a duration string like "30s", "5m", "1.5h", "500ms" into milliseconds.
+ * Bare numbers are treated as seconds for ergonomics.
+ *
+ * @throws Error on invalid input
+ */
+export function parseDurationMs(input: string): number {
+  if (typeof input !== "string" || input.trim() === "") {
+    throw new Error(`Invalid duration: ${JSON.stringify(input)}`);
+  }
+  const match = input.trim().match(DURATION_RE);
+  if (!match) {
+    throw new Error(
+      `Invalid duration: ${JSON.stringify(input)}. Use 30s, 5m, 1h, or 500ms.`,
+    );
+  }
+  const value = Number(match[1]);
+  const unit = (match[2] ?? "s").toLowerCase();
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`Invalid duration: ${JSON.stringify(input)} (must be > 0)`);
+  }
+  switch (unit) {
+    case "ms":
+      return Math.round(value);
+    case "s":
+      return Math.round(value * 1000);
+    case "m":
+      return Math.round(value * 60_000);
+    case "h":
+      return Math.round(value * 3_600_000);
+    default:
+      throw new Error(`Unknown duration unit: ${unit}`);
+  }
+}
+
+export interface WatchOptions {
+  /** Interval between ticks in milliseconds. */
+  intervalMs: number;
+  /** Run one tick body. May throw; the loop handles it. */
+  tick: () => Promise<void>;
+  /** Optional logger; defaults to console.error so stdio MCP stays clean. */
+  log?: (msg: string) => void;
+  /** Stop after this many consecutive failures (default 3). */
+  maxConsecutiveFailures?: number;
+  /**
+   * For tests: stop the loop after N ticks. Undefined = run forever (until
+   * SIGINT/SIGTERM or maxConsecutiveFailures).
+   */
+  maxTicks?: number;
+  /**
+   * For tests: skip installing real signal handlers. Production code leaves
+   * this undefined.
+   */
+  installSignalHandlers?: boolean;
+}
+
+export interface WatchResult {
+  ticks: number;
+  failures: number;
+  stoppedBy: "signal" | "max-ticks" | "max-failures";
+}
+
+/**
+ * Run a tick function on a fixed interval until interrupted.
+ *
+ * Behavior:
+ * - Fires one tick immediately on start, then every intervalMs.
+ * - Ticks never overlap; if a tick takes longer than the interval, the next
+ *   tick fires immediately on completion.
+ * - SIGINT / SIGTERM stop the loop cleanly between ticks.
+ * - maxConsecutiveFailures (default 3) triggers a non-zero exit.
+ */
+export async function runWatchLoop(opts: WatchOptions): Promise<WatchResult> {
+  const intervalMs = opts.intervalMs;
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+    throw new Error(`Invalid intervalMs: ${intervalMs}`);
+  }
+  const log = opts.log ?? ((msg: string) => process.stderr.write(msg + "\n"));
+  const maxFailures = opts.maxConsecutiveFailures ?? 3;
+  const installSignals = opts.installSignalHandlers !== false;
+
+  let ticks = 0;
+  let consecutiveFailures = 0;
+  let totalFailures = 0;
+  let stop = false;
+  let stoppedBy: WatchResult["stoppedBy"] = "signal";
+  let resolveStop: (() => void) | null = null;
+
+  const onSignal = (sig: NodeJS.Signals) => {
+    log(`Received ${sig}, stopping watch loop after current tick...`);
+    stop = true;
+    stoppedBy = "signal";
+    if (resolveStop) resolveStop();
+  };
+
+  if (installSignals) {
+    process.on("SIGINT", onSignal);
+    process.on("SIGTERM", onSignal);
+  }
+
+  try {
+    while (!stop) {
+      const tickStart = Date.now();
+      try {
+        await opts.tick();
+        consecutiveFailures = 0;
+      } catch (err) {
+        consecutiveFailures += 1;
+        totalFailures += 1;
+        const msg = err instanceof Error ? err.message : String(err);
+        log(`Watch tick failed (${consecutiveFailures}/${maxFailures}): ${msg}`);
+        if (consecutiveFailures >= maxFailures) {
+          stoppedBy = "max-failures";
+          stop = true;
+          break;
+        }
+      }
+
+      ticks += 1;
+      if (opts.maxTicks !== undefined && ticks >= opts.maxTicks) {
+        stoppedBy = "max-ticks";
+        break;
+      }
+      if (stop) break;
+
+      const elapsed = Date.now() - tickStart;
+      const delay = Math.max(0, intervalMs - elapsed);
+      if (delay > 0) {
+        await new Promise<void>((res) => {
+          const timer = setTimeout(() => {
+            resolveStop = null;
+            res();
+          }, delay);
+          // If a signal fires while we wait, cancel the timer and resolve so
+          // the loop exits promptly instead of waiting out the interval.
+          resolveStop = () => {
+            clearTimeout(timer);
+            resolveStop = null;
+            res();
+          };
+        });
+      }
+    }
+  } finally {
+    if (installSignals) {
+      process.off("SIGINT", onSignal);
+      process.off("SIGTERM", onSignal);
+    }
+  }
+
+  return { ticks, failures: totalFailures, stoppedBy };
+}

--- a/test/watch.test.ts
+++ b/test/watch.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import { parseDurationMs, runWatchLoop } from "../src/watch.js";
+
+describe("parseDurationMs", () => {
+  it("parses seconds suffix", () => {
+    expect(parseDurationMs("30s")).toBe(30_000);
+    expect(parseDurationMs("1s")).toBe(1_000);
+  });
+
+  it("parses minutes suffix", () => {
+    expect(parseDurationMs("5m")).toBe(300_000);
+    expect(parseDurationMs("1m")).toBe(60_000);
+  });
+
+  it("parses hours suffix", () => {
+    expect(parseDurationMs("1h")).toBe(3_600_000);
+    expect(parseDurationMs("2h")).toBe(7_200_000);
+  });
+
+  it("parses millisecond suffix", () => {
+    expect(parseDurationMs("500ms")).toBe(500);
+    expect(parseDurationMs("1ms")).toBe(1);
+  });
+
+  it("treats bare numbers as seconds", () => {
+    expect(parseDurationMs("30")).toBe(30_000);
+  });
+
+  it("accepts fractional values", () => {
+    expect(parseDurationMs("1.5m")).toBe(90_000);
+    expect(parseDurationMs("0.5h")).toBe(1_800_000);
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(parseDurationMs("  30s  ")).toBe(30_000);
+  });
+
+  it("is case-insensitive for the unit", () => {
+    expect(parseDurationMs("30S")).toBe(30_000);
+    expect(parseDurationMs("5M")).toBe(300_000);
+    expect(parseDurationMs("1H")).toBe(3_600_000);
+    expect(parseDurationMs("500MS")).toBe(500);
+  });
+
+  it("rejects empty input", () => {
+    expect(() => parseDurationMs("")).toThrow(/Invalid duration/);
+    expect(() => parseDurationMs("   ")).toThrow(/Invalid duration/);
+  });
+
+  it("rejects unknown units", () => {
+    expect(() => parseDurationMs("5d")).toThrow(/Invalid duration/);
+    expect(() => parseDurationMs("10w")).toThrow(/Invalid duration/);
+  });
+
+  it("rejects zero and negative durations", () => {
+    expect(() => parseDurationMs("0s")).toThrow(/must be > 0/);
+    expect(() => parseDurationMs("-1s")).toThrow(/Invalid duration/);
+  });
+
+  it("rejects non-numeric input", () => {
+    expect(() => parseDurationMs("abc")).toThrow(/Invalid duration/);
+    expect(() => parseDurationMs("s")).toThrow(/Invalid duration/);
+  });
+});
+
+describe("runWatchLoop", () => {
+  it("runs the tick function once per cycle and stops after maxTicks", async () => {
+    let count = 0;
+    const result = await runWatchLoop({
+      intervalMs: 5,
+      maxTicks: 3,
+      installSignalHandlers: false,
+      tick: async () => {
+        count += 1;
+      },
+    });
+
+    expect(count).toBe(3);
+    expect(result.ticks).toBe(3);
+    expect(result.failures).toBe(0);
+    expect(result.stoppedBy).toBe("max-ticks");
+  });
+
+  it("counts failures but keeps running below the threshold", async () => {
+    let attempts = 0;
+    const result = await runWatchLoop({
+      intervalMs: 1,
+      maxTicks: 4,
+      maxConsecutiveFailures: 5,
+      installSignalHandlers: false,
+      log: () => {},
+      tick: async () => {
+        attempts += 1;
+        if (attempts === 2) throw new Error("boom");
+      },
+    });
+
+    expect(attempts).toBe(4);
+    expect(result.failures).toBe(1);
+    expect(result.stoppedBy).toBe("max-ticks");
+  });
+
+  it("stops after maxConsecutiveFailures and returns max-failures", async () => {
+    let attempts = 0;
+    const result = await runWatchLoop({
+      intervalMs: 1,
+      maxConsecutiveFailures: 2,
+      installSignalHandlers: false,
+      log: () => {},
+      tick: async () => {
+        attempts += 1;
+        throw new Error(`fail ${attempts}`);
+      },
+    });
+
+    expect(attempts).toBe(2);
+    expect(result.failures).toBe(2);
+    expect(result.stoppedBy).toBe("max-failures");
+  });
+
+  it("resets the consecutive-failure counter on a successful tick", async () => {
+    let attempts = 0;
+    const result = await runWatchLoop({
+      intervalMs: 1,
+      maxTicks: 5,
+      maxConsecutiveFailures: 2,
+      installSignalHandlers: false,
+      log: () => {},
+      tick: async () => {
+        attempts += 1;
+        // Fail, succeed, fail, succeed, succeed — never two failures in a row.
+        if (attempts === 1 || attempts === 3) throw new Error("transient");
+      },
+    });
+
+    expect(attempts).toBe(5);
+    expect(result.failures).toBe(2);
+    expect(result.stoppedBy).toBe("max-ticks");
+  });
+
+  it("rejects an invalid intervalMs", async () => {
+    await expect(
+      runWatchLoop({
+        intervalMs: 0,
+        installSignalHandlers: false,
+        tick: async () => {},
+      }),
+    ).rejects.toThrow(/Invalid intervalMs/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `qmd update --watch [--interval <dur>] [--embed]` so users can keep the QMD index fresh without an external scheduler. This is the piece most often paired with `qmd mcp` in `mcp.json`-style setups where the agent expects the index to stay current as notes change.

## Why

A friend of mine asked whether he could drop QMD into `.vscode/mcp.json` the same way you'd drop in `@playwright/mcp` and forget about it. Today the missing piece is re-indexing: `qmd update` works great manually, but there's no built-in way to keep it running. People end up wiring cron jobs, launchd agents, or just forgetting and getting stale results.

This PR adds watch mode so the common case ("re-index every few minutes, embed if anything new shows up") is one flag.

## Design choices

- **Polling, not `fs.watch`.** `reindexCollection()` already hashes files and skips unchanged content, so idle ticks are near-zero cost. Polling avoids a new dependency (chokidar) and keeps cross-platform behavior identical on Linux, macOS, and Windows where `fs.watch` semantics differ.
- **Default interval: 5 minutes.** Configurable via `--interval` with units `ms`/`s`/`m`/`h` (e.g. `30s`, `5m`, `1.5h`). Bare numbers are treated as seconds.
- **Quiet by default.** Ticks only emit a line when documents actually change. Routine no-op ticks are silent so the log stays useful. Format: `[2026-05-15T20:27:31.844Z] smoke: 1 new, 0 updated, 0 removed`.
- **Optional `--embed`.** Runs `vectorIndex()` after any tick that left pending hashes, so semantic search stays current without a second cron job.
- **Circuit breaker.** After 3 consecutive tick failures, the loop exits non-zero so a supervisor (launchd/systemd/Task Scheduler) can restart it instead of looping forever.
- **Clean shutdown.** SIGINT/SIGTERM stop the loop between ticks. Follows the same `process.removeAllListeners` pattern used by `qmd mcp --http` to bypass the top-level cursor-restoring handlers.

## Usage

```sh
# Re-index every 5 minutes (default)
qmd update --watch

# Custom interval
qmd update --watch --interval 30s

# Auto-embed new hashes after each tick
qmd update --watch --embed
```

Paired with the MCP server:

```sh
# Terminal 1
qmd mcp --http --daemon
# Terminal 2
qmd update --watch --embed
```

## What I didn't do

- **Did not integrate into `qmd mcp`.** Keeping watch as a sibling process avoids contention concerns and keeps the PR small. Happy to land that as a follow-up if you'd like.
- **Did not add a launchd/systemd template.** Documented the pattern in README; users can wire their own supervisor.
- **Did not use `fs.watch`.** Open to revisiting if anyone wants true real-time, but polling covers the stated use case.

## Tests

- 17 new unit tests in `test/watch.test.ts` covering `parseDurationMs` (units, fractions, edge cases, error paths) and `runWatchLoop` (tick counting, failure tolerance, circuit breaker, consecutive-failure reset, invalid interval).
- All 843 existing tests still pass.
- E2E manual smoke test: created a fresh collection, started `qmd update --watch --interval 1s`, added a new `.md` file mid-run, observed exactly one timestamped log line, sent SIGINT, observed clean exit.

## Refactor notes

`updateCollections()` now takes `{ quiet?, keepDbOpen? }` and returns an `UpdateSummary`. Non-watch behavior is byte-identical to before. The only externally visible change in the legacy path: the existing `console.log` for custom-update-command stderr now routes through `console.error` (correct destination for stderr content; previously it went to stdout).

## Checklist

- [x] Tests added
- [x] `npm run build` passes
- [x] Full test suite passes (`npx vitest run`)
- [x] Changelog entry under `## [Unreleased]`
- [x] README updated
