### PR TITLE
Add path filtering and explain metadata to search APIs

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -997,21 +997,25 @@ function getDocument(filename: string, fromLine?: number, maxLines?: number, lin
 
     // Try exact match on collection + path
     doc = db.prepare(`
-      SELECT d.collection as collectionName, d.path, content.doc as body
+      SELECT d.collection as collectionName, COALESCE(d.original_path, d.path) as path, content.doc as body
       FROM documents d
       JOIN content ON content.hash = d.hash
-      WHERE d.collection = ? AND d.path = ? AND d.active = 1
-    `).get(parsed.collectionName, parsed.path) as typeof doc;
+      WHERE d.collection = ?
+        AND (d.path = ? OR d.original_path = ?)
+        AND d.active = 1
+    `).get(parsed.collectionName, parsed.path, parsed.path) as typeof doc;
 
     if (!doc) {
       // Try fuzzy match by path ending
       doc = db.prepare(`
-        SELECT d.collection as collectionName, d.path, content.doc as body
+        SELECT d.collection as collectionName, COALESCE(d.original_path, d.path) as path, content.doc as body
         FROM documents d
         JOIN content ON content.hash = d.hash
-        WHERE d.collection = ? AND d.path LIKE ? AND d.active = 1
+        WHERE d.collection = ?
+          AND (d.path LIKE ? OR d.original_path LIKE ?)
+          AND d.active = 1
         LIMIT 1
-      `).get(parsed.collectionName, `%${parsed.path}`) as typeof doc;
+      `).get(parsed.collectionName, `%${parsed.path}`, `%${parsed.path}`) as typeof doc;
     }
 
     virtualPath = inputPath;
@@ -1032,21 +1036,25 @@ function getDocument(filename: string, fromLine?: number, maxLines?: number, lin
         if (collExists) {
           // Try exact match on collection + path
           doc = db.prepare(`
-            SELECT d.collection as collectionName, d.path, content.doc as body
+            SELECT d.collection as collectionName, COALESCE(d.original_path, d.path) as path, content.doc as body
             FROM documents d
             JOIN content ON content.hash = d.hash
-            WHERE d.collection = ? AND d.path = ? AND d.active = 1
-          `).get(possibleCollection || "", possiblePath || "") as { collectionName: string; path: string; body: string } | null;
+            WHERE d.collection = ?
+              AND (d.path = ? OR d.original_path = ?)
+              AND d.active = 1
+          `).get(possibleCollection || "", possiblePath || "", possiblePath || "") as { collectionName: string; path: string; body: string } | null;
 
           if (!doc) {
             // Try fuzzy match by path ending
             doc = db.prepare(`
-              SELECT d.collection as collectionName, d.path, content.doc as body
+              SELECT d.collection as collectionName, COALESCE(d.original_path, d.path) as path, content.doc as body
               FROM documents d
               JOIN content ON content.hash = d.hash
-              WHERE d.collection = ? AND d.path LIKE ? AND d.active = 1
+              WHERE d.collection = ?
+                AND (d.path LIKE ? OR d.original_path LIKE ?)
+                AND d.active = 1
               LIMIT 1
-            `).get(possibleCollection || "", `%${possiblePath}`) as { collectionName: string; path: string; body: string } | null;
+            `).get(possibleCollection || "", `%${possiblePath}`, `%${possiblePath}`) as { collectionName: string; path: string; body: string } | null;
           }
 
           if (doc) {
@@ -1076,23 +1084,25 @@ function getDocument(filename: string, fromLine?: number, maxLines?: number, lin
       if (detected) {
         // Found collection - query by collection name + relative path
         doc = db.prepare(`
-          SELECT d.collection as collectionName, d.path, content.doc as body
+          SELECT d.collection as collectionName, COALESCE(d.original_path, d.path) as path, content.doc as body
           FROM documents d
           JOIN content ON content.hash = d.hash
-          WHERE d.collection = ? AND d.path = ? AND d.active = 1
-        `).get(detected.collectionName, detected.relativePath) as { collectionName: string; path: string; body: string } | null;
+          WHERE d.collection = ?
+            AND (d.path = ? OR d.original_path = ?)
+            AND d.active = 1
+        `).get(detected.collectionName, detected.relativePath, detected.relativePath) as { collectionName: string; path: string; body: string } | null;
       }
 
       // Fuzzy match by filename (last component of path)
       if (!doc) {
         const filename = inputPath.split('/').pop() || inputPath;
         doc = db.prepare(`
-          SELECT d.collection as collectionName, d.path, content.doc as body
+          SELECT d.collection as collectionName, COALESCE(d.original_path, d.path) as path, content.doc as body
           FROM documents d
           JOIN content ON content.hash = d.hash
-          WHERE d.path LIKE ? AND d.active = 1
+          WHERE (d.path LIKE ? OR d.original_path LIKE ?) AND d.active = 1
           LIMIT 1
-        `).get(`%${filename}`) as { collectionName: string; path: string; body: string } | null;
+        `).get(`%${filename}`, `%${filename}`) as { collectionName: string; path: string; body: string } | null;
       }
 
       if (doc) {
@@ -1160,42 +1170,49 @@ function multiGet(pattern: string, maxLines?: number, maxBytes: number = DEFAULT
           // Try exact match on collection + path
           doc = db.prepare(`
             SELECT
-              'qmd://' || d.collection || '/' || d.path as virtual_path,
+              'qmd://' || d.collection || '/' || COALESCE(d.original_path, d.path) as virtual_path,
               LENGTH(content.doc) as body_length,
               d.collection,
-              d.path
+              COALESCE(d.original_path, d.path) as path
             FROM documents d
             JOIN content ON content.hash = d.hash
-            WHERE d.collection = ? AND d.path = ? AND d.active = 1
-          `).get(parsed.collectionName, parsed.path) as typeof doc;
+            WHERE d.collection = ?
+              AND (d.path = ? OR d.original_path = ?)
+              AND d.active = 1
+          `).get(parsed.collectionName, parsed.path, parsed.path) as typeof doc;
         }
       } else {
         // Try exact match on path
         doc = db.prepare(`
           SELECT
-            'qmd://' || d.collection || '/' || d.path as virtual_path,
+            'qmd://' || d.collection || '/' || COALESCE(d.original_path, d.path) as virtual_path,
             LENGTH(content.doc) as body_length,
             d.collection,
-            d.path
+            COALESCE(d.original_path, d.path) as path
           FROM documents d
           JOIN content ON content.hash = d.hash
-          WHERE d.path = ? AND d.active = 1
+          WHERE (
+            d.path = ?
+            OR d.original_path = ?
+            OR d.collection || '/' || d.path = ?
+            OR d.collection || '/' || d.original_path = ?
+          ) AND d.active = 1
           LIMIT 1
-        `).get(name) as { virtual_path: string; body_length: number; collection: string; path: string } | null;
+        `).get(name, name, name, name) as { virtual_path: string; body_length: number; collection: string; path: string } | null;
 
         // Try suffix match
         if (!doc) {
           doc = db.prepare(`
             SELECT
-              'qmd://' || d.collection || '/' || d.path as virtual_path,
+              'qmd://' || d.collection || '/' || COALESCE(d.original_path, d.path) as virtual_path,
               LENGTH(content.doc) as body_length,
               d.collection,
-              d.path
+              COALESCE(d.original_path, d.path) as path
             FROM documents d
             JOIN content ON content.hash = d.hash
-            WHERE d.path LIKE ? AND d.active = 1
+            WHERE (d.path LIKE ? OR d.original_path LIKE ?) AND d.active = 1
             LIMIT 1
-          `).get(`%${name}`) as { virtual_path: string; body_length: number; collection: string; path: string } | null;
+          `).get(`%${name}`, `%${name}`) as { virtual_path: string; body_length: number; collection: string; path: string } | null;
         }
       }
 
@@ -1265,8 +1282,10 @@ function multiGet(pattern: string, maxLines?: number, maxBytes: number = DEFAULT
       SELECT content.doc as body, d.title
       FROM documents d
       JOIN content ON content.hash = d.hash
-      WHERE d.collection = ? AND d.path = ? AND d.active = 1
-    `).get(collection, path) as { body: string; title: string } | null;
+      WHERE d.collection = ?
+        AND (d.path = ? OR d.original_path = ?)
+        AND d.active = 1
+    `).get(collection, path, path) as { body: string; title: string } | null;
 
     if (!doc) continue;
 

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -2013,6 +2013,7 @@ type OutputOptions = {
   minScore: number;
   all?: boolean;
   collection?: string | string[];  // Filter by collection name(s)
+  path?: string;  // Filter by folder-prefix within collection(s)
   lineNumbers?: boolean; // Add line numbers to output
   explain?: boolean;     // Include retrieval score traces (query only)
   context?: string;      // Optional context for query expansion
@@ -2454,7 +2455,7 @@ function search(query: string, opts: OutputOptions): void {
   // Use large limit for --all, otherwise fetch more than needed and let outputResults filter
   const fetchLimit = opts.all ? 100000 : Math.max(50, opts.limit * 2);
   const results = filterByCollections(
-    searchFTS(db, query, fetchLimit, singleCollection),
+    searchFTS(db, query, fetchLimit, singleCollection, opts.path),
     collectionNames
   );
 
@@ -2507,6 +2508,7 @@ async function vectorSearch(query: string, opts: OutputOptions, _model: string =
   await withLLMSession(async () => {
     let results = await vectorSearchQuery(store, query, {
       collection: singleCollection,
+      pathPrefix: opts.path,
       limit: opts.all ? 500 : (opts.limit || 10),
       minScore: opts.minScore || 0.3,
       intent: opts.intent,
@@ -2582,6 +2584,7 @@ async function querySearch(query: string, opts: OutputOptions, _embedModel: stri
 
       results = await structuredSearch(store, structuredQueries, {
         collections: singleCollection ? [singleCollection] : undefined,
+        pathPrefix: opts.path,
         limit: opts.all ? 500 : (opts.limit || 10),
         minScore: opts.minScore || 0,
         candidateLimit: opts.candidateLimit,
@@ -2610,6 +2613,7 @@ async function querySearch(query: string, opts: OutputOptions, _embedModel: stri
       // Standard hybrid query with automatic expansion
       results = await hybridQuery(store, query, {
         collection: singleCollection,
+        pathPrefix: opts.path,
         limit: opts.all ? 500 : (opts.limit || 10),
         minScore: opts.minScore || 0,
         candidateLimit: opts.candidateLimit,
@@ -2712,6 +2716,7 @@ function parseCLI() {
       json: { type: "boolean" },
       explain: { type: "boolean" },
       collection: { type: "string", short: "c", multiple: true },  // Filter by collection(s)
+      path: { type: "string", short: "p" },  // Filter by folder-prefix within collection(s)
       // Collection options
       name: { type: "string" },  // collection name
       mask: { type: "string" },  // glob pattern
@@ -2785,6 +2790,7 @@ function parseCLI() {
     minScore: values["min-score"] ? parseFloat(String(values["min-score"])) || 0 : 0,
     all: isAll,
     collection: values.collection as string[] | undefined,
+    path: values.path as string | undefined,
     lineNumbers: !!values["line-numbers"],
     candidateLimit: values["candidate-limit"] ? parseInt(String(values["candidate-limit"]), 10) : undefined,
     skipRerank: !!values["no-rerank"],
@@ -3301,6 +3307,7 @@ function showHelp(): void {
   console.log("  --explain                  - Include retrieval score traces (query --json/CLI)");
   console.log("  --files | --json | --csv | --md | --xml  - Output format");
   console.log("  -c, --collection <name>    - Filter by one or more collections");
+  console.log("  -p, --path <folder-prefix>  - Filter to folder-prefix within collection(s) (folder-only)");
   console.log("");
   console.log("Embed/query options:");
   console.log("  --chunk-strategy <auto|regex> - Chunking mode (default: regex; auto uses AST for code files)");

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,6 +156,8 @@ export interface SearchOptions {
   collection?: string;
   /** Filter to specific collections */
   collections?: string[];
+  /** Filter to folder-prefix within collection(s); folder-only, not file-prefix. */
+  pathPrefix?: string;
   /** Max results (default: 10) */
   limit?: number;
   /** Max candidates to rerank (default: 40) */
@@ -174,6 +176,8 @@ export interface SearchOptions {
 export interface LexSearchOptions {
   limit?: number;
   collection?: string;
+  /** Filter to folder-prefix within collection; folder-only, not file-prefix. */
+  pathPrefix?: string;
 }
 
 /**
@@ -182,6 +186,8 @@ export interface LexSearchOptions {
 export interface VectorSearchOptions {
   limit?: number;
   collection?: string;
+  /** Filter to folder-prefix within collection; folder-only, not file-prefix. */
+  pathPrefix?: string;
 }
 
 /**
@@ -404,6 +410,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
           explain: opts.explain,
           intent: opts.intent,
           candidateLimit: opts.candidateLimit,
+          pathPrefix: opts.pathPrefix,
           skipRerank,
           chunkStrategy: opts.chunkStrategy,
         });
@@ -417,12 +424,13 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
         explain: opts.explain,
         intent: opts.intent,
         candidateLimit: opts.candidateLimit,
+        pathPrefix: opts.pathPrefix,
         skipRerank,
         chunkStrategy: opts.chunkStrategy,
       });
     },
-    searchLex: async (q, opts) => internal.searchFTS(q, opts?.limit, opts?.collection),
-    searchVector: async (q, opts) => internal.searchVec(q, llm.embedModelName, opts?.limit, opts?.collection),
+    searchLex: async (q, opts) => internal.searchFTS(q, opts?.limit, opts?.collection, opts?.pathPrefix),
+    searchVector: async (q, opts) => internal.searchVec(q, llm.embedModelName, opts?.limit, opts?.collection, undefined, undefined, opts?.pathPrefix),
     expandQuery: async (q, opts) => internal.expandQuery(q, undefined, opts?.intent),
     get: async (pathOrDocid, opts) => internal.findDocument(pathOrDocid, opts),
     getDocumentBody: async (pathOrDocid, opts) => {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -314,9 +314,15 @@ Intent-aware lex (C++ performance, not sports):
         rerank: z.boolean().optional().default(true).describe(
           "Rerank results using LLM (default: true). Set to false for faster results on CPU-only machines."
         ),
+        pathPrefix: z.string().optional().describe(
+          "Filter to folder-prefix within collection(s), e.g. 'docs/'. Folder-only — file paths are not supported."
+        ),
+        explain: z.boolean().optional().default(false).describe(
+          "Include score breakdown per result: scoreType, backendSources, ftsScores, vectorScores, RRF trace, rerankScore, and blendedScore."
+        ),
       },
     },
-    async ({ searches, limit, minScore, candidateLimit, collections, intent, rerank }) => {
+    async ({ searches, limit, minScore, candidateLimit, collections, intent, rerank, pathPrefix, explain }) => {
       // Map to internal format
       const queries: ExpandedQuery[] = searches.map(s => ({
         type: s.type,
@@ -334,6 +340,8 @@ Intent-aware lex (C++ performance, not sports):
         candidateLimit,
         rerank,
         intent,
+        pathPrefix,
+        explain,
       });
 
       // Use first lex or vec query for snippet extraction
@@ -347,10 +355,11 @@ Intent-aware lex (C++ performance, not sports):
           docid: `#${r.docid}`,
           file: r.displayPath,
           title: r.title,
-          score: Math.round(r.score * 100) / 100,
+          score: explain ? r.score : Math.round(r.score * 100) / 100,
           context: r.context,
           line,
           snippet: addLineNumbers(snippet, line),
+          ...(explain && r.explain ? { explain: r.explain } : {}),
         };
       });
 
