### PR TITLE
M1: clinical scaffold (fork rename + clinical front-matter schema spec)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,11 @@ texts/
 !README.md
 !CLAUDE.md
 !CHANGELOG.md
+!CLINICAL.md
 !skills/**/*.md
 !finetune/*.md
 !docs/*.md
+!clinical/**/*.md
 finetune/outputs/
 finetune/data/train/
 .claude/

--- a/CLINICAL.md
+++ b/CLINICAL.md
@@ -1,0 +1,68 @@
+# clinical-qmd
+
+A clinical fork of [`qmd`](https://github.com/tobi/qmd) — on-device hybrid retrieval over a physician's local notes, protocols, lab results, and references.
+
+## Why fork
+
+Upstream qmd is already an excellent on-device retrieval engine: SQLite FTS5 + sqlite-vec + local LLM query expansion and reranking via `node-llama-cpp`, exposed as a CLI and an MCP server. Everything runs locally on the device, which is exactly the property a clinical tool needs: **PHI must never leave the laptop**.
+
+The fork adds clinical-specific layers on top of upstream's primitives:
+
+| Layer | What it adds | Where it lives |
+| --- | --- | --- |
+| Schema | Clinical front-matter (note type, encounter date, problem list, ICD/SNOMED, meds, labs) parsed into queryable sidecar table | `src/clinical/schema.ts`, `src/clinical/parse.ts` |
+| Model defaults | Clinical-friendly embedder + reranker + query-expansion model | `src/clinical/defaults.ts`, config preset |
+| Query expansion | Clinical synonym and abbreviation expansion (MI ↔ myocardial infarction, BID ↔ twice daily, etc.) | `src/clinical/expansion.ts` |
+| MCP tools | `find_recent_labs`, `summarize_problem_list`, `pull_similar_cases`, `cite_with_source` | `src/clinical/mcp/*` |
+| Training data | Clinical query → `hyde:/lex:/vec:` examples for fine-tuning the query-expansion model | `finetune/data/clinical/*.jsonl` |
+| Eval harness | Clinical retrieval tasks scored against ground truth (right note, right lab, right protocol) | `finetune/evals/clinical/` |
+| PHI guardrails | Optional de-id pass on import, audit log of every query, no-network mode | `src/clinical/phi/*` |
+
+## Non-goals
+
+- Not an EHR. Notes are read-only inputs.
+- Not a clinical decision support tool. Retrieval only; the physician interprets.
+- Not a SaaS. Everything runs on-device. There is no server to hit.
+
+## Staying in sync with upstream
+
+Upstream is added as the `upstream` git remote and pulled periodically.
+
+```bash
+git fetch upstream
+git merge upstream/main          # or: git rebase upstream/main on feature branches
+```
+
+Clinical-specific code lives under `src/clinical/`, `finetune/data/clinical/`, `finetune/evals/clinical/`, and `clinical/` (docs). This keeps merge conflicts isolated to the layers we own.
+
+## Model swap
+
+Upstream is already model-agnostic — any GGUF works via env vars:
+
+```bash
+QMD_EMBED_MODEL=hf:org/your-clinical-embedder/model.gguf
+QMD_RERANK_MODEL=hf:org/your-clinical-reranker/model.gguf
+QMD_GENERATE_MODEL=hf:org/your-clinical-expansion-model/model.gguf
+```
+
+The clinical defaults will be set in `src/clinical/defaults.ts` and can be a clinical embedder (e.g. a Med-E5 GGUF), a clinical reranker, and a query-expansion model fine-tuned on clinical queries using the existing `finetune/` pipeline.
+
+## Roadmap
+
+1. **M1 — Scaffold + schema** (current): fork, dev loop, clinical front-matter sidecar table, schema spec. ← we are here
+2. **M2 — Clinical front-matter parsing in indexer**: parse the schema fields out of YAML front-matter into the sidecar table, expose them in query results.
+3. **M3 — Clinical defaults + config preset**: clinical-tuned embedder + reranker + expansion model selected automatically when `QMD_PROFILE=clinical`.
+4. **M4 — Autoresearch training loop for clinical queries**: clinical training data under `finetune/data/clinical/`, eval set under `finetune/evals/clinical/`, fine-tuned query-expansion model published to HF.
+5. **M5 — Clinical MCP tools**: `find_recent_labs`, `summarize_problem_list`, etc.
+6. **M6 — PHI guardrails + audit log**: optional de-id pass on import, queryable audit log.
+
+## Compliance posture
+
+clinical-qmd is a local tool — no network egress for indexing or querying. This means:
+
+- It does not transmit PHI off-device.
+- It does not require a BAA for itself (there is no service).
+- Models are downloaded once from Hugging Face and then run locally.
+- Audit logs (M6) record query text and timestamps locally so the physician can produce an access log if asked.
+
+This is not the same as being "HIPAA-certified" — HIPAA is a regulation that applies to covered entities, not software. clinical-qmd is designed to be **compatible with a HIPAA-compliant workflow**: a covered-entity physician can use it on a managed device with full-disk encryption and an organizational BAA covering the device, and clinical-qmd itself never widens the trust boundary.

--- a/clinical/schema.md
+++ b/clinical/schema.md
@@ -1,0 +1,117 @@
+# Clinical Front-Matter Schema
+
+clinical-qmd parses clinical metadata from the YAML front-matter of each note file and stores it in a sidecar SQLite table (`document_metadata`). The base `documents` and `content` tables from upstream are not modified — clinical data is purely additive, which keeps upstream merges clean.
+
+## Recognized YAML front-matter fields
+
+Every field is optional. Missing fields are simply not indexed; they do not cause errors.
+
+```yaml
+---
+note_type: progress          # SOAP | progress | H&P | consult | op-note | discharge | telehealth | followup | referral | imaging | path | other
+encounter_date: 2026-05-22   # ISO 8601 date (date or datetime)
+patient_id: PT-00482          # pseudo-ID. Never a real MRN. Never a name.
+provider: Dr. O. Said         # free text
+specialty: cardiology         # free text or SNOMED specialty code
+setting: outpatient           # outpatient | inpatient | ed | telehealth | home | other
+
+problem_list:                 # active problems addressed in this note
+  - HTN
+  - CKD stage 3
+  - "Type 2 diabetes mellitus"
+
+icd_codes:                    # ICD-10-CM
+  - I10
+  - N18.30
+  - E11.9
+
+snomed_codes:                 # SNOMED CT concept IDs
+  - 38341003                  # HTN
+  - 433144002                 # CKD stage 3
+
+medications:                  # active meds at time of note
+  - lisinopril 20 mg daily
+  - metformin 1000 mg BID
+
+labs_mentioned:               # labs referenced or ordered in this note
+  - A1c
+  - eGFR
+  - BMP
+
+procedures:                   # procedures performed in this note
+  - 99214
+
+allergies:                    # NKDA permitted
+  - penicillin (rash)
+
+tags:                         # free-form labels
+  - chronic-care
+  - case-of-the-week
+---
+
+# Note body in markdown follows...
+```
+
+## Sidecar SQL schema
+
+```sql
+CREATE TABLE IF NOT EXISTS document_metadata (
+  hash             TEXT PRIMARY KEY,
+  note_type        TEXT,
+  encounter_date   TEXT,             -- ISO 8601
+  patient_id       TEXT,             -- pseudo-ID only
+  provider         TEXT,
+  specialty        TEXT,
+  setting          TEXT,
+  problem_list     TEXT,             -- JSON array
+  icd_codes        TEXT,             -- JSON array
+  snomed_codes     TEXT,             -- JSON array
+  medications      TEXT,             -- JSON array
+  labs_mentioned   TEXT,             -- JSON array
+  procedures       TEXT,             -- JSON array
+  allergies        TEXT,             -- JSON array
+  tags             TEXT,             -- JSON array
+  raw_frontmatter  TEXT,             -- full original YAML, forward-compat
+  parsed_at        TEXT NOT NULL,
+  FOREIGN KEY (hash) REFERENCES content(hash) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_docmeta_note_type      ON document_metadata(note_type);
+CREATE INDEX IF NOT EXISTS idx_docmeta_encounter_date ON document_metadata(encounter_date);
+CREATE INDEX IF NOT EXISTS idx_docmeta_patient_id     ON document_metadata(patient_id);
+CREATE INDEX IF NOT EXISTS idx_docmeta_specialty      ON document_metadata(specialty);
+```
+
+JSON arrays (problem list, codes, meds, labs) are stored as JSON text and queried with SQLite's `json_each()` table-valued function when filtering by membership. This keeps the schema simple while letting us do queries like:
+
+```sql
+SELECT d.path
+FROM documents d
+JOIN document_metadata m USING (hash)
+JOIN json_each(m.icd_codes) c
+WHERE c.value = 'E11.9'
+  AND m.encounter_date >= '2026-01-01'
+ORDER BY m.encounter_date DESC;
+```
+
+## PHI posture for the schema
+
+- `patient_id` is a **pseudo-ID** chosen by the physician (e.g. `PT-00482`). Real MRNs and names should not be written into front-matter — they belong in the note body where the physician already knows they are present.
+- `provider` is intended to be the physician using the system, not the patient.
+- Indexes are local-only. The SQLite file at `~/.cache/qmd/index.sqlite` should sit on an encrypted volume.
+
+## Validation
+
+A front-matter parsing failure should never block indexing of the note body. If front-matter is malformed:
+
+1. Log a warning with the file path and the parse error.
+2. Skip the metadata insert for that note.
+3. Index the body normally so the note remains searchable by text.
+
+This is deliberate: a physician's notes are not test fixtures and clinical-qmd should never refuse to index a real note because its YAML is slightly off.
+
+## Open questions for M2
+
+- Should `patient_id` be hashed at index time to make the sidecar table itself non-identifying? (Likely yes — easy to add and a meaningful defense-in-depth.)
+- Should we support both an explicit `icd_codes:` list and inline `[I10]`-style annotations in the body? (Probably yes, with body-extraction as M3.)
+- Should `problem_list` be deduplicated against ICD codes automatically? (No — let the physician keep both, they encode different intent.)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@tobilu/qmd",
-  "version": "2.5.2",
-  "description": "Query Markup Documents - On-device hybrid search for markdown files with BM25, vector search, and LLM reranking",
+  "name": "@os1123/clinical-qmd",
+  "version": "0.1.0-clinical.0",
+  "description": "Clinical fork of qmd — on-device hybrid search and retrieval tuned for clinical notes (SOAP, H&P, consult, op-note, discharge). All processing local; no PHI leaves the device.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -49,11 +49,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tobi/qmd.git"
+    "url": "git+https://github.com/os1123/clinical-qmd.git"
   },
