### PR TITLE
feat: support QMD_LLAMA_RELEASE env var to use latest llama.cpp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,16 @@ qmd get abc123              # Leading # is optional
 qmd multi-get "#abc123, #def456"
 ```
 
-## Options
+## Environment Variables
+
+### General
+- `QMD_LLAMA_GPU`: Set GPU backend (e.g., `cuda`, `vulkan`, `false`).
+- `QMD_LLAMA_RELEASE`: Set the `llama.cpp` release to use (e.g., `master` for latest, or a specific commit hash).
+
+### Models
+- `QMD_EMBED_MODEL`: Override the default embedding model.
+- `QMD_RERANK_MODEL`: Override the default reranking model.
+- `QMD_GENERATE_MODEL`: Override the default generation model.
 
 ```sh
 # Search & retrieval

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -10,6 +10,7 @@ import type {
   LlamaEmbeddingContext,
   Token as LlamaToken,
 } from "node-llama-cpp";
+import { patchLlamaReleaseIfNeeded } from "./utils/llama-version.js";
 
 type NodeLlamaCppModule = {
   getLlama: (options: Record<string, unknown>) => Promise<Llama>;
@@ -61,10 +62,6 @@ export async function withNativeStdoutRedirectedToStderr<T>(fn: () => Promise<T>
     }
   }
 }
-
-import { homedir } from "os";
-import { join } from "path";
-import { existsSync, mkdirSync, statSync, unlinkSync, readdirSync, readFileSync, writeFileSync, openSync, readSync, closeSync } from "fs";
 
 // =============================================================================
 // Embedding Formatting Functions
@@ -762,6 +759,9 @@ export class LlamaCpp implements LLM {
    */
   private async ensureLlama(allowBuild = true): Promise<Llama> {
     if (!this.llama) {
+      // Check if we need to update the llama.cpp release version
+      patchLlamaReleaseIfNeeded();
+
       const gpuMode = resolveLlamaGpuMode();
 
       const { getLlama, LlamaLogLevel } = await loadNodeLlamaCpp();

--- a/src/utils/llama-version.ts
+++ b/src/utils/llama-version.ts
@@ -1,0 +1,40 @@
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+
+/**
+ * Check if QMD_LLAMA_RELEASE env var is set.
+ * If so, patch node-llama-cpp's binariesGithubRelease.json to use that release.
+ * This allows users to force QMD to use a specific version of llama.cpp
+ * (e.g., "master" for latest features, or a specific commit hash).
+ */
+export function patchLlamaReleaseIfNeeded(): void {
+  const release = process.env.QMD_LLAMA_RELEASE;
+  if (!release) return;
+
+  try {
+    // Resolve the path to node-llama-cpp's config file
+    // We look for it in the node_modules relative to the current module
+    const currentDir = dirname(fileURLToPath(import.meta.url));
+    // qmd/src/utils -> qmd/node_modules
+    const projectRoot = resolve(currentDir, "..", "..");
+    const nodeLlamaCppPath = join(projectRoot, "node_modules", "node-llama-cpp");
+    const configPath = join(nodeLlamaCppPath, "llama", "binariesGithubRelease.json");
+
+    if (!existsSync(configPath)) {
+      // Fallback: try to find it in the package structure if installed differently
+      // This is a best-effort patch
+      return;
+    }
+
+    const currentConfig = JSON.parse(readFileSync(configPath, "utf-8"));
+    if (currentConfig.release !== release) {
+      process.stderr.write(`[QMD] Updating llama.cpp release from "${currentConfig.release}" to "${release}"...\n`);
+      currentConfig.release = release;
+      writeFileSync(configPath, JSON.stringify(currentConfig, null, 4));
+      process.stderr.write("[QMD] llama.cpp release updated. The new version will be downloaded on next run.\n");
+    }
+  } catch (e) {
+    process.stderr.write(`[QMD] Warning: Failed to patch llama.cpp release: ${e instanceof Error ? e.message : String(e)}\n`);
+  }
+}


### PR DESCRIPTION
## Problem

QMD currently relies on `node-llama-cpp`'s default behavior, which pins the `llama.cpp` version to an older release (e.g., `b8390`). This prevents users from accessing the latest features, model support, and performance improvements available in the `master` branch of `llama.cpp`.

## Solution

This PR introduces the **`QMD_LLAMA_RELEASE`** environment variable.

When set (e.g., to `master`), QMD automatically patches `node-llama-cpp`'s internal configuration (`binariesGithubRelease.json`) before initializing the LLM engine. This forces `node-llama-cpp` to download and build the specified `llama.cpp` release.

## Usage

```bash
# Use the absolute latest llama.cpp (master branch)
QMD_LLAMA_RELEASE=master qmd status

# Use a specific commit hash
QMD_LLAMA_RELEASE=4f13cb7 qmd status
```

## Changes
1. **`src/utils/llama-version.ts`**: New utility function `patchLlamaReleaseIfNeeded` that handles the patching of `node-llama-cpp`'s release config.
2. **`src/llm.ts`**: Invokes the patch function before `getLlama` is called.
3. **`CLAUDE.md`**: Documentation update for the new environment variable.

This allows power users to opt-in to the latest engine without waiting for a formal QMD release, while preserving the stable default behavior for everyone else.
