### PR TITLE
perf(mcp): emit terse collection summary in serverInstructions

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -106,7 +106,6 @@ function getPackageVersion(): string {
  */
 async function buildInstructions(store: QMDStore): Promise<string> {
   const status = await store.getStatus();
-  const contexts = await store.listContexts();
   const globalCtx = await store.getGlobalContext();
   const lines: string[] = [];
 
@@ -115,15 +114,13 @@ async function buildInstructions(store: QMDStore): Promise<string> {
   if (globalCtx) lines.push(`Context: ${globalCtx}`);
 
   // --- What's searchable? ---
+  // Emit names only — the per-collection doc counts and descriptions can run to ~1.5 KB
+  // across a dozen collections, and the same info is available on demand via the `status` tool.
   if (status.collections.length > 0) {
     lines.push("");
-    lines.push("Collections (scope with `collection` parameter):");
-    for (const col of status.collections) {
-      // Find root context for this collection
-      const rootCtx = contexts.find(c => c.collection === col.name && (c.path === "" || c.path === "/"));
-      const desc = rootCtx ? ` — ${rootCtx.context}` : "";
-      lines.push(`  - "${col.name}" (${col.documents} docs)${desc}`);
-    }
+    const names = status.collections.map(c => c.name).join(", ");
+    lines.push(`Collections (scope with \`collection\` parameter): ${names}`);
+    lines.push("Call the `status` tool for collection descriptions, paths, and per-collection doc counts.");
   }
 
   // --- Capability gaps ---


### PR DESCRIPTION
Closes #647.

`buildInstructions` previously emitted one line per collection (name + doc count + description) into the MCP server prompt at `initialize`. On my setup that's ~1.5 KB for 12 collections, injected into every session whether the agent queries qmd or not.

This change emits a single comma-joined names line plus a one-line hint that the existing `status` tool returns descriptions and doc counts on demand. The `listContexts()` lookup is dropped because the per-collection descriptions are no longer rendered there.

**Before** (12 collections, ~1.5 KB):
```
Collections (scope with `collection` parameter):
  - "plans" (423 docs) — Claude Code implementation plans...
  - "films" (4347 docs) — Letterboxd watchlist...
  - ...etc...
```

**After** (~200 B regardless of count):
```
Collections (scope with `collection` parameter): plans, films, health, diarium, ...
Call the `status` tool for collection descriptions, paths, and per-collection doc counts.
```

Discoverability is preserved — `status` is already registered and returns the catalogue. Agents that actually need it can call once; agents that don't pay nothing.

## Test plan
- [x] `npm run build` clean
- [x] `npx vitest run test/mcp.test.ts` — 56/56 tests pass
- [x] Local install verified — session-start MCP block now ~200 B vs ~1.5 KB previously

Open to a different wording or a `QMD_MCP_VERBOSE_INSTRUCTIONS=1` opt-back-in if you'd rather keep the full catalogue available by env flag — happy to amend.