### PR TITLE
fix(embed): make session maxDuration env-configurable via QMD_EMBED_MAX_DURATION_MS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The embed session `maxDuration` is now env-configurable via
+  `QMD_EMBED_MAX_DURATION_MS` (default: 30 min). This prevents large-corpus
+  embeddings from being aborted by the hardcoded 30-minute ceiling (#673).
+- **build**: Remove `shell: true` from `spawnSync` in `scripts/build.mjs`. On
+  Windows, passing `shell: true` caused `cmd.exe` to misparse `process.execPath`
+  when the Node.js installation path contains spaces (e.g.
+  `C:\Program Files\nodejs\node.exe`). Since `run()` always receives a real
+  binary path + args array, no shell is needed — `spawnSync` can spawn
+  executables directly. (#681)
+
 ## [2.5.3] - 2026-05-28
 
 ### Features

--- a/src/store.ts
+++ b/src/store.ts
@@ -1824,7 +1824,7 @@ export async function generateEmbeddings(
     }
 
     return { chunksEmbedded, errors: activeErrorCount(), failures: failureList() };
-  }, { maxDuration: 30 * 60 * 1000, name: 'generateEmbeddings' });
+  }, { maxDuration: Number(process.env.QMD_EMBED_MAX_DURATION_MS ?? 30 * 60 * 1000), name: 'generateEmbeddings' });
 
   return {
     docsProcessed: totalDocs,


### PR DESCRIPTION
Fixes #673

## Root cause

`generateEmbeddings` session had a hardcoded `maxDuration: 30 * 60 * 1000`. On large corpora (e.g. 6,400 docs / 66,000 chunks), the 30-minute ceiling fires mid-run, `removeIncompleteEmbeddings()` purges partial work, and resume runs never converge — each run only flips ~230–323 docs to "done" so convergence takes 17–24 additional runs.

The 30-minute cap was added as a guard against the old node-llama-cpp memory leak (fixed in #500/#393). With that leak gone, the defensive cap just hurts large corpora.

## Fix

Make it env-configurable:

```ts
maxDuration: Number(process.env.QMD_EMBED_MAX_DURATION_MS ?? 30 * 60 * 1000)
```

Default stays 30 minutes (no behavior change for existing users). Large-corpus users set `QMD_EMBED_MAX_DURATION_MS=14400000` (4h) or remove the ceiling entirely with a very large value.