@@ -680,16 +689,32 @@ export async function startMcpHttpServer(
         return;
       }
 
-      // REST endpoint: POST /search — structured search without MCP protocol
       // REST endpoint: POST /query (alias: /search) — structured search without MCP protocol
       if ((pathname === "/query" || pathname === "/search") && nodeReq.method === "POST") {
         const rawBody = await collectBody(nodeReq);
-        const params = JSON.parse(rawBody) as Record<string, unknown>;
+        let params: Record<string, unknown>;
+        try {
+          params = JSON.parse(rawBody) as Record<string, unknown>;
+        } catch {
+          nodeRes.writeHead(400, { "Content-Type": "application/json" });
+          nodeRes.end(JSON.stringify({ error: "invalid JSON" }));
+          return;
+        }
 
         // Validate required fields
         if (!params.searches || !Array.isArray(params.searches)) {
           nodeRes.writeHead(400, { "Content-Type": "application/json" });
           nodeRes.end(JSON.stringify({ error: "Missing required field: searches (array)" }));
+          return;
+        }
+        if (params.pathPrefix !== undefined && typeof params.pathPrefix !== "string") {
+          nodeRes.writeHead(400, { "Content-Type": "application/json" });
+          nodeRes.end(JSON.stringify({ error: "pathPrefix must be string" }));
+          return;
+        }
+        if (params.explain !== undefined && typeof params.explain !== "boolean") {
+          nodeRes.writeHead(400, { "Content-Type": "application/json" });
+          nodeRes.end(JSON.stringify({ error: "explain must be boolean" }));
           return;
         }
 
@@ -711,6 +736,8 @@ export async function startMcpHttpServer(
           candidateLimit: typeof params.candidateLimit === "number" ? params.candidateLimit : undefined,
           intent: typeof params.intent === "string" ? params.intent : undefined,
           rerank: typeof params.rerank === "boolean" ? params.rerank : undefined,
+          pathPrefix: typeof params.pathPrefix === "string" ? params.pathPrefix : undefined,
+          explain: typeof params.explain === "boolean" ? params.explain : false,
         });
 
         // Use first lex or vec query for snippet extraction
