### PR TITLE
Report ignored documents distinctly

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -21,8 +21,7 @@ import {
   removeCollection,
   renameCollection,
   findSimilarFiles,
-  findDocumentByDocid,
-  isDocid,
+  findDocument,
   matchFilesByGlob,
   getHashesNeedingEmbedding,
   clearAllEmbeddings,
@@ -965,155 +964,34 @@ function getDocument(filename: string, fromLine?: number, maxLines?: number, lin
   if (fromLine !== undefined) fromLine = Math.max(1, fromLine);
 
   const parsedIndexPath = isVirtualPath(inputPath) ? parseVirtualPath(inputPath) : null;
-  if (parsedIndexPath?.indexName) {
-    setIndexName(parsedIndexPath.indexName);
-    setConfigIndexName(parsedIndexPath.indexName);
+  if (parsedIndexPath) {
+    if (parsedIndexPath.indexName) {
+      setIndexName(parsedIndexPath.indexName);
+      setConfigIndexName(parsedIndexPath.indexName);
+    }
+    inputPath = buildVirtualPath(parsedIndexPath.collectionName, parsedIndexPath.path);
   }
 
   const db = getDb();
-
-  // Handle docid lookup (#abc123, abc123, "#abc123", "abc123", etc.)
-  if (isDocid(inputPath)) {
-    const docidMatch = findDocumentByDocid(db, inputPath);
-    if (docidMatch) {
-      inputPath = docidMatch.filepath;
+  const doc = findDocument(db, inputPath, { includeBody: true });
+  if ("error" in doc) {
+    if (doc.error === "excluded_by_ignore") {
+      console.error(`Document is excluded by ignore rule: ${filename}`);
+      console.error(`Collection: ${doc.collection}`);
+      console.error(`Matched path: ${doc.path}`);
+      console.error(`Ignore rule: ${doc.rule}`);
     } else {
       console.error(`Document not found: ${filename}`);
-      closeDb();
-      process.exit(1);
-    }
-  }
-  let doc: { collectionName: string; path: string; body: string } | null = null;
-  let virtualPath: string;
-
-  // Handle virtual paths (qmd://collection/path)
-  if (isVirtualPath(inputPath)) {
-    const parsed = parseVirtualPath(inputPath);
-    if (!parsed) {
-      console.error(`Invalid virtual path: ${inputPath}`);
-      closeDb();
-      process.exit(1);
-    }
-
-    // Try exact match on collection + path
-    doc = db.prepare(`
-      SELECT d.collection as collectionName, d.path, content.doc as body
-      FROM documents d
-      JOIN content ON content.hash = d.hash
-      WHERE d.collection = ? AND d.path = ? AND d.active = 1
-    `).get(parsed.collectionName, parsed.path) as typeof doc;
-
-    if (!doc) {
-      // Try fuzzy match by path ending
-      doc = db.prepare(`
-        SELECT d.collection as collectionName, d.path, content.doc as body
-        FROM documents d
-        JOIN content ON content.hash = d.hash
-        WHERE d.collection = ? AND d.path LIKE ? AND d.active = 1
-        LIMIT 1
-      `).get(parsed.collectionName, `%${parsed.path}`) as typeof doc;
-    }
-
-    virtualPath = inputPath;
-  } else {
-    // Try to interpret as collection/path format first (before filesystem path)
-    // If path is relative (no / or ~ prefix), check if first component is a collection name
-    if (!inputPath.startsWith('/') && !inputPath.startsWith('~')) {
-      const parts = inputPath.split('/');
-      if (parts.length >= 2) {
-        const possibleCollection = parts[0];
-        const possiblePath = parts.slice(1).join('/');
-
-        // Check if this collection exists
-        const collExists = possibleCollection ? db.prepare(`
-          SELECT 1 FROM documents WHERE collection = ? AND active = 1 LIMIT 1
-        `).get(possibleCollection) : null;
-
-        if (collExists) {
-          // Try exact match on collection + path
-          doc = db.prepare(`
-            SELECT d.collection as collectionName, d.path, content.doc as body
-            FROM documents d
-            JOIN content ON content.hash = d.hash
-            WHERE d.collection = ? AND d.path = ? AND d.active = 1
-          `).get(possibleCollection || "", possiblePath || "") as { collectionName: string; path: string; body: string } | null;
-
-          if (!doc) {
-            // Try fuzzy match by path ending
-            doc = db.prepare(`
-              SELECT d.collection as collectionName, d.path, content.doc as body
-              FROM documents d
-              JOIN content ON content.hash = d.hash
-              WHERE d.collection = ? AND d.path LIKE ? AND d.active = 1
-              LIMIT 1
-            `).get(possibleCollection || "", `%${possiblePath}`) as { collectionName: string; path: string; body: string } | null;
-          }
-
-          if (doc) {
-            virtualPath = buildVirtualPath(doc.collectionName, doc.path);
-            // Skip the filesystem path handling below
-          }
-        }
+      if (doc.similarFiles.length > 0) {
+        console.error("Similar files:");
+        for (const file of doc.similarFiles) console.error(`  ${file}`);
       }
     }
-
-    // If not found as collection/path, handle as filesystem paths
-    if (!doc) {
-      let fsPath = inputPath;
-
-      // Expand ~ to home directory
-      if (fsPath.startsWith('~/')) {
-        fsPath = homedir() + fsPath.slice(1);
-      } else if (!fsPath.startsWith('/')) {
-        // Relative path - resolve from current directory
-        fsPath = resolve(getPwd(), fsPath);
-      }
-      fsPath = getRealPath(fsPath);
-
-      // Try to detect which collection contains this path
-      const detected = detectCollectionFromPath(db, fsPath);
-
-      if (detected) {
-        // Found collection - query by collection name + relative path
-        doc = db.prepare(`
-          SELECT d.collection as collectionName, d.path, content.doc as body
-          FROM documents d
-          JOIN content ON content.hash = d.hash
-          WHERE d.collection = ? AND d.path = ? AND d.active = 1
-        `).get(detected.collectionName, detected.relativePath) as { collectionName: string; path: string; body: string } | null;
-      }
-
-      // Fuzzy match by filename (last component of path)
-      if (!doc) {
-        const filename = inputPath.split('/').pop() || inputPath;
-        doc = db.prepare(`
-          SELECT d.collection as collectionName, d.path, content.doc as body
-          FROM documents d
-          JOIN content ON content.hash = d.hash
-          WHERE d.path LIKE ? AND d.active = 1
-          LIMIT 1
-        `).get(`%${filename}`) as { collectionName: string; path: string; body: string } | null;
-      }
-
-      if (doc) {
-        virtualPath = buildVirtualPath(doc.collectionName, doc.path);
-      } else {
-        virtualPath = inputPath;
-      }
-    }
-  }
-
-  // Ensure doc is not null before proceeding
-  if (!doc) {
-    console.error(`Document not found: ${filename}`);
     closeDb();
     process.exit(1);
   }
 
-  // Get context for this file
-  const context = getContextForPath(db, doc.collectionName, doc.path);
-
-  let output = doc.body;
+  let output = doc.body || "";
   const startLine = fromLine || 1;
 
   // Apply line filtering if specified
@@ -1130,8 +1008,8 @@ function getDocument(filename: string, fromLine?: number, maxLines?: number, lin
   }
 
   // Output context header if exists
-  if (context) {
-    console.log(`Folder Context: ${context}\n---\n`);
+  if (doc.context) {
+    console.log(`Folder Context: ${doc.context}\n---\n`);
   }
   console.log(output);
   closeDb();

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,8 @@ import {
   type Store as InternalStore,
   type DocumentResult,
   type DocumentNotFound,
+  type DocumentExcludedByIgnore,
+  type DocumentLookupError,
   type SearchResult,
   type HybridQueryResult,
   type HybridQueryOptions,
@@ -85,6 +87,8 @@ import {
 export type {
   DocumentResult,
   DocumentNotFound,
+  DocumentExcludedByIgnore,
+  DocumentLookupError,
   SearchResult,
   HybridQueryResult,
   HybridQueryOptions,
@@ -237,7 +241,7 @@ export interface QMDStore {
   // ── Document Retrieval ──────────────────────────────────────────────
 
   /** Get a single document by path or docid */
-  get(pathOrDocid: string, options?: { includeBody?: boolean }): Promise<DocumentResult | DocumentNotFound>;
+  get(pathOrDocid: string, options?: { includeBody?: boolean }): Promise<DocumentResult | DocumentLookupError>;
 
   /** Get the body content of a document, optionally sliced by line range */
   getDocumentBody(pathOrDocid: string, opts?: { fromLine?: number; maxLines?: number }): Promise<string | null>;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -199,7 +199,10 @@ async function createMcpServer(store: QMDStore): Promise<McpServer> {
       const result = await store.get(decodedPath, { includeBody: true });
 
       if ("error" in result) {
-        return { contents: [{ uri: uri.href, text: `Document not found: ${decodedPath}` }] };
+        const text = result.error === "excluded_by_ignore"
+          ? `Document excluded by ignore rule: ${decodedPath}\nCollection: ${result.collection}\nMatched path: ${result.path}\nIgnore rule: ${result.rule}`
+          : `Document not found: ${decodedPath}`;
+        return { contents: [{ uri: uri.href, text }] };
       }
 
       let text = addLineNumbers(result.body || "");  // Default to line numbers
@@ -392,8 +395,10 @@ Intent-aware lex (C++ performance, not sports):
       const result = await store.get(lookup, { includeBody: false });
 
       if ("error" in result) {
-        let msg = `Document not found: ${file}`;
-        if (result.similarFiles.length > 0) {
+        let msg = result.error === "excluded_by_ignore"
+          ? `Document excluded by ignore rule: ${file}\nCollection: ${result.collection}\nMatched path: ${result.path}\nIgnore rule: ${result.rule}`
+          : `Document not found: ${file}`;
+        if (result.error === "not_found" && result.similarFiles.length > 0) {
           msg += `\n\nDid you mean one of these?\n${result.similarFiles.map(s => `  - ${s}`).join('\n')}`;
         }
         return {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1222,7 +1222,7 @@ export type Store = {
   rerank: (query: string, documents: { file: string; text: string }[], model?: string, intent?: string) => Promise<{ file: string; score: number }[]>;
 
   // Document retrieval
-  findDocument: (filename: string, options?: { includeBody?: boolean }) => DocumentResult | DocumentNotFound;
+  findDocument: (filename: string, options?: { includeBody?: boolean }) => DocumentResult | DocumentLookupError;
   getDocumentBody: (doc: DocumentResult | { filepath: string }, fromLine?: number, maxLines?: number) => string | null;
   findDocuments: (pattern: string, options?: { includeBody?: boolean; maxBytes?: number }) => { docs: MultiGetResult[]; errors: string[] };
 
@@ -2083,6 +2083,16 @@ export type DocumentNotFound = {
   query: string;
   similarFiles: string[];
 };
+
+export type DocumentExcludedByIgnore = {
+  error: "excluded_by_ignore";
+  query: string;
+  collection: string;
+  path: string;
+  rule: string;
+};
+
+export type DocumentLookupError = DocumentNotFound | DocumentExcludedByIgnore;
 
 /**
  * Result from multi-get operations
@@ -3931,6 +3941,63 @@ type DbDocRow = {
   body?: string;
 };
 
+function normalizeLookupPathForIgnore(path: string): string {
+  let normalized = path.replace(/\\/g, '/').trim();
+  if (normalized.startsWith('~/')) {
+    normalized = homedir() + normalized.slice(1);
+  }
+  return normalized;
+}
+
+function matchesIgnoreRule(relativePath: string, rule: string): boolean {
+  const normalizedPath = relativePath.replace(/\\/g, '/').replace(/^\/+/, '');
+  const normalizedRule = rule.replace(/\\/g, '/').replace(/^\/+/, '');
+  const isMatch = picomatch(normalizedRule, { dot: true });
+  return isMatch(normalizedPath);
+}
+
+function getIgnoredLookupMatch(db: Database, query: string): DocumentExcludedByIgnore | null {
+  const normalizedQuery = normalizeLookupPathForIgnore(query);
+  const parsedVirtual = isVirtualPath(normalizedQuery) ? parseVirtualPath(normalizedQuery) : null;
+  const collections = getStoreCollections(db);
+
+  for (const coll of collections) {
+    if (!coll.ignore || coll.ignore.length === 0) continue;
+
+    const candidates: string[] = [];
+
+    if (parsedVirtual) {
+      if (parsedVirtual.collectionName !== coll.name) continue;
+      candidates.push(parsedVirtual.path);
+    } else if (normalizedQuery.startsWith(coll.path + '/')) {
+      candidates.push(normalizedQuery.slice(coll.path.length + 1));
+    } else if (!normalizedQuery.startsWith('/')) {
+      const collectionPrefix = `${coll.name}/`;
+      if (normalizedQuery.startsWith(collectionPrefix)) {
+        candidates.push(normalizedQuery.slice(collectionPrefix.length));
+      } else {
+        candidates.push(normalizedQuery);
+      }
+    }
+
+    for (const candidate of candidates) {
+      for (const rule of coll.ignore) {
+        if (matchesIgnoreRule(candidate, rule)) {
+          return {
+            error: "excluded_by_ignore",
+            query,
+            collection: coll.name,
+            path: candidate,
+            rule,
+          };
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
 /**
  * Find a document by filename/path, docid (#hash), or with fuzzy matching.
  * Returns document metadata without body by default.
@@ -3941,7 +4008,7 @@ type DbDocRow = {
  * - Relative paths: path/to/file.md
  * - Short docid: #abc123 (first 6 chars of hash)
  */
-export function findDocument(db: Database, filename: string, options: { includeBody?: boolean } = {}): DocumentResult | DocumentNotFound {
+export function findDocument(db: Database, filename: string, options: { includeBody?: boolean } = {}): DocumentResult | DocumentLookupError {
   let filepath = filename;
   const colonMatch = filepath.match(/:(\d+)$/);
   if (colonMatch) {
@@ -4024,6 +4091,9 @@ export function findDocument(db: Database, filename: string, options: { includeB
   }
 
   if (!doc) {
+    const ignored = getIgnoredLookupMatch(db, filepath);
+    if (ignored) return ignored;
+
     const similar = findSimilarFiles(db, filepath, 5, 5);
     return { error: "not_found", query: filename, similarFiles: similar };
   }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1721,6 +1721,69 @@ describe("get command path normalization", () => {
   });
 });
 
+describe("get command missing and ignored paths", () => {
+  let localDbPath: string;
+  let localConfigDir: string;
+  let getTestDir: string;
+
+  beforeAll(async () => {
+    const env = await createIsolatedTestEnv("get-missing-ignored");
+    localDbPath = env.dbPath;
+    localConfigDir = env.configDir;
+    getTestDir = join(testDir, "get-missing-ignored-fixtures");
+
+    await mkdir(join(getTestDir, "public"), { recursive: true });
+    await mkdir(join(getTestDir, "private"), { recursive: true });
+    await writeFile(join(getTestDir, "public", "prompt-log.md"), "# Public Log\nThis indexed file must not be returned for missing paths.");
+    await writeFile(join(getTestDir, "private", "log.md"), "# Private Log\nThis ignored file must not be indexed.");
+
+    await writeFile(
+      join(localConfigDir, "index.yml"),
+      `collections:
+  gettst:
+    path: ${getTestDir}
+    pattern: "**/*.md"
+    ignore:
+      - "private/**"
+`
+    );
+
+    const { exitCode, stderr } = await runQmd(["update"], {
+      cwd: getTestDir,
+      dbPath: localDbPath,
+      configDir: localConfigDir,
+    });
+    if (exitCode !== 0) console.error("update failed:", stderr);
+    expect(exitCode).toBe(0);
+  });
+
+  test("get reports ignored paths instead of falling back to same-basename fuzzy match", async () => {
+    const { stdout, stderr, exitCode } = await runQmd(["get", "private/log.md"], {
+      cwd: getTestDir,
+      dbPath: localDbPath,
+      configDir: localConfigDir,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stdout).not.toContain("Public Log");
+    expect(stderr).toContain("excluded by ignore rule");
+    expect(stderr).toContain("private/log.md");
+    expect(stderr).toContain("private/**");
+  });
+
+  test("get does not fall back to same-basename fuzzy match for missing paths", async () => {
+    const { stdout, stderr, exitCode } = await runQmd(["get", "missing/log.md"], {
+      cwd: getTestDir,
+      dbPath: localDbPath,
+      configDir: localConfigDir,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stdout).not.toContain("Public Log");
+    expect(stderr).toContain("Document not found");
+  });
+});
+
 // =============================================================================
 // Status and Collection List - No Full Paths
 // =============================================================================

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -475,7 +475,10 @@ describe("MCP Server", () => {
       const result = findDocument(testDb, "readm.md", { includeBody: false }); // typo
       expect("error" in result).toBe(true);
       if ("error" in result) {
-        expect(result.similarFiles.length).toBeGreaterThanOrEqual(0);
+        expect(result.error).toBe("not_found");
+        if (result.error === "not_found") {
+          expect(result.similarFiles.length).toBeGreaterThanOrEqual(0);
+        }
       }
     });
 

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -194,7 +194,7 @@ async function syncTestConfig(): Promise<void> {
 
 // Helper to create a test collection in YAML config
 async function createTestCollection(
-  options: { pwd?: string; glob?: string; name?: string } = {}
+  options: { pwd?: string; glob?: string; name?: string; ignore?: string[] } = {}
 ): Promise<string> {
   const pwd = options.pwd || "/test/collection";
   const glob = options.glob || "**/*.md";
@@ -210,6 +210,7 @@ async function createTestCollection(
   config.collections[name] = {
     path: pwd,
     pattern: glob,
+    ...(options.ignore ? { ignore: options.ignore } : {}),
   };
 
   // Write back
@@ -1693,8 +1694,54 @@ describe("Document Retrieval", () => {
       expect("error" in result).toBe(true);
       if ("error" in result) {
         expect(result.error).toBe("not_found");
-        // Levenshtein distance of 1 should be found with maxDistance 3
-        expect(result.similarFiles.length).toBeGreaterThanOrEqual(0); // May or may not find depending on distance calc
+        if (result.error === "not_found") {
+          // Levenshtein distance of 1 should be found with maxDistance 3
+          expect(result.similarFiles.length).toBeGreaterThanOrEqual(0); // May or may not find depending on distance calc
+        }
+      }
+
+      await cleanupTestDb(store);
+    });
+
+    test("findDocument reports ignored files separately from missing files", async () => {
+      const store = await createTestStore();
+      const collectionName = await createTestCollection({
+        pwd: "/path",
+        ignore: ["ignored/**"],
+      });
+
+      const result = store.findDocument("/path/ignored/secret.md");
+
+      expect("error" in result).toBe(true);
+      if ("error" in result) {
+        expect(result.error).toBe("excluded_by_ignore");
+        if (result.error === "excluded_by_ignore") {
+          expect(result.collection).toBe(collectionName);
+          expect(result.path).toBe("ignored/secret.md");
+          expect(result.rule).toBe("ignored/**");
+        }
+      }
+
+      await cleanupTestDb(store);
+    });
+
+    test("findDocument detects ignore rules for virtual paths", async () => {
+      const store = await createTestStore();
+      const collectionName = await createTestCollection({
+        name: "vault",
+        ignore: ["private/*.md"],
+      });
+
+      const result = store.findDocument("qmd://vault/private/note.md");
+
+      expect("error" in result).toBe(true);
+      if ("error" in result) {
+        expect(result.error).toBe("excluded_by_ignore");
+        if (result.error === "excluded_by_ignore") {
+          expect(result.collection).toBe(collectionName);
+          expect(result.path).toBe("private/note.md");
+          expect(result.rule).toBe("private/*.md");
+        }
       }
 
       await cleanupTestDb(store);


### PR DESCRIPTION
> Supersedes #667 — rebased onto current `main`. (That PR's head branch had been deleted, so its head was detached and could not be updated in place; this is the same change, conflict-resolved against the latest `getDocument()` refactor. Full suite 935/935 green, types clean.)

## Summary

- return a distinct `excluded_by_ignore` lookup result when a requested document matches a configured collection ignore rule
- surface that reason through the MCP `get` tool, `qmd://` resource, and CLI `qmd get` instead of presenting it as a generic missing file
- route CLI `qmd get` through the shared document lookup path so missing/ignored paths no longer fall back to an unrelated same-basename file
- add regression tests for absolute-path, virtual-path, CLI ignored-path, and CLI missing-path lookups

## Why

If a file is intentionally excluded by an ignore rule, `get` currently looks the same as a typo or stale path. Returning the matched collection/path/rule makes the failure actionable without scanning the index manually.

The CLI also had a separate fallback that matched only the last path component. A request like `private/log.md` could return a different indexed `*log.md` file. Reusing the shared lookup avoids that surprising cross-path fallback.

## Tests

- `bun test test/cli.test.ts --timeout 60000 --preload ./src/test-preload.ts`
- `npm run test:node -- test/cli.test.ts`
- `bun test test/store.test.ts test/mcp.test.ts --timeout 60000 --preload ./src/test-preload.ts`
- `npm run test:node -- test/store.test.ts test/mcp.test.ts`
- `bun run build`
- `npm run test:types`