-  "homepage": "https://github.com/tobi/qmd#readme",
+  "homepage": "https://github.com/os1123/clinical-qmd#readme",
   "bugs": {
-    "url": "https://github.com/tobi/qmd/issues"
+    "url": "https://github.com/os1123/clinical-qmd/issues"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.29.0",
@@ -101,10 +101,16 @@
     "node": ">=22.0.0"
   },
   "keywords": [
+    "clinical",
+    "clinical-notes",
+    "ehr",
+    "physician",
+    "medical",
+    "hipaa",
+    "on-device",
     "markdown",
     "search",
     "fts",
-    "full-text-search",
     "vector",
     "semantic-search",
     "sqlite",
@@ -113,10 +119,12 @@
     "rag",
     "mcp",
     "reranking",
-    "knowledge-base",
     "local-ai",
     "llm"
   ],
-  "author": "Tobi Lutke <tobi@lutke.com>",
+  "author": "Omar Said <omars1123@gmail.com>",
+  "contributors": [
+    "Tobi Lutke <tobi@lutke.com> (original qmd author)"
+  ],
   "license": "MIT"
 }

--- a/src/clinical/schema.ts
+++ b/src/clinical/schema.ts
@@ -1,0 +1,92 @@
+/**
+ * Clinical front-matter schema.
+ *
+ * Defines the YAML fields parsed out of clinical note front-matter and stored
+ * in the `document_metadata` sidecar table. See clinical/schema.md for the
+ * full spec, sample, and SQL DDL.
+ *
+ * Implementation of the parser and the indexer wiring lands in M2.
+ */
+
+export type NoteType =
+  | "SOAP"
+  | "progress"
+  | "H&P"
+  | "consult"
+  | "op-note"
+  | "discharge"
+  | "telehealth"
+  | "followup"
+  | "referral"
+  | "imaging"
+  | "path"
+  | "other";
+
+export type EncounterSetting =
+  | "outpatient"
+  | "inpatient"
+  | "ed"
+  | "telehealth"
+  | "home"
+  | "other";
+
+export interface ClinicalFrontmatter {
+  note_type?: NoteType;
+  encounter_date?: string;
+  patient_id?: string;
+  provider?: string;
+  specialty?: string;
+  setting?: EncounterSetting;
+  problem_list?: string[];
+  icd_codes?: string[];
+  snomed_codes?: string[];
+  medications?: string[];
+  labs_mentioned?: string[];
+  procedures?: string[];
+  allergies?: string[];
+  tags?: string[];
+}
+
+export const CLINICAL_FRONTMATTER_FIELDS = [
+  "note_type",
+  "encounter_date",
+  "patient_id",
+  "provider",
+  "specialty",
+  "setting",
+  "problem_list",
+  "icd_codes",
+  "snomed_codes",
+  "medications",
+  "labs_mentioned",
+  "procedures",
+  "allergies",
+  "tags",
+] as const;
+
+export const DOCUMENT_METADATA_DDL = `
+CREATE TABLE IF NOT EXISTS document_metadata (
+  hash             TEXT PRIMARY KEY,
+  note_type        TEXT,
+  encounter_date   TEXT,
+  patient_id       TEXT,
+  provider         TEXT,
+  specialty        TEXT,
+  setting          TEXT,
+  problem_list     TEXT,
+  icd_codes        TEXT,
+  snomed_codes     TEXT,
+  medications      TEXT,
+  labs_mentioned   TEXT,
+  procedures       TEXT,
+  allergies        TEXT,
+  tags             TEXT,
+  raw_frontmatter  TEXT,
+  parsed_at        TEXT NOT NULL,
+  FOREIGN KEY (hash) REFERENCES content(hash) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_docmeta_note_type      ON document_metadata(note_type);
+CREATE INDEX IF NOT EXISTS idx_docmeta_encounter_date ON document_metadata(encounter_date);
+CREATE INDEX IF NOT EXISTS idx_docmeta_patient_id     ON document_metadata(patient_id);
+CREATE INDEX IF NOT EXISTS idx_docmeta_specialty      ON document_metadata(specialty);
+`;


