### PR TITLE
feat(embed): add --timeout to override the 30-minute session cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- `qmd embed --timeout <minutes>` overrides the embed session's max duration
+  (previously hardcoded to 30 minutes). Use a larger value to let a big index
+  finish in one run, or `--timeout 0` to remove the cap entirely. When the cap is
+  reached, remaining document batches are skipped as before, so re-running
+  `qmd embed` continues where it left off.
+
 ### Documentation
 
 - README: documented collection filtering (`-c` semantics), the `collection

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -1938,6 +1938,17 @@ function parseChunkStrategy(value: unknown): ChunkStrategy | undefined {
   throw new Error(`--chunk-strategy must be "auto" or "regex" (got "${s}")`);
 }
 
+// --timeout for `qmd embed`: a cap on the whole embed session, in minutes. Returns
+// the value in milliseconds, or undefined to use the default. 0 disables the cap.
+function parseEmbedTimeoutOption(value: unknown): number | undefined {
+  if (value === undefined) return undefined;
+  const minutes = Number(value);
+  if (!Number.isFinite(minutes) || minutes < 0) {
+    throw new Error(`--timeout must be a non-negative number of minutes (0 = no limit)`);
+  }
+  return minutes * 60 * 1000;
+}
+
 function ensureModelsConfiguredForCli(): { embed: string; generate: string; rerank: string } {
   try {
     const config = loadConfig();
@@ -1979,7 +1990,7 @@ function resolveModelsForCli(): { embed: string; generate: string; rerank: strin
 async function vectorIndex(
   model: string = resolveEmbedModelForCli(),
   force: boolean = false,
-  batchOptions?: { maxDocsPerBatch?: number; maxBatchBytes?: number; chunkStrategy?: ChunkStrategy; collection?: string },
+  batchOptions?: { maxDocsPerBatch?: number; maxBatchBytes?: number; chunkStrategy?: ChunkStrategy; collection?: string; maxDurationMs?: number },
 ): Promise<void> {
   const storeInstance = getStore();
   const db = storeInstance.db;
@@ -2014,6 +2025,7 @@ async function vectorIndex(
     maxDocsPerBatch: batchOptions?.maxDocsPerBatch,
     maxBatchBytes: batchOptions?.maxBatchBytes,
     chunkStrategy: batchOptions?.chunkStrategy,
+    maxDurationMs: batchOptions?.maxDurationMs,
     onProgress: (info) => {
       if (info.totalBytes === 0) return;
       // Progress is measured by input bytes, not by chunks. The final chunk
@@ -2864,6 +2876,7 @@ function parseCLI() {
       force: { type: "boolean", short: "f" },
       "max-docs-per-batch": { type: "string" },
       "max-batch-mb": { type: "string" },
+      timeout: { type: "string" },  // embed session cap in minutes (0 = no limit; default 30)
       // Update options
       pull: { type: "boolean" },  // git pull before update
       refresh: { type: "boolean" },
@@ -3401,6 +3414,7 @@ function showHelp(): void {
   console.log("  qmd embed [-f] [-c <name>]    - Generate/refresh vector embeddings");
   console.log("    --max-docs-per-batch <n>    - Cap docs loaded into memory per embedding batch");
   console.log("    --max-batch-mb <n>          - Cap UTF-8 MB loaded into memory per embedding batch");
+  console.log("    --timeout <minutes>         - Embed session cap in minutes (0 = no limit; default 30)");
   console.log("  qmd cleanup                   - Clear caches, vacuum DB");
   console.log("");
   console.log("Query syntax (qmd query):");
@@ -3467,6 +3481,7 @@ function showHelp(): void {
   console.log("");
   console.log("Embed/query options:");
   console.log("  --chunk-strategy <auto|regex> - Chunking mode (default: regex; auto uses AST for code files)");
+  console.log("  --timeout <minutes>          - Embed session cap in minutes (0 = no limit; default 30)");
   console.log("");
   console.log("Multi-get options:");
   console.log("  -l <num>                   - Maximum lines per file");
@@ -4407,6 +4422,7 @@ if (isMain) {
         const maxDocsPerBatch = parseEmbedBatchOption("maxDocsPerBatch", cli.values["max-docs-per-batch"]);
         const maxBatchMb = parseEmbedBatchOption("maxBatchBytes", cli.values["max-batch-mb"]);
         const embedChunkStrategy = parseChunkStrategy(cli.values["chunk-strategy"]);
+        const embedMaxDurationMs = parseEmbedTimeoutOption(cli.values["timeout"]);
         // Validate -c against configured collections before dispatching, so a
         // typo errors with "Collection not found: X" instead of silently
         // reporting success because no pending docs match a nonexistent name.
@@ -4418,6 +4434,7 @@ if (isMain) {
           maxBatchBytes: maxBatchMb === undefined ? undefined : maxBatchMb * 1024 * 1024,
           chunkStrategy: embedChunkStrategy,
           collection: embedCollection,
+          maxDurationMs: embedMaxDurationMs,
         });
       } catch (error) {
         exitWithError(error);

--- a/src/store.ts
+++ b/src/store.ts
@@ -49,6 +49,7 @@ export const DEFAULT_GLOB = "**/*.md";
 export const DEFAULT_MULTI_GET_MAX_BYTES = 10 * 1024; // 10KB
 export const DEFAULT_EMBED_MAX_DOCS_PER_BATCH = 64;
 export const DEFAULT_EMBED_MAX_BATCH_BYTES = 64 * 1024 * 1024; // 64MB
+export const DEFAULT_EMBED_MAX_DURATION_MS = 30 * 60 * 1000; // 30 minutes; see EmbedOptions.maxDurationMs
 
 const EMBED_FINGERPRINT_PROBE_QUERY = "__qmd_embedding_query_probe__";
 const EMBED_FINGERPRINT_PROBE_TITLE = "__qmd_embedding_title_probe__";
@@ -1412,6 +1413,13 @@ export type EmbedOptions = {
   maxDocsPerBatch?: number;
   maxBatchBytes?: number;
   chunkStrategy?: ChunkStrategy;
+  /**
+   * Max wall-clock duration for the whole embed session, in milliseconds. When the
+   * cap is reached, remaining document batches are skipped (re-run `qmd embed` to
+   * continue). A value <= 0 disables the cap. Defaults to
+   * {@link DEFAULT_EMBED_MAX_DURATION_MS} (30 minutes).
+   */
+  maxDurationMs?: number;
   onProgress?: (info: EmbedProgress) => void;
 };
 
@@ -1827,7 +1835,7 @@ export async function generateEmbeddings(
     }
 
     return { chunksEmbedded, errors: activeErrorCount(), failures: failureList() };
-  }, { maxDuration: 30 * 60 * 1000, name: 'generateEmbeddings' });
+  }, { maxDuration: options?.maxDurationMs ?? DEFAULT_EMBED_MAX_DURATION_MS, name: 'generateEmbeddings' });
 
   return {
     docsProcessed: totalDocs,

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -3209,6 +3209,44 @@ describe("Embedding batching", () => {
     }
   });
 
+  test("generateEmbeddings stops early when maxDurationMs is exceeded", async () => {
+    const store = await createTestStore();
+    const db = store.db;
+    // A slow embedder so the short session cap trips between document batches.
+    const embedBatchCalls: string[][] = [];
+    const slowLlm = {
+      async embed() { return { embedding: [0.1, 0.2, 0.3], model: "fake-embed" }; },
+      async embedBatch(texts: string[]) {
+        embedBatchCalls.push([...texts]);
+        await new Promise((resolve) => setTimeout(resolve, 80));
+        return texts.map((_text, index) => ({ embedding: [index + 1, index + 2, index + 3], model: "fake-embed" }));
+      },
+    };
+
+    setDefaultLlamaCpp(createFakeTokenizer() as any);
+    store.llm = slowLlm as any;
+
+    try {
+      await insertTestDocument(db, "docs", { name: "one", body: "# One\n\nAlpha" });
+      await insertTestDocument(db, "docs", { name: "two", body: "# Two\n\nBeta" });
+      await insertTestDocument(db, "docs", { name: "three", body: "# Three\n\nGamma" });
+
+      const result = await generateEmbeddings(store, {
+        maxDocsPerBatch: 1,           // one doc per batch, so the cap can stop between docs
+        maxBatchBytes: 1024 * 1024,
+        maxDurationMs: 10,            // trips ~10ms in, well before the 80ms batches finish
+      });
+
+      // The first batch runs, then the session expires and the rest are skipped.
+      expect(embedBatchCalls.length).toBeGreaterThanOrEqual(1);
+      expect(embedBatchCalls.length).toBeLessThan(3);
+      expect(result.chunksEmbedded).toBeLessThan(3);
+    } finally {
+      setDefaultLlamaCpp(null);
+      await cleanupTestDb(store);
+    }
+  });
+
   test("generateEmbeddings flushes batches when maxBatchBytes is reached", async () => {
     const store = await createTestStore();
     const db = store.db;


### PR DESCRIPTION
## What this does

`qmd embed` runs inside a session capped at a hardcoded 30 minutes. When the cap is hit, the remaining document batches are skipped and you re-run `qmd embed` to continue. On a large corpus that turns one index into several supervised restarts, which is the behavior reported in #549 (and #124).

This adds an opt-in `qmd embed --timeout <minutes>` so you can set the cap yourself:

- `qmd embed --timeout 120` gives a big index a couple of hours to finish in one pass
- `qmd embed --timeout 0` removes the cap entirely
- omit it and the default stays 30 minutes, so nothing changes for existing users

## How

The flag is parsed in the embed command and threaded through `vectorIndex` into `generateEmbeddings` as a new `EmbedOptions.maxDurationMs`, which feeds the existing `withLLMSession({ maxDuration })`. A value of 0 or less disables the cap, which `withLLMSession` already supports. The default lives in a named `DEFAULT_EMBED_MAX_DURATION_MS` (30 min). The skip-and-resume behavior when the cap is reached is unchanged.

## Testing

- New unit test: `generateEmbeddings` stops early when `maxDurationMs` is exceeded (uses the existing fake-LLM harness).
- Existing embed tests pass; `npm run build` is clean.
- Manual: `--timeout 120`, `--timeout 0`, and invalid input (`abc`, negative) all behave correctly; `--help` documents it.

Related: #549, #124, #378.
