### PR TITLE
Boost title matches in hybrid search

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -2394,6 +2394,9 @@ function outputResults(results: OutputRow[], query: string, opts: OutputOptions)
         console.log(`${c.dim}Explain: fts=[${ftsScores}] vec=[${vecScores}]${c.reset}`);
         console.log(`${c.dim}  RRF: total=${formatExplainNumber(explain.rrf.totalScore)} base=${formatExplainNumber(explain.rrf.baseScore)} bonus=${formatExplainNumber(explain.rrf.topRankBonus)} rank=${explain.rrf.rank}${c.reset}`);
         console.log(`${c.dim}  Blend: ${Math.round(explain.rrf.weight * 100)}%*${formatExplainNumber(explain.rrf.positionScore)} + ${Math.round((1 - explain.rrf.weight) * 100)}%*${formatExplainNumber(explain.rerankScore)} = ${formatExplainNumber(explain.blendedScore)}${c.reset}`);
+        if (explain.titleBoost !== 1) {
+          console.log(`${c.dim}  Title boost: ${formatExplainNumber(explain.titleBoost)}x (applied to ranking before final score)${c.reset}`);
+        }
         if (contribSummary.length > 0) {
           console.log(`${c.dim}  Top RRF contributions: ${contribSummary}${c.reset}`);
         }