### PR DESCRIPTION
## Summary

First milestone for **clinical-qmd**, the clinical fork of [tobi/qmd](https://github.com/tobi/qmd).

- Rename package to `@os1123/clinical-qmd`; repo URLs point at the fork.
- New `CLINICAL.md` documenting fork purpose, layered architecture, upstream-sync workflow, model-swap story, roadmap M1–M6, and on-device PHI posture.
- New `clinical/schema.md` — full clinical YAML front-matter spec, `document_metadata` sidecar SQL DDL, PHI posture for the schema itself.
- New `src/clinical/schema.ts` — TypeScript types + DDL constant ready for M2 to wire into the indexer.
- `.gitignore` whitelists `CLINICAL.md` and `clinical/**/*.md` (upstream ignores `*.md` by default).

The base `documents`/`content` tables are untouched. Clinical metadata lands in a sidecar table joined by content hash so upstream merges stay conflict-free.

## What's next

- **M2** — wire the front-matter parser into the indexer and expose metadata-aware filters (`--note-type`, `--since`, `--icd`, ...).
- **M3** — clinical defaults + `QMD_PROFILE=clinical` config preset (Med-E5 embedder, clinical reranker, clinical-tuned expansion model).

## Test plan

- [x] `npm install` succeeds (317 packages, 0 vulnerabilities)
- [x] `npm run build` succeeds
- [x] `npm run test:types` passes (new TS files compile)
- [x] `./bin/qmd --help` still runs (upstream binary not broken)
- [ ] Manual review of CLINICAL.md and clinical/schema.md by Omar