### PR TITLE
docs: document native arm64 Node requirement for Apple Silicon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Documentation
+
+- Added a prominent **Apple Silicon arm64 Node requirement** section to README. Explains
+  that running qmd under a Rosetta x64 Node causes `node-llama-cpp`'s postinstall to abort
+  with "llama.cpp is not supported under Rosetta on Apple Silicon", and gives copy-pasteable
+  remediation steps for nvm, Homebrew, and mise, plus a `file $(which node)` arch sanity
+  check. Also cross-references the Intel Mac x64 crash (#448).
+
 ### Fixed
 
 - Filesystem paths with special characters (`#`, `&`, spaces, `[]`, `()`, etc.)

--- a/README.md
+++ b/README.md
@@ -481,6 +481,46 @@ The `query` command uses **Reciprocal Rank Fusion (RRF)** with position-aware bl
   brew install sqlite
   ```
 
+> **Apple Silicon (M1/M2/M3/M4): native arm64 Node required**
+>
+> QMD's LLM features use [node-llama-cpp](https://github.com/withcatai/node-llama-cpp), which compiles native binaries.
+> On Apple Silicon, you **must** run a native arm64 Node — not an x64 (Rosetta-translated) one.
+> Running under Rosetta causes `node-llama-cpp`'s postinstall to abort with:
+>
+> ```
+> llama.cpp is not supported under Rosetta on Apple Silicon
+> ```
+>
+> **Verify your Node architecture:**
+> ```sh
+> node -p process.arch   # must print: arm64
+> ```
+>
+> **Fix: install/select a native arm64 Node** (pick one):
+> ```sh
+> # nvm
+> nvm install 22
+> nvm use 22
+> node -p process.arch   # arm64 ✓
+>
+> # Homebrew
+> brew install node
+> node -p process.arch   # arm64 ✓
+>
+> # mise
+> mise install node@22
+> mise use node@22
+> node -p process.arch   # arm64 ✓
+> ```
+>
+> If you still see `x64` after switching, ensure your terminal is not itself running under Rosetta
+> (`file $(which node)` should show `Mach-O 64-bit executable arm64`).
+
+> **Intel Mac (x64):** LLM-powered features (`qmd query`, `qmd embed`, `qmd vsearch`) require the
+> x64 llama.cpp native binary. If you see `zsh: illegal hardware instruction` on an Intel Mac,
+> see [#448](https://github.com/tobi/qmd/issues/448). BM25 search (`qmd search`) works without
+> any native model and is unaffected.
+
 ### GGUF Models (via node-llama-cpp)
 
 QMD uses three local GGUF models (auto-downloaded on first use):


### PR DESCRIPTION
## What

Adds a prominent callout block in the README `### System Requirements` section documenting the native arm64 Node requirement on Apple Silicon, and a companion note for the Intel Mac x64 crash.

## Why

Installing qmd on Apple Silicon under a Rosetta-translated x64 Node fails at `npm install` time with a non-obvious error from node-llama-cpp:

```
llama.cpp is not supported under Rosetta on Apple Silicon
```

Users unfamiliar with nvm/Homebrew multi-arch behaviour hit this and have no obvious path to recovery. The README was silent on the requirement.

Related parent task: decomposed from the Rosetta/x64 install failure investigation (decision: optional deps + graceful degradation for the code side; this PR is the docs side).

Also cross-references issue #448 (Intel Mac `illegal hardware instruction` crash).

## Changes

- `README.md`: new blockquote callout in `### System Requirements` covering:
  - exact postinstall error string (searchable)
  - `node -p process.arch` verification step
  - copy-pasteable fix for nvm / Homebrew / mise
  - `file $(which node)` sanity check for persistent Rosetta terminals
  - Intel Mac x64 note linking to #448
- `CHANGELOG.md`: entry under `[Unreleased] > Documentation`