### PR TITLE
Add path filtering and explain metadata to search APIs

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -1999,6 +1999,7 @@ type OutputOptions = {
   minScore: number;
   all?: boolean;
   collection?: string | string[];  // Filter by collection name(s)
+  path?: string;  // Filter by folder-prefix within collection(s)
   lineNumbers?: boolean; // Add line numbers to output
   explain?: boolean;     // Include retrieval score traces (query only)
   context?: string;      // Optional context for query expansion
@@ -2186,7 +2187,9 @@ function outputResults(results: OutputRow[], query: string, opts: OutputOptions)
       // With --full-path, omit docid (the on-disk path is the identifier).
       return {
         ...(docid && !opts.fullPath && { docid: `#${docid}` }),
-        score: Math.round(row.score * 100) / 100,
+        // Full precision under --explain so `score` matches explain.blendedScore;
+        // otherwise round for readable output (mirrors the MCP query tool).
+        score: opts.explain ? row.score : Math.round(row.score * 100) / 100,
         file: displayPathFor(row),
         line: snippetInfo.line,
         title: row.title,
@@ -2481,7 +2484,7 @@ function search(query: string, opts: OutputOptions): void {
   // Use large limit for --all, otherwise fetch more than needed and let outputResults filter
   const fetchLimit = opts.all ? 100000 : Math.max(50, opts.limit * 2);
   const results = filterByCollections(
-    searchFTS(db, query, fetchLimit, singleCollection),
+    searchFTS(db, query, fetchLimit, singleCollection, opts.path),
     collectionNames
   );
 
@@ -2534,6 +2537,7 @@ async function vectorSearch(query: string, opts: OutputOptions, _model: string =
   await withLLMSession(async () => {
     let results = await vectorSearchQuery(store, query, {
       collection: singleCollection,
+      pathPrefix: opts.path,
       limit: opts.all ? 500 : (opts.limit || 10),
       minScore: opts.minScore || 0.3,
       intent: opts.intent,
@@ -2609,6 +2613,7 @@ async function querySearch(query: string, opts: OutputOptions, _embedModel: stri
 
       results = await structuredSearch(store, structuredQueries, {
         collections: singleCollection ? [singleCollection] : undefined,
+        pathPrefix: opts.path,
         limit: opts.all ? 500 : (opts.limit || 10),
         minScore: opts.minScore || 0,
         candidateLimit: opts.candidateLimit,
@@ -2637,6 +2642,7 @@ async function querySearch(query: string, opts: OutputOptions, _embedModel: stri
       // Standard hybrid query with automatic expansion
       results = await hybridQuery(store, query, {
         collection: singleCollection,
+        pathPrefix: opts.path,
         limit: opts.all ? 500 : (opts.limit || 10),
         minScore: opts.minScore || 0,
         candidateLimit: opts.candidateLimit,
@@ -2742,6 +2748,7 @@ function parseCLI() {
       json: { type: "boolean" },
       explain: { type: "boolean" },
       collection: { type: "string", short: "c", multiple: true },  // Filter by collection(s)
+      path: { type: "string", short: "p" },  // Filter by folder-prefix within collection(s)
       // Collection options
       name: { type: "string" },  // collection name
       mask: { type: "string" },  // glob pattern
@@ -2831,6 +2838,7 @@ function parseCLI() {
     minScore: values["min-score"] ? parseFloat(String(values["min-score"])) || 0 : 0,
     all: isAll,
     collection: values.collection as string[] | undefined,
+    path: values.path as string | undefined,
     lineNumbers: !!values["line-numbers"],
     candidateLimit: values["candidate-limit"] ? parseInt(String(values["candidate-limit"]), 10) : undefined,
     skipRerank: !!values["no-rerank"],
@@ -3352,6 +3360,7 @@ function showHelp(): void {
   console.log("  --explain                  - Include retrieval score traces (query, CLI/--format json)");
   console.log("  --format <kind>            - Output format: cli (default) | json | csv | md | xml | files");
   console.log("  -c, --collection <name>    - Filter by one or more collections");
+  console.log("  -p, --path <folder-prefix>  - Filter to folder-prefix within collection(s) (folder-only)");
   console.log("");
   console.log("Embed/query options:");
   console.log("  --chunk-strategy <auto|regex> - Chunking mode (default: regex; auto uses AST for code files)");

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,6 +160,8 @@ export interface SearchOptions {
   collection?: string;
   /** Filter to specific collections */
   collections?: string[];
+  /** Filter to folder-prefix within collection(s); folder-only, not file-prefix. */
+  pathPrefix?: string;
   /** Max results (default: 10) */
   limit?: number;
   /** Max candidates to rerank (default: 40) */
@@ -178,6 +180,8 @@ export interface SearchOptions {
 export interface LexSearchOptions {
   limit?: number;
   collection?: string;
+  /** Filter to folder-prefix within collection; folder-only, not file-prefix. */
+  pathPrefix?: string;
 }
 
 /**
@@ -186,6 +190,8 @@ export interface LexSearchOptions {
 export interface VectorSearchOptions {
   limit?: number;
   collection?: string;
+  /** Filter to folder-prefix within collection; folder-only, not file-prefix. */
+  pathPrefix?: string;
 }
 
 /**
@@ -408,6 +414,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
           explain: opts.explain,
           intent: opts.intent,
           candidateLimit: opts.candidateLimit,
+          pathPrefix: opts.pathPrefix,
           skipRerank,
           chunkStrategy: opts.chunkStrategy,
         });
@@ -421,12 +428,13 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
         explain: opts.explain,
         intent: opts.intent,
         candidateLimit: opts.candidateLimit,
+        pathPrefix: opts.pathPrefix,
         skipRerank,
         chunkStrategy: opts.chunkStrategy,
       });
     },
-    searchLex: async (q, opts) => internal.searchFTS(q, opts?.limit, opts?.collection),
-    searchVector: async (q, opts) => internal.searchVec(q, llm.embedModelName, opts?.limit, opts?.collection),
+    searchLex: async (q, opts) => internal.searchFTS(q, opts?.limit, opts?.collection, opts?.pathPrefix),
+    searchVector: async (q, opts) => internal.searchVec(q, llm.embedModelName, opts?.limit, opts?.collection, undefined, undefined, opts?.pathPrefix),
     expandQuery: async (q, opts) => internal.expandQuery(q, undefined, opts?.intent),
     get: async (pathOrDocid, opts) => internal.findDocument(pathOrDocid, opts),
     getDocumentBody: async (pathOrDocid, opts) => {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -323,9 +323,15 @@ Intent-aware lex (C++ performance, not sports):
         rerank: z.boolean().optional().default(true).describe(
           "Rerank results using LLM (default: true). Set to false for faster results on CPU-only machines."
         ),
+        pathPrefix: z.string().optional().describe(
+          "Filter to folder-prefix within collection(s), e.g. 'docs/'. Folder-only — file paths are not supported."
+        ),
+        explain: z.boolean().optional().default(false).describe(
+          "Include score breakdown per result: scoreType, backendSources, ftsScores, vectorScores, RRF trace, rerankScore, and blendedScore."
+        ),
       },
     },
-    async ({ query, searches, limit, minScore, candidateLimit, collections, intent, rerank }) => {
+    async ({ query, searches, limit, minScore, candidateLimit, collections, intent, rerank, pathPrefix, explain }) => {
       // Require exactly one of `query` (plain text, auto-expanded) or `searches` (typed sub-queries).
       if (!query && (!searches || searches.length === 0)) {
         return {
@@ -357,6 +363,8 @@ Intent-aware lex (C++ performance, not sports):
         candidateLimit,
         rerank,
         intent,
+        pathPrefix,
+        explain,
       });
 
       // Use the plain query, or the first lex/vec sub-query, for snippet extraction
@@ -372,10 +380,11 @@ Intent-aware lex (C++ performance, not sports):
           docid: `#${r.docid}`,
           file: r.displayPath,
           title: r.title,
-          score: Math.round(r.score * 100) / 100,
+          score: explain ? r.score : Math.round(r.score * 100) / 100,
           context: r.context,
           line,
           snippet: addLineNumbers(snippet, line),
+          ...(explain && r.explain ? { explain: r.explain } : {}),
         };
       });
 
@@ -718,16 +727,32 @@ export async function startMcpHttpServer(
         return;
       }
 
-      // REST endpoint: POST /search — structured search without MCP protocol
       // REST endpoint: POST /query (alias: /search) — structured search without MCP protocol
       if ((pathname === "/query" || pathname === "/search") && nodeReq.method === "POST") {
         const rawBody = await collectBody(nodeReq);
-        const params = JSON.parse(rawBody) as Record<string, unknown>;
+        let params: Record<string, unknown>;
+        try {
+          params = JSON.parse(rawBody) as Record<string, unknown>;
+        } catch {
+          nodeRes.writeHead(400, { "Content-Type": "application/json" });
+          nodeRes.end(JSON.stringify({ error: "invalid JSON" }));
+          return;
+        }
 
         // Validate required fields
         if (!params.searches || !Array.isArray(params.searches)) {
           nodeRes.writeHead(400, { "Content-Type": "application/json" });
           nodeRes.end(JSON.stringify({ error: "Missing required field: searches (array)" }));
+          return;
+        }
+        if (params.pathPrefix !== undefined && typeof params.pathPrefix !== "string") {
+          nodeRes.writeHead(400, { "Content-Type": "application/json" });
+          nodeRes.end(JSON.stringify({ error: "pathPrefix must be string" }));
+          return;
+        }
+        if (params.explain !== undefined && typeof params.explain !== "boolean") {
+          nodeRes.writeHead(400, { "Content-Type": "application/json" });
+          nodeRes.end(JSON.stringify({ error: "explain must be boolean" }));
           return;
         }
 
@@ -749,6 +774,8 @@ export async function startMcpHttpServer(
           candidateLimit: typeof params.candidateLimit === "number" ? params.candidateLimit : undefined,
           intent: typeof params.intent === "string" ? params.intent : undefined,
           rerank: typeof params.rerank === "boolean" ? params.rerank : undefined,
+          pathPrefix: typeof params.pathPrefix === "string" ? params.pathPrefix : undefined,
+          explain: typeof params.explain === "boolean" ? params.explain : false,
         });
 
         // Use first lex or vec query for snippet extraction
@@ -762,10 +789,11 @@ export async function startMcpHttpServer(
             docid: `#${r.docid}`,
             file: `qmd://${encodeQmdPath(r.displayPath)}`,
             title: r.title,
-            score: Math.round(r.score * 100) / 100,
+            score: params.explain ? r.score : Math.round(r.score * 100) / 100,
             context: r.context,
             line,
             snippet: addLineNumbers(snippet, line),
+            ...(params.explain && r.explain ? { explain: r.explain } : {}),
           };
         });
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -1308,8 +1308,8 @@ export type Store = {
   toVirtualPath: (absolutePath: string) => string | null;
 
   // Search
-  searchFTS: (query: string, limit?: number, collectionName?: string) => SearchResult[];
-  searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => Promise<SearchResult[]>;
+  searchFTS: (query: string, limit?: number, collectionName?: string, pathPrefix?: string) => SearchResult[];
+  searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[], pathPrefix?: string) => Promise<SearchResult[]>;
 
   // Query expansion & reranking
   expandQuery: (query: string, model?: string, intent?: string) => Promise<ExpandedQuery[]>;
@@ -1990,8 +1990,8 @@ export function createStore(dbPath?: string): Store {
     toVirtualPath: (absolutePath: string) => toVirtualPath(db, absolutePath),
 
     // Search
-    searchFTS: (query: string, limit?: number, collectionName?: string) => searchFTS(db, query, limit, collectionName),
-    searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => searchVec(db, query, model, limit, collectionName, session, precomputedEmbedding),
+    searchFTS: (query: string, limit?: number, collectionName?: string, pathPrefix?: string) => searchFTS(db, query, limit, collectionName, pathPrefix),
+    searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[], pathPrefix?: string) => searchVec(db, query, model, limit, collectionName, session, precomputedEmbedding, pathPrefix),
 
     // Query expansion & reranking
     expandQuery: (query: string, model?: string, intent?: string) => expandQuery(query, model ?? store.llm?.generateModelName ?? DEFAULT_QUERY_MODEL, db, intent, store.llm),
@@ -2164,6 +2164,8 @@ export type RRFScoreTrace = {
 };
 
 export type HybridQueryExplain = {
+  scoreType?: 'rerank-blend' | 'rrf-position';
+  backendSources?: ('bm25' | 'cosine')[];
   ftsScores: number[];
   vectorScores: number[];
   rrf: {
@@ -2529,7 +2531,7 @@ export function insertContent(db: Database, hash: string, content: string, creat
 
 function rebuildDocumentFTS(db: Database, documentId: number): void {
   const row = db.prepare(`
-    SELECT d.id, d.collection, d.path, d.title, content.doc as body
+    SELECT d.id, d.collection, d.path AS path, d.title, content.doc as body
     FROM documents d
     JOIN content ON content.hash = d.hash
     WHERE d.id = ? AND d.active = 1
@@ -2932,7 +2934,7 @@ export function findDocumentByDocid(db: Database, docid: string): { filepath: st
 
 export function findSimilarFiles(db: Database, query: string, maxDistance: number = 3, limit: number = 5): string[] {
   const allFiles = db.prepare(`
-    SELECT d.path
+    SELECT d.path AS path
     FROM documents d
     WHERE d.active = 1
   `).all() as { path: string }[];
@@ -3067,7 +3069,9 @@ export function getContextForFile(db: Database, filepath: string): string | null
   const doc = db.prepare(`
     SELECT d.path
     FROM documents d
-    WHERE d.collection = ? AND d.path = ? AND d.active = 1
+    WHERE d.collection = ?
+      AND d.path = ?
+      AND d.active = 1
     LIMIT 1
   `).get(collectionName, relativePath) as { path: string } | null;
 
@@ -3553,6 +3557,36 @@ export function validateSemanticQuery(query: string): string | null {
   return null;
 }
 
+/**
+ * Normalize a folder-prefix path for search pathPrefix filters.
+ *
+ * Folder-prefix ONLY. File-prefix matching is not supported — e.g.,
+ * normalizePathPrefix("README.md") returns "README.md/" which matches no docs
+ * (no document has path starting with "README.md/"). If you need to find a
+ * specific file, query without pathPrefix or use a folder containing the file.
+ *
+ * Returns null for empty/root input; callers must skip the SQL predicate then.
+ */
+function normalizePathPrefix(p: string): string | null {
+  const cleaned = p
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '');
+  if (!cleaned) return null;
+  return cleaned + '/';
+}
+
+/** Compute the exclusive upper bound for a folder-prefix range query. */
+function lexicographicSuccessor(p: string): string {
+  if (!p.endsWith('/')) {
+    throw new Error(`lexicographicSuccessor: input must end with '/', got: ${JSON.stringify(p)}`);
+  }
+  return p.slice(0, -1) + '0';
+}
+
+export const __testPathPrefixHelpers = { normalizePathPrefix, lexicographicSuccessor };
+
 export function validateLexQuery(query: string): string | null {
   if (/[\r\n]/.test(query)) {
     return 'Lex queries must be a single line. Remove newline characters or split into separate lex: lines.';
@@ -3564,7 +3598,7 @@ export function validateLexQuery(query: string): string | null {
   return null;
 }
 
-export function searchFTS(db: Database, query: string, limit: number = 20, collectionName?: string): SearchResult[] {
+export function searchFTS(db: Database, query: string, limit: number = 20, collectionName?: string, pathPrefix?: string): SearchResult[] {
   const ftsQuery = buildFTS5Query(query);
   if (!ftsQuery) return [];
 
@@ -3574,11 +3608,13 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
   // abandon the FTS5 index and fall back to a full scan — turning an 8ms
   // query into a 17-second query on large collections.
   const params: (string | number)[] = [ftsQuery];
+  const normalizedPath = pathPrefix ? normalizePathPrefix(pathPrefix) : null;
 
-  // When filtering by collection, fetch extra candidates from the FTS index
-  // since some will be filtered out. Without a collection filter we can
-  // fetch exactly the requested limit.
-  const ftsLimit = collectionName ? limit * 10 : limit;
+  // When filtering by collection/path, fetch extra candidates from the FTS index
+  // since some will be filtered out. Without a filter we can fetch exactly the requested limit.
+  // Recall behavior is documented but not guaranteed for highly selective filters; this
+  // matches qmd's existing collection-filter overfetch heuristic.
+  const ftsLimit = (collectionName || normalizedPath) ? limit * 10 : limit;
 
   let sql = `
     WITH fts_matches AS (
@@ -3604,6 +3640,10 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
   if (collectionName) {
     sql += ` AND d.collection = ?`;
     params.push(String(collectionName));
+  }
+  if (normalizedPath) {
+    sql += ` AND d.path COLLATE BINARY >= ? AND d.path COLLATE BINARY < ?`;
+    params.push(normalizedPath, lexicographicSuccessor(normalizedPath));
   }
 
   // bm25 lower is better; sort ascending.
@@ -3639,7 +3679,7 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
 // Vector Search
 // =============================================================================
 
-export async function searchVec(db: Database, query: string, model: string, limit: number = 20, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]): Promise<SearchResult[]> {
+export async function searchVec(db: Database, query: string, model: string, limit: number = 20, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[], pathPrefix?: string): Promise<SearchResult[]> {
   const tableExists = db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'`).get();
   if (!tableExists) return [];
 
@@ -3651,12 +3691,15 @@ export async function searchVec(db: Database, query: string, model: string, limi
   // "optimize" this by combining into a single query with JOINs - it will break.
   // See: https://github.com/tobi/qmd/pull/23
 
+  const normalizedPath = pathPrefix ? normalizePathPrefix(pathPrefix) : null;
+  const vecLimit = (collectionName || normalizedPath) ? limit * 10 : limit * 3;
+
   // Step 1: Get vector matches from sqlite-vec (no JOINs allowed)
   const vecResults = db.prepare(`
     SELECT hash_seq, distance
     FROM vectors_vec
     WHERE embedding MATCH ? AND k = ?
-  `).all(new Float32Array(embedding), limit * 3) as { hash_seq: string; distance: number }[];
+  `).all(new Float32Array(embedding), vecLimit) as { hash_seq: string; distance: number }[];
 
   if (vecResults.length === 0) return [];
 
@@ -3685,6 +3728,10 @@ export async function searchVec(db: Database, query: string, model: string, limi
   if (collectionName) {
     docSql += ` AND d.collection = ?`;
     params.push(collectionName);
+  }
+  if (normalizedPath) {
+    docSql += ` AND d.path COLLATE BINARY >= ? AND d.path COLLATE BINARY < ?`;
+    params.push(normalizedPath, lexicographicSuccessor(normalizedPath));
   }
 
   const docRows = withLazyContentVectorMigration(db, () => db.prepare(docSql).all(...params) as {
@@ -4671,6 +4718,8 @@ export interface SearchHooks {
 
 export interface HybridQueryOptions {
   collection?: string;
+  /** Filter to folder-prefix within collection (folder-only, not file-prefix). */
+  pathPrefix?: string;
   limit?: number;           // default 10
   minScore?: number;        // default 0
   candidateLimit?: number;  // default RERANK_CANDIDATE_LIMIT
@@ -4737,6 +4786,7 @@ export async function hybridQuery(
   const minScore = options?.minScore ?? 0;
   const candidateLimit = options?.candidateLimit ?? RERANK_CANDIDATE_LIMIT;
   const collection = options?.collection;
+  const pathPrefix = options?.pathPrefix;
   const explain = options?.explain ?? false;
   const intent = options?.intent;
   const skipRerank = options?.skipRerank ?? false;
@@ -4754,7 +4804,7 @@ export async function hybridQuery(
   // match may not be what the caller wants (e.g. "performance" with intent
   // "web page load times" should NOT shortcut to a sports-performance doc).
   // Pass collection directly into FTS query (filter at SQL level, not post-hoc)
-  const initialFts = store.searchFTS(query, 20, collection);
+  const initialFts = store.searchFTS(query, 20, collection, pathPrefix);
   const topScore = initialFts[0]?.score ?? 0;
   const secondScore = initialFts[1]?.score ?? 0;
   const hasStrongSignal = !intent && initialFts.length > 0
@@ -4791,7 +4841,7 @@ export async function hybridQuery(
   // 3a: Run FTS for all lex expansions right away (no LLM needed)
   for (const q of expanded) {
     if (q.type === 'lex') {
-      const ftsResults = store.searchFTS(q.query, 20, collection);
+      const ftsResults = store.searchFTS(q.query, 20, collection, pathPrefix);
       if (ftsResults.length > 0) {
         for (const r of ftsResults) docidMap.set(r.filepath, r.docid);
         rankedLists.push(ftsResults.map(r => ({
@@ -4830,7 +4880,7 @@ export async function hybridQuery(
 
       const vecResults = await store.searchVec(
         vecQueries[i]!.text, embedModel, 20, collection,
-        undefined, embedding
+        undefined, embedding, pathPrefix
       );
       if (vecResults.length > 0) {
         for (const r of vecResults) docidMap.set(r.filepath, r.docid);
@@ -4895,9 +4945,16 @@ export async function hybridQuery(
         const rrfRank = i + 1;
         const rrfScore = 1 / rrfRank;
         const trace = rrfTraceByFile?.get(cand.file);
+        const ftsScores = trace?.contributions.filter(c => c.source === "fts").map(c => c.backendScore) ?? [];
+        const vectorScores = trace?.contributions.filter(c => c.source === "vec").map(c => c.backendScore) ?? [];
         const explainData: HybridQueryExplain | undefined = explain ? {
-          ftsScores: trace?.contributions.filter(c => c.source === "fts").map(c => c.backendScore) ?? [],
-          vectorScores: trace?.contributions.filter(c => c.source === "vec").map(c => c.backendScore) ?? [],
+          scoreType: 'rrf-position' as const,
+          backendSources: [
+            ...(ftsScores.length > 0 ? ['bm25' as const] : []),
+            ...(vectorScores.length > 0 ? ['cosine' as const] : []),
+          ],
+          ftsScores,
+          vectorScores,
           rrf: {
             rank: rrfRank,
             positionScore: rrfScore,
@@ -4969,9 +5026,16 @@ export async function hybridQuery(
     const bestChunk = chunkInfo?.chunks[bestIdx]?.text || candidate?.body || "";
     const bestChunkPos = chunkInfo?.chunks[bestIdx]?.pos || 0;
     const trace = rrfTraceByFile?.get(r.file);
+    const ftsScores = trace?.contributions.filter(c => c.source === "fts").map(c => c.backendScore) ?? [];
+    const vectorScores = trace?.contributions.filter(c => c.source === "vec").map(c => c.backendScore) ?? [];
     const explainData: HybridQueryExplain | undefined = explain ? {
-      ftsScores: trace?.contributions.filter(c => c.source === "fts").map(c => c.backendScore) ?? [],
-      vectorScores: trace?.contributions.filter(c => c.source === "vec").map(c => c.backendScore) ?? [],
+      scoreType: 'rerank-blend' as const,
+      backendSources: [
+        ...(ftsScores.length > 0 ? ['bm25' as const] : []),
+        ...(vectorScores.length > 0 ? ['cosine' as const] : []),
+      ],
+      ftsScores,
+      vectorScores,
       rrf: {
         rank: rrfRank,
         positionScore: rrfScore,
@@ -5013,6 +5077,8 @@ export async function hybridQuery(
 
 export interface VectorSearchOptions {
   collection?: string;
+  /** Filter to folder-prefix within collection (folder-only, not file-prefix). */
+  pathPrefix?: string;
   limit?: number;           // default 10
   minScore?: number;        // default 0.3
   intent?: string;          // domain intent hint for disambiguation
@@ -5046,6 +5112,7 @@ export async function vectorSearchQuery(
   const limit = options?.limit ?? 10;
   const minScore = options?.minScore ?? 0.3;
   const collection = options?.collection;
+  const pathPrefix = options?.pathPrefix;
   const intent = options?.intent;
 
   const hasVectors = !!store.db.prepare(
@@ -5064,7 +5131,7 @@ export async function vectorSearchQuery(
   const queryTexts = [query, ...vecExpanded.map(q => q.query)];
   const allResults = new Map<string, VectorSearchResult>();
   for (const q of queryTexts) {
-    const vecResults = await store.searchVec(q, embedModel, limit, collection);
+    const vecResults = await store.searchVec(q, embedModel, limit, collection, undefined, undefined, pathPrefix);
     for (const r of vecResults) {
       const existing = allResults.get(r.filepath);
       if (!existing || r.score > existing.score) {
@@ -5097,6 +5164,8 @@ export async function vectorSearchQuery(
  */
 export interface StructuredSearchOptions {
   collections?: string[];   // Filter to specific collections (OR match)
+  /** Filter to folder-prefix within collection(s); folder-only, not file-prefix. */
+  pathPrefix?: string;
   limit?: number;           // default 10
   minScore?: number;        // default 0
   candidateLimit?: number;  // default RERANK_CANDIDATE_LIMIT
@@ -5141,6 +5210,7 @@ export async function structuredSearch(
   const hooks = options?.hooks;
 
   const collections = options?.collections;
+  const pathPrefix = options?.pathPrefix;
 
   if (searches.length === 0) return [];
 
@@ -5177,7 +5247,7 @@ export async function structuredSearch(
   for (const search of searches) {
     if (search.type === 'lex') {
       for (const coll of collectionList) {
-        const ftsResults = store.searchFTS(search.query, 20, coll);
+        const ftsResults = store.searchFTS(search.query, 20, coll, pathPrefix);
         if (ftsResults.length > 0) {
           for (const r of ftsResults) docidMap.set(r.filepath, r.docid);
           rankedLists.push(ftsResults.map(r => ({
@@ -5216,7 +5286,7 @@ export async function structuredSearch(
         for (const coll of collectionList) {
           const vecResults = await store.searchVec(
             vecSearches[i]!.query, embedModel, 20, coll,
-            undefined, embedding
+            undefined, embedding, pathPrefix
           );
           if (vecResults.length > 0) {
             for (const r of vecResults) docidMap.set(r.filepath, r.docid);
@@ -5289,9 +5359,16 @@ export async function structuredSearch(
         const rrfRank = i + 1;
         const rrfScore = 1 / rrfRank;
         const trace = rrfTraceByFile?.get(cand.file);
+        const ftsScores = trace?.contributions.filter(c => c.source === "fts").map(c => c.backendScore) ?? [];
+        const vectorScores = trace?.contributions.filter(c => c.source === "vec").map(c => c.backendScore) ?? [];
         const explainData: HybridQueryExplain | undefined = explain ? {
-          ftsScores: trace?.contributions.filter(c => c.source === "fts").map(c => c.backendScore) ?? [],
-          vectorScores: trace?.contributions.filter(c => c.source === "vec").map(c => c.backendScore) ?? [],
+          scoreType: 'rrf-position' as const,
+          backendSources: [
+            ...(ftsScores.length > 0 ? ['bm25' as const] : []),
+            ...(vectorScores.length > 0 ? ['cosine' as const] : []),
+          ],
+          ftsScores,
+          vectorScores,
           rrf: {
             rank: rrfRank,
             positionScore: rrfScore,
@@ -5362,9 +5439,16 @@ export async function structuredSearch(
     const bestChunk = chunkInfo?.chunks[bestIdx]?.text || candidate?.body || "";
     const bestChunkPos = chunkInfo?.chunks[bestIdx]?.pos || 0;
     const trace = rrfTraceByFile?.get(r.file);
+    const ftsScores = trace?.contributions.filter(c => c.source === "fts").map(c => c.backendScore) ?? [];
+    const vectorScores = trace?.contributions.filter(c => c.source === "vec").map(c => c.backendScore) ?? [];
     const explainData: HybridQueryExplain | undefined = explain ? {
-      ftsScores: trace?.contributions.filter(c => c.source === "fts").map(c => c.backendScore) ?? [],
-      vectorScores: trace?.contributions.filter(c => c.source === "vec").map(c => c.backendScore) ?? [],
+      scoreType: 'rerank-blend' as const,
+      backendSources: [
+        ...(ftsScores.length > 0 ? ['bm25' as const] : []),
+        ...(vectorScores.length > 0 ? ['cosine' as const] : []),
+      ],
+      ftsScores,
+      vectorScores,
       rrf: {
         rank: rrfRank,
         positionScore: rrfScore,

--- a/test/path-filter.test.ts
+++ b/test/path-filter.test.ts
@@ -1,0 +1,128 @@
+import { describe, test, expect, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  createStore,
+  hashContent,
+  insertContent,
+  insertDocument,
+  searchFTS,
+  structuredSearch,
+  __testPathPrefixHelpers,
+  type Store,
+} from "../src/store.js";
+
+const stores: Store[] = [];
+const dirs: string[] = [];
+
+async function makeStore(): Promise<Store> {
+  const dir = await mkdtemp(join(tmpdir(), "qmd-path-filter-"));
+  dirs.push(dir);
+  const store = createStore(join(dir, "test.sqlite"));
+  stores.push(store);
+  return store;
+}
+
+async function addDoc(store: Store, path: string, body: string, title = path): Promise<void> {
+  const now = new Date().toISOString();
+  const hash = await hashContent(`${path}\n${body}`);
+  insertContent(store.db, hash, body, now);
+  insertDocument(store.db, "docs", path, title, hash, now, now);
+}
+
+afterEach(async () => {
+  while (stores.length) stores.pop()!.close();
+  while (dirs.length) await rm(dirs.pop()!, { recursive: true, force: true });
+});
+
+describe("searchFTS pathPrefix", () => {
+  test("returns all docs without filter", async () => {
+    const store = await makeStore();
+    await addDoc(store, "stack/a.md", "fcose graph layout");
+    await addDoc(store, "other/b.md", "fcose graph layout");
+
+    const results = searchFTS(store.db, "fcose", 10, "docs");
+    expect(results.map(r => r.filepath).sort()).toEqual([
+      "qmd://docs/other/b.md",
+      "qmd://docs/stack/a.md",
+    ]);
+  });
+
+  test("filters by folder-prefix and normalizes slashes/whitespace", async () => {
+    const store = await makeStore();
+    await addDoc(store, "foo/bar/a.md", "fcose graph layout");
+    await addDoc(store, "foo/baz/b.md", "fcose graph layout");
+
+    const results = searchFTS(store.db, "fcose", 10, "docs", "  /foo\\bar/  ");
+    expect(results.map(r => r.filepath)).toEqual(["qmd://docs/foo/bar/a.md"]);
+  });
+
+  test("root and empty path mean no filter", async () => {
+    const store = await makeStore();
+    await addDoc(store, "stack/a.md", "fcose graph layout");
+    await addDoc(store, "other/b.md", "fcose graph layout");
+
+    expect(searchFTS(store.db, "fcose", 10, "docs", "/")).toHaveLength(2);
+    expect(searchFTS(store.db, "fcose", 10, "docs", "   ")).toHaveLength(2);
+  });
+
+  test("range predicate respects folder boundary", async () => {
+    const store = await makeStore();
+    await addDoc(store, "stack/a.md", "fcose graph layout");
+    await addDoc(store, "stack0/b.md", "fcose graph layout");
+    await addDoc(store, "stack-monitor/c.md", "fcose graph layout");
+
+    const results = searchFTS(store.db, "fcose", 10, "docs", "stack");
+    expect(results.map(r => r.filepath)).toEqual(["qmd://docs/stack/a.md"]);
+  });
+
+  test("range predicate is case-sensitive", async () => {
+    const store = await makeStore();
+    await addDoc(store, "Stack/a.md", "fcose graph layout");
+    await addDoc(store, "stack/b.md", "fcose graph layout");
+
+    const results = searchFTS(store.db, "fcose", 10, "docs", "stack");
+    expect(results.map(r => r.filepath)).toEqual(["qmd://docs/stack/b.md"]);
+  });
+
+  test("folder-only design: file-like path matches no documents", async () => {
+    const store = await makeStore();
+    await addDoc(store, "README.md", "fcose graph layout");
+
+    expect(searchFTS(store.db, "fcose", 10, "docs", "README.md")).toEqual([]);
+  });
+
+  test("SQL injection probe is parameterized", async () => {
+    const store = await makeStore();
+    await addDoc(store, "stack/a.md", "fcose graph layout");
+
+    const results = searchFTS(store.db, "fcose", 10, "docs", "'; DROP TABLE documents;--");
+    expect(results).toEqual([]);
+    expect(searchFTS(store.db, "fcose", 10, "docs", "stack")).toHaveLength(1);
+  });
+
+  test("lexicographicSuccessor invariant", () => {
+    expect(__testPathPrefixHelpers.lexicographicSuccessor("stack/")).toBe("stack0");
+    expect(() => __testPathPrefixHelpers.lexicographicSuccessor("stack")).toThrow(/must end with '\/'/);
+  });
+});
+
+describe("structuredSearch pathPrefix", () => {
+  test("passes pathPrefix through structured lex search", async () => {
+    const store = await makeStore();
+    await addDoc(store, "stack/a.md", "fcose graph layout");
+    await addDoc(store, "other/b.md", "fcose graph layout");
+
+    const results = await structuredSearch(
+      store,
+      [{ type: "lex", query: "fcose" }],
+      { collections: ["docs"], pathPrefix: "stack", skipRerank: true, explain: true }
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.file).toBe("qmd://docs/stack/a.md");
+    expect(results[0]!.explain?.scoreType).toBe("rrf-position");
+    expect(results[0]!.explain?.backendSources).toEqual(["bm25"]);
+  });
+});

--- a/test/score-breakdown.test.ts
+++ b/test/score-breakdown.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  createStore,
+  hashContent,
+  insertContent,
+  insertDocument,
+  structuredSearch,
+  type Store,
+} from "../src/store.js";
+
+const stores: Store[] = [];
+const dirs: string[] = [];
+
+async function makeStore(): Promise<Store> {
+  const dir = await mkdtemp(join(tmpdir(), "qmd-score-breakdown-"));
+  dirs.push(dir);
+  const store = createStore(join(dir, "test.sqlite"));
+  stores.push(store);
+  return store;
+}
+
+async function addDoc(store: Store, path: string, body: string, title = path): Promise<void> {
+  const now = new Date().toISOString();
+  const hash = await hashContent(`${path}\n${body}`);
+  insertContent(store.db, hash, body, now);
+  insertDocument(store.db, "docs", path, title, hash, now, now);
+}
+
+afterEach(async () => {
+  while (stores.length) stores.pop()!.close();
+  while (dirs.length) await rm(dirs.pop()!, { recursive: true, force: true });
+});
+
+describe("score breakdown", () => {
+  test("rerank:false exposes rrf-position and per-result bm25 backend", async () => {
+    const store = await makeStore();
+    await addDoc(store, "stack/a.md", "fcose graph layout");
+
+    const results = await structuredSearch(
+      store,
+      [{ type: "lex", query: "fcose" }],
+      { collections: ["docs"], skipRerank: true, explain: true }
+    );
+
+    expect(results[0]!.score).toBe(1);
+    expect(results[0]!.explain?.scoreType).toBe("rrf-position");
+    expect(results[0]!.explain?.backendSources).toEqual(["bm25"]);
+    expect(results[0]!.explain?.ftsScores.length).toBeGreaterThan(0);
+    expect(results[0]!.explain?.vectorScores).toEqual([]);
+  });
+
+  test("rerank:true exposes rerank-blend without calling a real LLM", async () => {
+    const store = await makeStore();
+    await addDoc(store, "stack/a.md", "fcose graph layout");
+    store.rerank = async (_query, docs) => docs.map(doc => ({ file: doc.file, score: 0.5 }));
+
+    const results = await structuredSearch(
+      store,
+      [{ type: "lex", query: "fcose" }],
+      { collections: ["docs"], skipRerank: false, explain: true }
+    );
+
+    expect(results[0]!.explain?.scoreType).toBe("rerank-blend");
+    expect(results[0]!.explain?.backendSources).toEqual(["bm25"]);
+    expect(results[0]!.explain?.rerankScore).toBe(0.5);
+    expect(results[0]!.score).toBe(results[0]!.explain?.blendedScore);
+  });
+
+  test("score is unrounded when explain payload is available", async () => {
+    const store = await makeStore();
+    await addDoc(store, "stack/a.md", "fcose graph layout");
+
+    const results = await structuredSearch(
+      store,
+      [{ type: "lex", query: "fcose" }],
+      { collections: ["docs"], skipRerank: true, explain: true }
+    );
+
+    expect(results[0]!.explain).toBeDefined();
+    expect(results[0]!.score).toBe(results[0]!.explain!.blendedScore);
+  });
+});


### PR DESCRIPTION
## Summary

Adds two opt-in capabilities to the search APIs (CLI `query`/`search`, the MCP `query` tool, and the SDK `store.search`):

1. **`pathPrefix` folder filtering** — restrict results to a folder-prefix within the selected collection(s), e.g. `--path stack/` / `pathPrefix: "stack"`.
2. **`explain` score breakdown** — opt-in per-result retrieval trace (`scoreType`, `backendSources`, `ftsScores`, `vectorScores`, RRF trace, `rerankScore`, `blendedScore`).

Addresses the folder-scoped search request in #6.

## Details

- `pathPrefix` is normalized (slash/whitespace, leading/trailing `/`) and applied as a `COLLATE BINARY` range predicate (`>= prefix/ AND < successor`) using a folder-boundary-safe lexicographic successor; fully parameterized. Folder-only by design — a file-like path matches no documents.
- Candidate filtering is **bounded**: FTS/vector overfetch `limit * 10` candidates before the prefix is applied — the same trade-off as the existing collection filter. Highly selective prefixes can therefore under-return; this is intentional MVP behavior, documented in code, not hidden filtering. If stricter recall is wanted I'm happy to follow up with a pre-filterable candidate source.
- Under `explain` the CLI/JSON and MCP `score` is emitted at full precision so it matches `explain.blendedScore`.

## Notes

- Rebased onto current `main` (v2.6.3).
- The earlier `original_path` round-trip machinery that previously lived on this branch has been **removed** to keep the PR focused on path filtering + explain. The shared lookup paths (`findDocument`/`findDocuments`/`multiGet`) are unchanged from `main` apart from the two features above.

## Testing

- `npm run test:types`, vitest (`test:node`) and bun (`test:bun`) suites pass.
- `npm run build` passes.
- New tests: `test/path-filter.test.ts` (pathPrefix range/normalization/injection/folder-boundary) and `test/score-breakdown.test.ts` (explain).
