### PR TITLE
fix(store): embed searchVec query with the store's pinned model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Fixes
+
+- `store.searchVector()` (and the internal multi-query vector path) now embed the
+  query with the store's pinned embed model instead of the global
+  `QMD_EMBED_MODEL`. A store created with a non-default `models.embed` previously
+  failed with `Dimension mismatch ... Expected N ... received M` and loaded the
+  wrong (often much larger) model at query time, because the query was embedded
+  with the env model rather than the store's. Hybrid/precomputed/session search
+  paths were unaffected and stay unchanged.
+
 ## [2.5.3] - 2026-05-28
 
 ### Features

--- a/src/store.ts
+++ b/src/store.ts
@@ -1887,7 +1887,7 @@ export function createStore(dbPath?: string): Store {
 
     // Search
     searchFTS: (query: string, limit?: number, collectionName?: string) => searchFTS(db, query, limit, collectionName),
-    searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => searchVec(db, query, model, limit, collectionName, session, precomputedEmbedding),
+    searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => searchVec(db, query, model, limit, collectionName, session, precomputedEmbedding, getLlm(store)),
 
     // Query expansion & reranking
     expandQuery: (query: string, model?: string, intent?: string) => expandQuery(query, model ?? store.llm?.generateModelName ?? DEFAULT_QUERY_MODEL, db, intent, store.llm),
@@ -3464,11 +3464,11 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
 // Vector Search
 // =============================================================================
 
-export async function searchVec(db: Database, query: string, model: string, limit: number = 20, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]): Promise<SearchResult[]> {
+export async function searchVec(db: Database, query: string, model: string, limit: number = 20, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[], llm?: LlamaCpp): Promise<SearchResult[]> {
   const tableExists = db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'`).get();
   if (!tableExists) return [];
 
-  const embedding = precomputedEmbedding ?? await getEmbedding(query, model, true, session);
+  const embedding = precomputedEmbedding ?? await getEmbedding(query, model, true, session, llm);
   if (!embedding) return [];
 
   // IMPORTANT: We use a two-step query approach here because sqlite-vec virtual tables

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -3384,6 +3384,59 @@ describe("Embedding batching", () => {
     }
   });
 
+  test("searchVec embeds the query with the store's pinned llm, not the global default (qmd-prm regression)", async () => {
+    const store = await createTestStore();
+    const db = store.db;
+
+    // Store is pinned to a 3-dim embed model. Docs AND the query must use it,
+    // so vectors_vec is created as float[3].
+    const storeModel = "hf:store/embeddinggemma-300M.gguf";
+    const storeLlm = {
+      embedModelName: storeModel,
+      async embed(_text: string, _options?: { model?: string }) {
+        return { embedding: [0.1, 0.2, 0.3], model: storeModel };
+      },
+      async embedBatch(texts: string[], _options?: { model?: string }) {
+        return texts.map(() => ({ embedding: [0.1, 0.2, 0.3], model: storeModel }));
+      },
+    };
+
+    // The global default (env QMD_EMBED_MODEL) is a DIFFERENT, 4-dim model.
+    // If the query is wrongly embedded with this, sqlite-vec rejects the 4-dim
+    // vector against the float[3] table (the reported dim-mismatch symptom).
+    let defaultEmbedCalls = 0;
+    const defaultLlm = {
+      // Chunking tokenizes via the global default (chunkDocumentByTokens passes
+      // no tokenizer), so the default must provide tokenize.
+      async tokenize(text: string) {
+        return new Array(Math.max(1, Math.ceil(text.length / 16))).fill(1);
+      },
+      async embed(_text: string, _options?: { model?: string }) {
+        defaultEmbedCalls++;
+        return { embedding: [9, 9, 9, 9], model: "env-8b" };
+      },
+    };
+
+    setDefaultLlamaCpp(defaultLlm as any);
+    store.llm = storeLlm as any;
+
+    try {
+      await insertTestDocument(db, "docs", { name: "alpha", body: "# Alpha\n\nvector regression doc" });
+      const embed = await generateEmbeddings(store);
+      expect(embed.chunksEmbedded).toBeGreaterThan(0);
+
+      // Inline-embed path (no session, no precomputed embedding): the query must
+      // be embedded with the store's llm. Pre-fix this threw a dim mismatch.
+      const results = await store.searchVec("find alpha", storeModel);
+
+      expect(results.length).toBeGreaterThan(0);
+      expect(defaultEmbedCalls).toBe(0);
+    } finally {
+      setDefaultLlamaCpp(null);
+      await cleanupTestDb(store);
+    }
+  });
+
   test("hybridQuery uses the active llm embed model for precomputed vector lookups", async () => {
     const store = await createTestStore();
     const model = "hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf";


### PR DESCRIPTION
## Problem

`store.searchVector()` (and the internal multi-query vector path) embed the
search-time query with the global `QMD_EMBED_MODEL` (`getDefaultLlamaCpp()`)
instead of the store's pinned embed model. When a store is created with
`config.models.embed` different from `QMD_EMBED_MODEL`, the query vector width
differs from the stored vectors and sqlite-vec rejects it before any comparison:

```
SqliteError: Dimension mismatch for query vector for the "embedding" column. Expected 768 dimensions but received 4096.
```

(store embedded with embeddinggemma-300M → 768-dim stored vectors; env
`QMD_EMBED_MODEL` = Qwen3-Embedding-8B → query embedded at 4096-dim.) It also
loads the wrong, often much larger model at query time.

## Root cause

`searchVec()` calls `getEmbedding(query, model, true, session)` without an
`llmOverride`, so `getEmbedding` falls back to `getDefaultLlamaCpp()` (the env
model). The store's own llm (`store.llm`) is never threaded into the query-embed
step. `getEmbedding` already accepts an `llmOverride` parameter — it simply isn't
passed.

Hybrid search (`store.search`) is unaffected: it pre-computes query embeddings
via the store session/llm and passes them as `precomputedEmbedding`, which
short-circuits before `getEmbedding`. Only the inline-embed paths hit the bug.

## Fix

Thread `getLlm(store)` (which returns `store.llm ?? getDefaultLlamaCpp()`)
through the bound `store.searchVec` into `getEmbedding`, mirroring the existing
`expandQuery`/`rerank` llm threading. Three small edits in `src/store.ts`:

1. the bound `store.searchVec` passes `getLlm(store)` as the new last arg
2. `searchVec()` gains an optional `llm?: LlamaCpp` parameter
3. it forwards that into `getEmbedding(query, model, true, session, llm)`

Backward compatible — the new param is optional; `session`- and
`precomputedEmbedding`-based callers are unaffected (session is preferred over
the override, and precomputed skips `getEmbedding` entirely).

## Test

Adds a regression test in `test/store.test.ts`: it pins a store to a
non-default (3-dim) embed model, sets the global default to a different (4-dim)
model, embeds a doc, then calls `store.searchVec()`. It asserts hits are returned
with no dimension mismatch and that the global default llm is never used to embed
the query. The test fails on the current code with `Dimension mismatch ...
Expected 3 ... received 4` and passes with the fix.