### PR TITLE
feat(mcp): add --host flag (and QMD_HOST env) to the HTTP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,17 @@ By default, QMD's MCP server uses stdio (launched as a subprocess by each client
 # Foreground (Ctrl-C to stop)
 qmd mcp --http                    # localhost:8181
 qmd mcp --http --port 8080        # custom port
+qmd mcp --http --host 0.0.0.0     # bind all interfaces (e.g. container probes)
 
 # Background daemon
 qmd mcp --http --daemon           # start, writes PID to ~/.cache/qmd/mcp.pid
 qmd mcp stop                      # stop via PID file
 qmd status                        # shows "MCP: running (PID ...)" when active
 ```
+
+The server binds to `localhost` by default. Pass `--host` (or set the `QMD_HOST`
+environment variable) to override — `--host 0.0.0.0` is useful when the server
+runs in a container and a liveness probe connects from a non-loopback address.
 
 The HTTP server exposes two endpoints:
 - `POST /mcp` — MCP Streamable HTTP (JSON responses, stateless)

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -2738,6 +2738,7 @@ function parseCLI() {
       http: { type: "boolean" },
       daemon: { type: "boolean" },
       port: { type: "string" },
+      host: { type: "string" },
     },
     allowPositionals: true,
     strict: false, // Allow unknown options to pass through
@@ -4334,6 +4335,10 @@ if (isMain) {
 
       if (cli.values.http) {
         const port = Number(cli.values.port) || 8181;
+        // --host overrides the default localhost bind; QMD_HOST env is the
+        // fallback (resolved in startMcpHttpServer). Use "0.0.0.0" to accept
+        // off-host connections, e.g. a container liveness probe.
+        const host = cli.values.host ? String(cli.values.host) : undefined;
 
         if (cli.values.daemon) {
           // Guard: check if already running
@@ -4353,9 +4358,10 @@ if (isMain) {
           const logFd = openSync(logPath, "w"); // truncate — fresh log per daemon run
           const selfPath = fileURLToPath(import.meta.url);
           const indexArgs = cli.values.index ? ["--index", String(cli.values.index)] : [];
+          const hostArgs = host ? ["--host", host] : [];
           const spawnArgs = selfPath.endsWith(".ts")
-            ? ["--import", pathJoin(dirname(selfPath), "..", "..", "node_modules", "tsx", "dist", "esm", "index.mjs"), selfPath, ...indexArgs, "mcp", "--http", "--port", String(port)]
-            : [selfPath, ...indexArgs, "mcp", "--http", "--port", String(port)];
+            ? ["--import", pathJoin(dirname(selfPath), "..", "..", "node_modules", "tsx", "dist", "esm", "index.mjs"), selfPath, ...indexArgs, "mcp", "--http", "--port", String(port), ...hostArgs]
+            : [selfPath, ...indexArgs, "mcp", "--http", "--port", String(port), ...hostArgs];
           const child = nodeSpawn(process.execPath, spawnArgs, {
             stdio: ["ignore", logFd, logFd],
             detached: true,
@@ -4364,7 +4370,7 @@ if (isMain) {
           closeSync(logFd); // parent's copy; child inherited the fd
 
           writeFileSync(pidPath, String(child.pid));
-          console.log(`Started on http://localhost:${port}/mcp (PID ${child.pid})`);
+          console.log(`Started on http://${host ?? "localhost"}:${port}/mcp (PID ${child.pid})`);
           console.log(`Logs: ${logPath}`);
           process.exit(0);
         }
@@ -4375,7 +4381,7 @@ if (isMain) {
         process.removeAllListeners("SIGINT");
         const { startMcpHttpServer } = await import("../mcp/server.js");
         try {
-          await startMcpHttpServer(port, { dbPath: getDbPath() });
+          await startMcpHttpServer(port, { dbPath: getDbPath(), host });
         } catch (e: unknown) {
           if (typeof e === "object" && e !== null && "code" in e && e.code === "EADDRINUSE") {
             console.error(`Port ${port} already in use. Try a different port with --port.`);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -574,11 +574,13 @@ export type HttpServerHandle = {
 
 /**
  * Start MCP server over Streamable HTTP (JSON responses, no SSE).
- * Binds to localhost only. Returns a handle for shutdown and port discovery.
+ * Binds to `options.host` (default "localhost", overridable via the QMD_HOST
+ * env var) — set "0.0.0.0" to accept connections from other hosts, e.g. a
+ * container liveness probe. Returns a handle for shutdown and port discovery.
  */
 export async function startMcpHttpServer(
   port: number,
-  options: ({ quiet?: boolean } & McpStartupOptions) = {},
+  options: ({ quiet?: boolean; host?: string } & McpStartupOptions) = {},
 ): Promise<HttpServerHandle> {
   // See startMcpServer() for the rationale — flip production mode here so the
   // HTTP transport resolves the real database path, without leaking state into
@@ -830,9 +832,10 @@ export async function startMcpHttpServer(
     }
   });
 
+  const host = options.host ?? process.env.QMD_HOST ?? "localhost";
   await new Promise<void>((resolve, reject) => {
     httpServer.on("error", reject);
-    httpServer.listen(port, "localhost", () => resolve());
+    httpServer.listen(port, host, () => resolve());
   });
 
   const actualPort = (httpServer.address() as import("net").AddressInfo).port;
@@ -860,7 +863,7 @@ export async function startMcpHttpServer(
     process.exit(0);
   });
 
-  log(`QMD MCP server listening on http://localhost:${actualPort}/mcp`);
+  log(`QMD MCP server listening on http://${host}:${actualPort}/mcp`);
   return { httpServer, port: actualPort, stop };
 }
 


### PR DESCRIPTION
## Problem

`startMcpHttpServer` hardcodes `httpServer.listen(port, "localhost", …)`, so the HTTP MCP server only accepts loopback connections. When `qmd mcp --http` runs inside a container, a Kubernetes liveness/readiness probe connects from the pod IP (e.g. `10.42.x.x`), not `127.0.0.1` — the bind refuses it and the probe fails, so the pod never goes ready.

Today the only workaround is to patch the published `dist/mcp/server.js` at image-build time:

```dockerfile
sed -i 's@listen(port, "localhost"@listen(port, process.env.QMD_HOST || "localhost"@g' "$QMD_DIST"
```

which is brittle and breaks on every release.

## Change

Add a `--host` flag to `qmd mcp --http`, with a `QMD_HOST` environment-variable fallback:

```
host = options.host ?? process.env.QMD_HOST ?? "localhost"
```

- **Default is unchanged** (`localhost`) — no behavior change out of the box.
- `--host 0.0.0.0` (or `QMD_HOST=0.0.0.0`) binds all interfaces for container/probe reachability.
- The flag is forwarded to the detached process in `--daemon` mode and reflected in the startup log / `Started on …` message.

Files:
- `src/mcp/server.ts` — `startMcpHttpServer` resolves and binds `host`; JSDoc + listening log updated.
- `src/cli/qmd.ts` — `--host` flag parsed, forwarded to daemon spawn, shown in logs.
- `README.md` — documents `--host` / `QMD_HOST`.

## Verification

- `npm run test:types` — passes.
- `test/mcp.test.ts` — 57/57 pass (existing HTTP test uses the default and still binds `localhost`).
- Functional smoke:
  ```
  $ qmd mcp --http --host 0.0.0.0 --port 18234
  QMD MCP server listening on http://0.0.0.0:18234/mcp
  $ lsof -nP -iTCP:18234 -sTCP:LISTEN
  node … TCP *:18234 (LISTEN)        # * = all interfaces
  $ curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:18234/health
  200
  ```