--- a/src/store.ts
+++ b/src/store.ts
@@ -2066,7 +2066,7 @@ export type HybridQueryExplain = {
   ftsScores: number[];
   vectorScores: number[];
   rrf: {
-    rank: number;          // Rank after RRF fusion (1-indexed)
+    rank: number;          // Rank after RRF fusion and title-boost ordering (1-indexed)
     positionScore: number; // 1 / rank used in position-aware blending
     weight: number;        // Position-aware RRF weight (0.75 / 0.60 / 0.40)
     baseScore: number;
@@ -2075,6 +2075,7 @@ export type HybridQueryExplain = {
     contributions: RRFContributionTrace[];
   };
   rerankScore: number;
+  titleBoost: number;
   blendedScore: number;
 };
 
@@ -4545,6 +4546,57 @@ export function getHybridRrfWeights(rankedListMeta: RankedListMeta[]): number[] 
 }
 
 /**
+ * Build normalized query terms used for title-match boosting.
+ *
+ * This intentionally reuses the intent-term tokenizer so short domain terms
+ * such as API/SQL/LLM survive while common function words are ignored.
+ */
+export function getTitleBoostTerms(...texts: (string | undefined)[]): string[] {
+  const terms = new Set<string>();
+  for (const text of texts) {
+    if (!text) continue;
+    for (const term of extractTitleMatchTerms(text)) terms.add(term);
+  }
+  return [...terms];
+}
+
+function extractTitleMatchTerms(text: string): string[] {
+  return text.toLowerCase()
+    .split(/[^\p{L}\p{N}]+/gu)
+    .filter(t => t.length > 1 && !INTENT_STOP_WORDS.has(t));
+}
+
+function getTitleTerms(title: string | undefined): Set<string> {
+  return new Set(extractTitleMatchTerms(title || ""));
+}
+
+/**
+ * Small, capped boost for candidates whose document title contains query terms.
+ *
+ * The boost is deliberately modest per term and capped at 3x: title matches
+ * should help recover convention/lookup-style queries, not overwhelm retrieval
+ * and reranker evidence.
+ */
+export function getTitleMatchBoost(title: string | undefined, terms: string[]): number {
+  if (!title || terms.length === 0) return 1;
+  const titleTerms = getTitleTerms(title);
+  const overlap = terms.filter(term => titleTerms.has(term)).length;
+  return Math.min(3.0, 1 + 0.7 * overlap);
+}
+
+function applyTitleMatchBoost<T extends RankedResult>(results: T[], terms: string[]): T[] {
+  if (terms.length === 0) return results;
+  return results
+    .map((result, index) => ({
+      result,
+      index,
+      rankScore: result.score * getTitleMatchBoost(result.title, terms),
+    }))
+    .sort((a, b) => (b.rankScore - a.rankScore) || (a.index - b.index))
+    .map(entry => entry.result);
+}
+
+/**
  * Hybrid search: BM25 + vector + query expansion + RRF + chunked reranking.
  *
  * Pipeline:
@@ -4554,7 +4606,7 @@ export function getHybridRrfWeights(rankedListMeta: RankedListMeta[]): number[] 
  * 4. RRF fusion → slice to candidateLimit
  * 5. chunkDocument() + keyword-best-chunk selection
  * 6. rerank on chunks (NOT full bodies — O(tokens) trap)
- * 7. Position-aware score blending (RRF rank × reranker score)
+ * 7. Position-aware score blending (RRF rank × reranker score) + capped title boost
  * 8. Dedup by file, filter by minScore, slice to limit
  */
 export async function hybridQuery(
@@ -4600,6 +4652,7 @@ export async function hybridQuery(
     : await store.expandQuery(query, undefined, intent);
 
   hooks?.onExpand?.(query, expanded, Date.now() - expandStart);
+  const titleBoostTerms = getTitleBoostTerms(query, intent);
 
   // Seed with initial FTS results (avoid re-running original query FTS)
   if (initialFts.length > 0) {
@@ -4679,7 +4732,7 @@ export async function hybridQuery(
   // Step 4: RRF fusion — original-query FTS and vector lists get 2x weight;
   // expansion-derived lists stay at 1x independent of insertion order.
   const weights = getHybridRrfWeights(rankedListMeta);
-  const fused = reciprocalRankFusion(rankedLists, weights);
+  const fused = applyTitleMatchBoost(reciprocalRankFusion(rankedLists, weights), titleBoostTerms);
   const rrfTraceByFile = explain ? buildRrfTrace(rankedLists, weights, rankedListMeta) : null;
   const candidates = fused.slice(0, candidateLimit);
 
@@ -4737,6 +4790,7 @@ export async function hybridQuery(
             contributions: trace?.contributions ?? [],
           },
           rerankScore: 0,
+          titleBoost: getTitleMatchBoost(cand.title, titleBoostTerms),
           blendedScore: rrfScore,
         } : undefined;
 
@@ -4811,6 +4865,7 @@ export async function hybridQuery(
         contributions: trace?.contributions ?? [],
       },
       rerankScore: r.score,
+      titleBoost: getTitleMatchBoost(candidate?.title, titleBoostTerms),
       blendedScore,
     } : undefined;
 
@@ -5066,9 +5121,11 @@ export async function structuredSearch(
 
   if (rankedLists.length === 0) return [];
 
+  const titleBoostTerms = getTitleBoostTerms(intent, ...searches.map(s => s.query));
+
   // Step 3: RRF fusion — first list gets 2x weight (assume caller ordered by importance)
   const weights = rankedLists.map((_, i) => i === 0 ? 2.0 : 1.0);
-  const fused = reciprocalRankFusion(rankedLists, weights);
+  const fused = applyTitleMatchBoost(reciprocalRankFusion(rankedLists, weights), titleBoostTerms);
   const rrfTraceByFile = explain ? buildRrfTrace(rankedLists, weights, rankedListMeta) : null;
   const candidates = fused.slice(0, candidateLimit);
 
@@ -5131,6 +5188,7 @@ export async function structuredSearch(
             contributions: trace?.contributions ?? [],
           },
           rerankScore: 0,
+          titleBoost: getTitleMatchBoost(cand.title, titleBoostTerms),
           blendedScore: rrfScore,
         } : undefined;
 
@@ -5204,6 +5262,7 @@ export async function structuredSearch(
         contributions: trace?.contributions ?? [],
       },
       rerankScore: r.score,
+      titleBoost: getTitleMatchBoost(candidate?.title, titleBoostTerms),
       blendedScore,
     } : undefined;
 

--- a/test/store.helpers.unit.test.ts
+++ b/test/store.helpers.unit.test.ts
@@ -18,6 +18,8 @@ import {
   handelize,
   cleanupOrphanedVectors,
   sanitizeFTS5Term,
+  getTitleBoostTerms,
+  getTitleMatchBoost,
 } from "../src/store";
 
 // =============================================================================
@@ -111,6 +113,48 @@ describe("cleanupOrphanedVectors", () => {
     } as any;
 
     expect(cleanupOrphanedVectors(db)).toBe(0);
+  });
+});
+
+// =============================================================================
+// Ranking Helpers
+// =============================================================================
+
+describe("title match boost", () => {
+  test("extracts useful title-boost terms and drops common words", () => {
+    expect(getTitleBoostTerms("Where is the API SQL guide?", "LLM routing")).toEqual([
+      "api",
+      "sql",
+      "guide",
+      "llm",
+      "routing",
+    ]);
+  });
+
+  test("boosts titles with query-term overlap and caps the multiplier", () => {
+    expect(getTitleMatchBoost("API routing guide", ["api", "routing", "guide"])).toBeCloseTo(3.0);
+    expect(getTitleMatchBoost("API reference", ["api", "routing"])).toBeCloseTo(1.7);
+    expect(getTitleMatchBoost("Unrelated", ["api", "routing"])).toBe(1);
+    expect(getTitleMatchBoost(undefined, ["api"])).toBe(1);
+  });
+
+  test("matches title terms exactly, not arbitrary substrings", () => {
+    expect(getTitleMatchBoost("Brain routing", ["ai"])).toBe(1);
+    expect(getTitleMatchBoost("AI routing", ["ai"])).toBeCloseTo(1.7);
+  });
+
+  test("matches title terms across common technical separators", () => {
+    expect(getTitleBoostTerms("API/SQL qmd:title-match LLM-RAG")).toEqual([
+      "api",
+      "sql",
+      "qmd",
+      "title",
+      "match",
+      "llm",
+      "rag",
+    ]);
+    expect(getTitleMatchBoost("API-routing guide", ["api", "routing"])).toBeCloseTo(2.4);
+    expect(getTitleMatchBoost("LLM/RAG notes", ["llm", "rag"])).toBeCloseTo(2.4);
   });
 });
 

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -2320,6 +2320,82 @@ describe("Reciprocal Rank Fusion", () => {
     // Lower k = higher scores for top ranks
     expect(fused30[0]!.score).toBeGreaterThan(fused60[0]!.score);
   });
