### PR TITLE
fix(build): remove shell:true from spawnSync so paths with spaces work on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **build**: Remove `shell: true` from `spawnSync` in `scripts/build.mjs`. On
+  Windows, passing `shell: true` caused `cmd.exe` to misparse `process.execPath`
+  when the Node.js installation path contains spaces (e.g.
+  `C:\Program Files\nodejs\node.exe`). Since `run()` always receives a real
+  binary path + args array, no shell is needed — `spawnSync` can spawn
+  executables directly. (#681)
+
 ## [2.5.3] - 2026-05-28
 
 ### Features

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -10,7 +10,7 @@ function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
     cwd: root,
     stdio: "inherit",
-    shell: process.platform === "win32",
+    shell: false,
     ...options,
   });
   if (result.status !== 0) {


### PR DESCRIPTION
Fixes #681

## Root cause

`scripts/build.mjs`'s `run()` helper passed `shell: process.platform === 'win32'` to `spawnSync`. On Windows, this hands the command to `cmd.exe` unquoted, so a Node install at `C:\Program Files\nodejs\node.exe` gets split at the space — `cmd.exe` tries to execute `C:\Program` and fails silently (exit code not propagated). Result: `dist/` is never produced, but `npm run build` reports success.

## Fix

`shell: false`. `spawnSync` with a binary path + args array has never needed shell mode — that's only for passing a shell command string. The binary is invoked directly.