### PR TITLE
fix(cli): accept --glob as alias for --mask in collection add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixes
+
+- CLI: accept `--glob` as an alias for `--mask` in `qmd collection add` so tools that pass `--glob <pattern>` (e.g. OpenClaw) are not silently ignored and do not fall back to the default `**/*.md` pattern. Fixes #536.
+
 ## [2.5.1] - 2026-05-20
 
 ### Changes

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -2715,6 +2715,7 @@ function parseCLI() {
       // Collection options
       name: { type: "string" },  // collection name
       mask: { type: "string" },  // glob pattern
+      glob: { type: "string" },  // alias for --mask
       // Embed options
       force: { type: "boolean", short: "f" },
       "max-docs-per-batch": { type: "string" },
@@ -4060,7 +4061,7 @@ if (isMain) {
         case "add": {
           const pwd = cli.args[1] || getPwd();
           const resolvedPwd = pwd === '.' ? getPwd() : getRealPath(resolve(pwd));
-          const globPattern = cli.values.mask as string || DEFAULT_GLOB;
+          const globPattern = (cli.values.mask ?? cli.values.glob) as string || DEFAULT_GLOB;
           const name = cli.values.name as string | undefined;
 
           await collectionAdd(resolvedPwd, globPattern, name);
@@ -4167,7 +4168,7 @@ if (isMain) {
           console.log("");
           console.log("Commands:");
           console.log("  list                      List all collections");
-          console.log("  add <path> [--name NAME]  Add a collection");
+          console.log("  add <path> [--name NAME] [--glob PATTERN]  Add a collection");
           console.log("  remove <name>             Remove a collection");
           console.log("  rename <old> <new>        Rename a collection");
           console.log("  show <name>               Show collection details");

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -487,6 +487,23 @@ describe("CLI Add Command", () => {
     expect(stdout).toContain("notes/*.md");
   });
 
+  test("--glob is accepted as an alias for --mask", async () => {
+    const { stdout, stderr, exitCode } = await runQmd(["collection", "add", ".", "--name", "glob-alias", "--glob", "notes/*.md"]);
+    if (exitCode !== 0) {
+      console.error("Command failed:", stderr);
+    }
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("notes/*.md");
+  });
+
+  test("two collections on the same path with different globs are both accepted", async () => {
+    const { exitCode: e1 } = await runQmd(["collection", "add", ".", "--name", "col-md", "--glob", "**/*.md"]);
+    expect(e1).toBe(0);
+    const { exitCode: e2, stderr } = await runQmd(["collection", "add", ".", "--name", "col-specific", "--glob", "notes/*.md"]);
+    expect(e2).toBe(0);
+    expect(stderr).not.toContain("already exists");
+  });
+
   test("can recreate collection with remove and add", async () => {
     // First add
     await runQmd(["collection", "add", "."]);


### PR DESCRIPTION
## Problem

`qmd collection add --glob <pattern>` silently ignores the flag and falls back to `**/*.md`. Tools such as OpenClaw pass `--glob` when registering per-agent memory collections on the same workspace path, causing the duplicate-path guard to fire and leaving collections uncreated — with a timeout on every subsequent `memory_search` call.

## Root cause

The option parser only registered `--mask` for the glob pattern. `--glob` was unknown, so `parseArgs` silently discarded it (the parser runs with `strict: false`). Both collections ended up with path + `**/*.md`, matching the `(path, pattern)` uniqueness check and exiting 1.

## Fix

- Register `glob` alongside `mask` in the option table
- Coalesce `(mask ?? glob)` at the `collection add` use site
- Update `collection help` to surface `--glob` in the usage line

## Test Plan

- `bun test --preload ./src/test-preload.ts test/cli.test.ts -t "CLI Add Command"`
- `CI=true bun test --timeout 60000 --preload ./src/test-preload.ts test/` — 820 pass
- `CI=true npx vitest run --reporter=verbose --testTimeout 60000 test/` — 820 pass
- `npm run test:types`
- `git diff --check`

Fixes #536.