@@ -724,10 +751,11 @@ export async function startMcpHttpServer(
             docid: `#${r.docid}`,
             file: r.displayPath,
             title: r.title,
-            score: Math.round(r.score * 100) / 100,
+            score: params.explain ? r.score : Math.round(r.score * 100) / 100,
             context: r.context,
             line,
             snippet: addLineNumbers(snippet, line),
+            ...(params.explain && r.explain ? { explain: r.explain } : {}),
           };
         });
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -2812,7 +2812,7 @@ export function findDocumentByDocid(db: Database, docid: string): { filepath: st
 
 export function findSimilarFiles(db: Database, query: string, maxDistance: number = 3, limit: number = 5): string[] {
   const allFiles = db.prepare(`
-    SELECT d.path
+    SELECT COALESCE(d.original_path, d.path) AS path
     FROM documents d
     WHERE d.active = 1
   `).all() as { path: string }[];
@@ -2828,21 +2828,29 @@ export function findSimilarFiles(db: Database, query: string, maxDistance: numbe
 export function matchFilesByGlob(db: Database, pattern: string): { filepath: string; displayPath: string; bodyLength: number }[] {
   const allFiles = db.prepare(`
     SELECT
-      'qmd://' || d.collection || '/' || d.path as virtual_path,
+      'qmd://' || d.collection || '/' || COALESCE(d.original_path, d.path) as virtual_path,
       LENGTH(content.doc) as body_length,
       d.path,
+      d.original_path,
       d.collection
     FROM documents d
     JOIN content ON content.hash = d.hash
     WHERE d.active = 1
-  `).all() as { virtual_path: string; body_length: number; path: string; collection: string }[];
+  `).all() as { virtual_path: string; body_length: number; path: string; original_path: string | null; collection: string }[];
 
   const isMatch = picomatch(pattern);
   return allFiles
-    .filter(f => isMatch(f.virtual_path) || isMatch(f.path) || isMatch(f.collection + '/' + f.path))
+    .filter(f => {
+      const displayPath = f.original_path || f.path;
+      return isMatch(f.virtual_path)
+        || isMatch(f.path)
+        || isMatch(displayPath)
+        || isMatch(f.collection + '/' + f.path)
+        || isMatch(f.collection + '/' + displayPath);
+    })
     .map(f => ({
       filepath: f.virtual_path,  // Virtual path for precise lookup
-      displayPath: f.path,        // Relative path for display
+      displayPath: f.original_path || f.path, // Relative path for display
       bodyLength: f.body_length
     }));
 }
@@ -2947,9 +2955,11 @@ export function getContextForFile(db: Database, filepath: string): string | null
   const doc = db.prepare(`
     SELECT d.path
     FROM documents d
-    WHERE d.collection = ? AND d.path = ? AND d.active = 1
+    WHERE d.collection = ?
+      AND (d.path = ? OR d.original_path = ?)
+      AND d.active = 1
     LIMIT 1
-  `).get(collectionName, relativePath) as { path: string } | null;
+  `).get(collectionName, relativePath, relativePath) as { path: string } | null;
 
   if (!doc) return null;
 
@@ -4026,8 +4036,8 @@ export function findDocument(db: Database, filename: string, options: { includeB
   // Build computed columns
   // Note: absoluteFilepath is computed from YAML collections after query
   const selectCols = `
-    'qmd://' || d.collection || '/' || d.path as virtual_path,
-    d.collection || '/' || d.path as display_path,
+    'qmd://' || d.collection || '/' || COALESCE(d.original_path, d.path) as virtual_path,
+    d.collection || '/' || COALESCE(d.original_path, d.path) as display_path,
     d.title,
     d.hash,
     d.collection,
@@ -4041,8 +4051,11 @@ export function findDocument(db: Database, filename: string, options: { includeB
     SELECT ${selectCols}
     FROM documents d
     JOIN content ON content.hash = d.hash
-    WHERE 'qmd://' || d.collection || '/' || d.path = ? AND d.active = 1
-  `).get(filepath) as DbDocRow | null;
+    WHERE (
+      'qmd://' || d.collection || '/' || COALESCE(d.original_path, d.path) = ?
+      OR 'qmd://' || d.collection || '/' || d.path = ?
+    ) AND d.active = 1
+  `).get(filepath, filepath) as DbDocRow | null;
 
   // Try fuzzy match by virtual path
   if (!doc) {
@@ -4050,9 +4063,12 @@ export function findDocument(db: Database, filename: string, options: { includeB
       SELECT ${selectCols}
       FROM documents d
       JOIN content ON content.hash = d.hash
-      WHERE 'qmd://' || d.collection || '/' || d.path LIKE ? AND d.active = 1
+      WHERE (
+        'qmd://' || d.collection || '/' || COALESCE(d.original_path, d.path) LIKE ?
+        OR 'qmd://' || d.collection || '/' || d.path LIKE ?
+      ) AND d.active = 1
       LIMIT 1
-    `).get(`%${filepath}`) as DbDocRow | null;
+    `).get(`%${filepath}`, `%${filepath}`) as DbDocRow | null;
   }
 
   // Try to match by absolute path (requires looking up collection paths from DB)
@@ -4067,7 +4083,10 @@ export function findDocument(db: Database, filename: string, options: { includeB
       }
       // Otherwise treat filepath as relative to collection
       else if (!filepath.startsWith('/')) {
-        relativePath = filepath;
+        const collectionPrefix = `${coll.name}/`;
+        relativePath = filepath.startsWith(collectionPrefix)
+          ? filepath.slice(collectionPrefix.length)
+          : filepath;
       }
 
       if (relativePath) {
@@ -4075,8 +4094,10 @@ export function findDocument(db: Database, filename: string, options: { includeB
           SELECT ${selectCols}
           FROM documents d
           JOIN content ON content.hash = d.hash
-          WHERE d.collection = ? AND d.path = ? AND d.active = 1
-        `).get(coll.name, relativePath) as DbDocRow | null;
+          WHERE d.collection = ?
+            AND (d.path = ? OR d.original_path = ?)
+            AND d.active = 1
+        `).get(coll.name, relativePath, relativePath) as DbDocRow | null;
         if (doc) break;
       }
     }
@@ -4121,8 +4142,11 @@ export function getDocumentBody(db: Database, doc: DocumentResult | { filepath: 
       SELECT content.doc as body
       FROM documents d
       JOIN content ON content.hash = d.hash
-      WHERE 'qmd://' || d.collection || '/' || d.path = ? AND d.active = 1
-    `).get(filepath) as { body: string } | null;
+      WHERE (
+        'qmd://' || d.collection || '/' || COALESCE(d.original_path, d.path) = ?
+        OR 'qmd://' || d.collection || '/' || d.path = ?
+      ) AND d.active = 1
+    `).get(filepath, filepath) as { body: string } | null;
   }
 
   // Try absolute path by looking up in DB store_collections
@@ -4135,8 +4159,10 @@ export function getDocumentBody(db: Database, doc: DocumentResult | { filepath: 
           SELECT content.doc as body
           FROM documents d
           JOIN content ON content.hash = d.hash
-          WHERE d.collection = ? AND d.path = ? AND d.active = 1
-        `).get(coll.name, relativePath) as { body: string } | null;
+          WHERE d.collection = ?
+            AND (d.path = ? OR d.original_path = ?)
+            AND d.active = 1
+        `).get(coll.name, relativePath, relativePath) as { body: string } | null;
         if (row) break;
       }
     }
@@ -4170,8 +4196,8 @@ export function findDocuments(
 
   const bodyCol = options.includeBody ? `, content.doc as body` : ``;
   const selectCols = `
-    'qmd://' || d.collection || '/' || d.path as virtual_path,
-    d.collection || '/' || d.path as display_path,
+    'qmd://' || d.collection || '/' || COALESCE(d.original_path, d.path) as virtual_path,
+    d.collection || '/' || COALESCE(d.original_path, d.path) as display_path,
     d.title,
     d.hash,
     d.collection,