+
+  test("structuredSearch title boost can affect skip-rerank ordering", async () => {
+    const store = {
+      db: { prepare: () => ({ get: () => undefined }) },
+      searchFTS: () => [
+        { filepath: "qmd://docs/body.md", displayPath: "docs/body.md", title: "Body Match", body: "api routing details", score: 10, docid: "body" },
+        { filepath: "qmd://docs/title.md", displayPath: "docs/title.md", title: "API Routing", body: "details", score: 1, docid: "title" },
+      ],
+      searchVec: async () => [],
+      getContextForFile: () => null,
+    } as unknown as Store;
+
+    const results = await structuredSearch(store, [{ type: "lex", query: "api routing" }], {
+      skipRerank: true,
+      minScore: 0,
+      limit: 2,
+    });
+
+    expect(results.map(r => r.file)).toEqual([
+      "qmd://docs/title.md",
+      "qmd://docs/body.md",
+    ]);
+    expect(results[0]!.score).toBeLessThanOrEqual(1);
+  });
+
+  test("structuredSearch title boost affects rerank blending through boosted rank", async () => {
+    const store = {
+      db: { prepare: () => ({ get: () => undefined }) },
+      searchFTS: () => [
+        { filepath: "qmd://docs/body.md", displayPath: "docs/body.md", title: "Body Match", body: "api details", score: 10, docid: "body" },
+        { filepath: "qmd://docs/title.md", displayPath: "docs/title.md", title: "API Reference", body: "details", score: 1, docid: "title" },
+      ],
+      searchVec: async () => [],
+      rerank: async () => [
+        { file: "qmd://docs/body.md", score: 0 },
+        { file: "qmd://docs/title.md", score: 1 },
+      ],
+      getContextForFile: () => null,
+    } as unknown as Store;
+
+    const results = await structuredSearch(store, [{ type: "lex", query: "api" }], {
+      skipRerank: false,
+      minScore: 0,
+      limit: 2,
+    });
+
+    expect(results.map(r => r.file)).toEqual([
+      "qmd://docs/title.md",
+      "qmd://docs/body.md",
+    ]);
+    expect(results[0]!.score).toBeLessThanOrEqual(1);
+  });
+
+  test("structuredSearch explain shows title boost without changing score equation", async () => {
+    const store = {
+      db: { prepare: () => ({ get: () => undefined }) },
+      searchFTS: () => [
+        { filepath: "qmd://docs/body.md", displayPath: "docs/body.md", title: "Body Match", body: "api routing details", score: 10, docid: "body" },
+        { filepath: "qmd://docs/title.md", displayPath: "docs/title.md", title: "API Routing", body: "details", score: 1, docid: "title" },
+      ],
+      searchVec: async () => [],
+      getContextForFile: () => null,
+    } as unknown as Store;
+
+    const results = await structuredSearch(store, [{ type: "lex", query: "api routing" }], {
+      skipRerank: true,
+      explain: true,
+      minScore: 0,
+      limit: 2,
+    });
+
+    expect(results[0]!.file).toBe("qmd://docs/title.md");
+    expect(results[0]!.score).toBe(results[0]!.explain!.blendedScore);
+    expect(results[0]!.explain!.titleBoost).toBeGreaterThan(1);
+    expect(results[0]!.explain!.rrf.positionScore).toBe(1);
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
> Supersedes #669 — rebased onto current `main` (re-opened from a network-linked fork because the original head branch/fork was detached and couldn't be updated in place). Same change; full test suite green.

## Summary
- add a capped title-match boost for hybrid and structured search candidate ordering
- keep final scores bounded while exposing the applied title boost in `--explain`
- add regression tests for ordering, explain consistency, exact term matching, and common technical separators

## Why
Title matches are strong evidence for lookup-style queries. The boost is applied to candidate ordering before final scoring, so it can recover relevant title hits without changing the final score equation or producing scores above 1.0.

## Tests
- `bun test test/store.helpers.unit.test.ts test/store.test.ts --timeout 60000 --preload ./src/test-preload.ts`
- `npm run test:node -- test/store.helpers.unit.test.ts test/store.test.ts`
- `bun run build`
- `npm run test:types`

