### PR TITLE
fix: prevent macOS Metal JSON query aborts after successful output

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -4,8 +4,9 @@ import fastGlob from "fast-glob";
 import { execSync, spawn as nodeSpawn } from "child_process";
 import { fileURLToPath } from "url";
 import { basename, dirname, join as pathJoin, relative as relativePath, resolve as pathResolve } from "path";
+import { constants as osConstants } from "os";
 import { parseArgs } from "util";
-import { readFileSync, readdirSync, realpathSync, statSync, existsSync, unlinkSync, writeFileSync, openSync, closeSync, mkdirSync, lstatSync, rmSync, symlinkSync, readlinkSync, copyFileSync } from "fs";
+import { readFileSync, readdirSync, realpathSync, statSync, existsSync, unlinkSync, writeFileSync, openSync, closeSync, mkdirSync, lstatSync, rmSync, symlinkSync, readlinkSync, copyFileSync, writeSync } from "fs";
 import { createInterface } from "readline/promises";
 import {
   getPwd,
@@ -81,7 +82,7 @@ import {
   type ReindexResult,
   type ChunkStrategy,
 } from "../store.js";
-import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, setDefaultLlamaCpp, LlamaCpp, withLLMSession, pullModels, DEFAULT_MODEL_CACHE_DIR, resolveEmbedModel, resolveGenerateModel, resolveRerankModel, resolveModels, inspectGgufFile } from "../llm.js";
+import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, setDefaultLlamaCpp, LlamaCpp, withLLMSession, pullModels, DEFAULT_MODEL_CACHE_DIR, resolveEmbedModel, resolveGenerateModel, resolveRerankModel, resolveModels, inspectGgufFile, isLlamaGpuDisabledByEnv } from "../llm.js";
 import {
   formatSearchResults,
   formatDocuments,
@@ -220,58 +221,196 @@ type CliLifecycleWritable = {
   write(chunk: string | Uint8Array, callback?: (error?: Error | null) => void): boolean;
 };
 
+const DARWIN_QUERY_JSON_CHILD_ENV = "QMD_DARWIN_QUERY_JSON_CHILD";
+const DARWIN_QUERY_JSON_SUCCESS_FD_ENV = "QMD_DARWIN_QUERY_JSON_SUCCESS_FD";
+const DARWIN_QUERY_JSON_SUCCESS_SENTINEL = "qmd:query-json-success\n";
+
 type FinishSuccessfulCliCommandOptions = {
   command: string;
   format?: OutputFormat;
   cleanup?: () => Promise<void>;
   exit?: (code: number) => void;
-  immediateExit?: (code: number) => void;
+  terminateImmediately?: () => void;
+  successFd?: number;
+  writeSync?: (fd: number, data: string | Uint8Array) => number;
   stdout?: CliLifecycleWritable;
   stderr?: CliLifecycleWritable;
   platform?: NodeJS.Platform;
 };
 
-async function flushWritable(stream: CliLifecycleWritable): Promise<void> {
+type DarwinJsonQuerySupervisorDecision = {
+  command: string;
+  query?: string;
+  format?: OutputFormat;
+  values?: Record<string, unknown>;
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+};
+
+type DarwinJsonQuerySupervisorResult = {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  successOutput: string;
+};
+
+async function writeWritable(stream: CliLifecycleWritable, chunk: string | Uint8Array): Promise<void> {
   await new Promise<void>((resolve) => {
-    stream.write("", () => resolve());
+    stream.write(chunk, () => resolve());
   });
+}
+
+async function flushWritable(stream: CliLifecycleWritable): Promise<void> {
+  await writeWritable(stream, "");
+}
+
+function isJsonQueryCommand(command: string): boolean {
+  return command === "query" || command === "deep-search";
+}
+
+export function shouldSuperviseDarwinJsonQuery(options: DarwinJsonQuerySupervisorDecision): boolean {
+  const env = options.env ?? process.env;
+  const values = options.values ?? {};
+  return (
+    (options.platform ?? process.platform) === "darwin" &&
+    isJsonQueryCommand(options.command) &&
+    options.format === "json" &&
+    Boolean(options.query?.trim()) &&
+    env.QMD_DISABLE_DARWIN_QUERY_JSON_SAFE_EXIT !== "1" &&
+    env[DARWIN_QUERY_JSON_CHILD_ENV] !== "1" &&
+    values["no-gpu"] !== true &&
+    !isLlamaGpuDisabledByEnv(env.QMD_LLAMA_GPU ?? "", env.QMD_FORCE_CPU ?? "")
+  );
+}
+
+function getSupervisedSuccessFd(options: FinishSuccessfulCliCommandOptions): number | undefined {
+  if (options.successFd !== undefined) return options.successFd;
+  if (process.env[DARWIN_QUERY_JSON_CHILD_ENV] !== "1") return undefined;
+  const raw = process.env[DARWIN_QUERY_JSON_SUCCESS_FD_ENV];
+  if (!raw) return undefined;
+  const fd = Number.parseInt(raw, 10);
+  return Number.isFinite(fd) && fd >= 0 ? fd : undefined;
+}
+
+function terminateWithoutNativeCleanup(options: FinishSuccessfulCliCommandOptions): void {
+  if (options.terminateImmediately) {
+    options.terminateImmediately();
+    return;
+  }
+  process.kill(process.pid, "SIGKILL");
+}
+
+export function isSuccessfulJsonSupervisorOutput(stdout: string, successOutput: string): boolean {
+  if (!successOutput.includes(DARWIN_QUERY_JSON_SUCCESS_SENTINEL)) return false;
+  try {
+    JSON.parse(stdout.trim());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function getSelfSpawnArgs(selfPath: string, argvArgs: string[], runtimeIsBun: boolean = isBun): string[] {
+  if (!selfPath.endsWith(".ts")) {
+    return [selfPath, ...argvArgs];
+  }
+  if (runtimeIsBun) {
+    return [selfPath, ...argvArgs];
+  }
+  return ["--import", pathJoin(dirname(selfPath), "..", "..", "node_modules", "tsx", "dist", "esm", "index.mjs"), selfPath, ...argvArgs];
+}
+
+function signalExitCode(signal: NodeJS.Signals | null): number {
+  if (!signal) return 1;
+  const signalNumber = (osConstants.signals as Record<string, number>)[signal];
+  return typeof signalNumber === "number" ? 128 + signalNumber : 1;
+}
+
+export async function writeSupervisorOutput(
+  stdoutText: string,
+  stderrText: string,
+  stdout: CliLifecycleWritable = process.stdout,
+  stderr: CliLifecycleWritable = process.stderr,
+): Promise<void> {
+  if (stderrText) await writeWritable(stderr, stderrText);
+  if (stdoutText) await writeWritable(stdout, stdoutText);
+}
+
+async function collectDarwinJsonQueryChild(selfPath: string, argvArgs: string[]): Promise<DarwinJsonQuerySupervisorResult> {
+  const child = nodeSpawn(process.execPath, getSelfSpawnArgs(selfPath, argvArgs), {
+    env: {
+      ...process.env,
+      [DARWIN_QUERY_JSON_CHILD_ENV]: "1",
+      [DARWIN_QUERY_JSON_SUCCESS_FD_ENV]: "3",
+    },
+    stdio: ["ignore", "pipe", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+  let successOutput = "";
+
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk: string) => { stdout += chunk; });
+  child.stderr?.on("data", (chunk: string) => { stderr += chunk; });
+
+  const successStream = child.stdio[3];
+  if (successStream && "setEncoding" in successStream) {
+    successStream.setEncoding("utf8");
+    successStream.on("data", (chunk: string) => { successOutput += chunk; });
+  }
+
+  return await new Promise((resolve) => {
+    child.on("close", (code, signal) => {
+      resolve({ code, signal, stdout, stderr, successOutput });
+    });
+    child.on("error", (error) => {
+      resolve({ code: 1, signal: null, stdout, stderr: `${stderr}${error.message}\n`, successOutput });
+    });
+  });
+}
+
+async function superviseDarwinJsonQuery(selfPath: string, argvArgs: string[]): Promise<number> {
+  const result = await collectDarwinJsonQueryChild(selfPath, argvArgs);
+  const success = isSuccessfulJsonSupervisorOutput(result.stdout, result.successOutput);
+
+  if (success) {
+    await writeSupervisorOutput(result.stdout, result.stderr);
+    return 0;
+  }
+
+  await writeSupervisorOutput(result.stdout, result.stderr);
+  return result.code ?? signalExitCode(result.signal);
 }
 
 function shouldBypassNativeCleanup(options: FinishSuccessfulCliCommandOptions): boolean {
   return (
     (options.platform ?? process.platform) === "darwin" &&
-    options.command === "query" &&
+    isJsonQueryCommand(options.command) &&
     options.format === "json" &&
     process.env.QMD_DISABLE_DARWIN_QUERY_JSON_SAFE_EXIT !== "1"
   );
 }
 
-function immediateProcessExit(code: number): void {
-  const processWithReallyExit = process as NodeJS.Process & { reallyExit?: (code?: number) => void };
-  if (typeof processWithReallyExit.reallyExit === "function") {
-    processWithReallyExit.reallyExit(code);
-    return;
-  }
-  process.exit(code);
-}
-
 /**
- * Finish a successful CLI command after output has been flushed. On macOS JSON
- * query runs, skip normal native teardown and use Node/Bun's immediate exit path:
- * ggml Metal can abort from C++ finalizers after valid JSON has already been
- * produced (#368). This wrapper is only reached after the command completed, so
- * real query failures still exit through the normal error path before this runs.
+ * Finish a successful CLI command after output has been flushed. In a supervised
+ * macOS JSON query child, write the success sentinel and terminate before native
+ * Metal finalizers can abort after valid JSON has already been produced (#368).
+ * Real query failures still exit through the normal error path before this runs.
  */
 export async function finishSuccessfulCliCommand(options: FinishSuccessfulCliCommandOptions): Promise<void> {
   const stderr = options.stderr ?? process.stderr;
   const exit = options.exit ?? ((code: number) => process.exit(code));
-  const immediateExit = options.immediateExit ?? immediateProcessExit;
 
   await flushWritable(options.stdout ?? process.stdout);
 
-  if (shouldBypassNativeCleanup(options)) {
+  const successFd = getSupervisedSuccessFd(options);
+  if (successFd !== undefined && shouldBypassNativeCleanup(options)) {
     await flushWritable(stderr);
-    immediateExit(0);
+    (options.writeSync ?? writeSync)(successFd, DARWIN_QUERY_JSON_SUCCESS_SENTINEL);
+    terminateWithoutNativeCleanup(options);
     return;
   }
 
@@ -3941,6 +4080,16 @@ if (isMain) {
   if (!cli.command || cli.values.help) {
     showHelp();
     process.exit(cli.values.help ? 0 : 1);
+  }
+
+  if (shouldSuperviseDarwinJsonQuery({
+    command: cli.command,
+    query: cli.query,
+    format: cli.opts.format,
+    values: cli.values,
+  })) {
+    const code = await superviseDarwinJsonQuery(__filename, process.argv.slice(2));
+    process.exit(code);
   }
 
   switch (cli.command) {

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -626,18 +626,27 @@ export function resolveSafeParallelism(options: ParallelismOptions): number {
   return Math.max(1, options.computed);
 }
 
+const LLAMA_GPU_DISABLED_VALUES = new Set(["false", "off", "none", "disable", "disabled", "0"]);
+
+export function isLlamaGpuDisabledByEnv(
+  envValue = process.env.QMD_LLAMA_GPU,
+  forceCpuValue = process.env.QMD_FORCE_CPU
+): boolean {
+  const forceCpu = forceCpuValue?.trim().toLowerCase() ?? "";
+  if (forceCpu && !LLAMA_GPU_DISABLED_VALUES.has(forceCpu)) return true;
+
+  const normalized = envValue?.trim().toLowerCase() ?? "";
+  return LLAMA_GPU_DISABLED_VALUES.has(normalized);
+}
+
 export function resolveLlamaGpuMode(
   envValue = process.env.QMD_LLAMA_GPU,
   forceCpuValue = process.env.QMD_FORCE_CPU
 ): LlamaGpuMode {
-  const forceCpu = forceCpuValue?.trim().toLowerCase() ?? "";
-  if (forceCpu && !["false", "off", "none", "disable", "disabled", "0"].includes(forceCpu)) {
-    return false;
-  }
+  if (isLlamaGpuDisabledByEnv(envValue, forceCpuValue)) return false;
 
   const normalized = envValue?.trim().toLowerCase() ?? "";
   if (!normalized) return "auto";
-  if (["false", "off", "none", "disable", "disabled", "0"].includes(normalized)) return false;
   if (normalized === "metal" || normalized === "vulkan" || normalized === "cuda") return normalized;
 
   process.stderr.write(`QMD Warning: invalid QMD_LLAMA_GPU="${envValue}", using auto GPU selection.\n`);

--- a/test/cli-exit-lifecycle.test.ts
+++ b/test/cli-exit-lifecycle.test.ts
@@ -1,5 +1,12 @@
+import { join as pathJoin } from "path";
 import { describe, expect, test } from "vitest";
-import { finishSuccessfulCliCommand } from "../src/cli/qmd.ts";
+import {
+  finishSuccessfulCliCommand,
+  getSelfSpawnArgs,
+  isSuccessfulJsonSupervisorOutput,
+  shouldSuperviseDarwinJsonQuery,
+  writeSupervisorOutput,
+} from "../src/cli/qmd.ts";
 import { LlamaCpp } from "../src/llm.ts";
 
 describe("CLI successful-exit lifecycle", () => {
@@ -27,27 +34,244 @@ describe("CLI successful-exit lifecycle", () => {
     expect(flushed).toEqual([""]);
   });
 
-  test("uses immediate exit for successful macOS JSON query after stdout flush", async () => {
+  test("uses normal cleanup for unsupervised macOS JSON query runs", async () => {
     const calls: string[] = [];
+    const previousChild = process.env.QMD_DARWIN_QUERY_JSON_CHILD;
+    const previousSuccessFd = process.env.QMD_DARWIN_QUERY_JSON_SUCCESS_FD;
+    delete process.env.QMD_DARWIN_QUERY_JSON_CHILD;
+    process.env.QMD_DARWIN_QUERY_JSON_SUCCESS_FD = "3";
 
-    await finishSuccessfulCliCommand({
+    try {
+      await finishSuccessfulCliCommand({
+        command: "query",
+        format: "json",
+        platform: "darwin",
+        cleanup: async () => {
+          calls.push("cleanup");
+        },
+        exit: (code) => {
+          calls.push(`exit:${code}`);
+        },
+        writeSync: (fd, data) => {
+          calls.push(`sentinel:${fd}:${String(data)}`);
+          return String(data).length;
+        },
+        terminateImmediately: () => {
+          calls.push("terminate");
+        },
+        stdout: { write: (_chunk: string | Uint8Array, cb?: (error?: Error | null) => void) => { calls.push("stdout-flush"); cb?.(); return true; } },
+        stderr: { write: (_chunk: string | Uint8Array, cb?: (error?: Error | null) => void) => { calls.push("stderr-flush"); cb?.(); return true; } },
+      });
+    } finally {
+      if (previousChild === undefined) {
+        delete process.env.QMD_DARWIN_QUERY_JSON_CHILD;
+      } else {
+        process.env.QMD_DARWIN_QUERY_JSON_CHILD = previousChild;
+      }
+      if (previousSuccessFd === undefined) {
+        delete process.env.QMD_DARWIN_QUERY_JSON_SUCCESS_FD;
+      } else {
+        process.env.QMD_DARWIN_QUERY_JSON_SUCCESS_FD = previousSuccessFd;
+      }
+    }
+
+    expect(calls).toEqual(["stdout-flush", "cleanup", "stderr-flush", "exit:0"]);
+  });
+
+  test("supervised macOS JSON query commands write success sentinel and terminate before native cleanup", async () => {
+    for (const command of ["query", "deep-search"]) {
+      const calls: string[] = [];
+
+      await finishSuccessfulCliCommand({
+        command,
+        format: "json",
+        platform: "darwin",
+        successFd: 3,
+        cleanup: async () => {
+          calls.push("cleanup");
+        },
+        writeSync: (fd, data) => {
+          calls.push(`sentinel:${fd}:${String(data)}`);
+          return String(data).length;
+        },
+        terminateImmediately: () => {
+          calls.push("terminate");
+        },
+        stdout: { write: (_chunk: string | Uint8Array, cb?: (error?: Error | null) => void) => { calls.push("stdout-flush"); cb?.(); return true; } },
+        stderr: { write: (_chunk: string | Uint8Array, cb?: (error?: Error | null) => void) => { calls.push("stderr-flush"); cb?.(); return true; } },
+      });
+
+      expect(calls).toEqual([
+        "stdout-flush",
+        "stderr-flush",
+        "sentinel:3:qmd:query-json-success\n",
+        "terminate",
+      ]);
+    }
+  });
+
+  test("supervisor is limited to GPU-capable macOS query JSON runs", () => {
+    expect(shouldSuperviseDarwinJsonQuery({
       command: "query",
+      query: "test",
       format: "json",
       platform: "darwin",
-      cleanup: async () => {
-        calls.push("cleanup");
+      env: {},
+      values: {},
+    })).toBe(true);
+
+    expect(shouldSuperviseDarwinJsonQuery({
+      command: "deep-search",
+      query: "test",
+      format: "json",
+      platform: "darwin",
+      env: {},
+      values: {},
+    })).toBe(true);
+
+    expect(shouldSuperviseDarwinJsonQuery({
+      command: "query",
+      query: "test",
+      format: "json",
+      platform: "darwin",
+      env: { QMD_FORCE_CPU: "1" },
+      values: {},
+    })).toBe(false);
+
+    expect(shouldSuperviseDarwinJsonQuery({
+      command: "query",
+      query: "test",
+      format: "json",
+      platform: "darwin",
+      env: { QMD_FORCE_CPU: "on" },
+      values: {},
+    })).toBe(false);
+
+    expect(shouldSuperviseDarwinJsonQuery({
+      command: "query",
+      query: "test",
+      format: "json",
+      platform: "darwin",
+      env: { QMD_LLAMA_GPU: "off" },
+      values: {},
+    })).toBe(false);
+
+    expect(shouldSuperviseDarwinJsonQuery({
+      command: "query",
+      query: "test",
+      format: "json",
+      platform: "darwin",
+      env: { QMD_LLAMA_GPU: "disabled" },
+      values: {},
+    })).toBe(false);
+
+    expect(shouldSuperviseDarwinJsonQuery({
+      command: "query",
+      query: "test",
+      format: "json",
+      platform: "darwin",
+      env: {},
+      values: { "no-gpu": true },
+    })).toBe(false);
+
+    expect(shouldSuperviseDarwinJsonQuery({
+      command: "query",
+      query: "test",
+      format: "json",
+      platform: "darwin",
+      env: { QMD_DARWIN_QUERY_JSON_CHILD: "1" },
+      values: {},
+    })).toBe(false);
+
+    expect(shouldSuperviseDarwinJsonQuery({
+      command: "query",
+      query: "test",
+      format: "json",
+      platform: "linux",
+      env: {},
+      values: {},
+    })).toBe(false);
+
+    expect(shouldSuperviseDarwinJsonQuery({
+      command: "search",
+      query: "test",
+      format: "json",
+      platform: "darwin",
+      env: {},
+      values: {},
+    })).toBe(false);
+
+    expect(shouldSuperviseDarwinJsonQuery({
+      command: "query",
+      query: "test",
+      format: "cli",
+      platform: "darwin",
+      env: {},
+      values: {},
+    })).toBe(false);
+
+    expect(shouldSuperviseDarwinJsonQuery({
+      command: "query",
+      query: "   ",
+      format: "json",
+      platform: "darwin",
+      env: {},
+      values: {},
+    })).toBe(false);
+
+    expect(shouldSuperviseDarwinJsonQuery({
+      command: "query",
+      query: "test",
+      format: "json",
+      platform: "darwin",
+      env: { QMD_DISABLE_DARWIN_QUERY_JSON_SAFE_EXIT: "1" },
+      values: {},
+    })).toBe(false);
+  });
+
+  test("supervisor requires both valid JSON and the side-channel success sentinel", () => {
+    expect(isSuccessfulJsonSupervisorOutput("[]\n", "qmd:query-json-success\n")).toBe(true);
+    expect(isSuccessfulJsonSupervisorOutput("[]\n", "")).toBe(false);
+    expect(isSuccessfulJsonSupervisorOutput("not json\n", "qmd:query-json-success\n")).toBe(false);
+  });
+
+  test("forwards supervised stderr before stdout and waits for callbacks", async () => {
+    const calls: string[] = [];
+    const makeStream = (name: string) => ({
+      write: (chunk: string | Uint8Array, cb?: (error?: Error | null) => void) => {
+        calls.push(`${name}:start:${String(chunk)}`);
+        queueMicrotask(() => {
+          calls.push(`${name}:flushed`);
+          cb?.();
+        });
+        return true;
       },
-      exit: (code) => {
-        calls.push(`exit:${code}`);
-      },
-      immediateExit: (code) => {
-        calls.push(`immediate-exit:${code}`);
-      },
-      stdout: { write: (_chunk: string | Uint8Array, cb?: (error?: Error | null) => void) => { calls.push("stdout-flush"); cb?.(); return true; } },
-      stderr: { write: (_chunk: string | Uint8Array, cb?: (error?: Error | null) => void) => { calls.push("stderr-flush"); cb?.(); return true; } },
     });
 
-    expect(calls).toEqual(["stdout-flush", "stderr-flush", "immediate-exit:0"]);
+    await writeSupervisorOutput("json\n", "status\n", makeStream("stdout"), makeStream("stderr"));
+
+    expect(calls).toEqual([
+      "stderr:start:status\n",
+      "stderr:flushed",
+      "stdout:start:json\n",
+      "stdout:flushed",
+    ]);
+  });
+
+  test("builds self-spawn args for compiled, Node source, and Bun source entrypoints", () => {
+    const compiledPath = pathJoin("repo", "dist", "cli", "qmd.js");
+    const sourcePath = pathJoin("repo", "src", "cli", "qmd.ts");
+
+    expect(getSelfSpawnArgs(compiledPath, ["query"], false)).toEqual([compiledPath, "query"]);
+    expect(getSelfSpawnArgs(sourcePath, ["query"], true)).toEqual([sourcePath, "query"]);
+
+    const nodeSourceArgs = getSelfSpawnArgs(sourcePath, ["query"], false);
+    expect(nodeSourceArgs).toEqual([
+      "--import",
+      pathJoin("repo", "node_modules", "tsx", "dist", "esm", "index.mjs"),
+      sourcePath,
+      "query",
+    ]);
   });
 
   test("disposes Llama resources in dependency order before CLI exit", async () => {

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -12,6 +12,7 @@ import {
   LlamaCpp,
   getDefaultLlamaCpp,
   disposeDefaultLlamaCpp,
+  isLlamaGpuDisabledByEnv,
   resolveLlamaGpuMode,
   setNodeLlamaCppModuleForTest,
   withNativeStdoutRedirectedToStderr,
@@ -123,22 +124,22 @@ describe("LlamaCpp.modelExists", () => {
 
 describe("QMD_LLAMA_GPU resolution", () => {
   test("uses auto when unset or blank", () => {
-    expect(resolveLlamaGpuMode(undefined)).toBe("auto");
-    expect(resolveLlamaGpuMode("   ")).toBe("auto");
+    expect(resolveLlamaGpuMode(undefined, "")).toBe("auto");
+    expect(resolveLlamaGpuMode("   ", "")).toBe("auto");
   });
 
   test("maps CPU disable values to false", () => {
-    expect(resolveLlamaGpuMode("false")).toBe(false);
-    expect(resolveLlamaGpuMode("OFF")).toBe(false);
-    expect(resolveLlamaGpuMode(" none ")).toBe(false);
-    expect(resolveLlamaGpuMode("disabled")).toBe(false);
-    expect(resolveLlamaGpuMode("0")).toBe(false);
+    expect(resolveLlamaGpuMode("false", "")).toBe(false);
+    expect(resolveLlamaGpuMode("OFF", "")).toBe(false);
+    expect(resolveLlamaGpuMode(" none ", "")).toBe(false);
+    expect(resolveLlamaGpuMode("disabled", "")).toBe(false);
+    expect(resolveLlamaGpuMode("0", "")).toBe(false);
   });
 
   test("passes through supported GPU backends", () => {
-    expect(resolveLlamaGpuMode("metal")).toBe("metal");
-    expect(resolveLlamaGpuMode("VULKAN")).toBe("vulkan");
-    expect(resolveLlamaGpuMode(" cuda ")).toBe("cuda");
+    expect(resolveLlamaGpuMode("metal", "")).toBe("metal");
+    expect(resolveLlamaGpuMode("VULKAN", "")).toBe("vulkan");
+    expect(resolveLlamaGpuMode(" cuda ", "")).toBe("cuda");
   });
 
   test("QMD_FORCE_CPU disables GPU before QMD_LLAMA_GPU auto-detection", () => {
@@ -164,10 +165,17 @@ describe("QMD_LLAMA_GPU resolution", () => {
     }
   });
 
+  test("pure GPU-disabled predicate matches CPU-forcing env semantics", () => {
+    expect(isLlamaGpuDisabledByEnv("metal", "1")).toBe(true);
+    expect(isLlamaGpuDisabledByEnv("metal", "on")).toBe(true);
+    expect(isLlamaGpuDisabledByEnv("disabled", undefined)).toBe(true);
+    expect(isLlamaGpuDisabledByEnv("metal", "0")).toBe(false);
+  });
+
   test("warns and falls back to auto for unsupported values", () => {
     const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
     try {
-      expect(resolveLlamaGpuMode("rocm")).toBe("auto");
+      expect(resolveLlamaGpuMode("rocm", "")).toBe("auto");
       expect(stderrSpy).toHaveBeenCalled();
       expect(String(stderrSpy.mock.calls[0]?.[0] || "")).toContain("QMD_LLAMA_GPU");
     } finally {
@@ -537,6 +545,8 @@ describe("LlamaCpp rerank deduping", () => {
 
 describe("LlamaCpp.getDeviceInfo", () => {
   test("can skip build attempts for status probes", async () => {
+    const prevForceCpu = process.env.QMD_FORCE_CPU;
+    delete process.env.QMD_FORCE_CPU;
     const llm = new LlamaCpp({}) as any;
     const fakeLlama = {
       gpu: "metal",
@@ -548,16 +558,21 @@ describe("LlamaCpp.getDeviceInfo", () => {
 
     llm.ensureLlama = vi.fn().mockResolvedValue(fakeLlama);
 
-    const device = await llm.getDeviceInfo({ allowBuild: false });
+    try {
+      const device = await llm.getDeviceInfo({ allowBuild: false });
 
-    expect(llm.ensureLlama).toHaveBeenCalledWith(false);
-    expect(device).toEqual({
-      gpu: "metal",
-      gpuOffloading: true,
-      gpuDevices: ["Apple GPU"],
-      vram: { total: 1024, used: 256, free: 768 },
-      cpuCores: 8,
-    });
+      expect(llm.ensureLlama).toHaveBeenCalledWith(false);
+      expect(device).toEqual({
+        gpu: "metal",
+        gpuOffloading: true,
+        gpuDevices: ["Apple GPU"],
+        vram: { total: 1024, used: 256, free: 768 },
+        cpuCores: 8,
+      });
+    } finally {
+      if (prevForceCpu === undefined) delete process.env.QMD_FORCE_CPU;
+      else process.env.QMD_FORCE_CPU = prevForceCpu;
+    }
   });
 });
 


### PR DESCRIPTION
## Problem

On macOS Metal, `qmd query --json` and `qmd deep-search --json` can produce valid JSON and then abort during native llama.cpp cleanup. That leaves callers with a non-zero exit even though the command already completed successfully.

This mainly breaks machine-readable JSON workflows. The output is valid, but the process lifecycle reports failure.

## Fix

This adds a macOS-only supervised exit path for GPU-backed JSON `query` and `deep-search` runs.

The parent process runs the query in a child process and accepts success only when both conditions are true:

- stdout parses as valid JSON
- the child writes a success sentinel on a side-channel fd after output is flushed

The child then terminates before native Metal finalizers can abort after successful output. Real query failures still return through the normal failure path.

I also tightened the GPU env handling so the supervisor only runs when GPU use is actually enabled, and the CLI reuses the same GPU-disabled semantics as the LLM layer.

## Verification

- `node scripts/build.mjs`
- `node ./node_modules/typescript/bin/tsc -p tsconfig.build.json --noEmit`
- full Node/Vitest suite: 24 files passed, 824 passed, 73 skipped
- real macOS fixture checks with `QMD_FORCE_CPU=0 QMD_LLAMA_GPU=metal`:
  - `qmd query "metal cleanup" --json -c docs`
  - `qmd deep-search "metal cleanup" --json -c docs`

## Notes

The workaround is intentionally narrow: Darwin only, JSON only, `query`/`deep-search` only, non-child process only, and disabled for explicit CPU/no-GPU runs.