@@ -4190,16 +4216,22 @@ export function findDocuments(
         SELECT ${selectCols}
         FROM documents d
         JOIN content ON content.hash = d.hash
-        WHERE 'qmd://' || d.collection || '/' || d.path = ? AND d.active = 1
-      `).get(name) as DbDocRow | null;
+        WHERE (
+          'qmd://' || d.collection || '/' || COALESCE(d.original_path, d.path) = ?
+          OR 'qmd://' || d.collection || '/' || d.path = ?
+        ) AND d.active = 1
+      `).get(name, name) as DbDocRow | null;
       if (!doc) {
         doc = db.prepare(`
           SELECT ${selectCols}
           FROM documents d
           JOIN content ON content.hash = d.hash
-          WHERE 'qmd://' || d.collection || '/' || d.path LIKE ? AND d.active = 1
+          WHERE (
+            'qmd://' || d.collection || '/' || COALESCE(d.original_path, d.path) LIKE ?
+            OR 'qmd://' || d.collection || '/' || d.path LIKE ?
+          ) AND d.active = 1
           LIMIT 1
-        `).get(`%${name}`) as DbDocRow | null;
+        `).get(`%${name}`, `%${name}`) as DbDocRow | null;
       }
       if (doc) {
         fileRows.push(doc);
@@ -4225,8 +4257,11 @@ export function findDocuments(
       SELECT ${selectCols}
       FROM documents d
       JOIN content ON content.hash = d.hash
-      WHERE 'qmd://' || d.collection || '/' || d.path IN (${placeholders}) AND d.active = 1
-    `).all(...virtualPaths) as DbDocRow[];
+      WHERE (
+        'qmd://' || d.collection || '/' || COALESCE(d.original_path, d.path) IN (${placeholders})
+        OR 'qmd://' || d.collection || '/' || d.path IN (${placeholders})
+      ) AND d.active = 1
+    `).all(...virtualPaths, ...virtualPaths) as DbDocRow[];
   }
 
   const results: MultiGetResult[] = [];

--- a/src/store.ts
+++ b/src/store.ts
@@ -795,7 +795,7 @@ function rebuildFTSForCjkNormalization(db: Database): void {
     `);
   }
   const rows = db.prepare(`
-    SELECT d.id, d.collection, d.path, d.title, content.doc as body
+    SELECT d.id, d.collection, COALESCE(d.original_path, d.path) AS path, d.title, content.doc as body
     FROM documents d
     JOIN content ON content.hash = d.hash
     WHERE d.active = 1
@@ -853,6 +853,7 @@ function initializeDatabase(db: Database): void {
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       collection TEXT NOT NULL,
       path TEXT NOT NULL,
+      original_path TEXT,
       title TEXT NOT NULL,
       hash TEXT NOT NULL,
       created_at TEXT NOT NULL,
@@ -862,6 +863,11 @@ function initializeDatabase(db: Database): void {
       UNIQUE(collection, path)
     )
   `);
+
+  const documentsInfo = db.prepare(`PRAGMA table_info(documents)`).all() as { name: string }[];
+  if (!documentsInfo.some(col => col.name === 'original_path')) {
+    db.exec(`ALTER TABLE documents ADD COLUMN original_path TEXT`);
+  }
 
   db.exec(`CREATE INDEX IF NOT EXISTS idx_documents_collection ON documents(collection, active)`);
   db.exec(`CREATE INDEX IF NOT EXISTS idx_documents_hash ON documents(hash)`);
@@ -931,7 +937,7 @@ function initializeDatabase(db: Database): void {
       INSERT INTO documents_fts(rowid, filepath, title, body)
       SELECT
         new.id,
-        new.collection || '/' || new.path,
+        new.collection || '/' || COALESCE(new.original_path, new.path),
         new.title,
         (SELECT doc FROM content WHERE hash = new.hash)
       WHERE new.active = 1;
@@ -956,7 +962,7 @@ function initializeDatabase(db: Database): void {
       INSERT OR REPLACE INTO documents_fts(rowid, filepath, title, body)
       SELECT
         new.id,
-        new.collection || '/' || new.path,
+        new.collection || '/' || COALESCE(new.original_path, new.path),
         new.title,
         (SELECT doc FROM content WHERE hash = new.hash)
       WHERE new.active = 1;
@@ -1214,8 +1220,8 @@ export type Store = {
   toVirtualPath: (absolutePath: string) => string | null;
 
   // Search
-  searchFTS: (query: string, limit?: number, collectionName?: string) => SearchResult[];
-  searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => Promise<SearchResult[]>;
+  searchFTS: (query: string, limit?: number, collectionName?: string, pathPrefix?: string) => SearchResult[];
+  searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[], pathPrefix?: string) => Promise<SearchResult[]>;
 
   // Query expansion & reranking
   expandQuery: (query: string, model?: string, intent?: string) => Promise<ExpandedQuery[]>;
@@ -1233,7 +1239,7 @@ export type Store = {
 
   // Document indexing operations
   insertContent: (hash: string, content: string, createdAt: string) => void;
-  insertDocument: (collectionName: string, path: string, title: string, hash: string, createdAt: string, modifiedAt: string) => void;
+  insertDocument: (collectionName: string, path: string, title: string, hash: string, createdAt: string, modifiedAt: string, originalPath?: string | null) => void;
   findActiveDocument: (collectionName: string, path: string) => { id: number; hash: string; title: string } | null;
   findOrMigrateLegacyDocument: (collectionName: string, path: string) => { id: number; hash: string; title: string } | null;
   updateDocumentTitle: (documentId: number, title: string, modifiedAt: string) => void;
@@ -1332,8 +1338,12 @@ export async function reindexCollection(
       if (existing.hash === hash) {
         if (existing.title !== title) {
           updateDocumentTitle(db, existing.id, title, now);
+          db.prepare(`UPDATE documents SET original_path = ? WHERE id = ? AND (original_path IS NULL OR original_path != ?)`)
+            .run(relativeFile, existing.id, relativeFile);
           updated++;
         } else {
+          db.prepare(`UPDATE documents SET original_path = ? WHERE id = ? AND (original_path IS NULL OR original_path != ?)`)
+            .run(relativeFile, existing.id, relativeFile);
           unchanged++;
         }
       } else {
@@ -1341,6 +1351,7 @@ export async function reindexCollection(
         const stat = statSync(filepath);
         updateDocument(db, existing.id, title, hash,
           stat ? new Date(stat.mtime).toISOString() : now);
+        db.prepare(`UPDATE documents SET original_path = ? WHERE id = ?`).run(relativeFile, existing.id);
         updated++;
       }
     } else {
@@ -1349,7 +1360,8 @@ export async function reindexCollection(
       const stat = statSync(filepath);
       insertDocument(db, collectionName, path, title, hash,
         stat ? new Date(stat.birthtime).toISOString() : now,
-        stat ? new Date(stat.mtime).toISOString() : now);
+        stat ? new Date(stat.mtime).toISOString() : now,
+        relativeFile);
     }
 
     processed++;
@@ -1886,8 +1898,8 @@ export function createStore(dbPath?: string): Store {
     toVirtualPath: (absolutePath: string) => toVirtualPath(db, absolutePath),
 
     // Search
-    searchFTS: (query: string, limit?: number, collectionName?: string) => searchFTS(db, query, limit, collectionName),
-    searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => searchVec(db, query, model, limit, collectionName, session, precomputedEmbedding),
+    searchFTS: (query: string, limit?: number, collectionName?: string, pathPrefix?: string) => searchFTS(db, query, limit, collectionName, pathPrefix),
+    searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[], pathPrefix?: string) => searchVec(db, query, model, limit, collectionName, session, precomputedEmbedding, pathPrefix),
 
     // Query expansion & reranking
     expandQuery: (query: string, model?: string, intent?: string) => expandQuery(query, model ?? store.llm?.generateModelName ?? DEFAULT_QUERY_MODEL, db, intent, store.llm),
@@ -1905,7 +1917,7 @@ export function createStore(dbPath?: string): Store {
 
     // Document indexing operations
     insertContent: (hash: string, content: string, createdAt: string) => insertContent(db, hash, content, createdAt),
-    insertDocument: (collectionName: string, path: string, title: string, hash: string, createdAt: string, modifiedAt: string) => insertDocument(db, collectionName, path, title, hash, createdAt, modifiedAt),
+    insertDocument: (collectionName: string, path: string, title: string, hash: string, createdAt: string, modifiedAt: string, originalPath?: string | null) => insertDocument(db, collectionName, path, title, hash, createdAt, modifiedAt, originalPath),
     findActiveDocument: (collectionName: string, path: string) => findActiveDocument(db, collectionName, path),
     findOrMigrateLegacyDocument: (collectionName: string, path: string) => findOrMigrateLegacyDocument(db, collectionName, path),
     updateDocumentTitle: (documentId: number, title: string, modifiedAt: string) => updateDocumentTitle(db, documentId, title, modifiedAt),
@@ -2060,6 +2072,8 @@ export type RRFScoreTrace = {
 };
 
 export type HybridQueryExplain = {
+  scoreType?: 'rerank-blend' | 'rrf-position';
+  backendSources?: ('bm25' | 'cosine')[];
   ftsScores: number[];
   vectorScores: number[];
   rrf: {
@@ -2415,7 +2429,7 @@ export function insertContent(db: Database, hash: string, content: string, creat
 
 function rebuildDocumentFTS(db: Database, documentId: number): void {
   const row = db.prepare(`
-    SELECT d.id, d.collection, d.path, d.title, content.doc as body
+    SELECT d.id, d.collection, COALESCE(d.original_path, d.path) AS path, d.title, content.doc as body
     FROM documents d
     JOIN content ON content.hash = d.hash
     WHERE d.id = ? AND d.active = 1
@@ -2445,17 +2459,19 @@ export function insertDocument(
   title: string,
   hash: string,
   createdAt: string,
-  modifiedAt: string
+  modifiedAt: string,
+  originalPath?: string | null
 ): void {
   db.prepare(`
-    INSERT INTO documents (collection, path, title, hash, created_at, modified_at, active)
-    VALUES (?, ?, ?, ?, ?, ?, 1)
+    INSERT INTO documents (collection, path, original_path, title, hash, created_at, modified_at, active)
+    VALUES (?, ?, ?, ?, ?, ?, ?, 1)
     ON CONFLICT(collection, path) DO UPDATE SET
+      original_path = COALESCE(excluded.original_path, documents.original_path),
       title = excluded.title,
       hash = excluded.hash,
       modified_at = excluded.modified_at,
       active = 1
-  `).run(collectionName, path, title, hash, createdAt, modifiedAt);
+  `).run(collectionName, path, originalPath ?? null, title, hash, createdAt, modifiedAt);
 
   const row = db.prepare(`SELECT id FROM documents WHERE collection = ? AND path = ?`).get(collectionName, path) as { id: number } | undefined;
   if (row) rebuildDocumentFTS(db, row.id);
@@ -3378,6 +3394,36 @@ export function validateSemanticQuery(query: string): string | null {
   return null;
 }
 
+/**
+ * Normalize a folder-prefix path for search pathPrefix filters.
+ *
+ * Folder-prefix ONLY. File-prefix matching is not supported — e.g.,
+ * normalizePathPrefix("README.md") returns "README.md/" which matches no docs
+ * (no document has path starting with "README.md/"). If you need to find a
+ * specific file, query without pathPrefix or use a folder containing the file.
+ *
+ * Returns null for empty/root input; callers must skip the SQL predicate then.
+ */
+function normalizePathPrefix(p: string): string | null {
+  const cleaned = p
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '');
+  if (!cleaned) return null;
+  return cleaned + '/';
+}
+
+/** Compute the exclusive upper bound for a folder-prefix range query. */
+function lexicographicSuccessor(p: string): string {
+  if (!p.endsWith('/')) {
+    throw new Error(`lexicographicSuccessor: input must end with '/', got: ${JSON.stringify(p)}`);
+  }
+  return p.slice(0, -1) + '0';
+}
+
+export const __testPathPrefixHelpers = { normalizePathPrefix, lexicographicSuccessor };
+
 export function validateLexQuery(query: string): string | null {
   if (/[\r\n]/.test(query)) {
     return 'Lex queries must be a single line. Remove newline characters or split into separate lex: lines.';
@@ -3389,7 +3435,7 @@ export function validateLexQuery(query: string): string | null {
   return null;
 }
 
-export function searchFTS(db: Database, query: string, limit: number = 20, collectionName?: string): SearchResult[] {
+export function searchFTS(db: Database, query: string, limit: number = 20, collectionName?: string, pathPrefix?: string): SearchResult[] {
   const ftsQuery = buildFTS5Query(query);
   if (!ftsQuery) return [];
 
@@ -3399,11 +3445,13 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
   // abandon the FTS5 index and fall back to a full scan — turning an 8ms
   // query into a 17-second query on large collections.
   const params: (string | number)[] = [ftsQuery];
+  const normalizedPath = pathPrefix ? normalizePathPrefix(pathPrefix) : null;
 
-  // When filtering by collection, fetch extra candidates from the FTS index
-  // since some will be filtered out. Without a collection filter we can
-  // fetch exactly the requested limit.
-  const ftsLimit = collectionName ? limit * 10 : limit;
+  // When filtering by collection/path, fetch extra candidates from the FTS index
+  // since some will be filtered out. Without a filter we can fetch exactly the requested limit.
+  // Recall behavior is documented but not guaranteed for highly selective filters; this
+  // matches qmd's existing collection-filter overfetch heuristic.
+  const ftsLimit = (collectionName || normalizedPath) ? limit * 10 : limit;
 
   let sql = `
     WITH fts_matches AS (
@@ -3414,8 +3462,8 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
       LIMIT ${ftsLimit}
     )
     SELECT
-      'qmd://' || d.collection || '/' || d.path as filepath,
-      d.collection || '/' || d.path as display_path,
+      'qmd://' || d.collection || '/' || COALESCE(d.original_path, d.path) as filepath,
+      d.collection || '/' || COALESCE(d.original_path, d.path) as display_path,
       d.title,
       content.doc as body,
       d.hash,
@@ -3429,6 +3477,10 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
   if (collectionName) {
     sql += ` AND d.collection = ?`;
     params.push(String(collectionName));
+  }
+  if (normalizedPath) {
+    sql += ` AND COALESCE(d.original_path, d.path) COLLATE BINARY >= ? AND COALESCE(d.original_path, d.path) COLLATE BINARY < ?`;
+    params.push(normalizedPath, lexicographicSuccessor(normalizedPath));
   }
 
   // bm25 lower is better; sort ascending.
@@ -3464,7 +3516,7 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
 // Vector Search
 // =============================================================================
 
-export async function searchVec(db: Database, query: string, model: string, limit: number = 20, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]): Promise<SearchResult[]> {
+export async function searchVec(db: Database, query: string, model: string, limit: number = 20, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[], pathPrefix?: string): Promise<SearchResult[]> {
   const tableExists = db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'`).get();
   if (!tableExists) return [];
 
@@ -3476,12 +3528,15 @@ export async function searchVec(db: Database, query: string, model: string, limi
   // "optimize" this by combining into a single query with JOINs - it will break.
   // See: https://github.com/tobi/qmd/pull/23
 
+  const normalizedPath = pathPrefix ? normalizePathPrefix(pathPrefix) : null;
+  const vecLimit = (collectionName || normalizedPath) ? limit * 10 : limit * 3;
+
   // Step 1: Get vector matches from sqlite-vec (no JOINs allowed)
   const vecResults = db.prepare(`
     SELECT hash_seq, distance
     FROM vectors_vec
     WHERE embedding MATCH ? AND k = ?
-  `).all(new Float32Array(embedding), limit * 3) as { hash_seq: string; distance: number }[];
+  `).all(new Float32Array(embedding), vecLimit) as { hash_seq: string; distance: number }[];
 
   if (vecResults.length === 0) return [];
 
@@ -3496,8 +3551,8 @@ export async function searchVec(db: Database, query: string, model: string, limi
       cv.hash || '_' || cv.seq as hash_seq,
       cv.hash,
       cv.pos,
-      'qmd://' || d.collection || '/' || d.path as filepath,
-      d.collection || '/' || d.path as display_path,
+      'qmd://' || d.collection || '/' || COALESCE(d.original_path, d.path) as filepath,
+      d.collection || '/' || COALESCE(d.original_path, d.path) as display_path,
       d.title,
       content.doc as body
     FROM content_vectors cv
@@ -3510,6 +3565,10 @@ export async function searchVec(db: Database, query: string, model: string, limi
   if (collectionName) {
     docSql += ` AND d.collection = ?`;
     params.push(collectionName);
+  }
+  if (normalizedPath) {
+    docSql += ` AND COALESCE(d.original_path, d.path) COLLATE BINARY >= ? AND COALESCE(d.original_path, d.path) COLLATE BINARY < ?`;
+    params.push(normalizedPath, lexicographicSuccessor(normalizedPath));
   }
 
   const docRows = withLazyContentVectorMigration(db, () => db.prepare(docSql).all(...params) as {
@@ -4436,6 +4495,8 @@ export interface SearchHooks {
 
 export interface HybridQueryOptions {
   collection?: string;
+  /** Filter to folder-prefix within collection (folder-only, not file-prefix). */
+  pathPrefix?: string;
   limit?: number;           // default 10
   minScore?: number;        // default 0
   candidateLimit?: number;  // default RERANK_CANDIDATE_LIMIT
@@ -4502,6 +4563,7 @@ export async function hybridQuery(
   const minScore = options?.minScore ?? 0;
   const candidateLimit = options?.candidateLimit ?? RERANK_CANDIDATE_LIMIT;
   const collection = options?.collection;
+  const pathPrefix = options?.pathPrefix;
   const explain = options?.explain ?? false;
   const intent = options?.intent;
   const skipRerank = options?.skipRerank ?? false;
@@ -4519,7 +4581,7 @@ export async function hybridQuery(
   // match may not be what the caller wants (e.g. "performance" with intent
   // "web page load times" should NOT shortcut to a sports-performance doc).
   // Pass collection directly into FTS query (filter at SQL level, not post-hoc)
-  const initialFts = store.searchFTS(query, 20, collection);
+  const initialFts = store.searchFTS(query, 20, collection, pathPrefix);
   const topScore = initialFts[0]?.score ?? 0;
   const secondScore = initialFts[1]?.score ?? 0;
   const hasStrongSignal = !intent && initialFts.length > 0
@@ -4556,7 +4618,7 @@ export async function hybridQuery(
   // 3a: Run FTS for all lex expansions right away (no LLM needed)
   for (const q of expanded) {
     if (q.type === 'lex') {
-      const ftsResults = store.searchFTS(q.query, 20, collection);
+      const ftsResults = store.searchFTS(q.query, 20, collection, pathPrefix);
       if (ftsResults.length > 0) {
         for (const r of ftsResults) docidMap.set(r.filepath, r.docid);
         rankedLists.push(ftsResults.map(r => ({
@@ -4595,7 +4657,7 @@ export async function hybridQuery(
 
       const vecResults = await store.searchVec(
         vecQueries[i]!.text, embedModel, 20, collection,
-        undefined, embedding
+        undefined, embedding, pathPrefix
       );
       if (vecResults.length > 0) {
         for (const r of vecResults) docidMap.set(r.filepath, r.docid);
@@ -4660,9 +4722,16 @@ export async function hybridQuery(
         const rrfRank = i + 1;
         const rrfScore = 1 / rrfRank;
         const trace = rrfTraceByFile?.get(cand.file);
+        const ftsScores = trace?.contributions.filter(c => c.source === "fts").map(c => c.backendScore) ?? [];
+        const vectorScores = trace?.contributions.filter(c => c.source === "vec").map(c => c.backendScore) ?? [];
         const explainData: HybridQueryExplain | undefined = explain ? {
-          ftsScores: trace?.contributions.filter(c => c.source === "fts").map(c => c.backendScore) ?? [],
-          vectorScores: trace?.contributions.filter(c => c.source === "vec").map(c => c.backendScore) ?? [],
+          scoreType: 'rrf-position' as const,
+          backendSources: [
+            ...(ftsScores.length > 0 ? ['bm25' as const] : []),
+            ...(vectorScores.length > 0 ? ['cosine' as const] : []),
+          ],
+          ftsScores,
+          vectorScores,
           rrf: {
             rank: rrfRank,
             positionScore: rrfScore,
@@ -4734,9 +4803,16 @@ export async function hybridQuery(
     const bestChunk = chunkInfo?.chunks[bestIdx]?.text || candidate?.body || "";
     const bestChunkPos = chunkInfo?.chunks[bestIdx]?.pos || 0;
     const trace = rrfTraceByFile?.get(r.file);
+    const ftsScores = trace?.contributions.filter(c => c.source === "fts").map(c => c.backendScore) ?? [];
+    const vectorScores = trace?.contributions.filter(c => c.source === "vec").map(c => c.backendScore) ?? [];
     const explainData: HybridQueryExplain | undefined = explain ? {
-      ftsScores: trace?.contributions.filter(c => c.source === "fts").map(c => c.backendScore) ?? [],
-      vectorScores: trace?.contributions.filter(c => c.source === "vec").map(c => c.backendScore) ?? [],
+      scoreType: 'rerank-blend' as const,
+      backendSources: [
+        ...(ftsScores.length > 0 ? ['bm25' as const] : []),
+        ...(vectorScores.length > 0 ? ['cosine' as const] : []),
+      ],
+      ftsScores,
+      vectorScores,
       rrf: {
         rank: rrfRank,
         positionScore: rrfScore,
@@ -4778,6 +4854,8 @@ export async function hybridQuery(
 
 export interface VectorSearchOptions {
   collection?: string;
+  /** Filter to folder-prefix within collection (folder-only, not file-prefix). */
+  pathPrefix?: string;
   limit?: number;           // default 10
   minScore?: number;        // default 0.3
   intent?: string;          // domain intent hint for disambiguation
@@ -4811,6 +4889,7 @@ export async function vectorSearchQuery(
   const limit = options?.limit ?? 10;
   const minScore = options?.minScore ?? 0.3;
   const collection = options?.collection;
+  const pathPrefix = options?.pathPrefix;
   const intent = options?.intent;
 
   const hasVectors = !!store.db.prepare(
@@ -4829,7 +4908,7 @@ export async function vectorSearchQuery(
   const queryTexts = [query, ...vecExpanded.map(q => q.query)];
   const allResults = new Map<string, VectorSearchResult>();
   for (const q of queryTexts) {
-    const vecResults = await store.searchVec(q, embedModel, limit, collection);
+    const vecResults = await store.searchVec(q, embedModel, limit, collection, undefined, undefined, pathPrefix);
     for (const r of vecResults) {
       const existing = allResults.get(r.filepath);
       if (!existing || r.score > existing.score) {
@@ -4862,6 +4941,8 @@ export async function vectorSearchQuery(
  */
 export interface StructuredSearchOptions {
   collections?: string[];   // Filter to specific collections (OR match)
+  /** Filter to folder-prefix within collection(s); folder-only, not file-prefix. */
+  pathPrefix?: string;
   limit?: number;           // default 10
   minScore?: number;        // default 0
   candidateLimit?: number;  // default RERANK_CANDIDATE_LIMIT
@@ -4906,6 +4987,7 @@ export async function structuredSearch(
   const hooks = options?.hooks;
 
   const collections = options?.collections;
+  const pathPrefix = options?.pathPrefix;
 
   if (searches.length === 0) return [];
 
@@ -4942,7 +5024,7 @@ export async function structuredSearch(
   for (const search of searches) {
     if (search.type === 'lex') {
       for (const coll of collectionList) {
-        const ftsResults = store.searchFTS(search.query, 20, coll);
+        const ftsResults = store.searchFTS(search.query, 20, coll, pathPrefix);
         if (ftsResults.length > 0) {
           for (const r of ftsResults) docidMap.set(r.filepath, r.docid);
           rankedLists.push(ftsResults.map(r => ({
@@ -4981,7 +5063,7 @@ export async function structuredSearch(
         for (const coll of collectionList) {
           const vecResults = await store.searchVec(
             vecSearches[i]!.query, embedModel, 20, coll,
-            undefined, embedding
+            undefined, embedding, pathPrefix
           );
           if (vecResults.length > 0) {
             for (const r of vecResults) docidMap.set(r.filepath, r.docid);
@@ -5054,9 +5136,16 @@ export async function structuredSearch(
         const rrfRank = i + 1;
         const rrfScore = 1 / rrfRank;
         const trace = rrfTraceByFile?.get(cand.file);
+        const ftsScores = trace?.contributions.filter(c => c.source === "fts").map(c => c.backendScore) ?? [];
+        const vectorScores = trace?.contributions.filter(c => c.source === "vec").map(c => c.backendScore) ?? [];
         const explainData: HybridQueryExplain | undefined = explain ? {
-          ftsScores: trace?.contributions.filter(c => c.source === "fts").map(c => c.backendScore) ?? [],
-          vectorScores: trace?.contributions.filter(c => c.source === "vec").map(c => c.backendScore) ?? [],
+          scoreType: 'rrf-position' as const,
+          backendSources: [
+            ...(ftsScores.length > 0 ? ['bm25' as const] : []),
+            ...(vectorScores.length > 0 ? ['cosine' as const] : []),
+          ],
+          ftsScores,
+          vectorScores,
           rrf: {
             rank: rrfRank,
             positionScore: rrfScore,
@@ -5127,9 +5216,16 @@ export async function structuredSearch(
     const bestChunk = chunkInfo?.chunks[bestIdx]?.text || candidate?.body || "";
     const bestChunkPos = chunkInfo?.chunks[bestIdx]?.pos || 0;
     const trace = rrfTraceByFile?.get(r.file);
+    const ftsScores = trace?.contributions.filter(c => c.source === "fts").map(c => c.backendScore) ?? [];
+    const vectorScores = trace?.contributions.filter(c => c.source === "vec").map(c => c.backendScore) ?? [];
     const explainData: HybridQueryExplain | undefined = explain ? {
-      ftsScores: trace?.contributions.filter(c => c.source === "fts").map(c => c.backendScore) ?? [],
-      vectorScores: trace?.contributions.filter(c => c.source === "vec").map(c => c.backendScore) ?? [],
+      scoreType: 'rerank-blend' as const,
+      backendSources: [
+        ...(ftsScores.length > 0 ? ['bm25' as const] : []),
+        ...(vectorScores.length > 0 ? ['cosine' as const] : []),
+      ],
+      ftsScores,
+      vectorScores,
       rrf: {
         rank: rrfRank,
         positionScore: rrfScore,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -869,6 +869,80 @@ describe("CLI Multi-Get Command", () => {
   });
 });
 
+describe("CLI original path roundtrip", () => {
+  let localDbPath: string;
+  let localConfigDir: string;
+  let roundtripDir: string;
+
+  beforeAll(async () => {
+    const env = await createIsolatedTestEnv("cli-original-roundtrip");
+    localDbPath = env.dbPath;
+    localConfigDir = env.configDir;
+    roundtripDir = join(testDir, "cli-original-roundtrip-fixtures");
+
+    await mkdir(join(roundtripDir, "+Projects", "Some Folder"), { recursive: true });
+    await writeFile(join(roundtripDir, "+Projects", "Some Folder", "Case File.md"), "# Case File\nroundtrip-special-token");
+
+    await writeFile(
+      join(localConfigDir, "index.yml"),
+      `collections:
+  vault:
+    path: ${roundtripDir}
+    pattern: "**/*.md"
+`
+    );
+
+    const { exitCode, stderr } = await runQmd(["update"], {
+      cwd: roundtripDir,
+      dbPath: localDbPath,
+      configDir: localConfigDir,
+    });
+    if (exitCode !== 0) console.error("update failed:", stderr);
+    expect(exitCode).toBe(0);
+  });
+
+  test("search result paths can be passed back to get", async () => {
+    const search = await runQmd(["search", "roundtrip-special-token", "--json", "-n", "1"], {
+      cwd: roundtripDir,
+      dbPath: localDbPath,
+      configDir: localConfigDir,
+    });
+    expect(search.exitCode).toBe(0);
+    const results = JSON.parse(search.stdout) as { file: string }[];
+    expect(results[0]!.file).toBe("qmd://vault/+Projects/Some Folder/Case File.md");
+
+    const get = await runQmd(["get", results[0]!.file, "-l", "1"], {
+      cwd: roundtripDir,
+      dbPath: localDbPath,
+      configDir: localConfigDir,
+    });
+    expect(get.exitCode).toBe(0);
+    expect(get.stdout).toContain("# Case File");
+  });
+
+  test("get and multi-get accept original paths with spaces and symbols", async () => {
+    const originalPath = "+Projects/Some Folder/Case File.md";
+    const get = await runQmd(["get", originalPath, "-l", "1"], {
+      cwd: roundtripDir,
+      dbPath: localDbPath,
+      configDir: localConfigDir,
+    });
+    expect(get.exitCode).toBe(0);
+    expect(get.stdout).toContain("# Case File");
+
+    const multi = await runQmd(["multi-get", "+Projects/Some Folder/*.md", "--json"], {
+      cwd: roundtripDir,
+      dbPath: localDbPath,
+      configDir: localConfigDir,
+    });
+    expect(multi.exitCode).toBe(0);
+    const docs = JSON.parse(multi.stdout) as { file: string; body: string }[];
+    expect(docs).toHaveLength(1);
+    expect(docs[0]!.file).toBe("+Projects/Some Folder/Case File.md");
+    expect(docs[0]!.body).toContain("roundtrip-special-token");
+  });
+});
+
 describe("CLI Update Command", () => {
   let localDbPath: string;
 

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -53,6 +53,7 @@ function initTestDatabase(db: Database): void {
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       collection TEXT NOT NULL,
       path TEXT NOT NULL,
+      original_path TEXT,
       title TEXT NOT NULL,
       hash TEXT NOT NULL,
       created_at TEXT NOT NULL,

--- a/test/path-filter.test.ts
+++ b/test/path-filter.test.ts
@@ -7,6 +7,8 @@ import {
   hashContent,
   insertContent,
   insertDocument,
+  findDocument,
+  findDocuments,
   searchFTS,
   structuredSearch,
   __testPathPrefixHelpers,
@@ -120,6 +122,63 @@ describe("searchFTS pathPrefix", () => {
   test("lexicographicSuccessor invariant", () => {
     expect(__testPathPrefixHelpers.lexicographicSuccessor("stack/")).toBe("stack0");
     expect(() => __testPathPrefixHelpers.lexicographicSuccessor("stack")).toThrow(/must end with '\/'/);
+  });
+});
+
+describe("original path roundtrip", () => {
+  test("findDocument accepts original, virtual original, collection-prefixed original, and slug paths", async () => {
+    const store = await makeStore();
+    await addDoc(
+      store,
+      "projects/04-dashboard/docs/infra-tab.md",
+      "fcose graph layout",
+      "Infra Tab",
+      "+projects/04 Dashboard/docs/infra-tab.md"
+    );
+
+    const lookups = [
+      "+projects/04 Dashboard/docs/infra-tab.md",
+      "docs/+projects/04 Dashboard/docs/infra-tab.md",
+      "qmd://docs/+projects/04 Dashboard/docs/infra-tab.md",
+      "projects/04-dashboard/docs/infra-tab.md",
+      "qmd://docs/projects/04-dashboard/docs/infra-tab.md",
+    ];
+
+    for (const lookup of lookups) {
+      const doc = findDocument(store.db, lookup, { includeBody: true });
+      expect("error" in doc ? doc.error : null, lookup).toBeNull();
+      if (!("error" in doc)) {
+        expect(doc.filepath).toBe("qmd://docs/+projects/04 Dashboard/docs/infra-tab.md");
+        expect(doc.displayPath).toBe("docs/+projects/04 Dashboard/docs/infra-tab.md");
+        expect(doc.body).toContain("fcose graph layout");
+      }
+    }
+  });
+
+  test("findDocuments glob matches original paths and returns original display paths", async () => {
+    const store = await makeStore();
+    await addDoc(
+      store,
+      "projects/04-dashboard/docs/a.md",
+      "fcose graph layout",
+      "A",
+      "+projects/04 Dashboard/docs/a.md"
+    );
+    await addDoc(
+      store,
+      "projects/04-dashboard/docs/b.md",
+      "fcose graph layout",
+      "B",
+      "+projects/04 Dashboard/docs/b.md"
+    );
+
+    const result = findDocuments(store.db, "+projects/04 Dashboard/docs/*.md", { includeBody: true });
+    expect(result.errors).toEqual([]);
+    expect(result.docs.map(r => r.doc.filepath).sort()).toEqual([
+      "qmd://docs/+projects/04 Dashboard/docs/a.md",
+      "qmd://docs/+projects/04 Dashboard/docs/b.md",
+    ]);
+    expect(result.docs.every(r => !r.skipped && r.doc.body?.includes("fcose graph layout"))).toBe(true);
   });
 });
 

--- a/test/path-filter.test.ts
+++ b/test/path-filter.test.ts
@@ -1,0 +1,143 @@
+import { describe, test, expect, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  createStore,
+  hashContent,
+  insertContent,
+  insertDocument,
+  searchFTS,
+  structuredSearch,
+  __testPathPrefixHelpers,
+  type Store,
+} from "../src/store.js";
+
+const stores: Store[] = [];
+const dirs: string[] = [];
+
+async function makeStore(): Promise<Store> {
+  const dir = await mkdtemp(join(tmpdir(), "qmd-path-filter-"));
+  dirs.push(dir);
+  const store = createStore(join(dir, "test.sqlite"));
+  stores.push(store);
+  return store;
+}
+
+async function addDoc(store: Store, path: string, body: string, title = path, originalPath?: string): Promise<void> {
+  const now = new Date().toISOString();
+  const hash = await hashContent(`${path}\n${body}`);
+  insertContent(store.db, hash, body, now);
+  insertDocument(store.db, "docs", path, title, hash, now, now, originalPath);
+}
+
+afterEach(async () => {
+  while (stores.length) stores.pop()!.close();
+  while (dirs.length) await rm(dirs.pop()!, { recursive: true, force: true });
+});
+
+describe("searchFTS pathPrefix", () => {
+  test("returns all docs without filter", async () => {
+    const store = await makeStore();
+    await addDoc(store, "stack/a.md", "fcose graph layout");
+    await addDoc(store, "other/b.md", "fcose graph layout");
+
+    const results = searchFTS(store.db, "fcose", 10, "docs");
+    expect(results.map(r => r.filepath).sort()).toEqual([
+      "qmd://docs/other/b.md",
+      "qmd://docs/stack/a.md",
+    ]);
+  });
+
+  test("filters by folder-prefix and normalizes slashes/whitespace", async () => {
+    const store = await makeStore();
+    await addDoc(store, "foo/bar/a.md", "fcose graph layout");
+    await addDoc(store, "foo/baz/b.md", "fcose graph layout");
+
+    const results = searchFTS(store.db, "fcose", 10, "docs", "  /foo\\bar/  ");
+    expect(results.map(r => r.filepath)).toEqual(["qmd://docs/foo/bar/a.md"]);
+  });
+
+  test("root and empty path mean no filter", async () => {
+    const store = await makeStore();
+    await addDoc(store, "stack/a.md", "fcose graph layout");
+    await addDoc(store, "other/b.md", "fcose graph layout");
+
+    expect(searchFTS(store.db, "fcose", 10, "docs", "/")).toHaveLength(2);
+    expect(searchFTS(store.db, "fcose", 10, "docs", "   ")).toHaveLength(2);
+  });
+
+  test("range predicate respects folder boundary", async () => {
+    const store = await makeStore();
+    await addDoc(store, "stack/a.md", "fcose graph layout");
+    await addDoc(store, "stack0/b.md", "fcose graph layout");
+    await addDoc(store, "stack-monitor/c.md", "fcose graph layout");
+
+    const results = searchFTS(store.db, "fcose", 10, "docs", "stack");
+    expect(results.map(r => r.filepath)).toEqual(["qmd://docs/stack/a.md"]);
+  });
+
+  test("range predicate is case-sensitive", async () => {
+    const store = await makeStore();
+    await addDoc(store, "Stack/a.md", "fcose graph layout");
+    await addDoc(store, "stack/b.md", "fcose graph layout");
+
+    const results = searchFTS(store.db, "fcose", 10, "docs", "stack");
+    expect(results.map(r => r.filepath)).toEqual(["qmd://docs/stack/b.md"]);
+  });
+
+  test("uses original paths for case-sensitive folder filtering and result paths", async () => {
+    const store = await makeStore();
+    await addDoc(store, "stack/a.md", "fcose graph layout", "stack/a.md", "stack/a.md");
+    await addDoc(store, "stack/d.md", "fcose graph layout", "Stack/d.md", "Stack/d.md");
+    await addDoc(store, "stack/sub/e.md", "fcose graph layout", "stack/sub/e.md", "stack/sub/e.md");
+
+    expect(searchFTS(store.db, "fcose", 10, "docs", "stack").map(r => r.filepath).sort()).toEqual([
+      "qmd://docs/stack/a.md",
+      "qmd://docs/stack/sub/e.md",
+    ]);
+    expect(searchFTS(store.db, "fcose", 10, "docs", "Stack").map(r => r.filepath)).toEqual([
+      "qmd://docs/Stack/d.md",
+    ]);
+  });
+
+  test("folder-only design: file-like path matches no documents", async () => {
+    const store = await makeStore();
+    await addDoc(store, "README.md", "fcose graph layout");
+
+    expect(searchFTS(store.db, "fcose", 10, "docs", "README.md")).toEqual([]);
+  });
+
+  test("SQL injection probe is parameterized", async () => {
+    const store = await makeStore();
+    await addDoc(store, "stack/a.md", "fcose graph layout");
+
+    const results = searchFTS(store.db, "fcose", 10, "docs", "'; DROP TABLE documents;--");
+    expect(results).toEqual([]);
+    expect(searchFTS(store.db, "fcose", 10, "docs", "stack")).toHaveLength(1);
+  });
+
+  test("lexicographicSuccessor invariant", () => {
+    expect(__testPathPrefixHelpers.lexicographicSuccessor("stack/")).toBe("stack0");
+    expect(() => __testPathPrefixHelpers.lexicographicSuccessor("stack")).toThrow(/must end with '\/'/);
+  });
+});
+
+describe("structuredSearch pathPrefix", () => {
+  test("passes pathPrefix through structured lex search", async () => {
+    const store = await makeStore();
+    await addDoc(store, "stack/a.md", "fcose graph layout");
+    await addDoc(store, "other/b.md", "fcose graph layout");
+
+    const results = await structuredSearch(
+      store,
+      [{ type: "lex", query: "fcose" }],
+      { collections: ["docs"], pathPrefix: "stack", skipRerank: true, explain: true }
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.file).toBe("qmd://docs/stack/a.md");
+    expect(results[0]!.explain?.scoreType).toBe("rrf-position");
+    expect(results[0]!.explain?.backendSources).toEqual(["bm25"]);
+  });
+});

--- a/test/score-breakdown.test.ts
+++ b/test/score-breakdown.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  createStore,
+  hashContent,
+  insertContent,
+  insertDocument,
+  structuredSearch,
+  type Store,
+} from "../src/store.js";
+
+const stores: Store[] = [];
+const dirs: string[] = [];
+
+async function makeStore(): Promise<Store> {
+  const dir = await mkdtemp(join(tmpdir(), "qmd-score-breakdown-"));
+  dirs.push(dir);
+  const store = createStore(join(dir, "test.sqlite"));
+  stores.push(store);
+  return store;
+}
+
+async function addDoc(store: Store, path: string, body: string, title = path): Promise<void> {
+  const now = new Date().toISOString();
+  const hash = await hashContent(`${path}\n${body}`);
+  insertContent(store.db, hash, body, now);
+  insertDocument(store.db, "docs", path, title, hash, now, now);
+}
+
+afterEach(async () => {
+  while (stores.length) stores.pop()!.close();
+  while (dirs.length) await rm(dirs.pop()!, { recursive: true, force: true });
+});
+
+describe("score breakdown", () => {
+  test("rerank:false exposes rrf-position and per-result bm25 backend", async () => {
+    const store = await makeStore();
+    await addDoc(store, "stack/a.md", "fcose graph layout");
+
+    const results = await structuredSearch(
+      store,
+      [{ type: "lex", query: "fcose" }],
+      { collections: ["docs"], skipRerank: true, explain: true }
+    );
+
+    expect(results[0]!.score).toBe(1);
+    expect(results[0]!.explain?.scoreType).toBe("rrf-position");
+    expect(results[0]!.explain?.backendSources).toEqual(["bm25"]);
+    expect(results[0]!.explain?.ftsScores.length).toBeGreaterThan(0);
+    expect(results[0]!.explain?.vectorScores).toEqual([]);
+  });
+
+  test("rerank:true exposes rerank-blend without calling a real LLM", async () => {
+    const store = await makeStore();
+    await addDoc(store, "stack/a.md", "fcose graph layout");
+    store.rerank = async (_query, docs) => docs.map(doc => ({ file: doc.file, score: 0.5 }));
+
+    const results = await structuredSearch(
+      store,
+      [{ type: "lex", query: "fcose" }],
+      { collections: ["docs"], skipRerank: false, explain: true }
+    );
+
+    expect(results[0]!.explain?.scoreType).toBe("rerank-blend");
+    expect(results[0]!.explain?.backendSources).toEqual(["bm25"]);
+    expect(results[0]!.explain?.rerankScore).toBe(0.5);
+    expect(results[0]!.score).toBe(results[0]!.explain?.blendedScore);
+  });
+
+  test("score is unrounded when explain payload is available", async () => {
+    const store = await makeStore();
+    await addDoc(store, "stack/a.md", "fcose graph layout");
+
+    const results = await structuredSearch(
+      store,
+      [{ type: "lex", query: "fcose" }],
+      { collections: ["docs"], skipRerank: true, explain: true }
+    );
+
+    expect(results[0]!.explain).toBeDefined();
+    expect(results[0]!.score).toBe(results[0]!.explain!.blendedScore);
+  });
+});


### PR DESCRIPTION
## Summary

Adds folder-scoped search filtering and richer score explanation metadata across qmd search APIs.

## Changes

- Add `pathPrefix` filtering to SDK/MCP/REST search paths and `--path/-p` to the CLI.
- Preserve original indexed file paths in `documents.original_path` and use them for user-facing path filtering/results, while keeping existing normalized path compatibility.
- Preserve original paths in document lookup, CLI `get`, and CLI/SDK multi-get as well, so a path returned by search (for example `qmd://collection/+Projects/Some Folder/file.md`) can be passed back to `qmd get`, MCP/SDK lookup, and glob multi-get without manually converting to the normalized slug form.
- Make `pathPrefix` folder-only, case-sensitive, boundary-safe, and slash-normalized:
  - `stack` matches `stack/...`
  - `stack` does not match `stack0/...` or `stack-monitor/...`
  - `Stack` and `stack` remain distinct
  - empty string and `/` behave as no filter
- Add `explain.scoreType` and per-result `explain.backendSources` so callers can distinguish RRF-position scores from rerank-blend scores and see whether a result came from BM25 and/or vector evidence.
- Harden HTTP `/query` JSON handling for malformed JSON and invalid `pathPrefix` / `explain` types.

## Semantics

`pathPrefix` is intentionally folder-scoped, not file-prefix matching. File-like prefixes such as `README.md` normalize to a folder prefix and therefore do not match the file itself.

## Tests

Latest targeted verification after the original-path roundtrip fix:

- `bun test test/path-filter.test.ts test/score-breakdown.test.ts test/cli.test.ts --timeout 60000 --preload ./src/test-preload.ts` — 137 passed
- `npm run test:node -- test/path-filter.test.ts test/score-breakdown.test.ts test/cli.test.ts` — 137 passed
- `bun run build`
- `npm run test:types`

Earlier full-suite verification on this PR branch:

- `npm run test:node -- test/path-filter.test.ts test/score-breakdown.test.ts test/mcp.test.ts` — 70 passed
- `npm run test:node` — 904 passed
- `npm run test:bun` — 904 passed
