### PR TITLE
docs: refresh stale command reference in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,19 +9,22 @@ qmd collection add . --name <n>   # Create/index collection
 qmd collection list               # List all collections with details
 qmd collection remove <name>      # Remove a collection by name
 qmd collection rename <old> <new> # Rename a collection
+qmd init                          # Create a project-local .qmd index
 qmd ls [collection[/path]]        # List collections or files in a collection
 qmd context add [path] "text"     # Add context for path (defaults to current dir)
 qmd context list                  # List all contexts
 qmd context check                 # Check for collections/paths missing context
 qmd context rm <path>             # Remove context
-qmd get <file>                    # Get document by path or docid (#abc123)
+qmd get <file>[:from[:count]]     # Get by path or docid (#abc123); optional line range
 qmd multi-get <pattern>           # Get multiple docs by glob or comma-separated list
 qmd status                        # Show index status and collections
-qmd update [--pull]               # Re-index all collections (--pull: git pull first)
+qmd doctor                        # Diagnose config, index, model, and device issues
+qmd update                        # Re-index collections; configured update hooks run first
 qmd embed                         # Generate vector embeddings (uses node-llama-cpp)
 qmd query <query>                 # Search with query expansion + reranking (recommended)
 qmd search <query>                # Full-text keyword search (BM25, no LLM)
 qmd vsearch <query>               # Vector similarity search (no reranking)
+qmd bench <fixture.json>          # Run search-quality benchmarks
 qmd mcp                           # Start MCP server (stdio transport)
 qmd mcp --http [--port N]         # Start MCP server (HTTP, default port 8181)
 qmd mcp --http --daemon           # Start as background daemon
@@ -42,6 +45,17 @@ qmd collection remove mynotes
 
 # Rename a collection
 qmd collection rename mynotes my-notes
+
+# Show collection details
+qmd collection show mynotes
+
+# Set or clear the pre-update hook (runs before re-indexing on `qmd update`)
+qmd collection update-cmd mynotes 'git pull --ff-only'
+qmd collection update-cmd mynotes            # clear
+
+# Include or exclude from default (unscoped) queries
+qmd collection exclude mynotes
+qmd collection include mynotes
 
 # List all files in a collection
 qmd ls mynotes
@@ -100,19 +114,23 @@ qmd multi-get "#abc123, #def456"
 
 ```sh
 # Search & retrieval
--c, --collection <name>  # Restrict search to a collection (matches pwd suffix)
+-c, --collection <name>  # Restrict search to collection(s) (repeatable)
 -n <num>                 # Number of results
 --all                    # Return all matches
 --min-score <num>        # Minimum score threshold
 --full                   # Show full document content
---line-numbers           # Add line numbers to output
+--intent <text>          # Describe what you're after to sharpen ranking (query)
+--no-rerank              # Skip LLM reranking (faster, lower quality)
+--full-path              # Show on-disk paths instead of qmd:// URIs
 
-# Multi-get specific
+# Get / multi-get
 -l <num>                 # Maximum lines per file
 --max-bytes <num>        # Skip files larger than this (default 10KB)
+--no-line-numbers        # Disable line numbers (on by default for get/multi-get)
 
-# Output formats (search and multi-get)
---json, --csv, --md, --xml, --files
+# Output format (search, query, multi-get)
+--format <kind>          # cli (default) | json | csv | md | xml | files
+                         # legacy --json/--csv/--md/--xml/--files still work as aliases
 ```
 
 ## Development


### PR DESCRIPTION
## Summary

`CLAUDE.md`'s command reference has drifted from the CLI — its last substantive
update was the March AST-chunking change. Most notably it documents `qmd update
--pull` as "git pull first," but `--pull` is parsed and never consumed by
`updateCollections()`, so it's a no-op. #715 already removed this same claim from
the README; this brings `CLAUDE.md` in line and refreshes the rest of the list.

Scope is deliberately a cheat-sheet refresh: remove wrong guidance, add commands and
flags an agent is likely to use. No behavior changes, and nothing stylistic touched.

## Changes

- **Fix `--pull`**: it's dead code. The real pre-reindex mechanism is a per-collection
  `update` hook (`qmd collection update-cmd`), which runs automatically on `qmd update`.
- **Add commands that now exist**: `qmd init`, `qmd doctor`, `qmd bench`.
- **Add collection subcommands**: `show`, `update-cmd`, `include`, `exclude`.
- **Lead output options with `--format <kind>`** (`cli|json|csv|md|xml|files`); the bare
  `--json`/`--csv`/`--md`/`--xml`/`--files` booleans are noted as legacy aliases.
- **Document `qmd get <file>[:from[:count]]`** line-range syntax and add the
  `--intent`, `--no-rerank`, `--full-path`, and `--no-line-numbers` flags.

## Left untouched

The Bun-first guidance, the "Do NOT run automatically" / "Do NOT compile" sections,
the Architecture notes, and the Releasing section — all still accurate.

## Verification

Every command and flag was checked against `src/cli/qmd.ts` in current source.
`--pull` is confirmed parsed but never read by `updateCollections()`. The
`vector-search`/`deep-search` aliases were intentionally left undocumented — the
source labels them "undocumented alias."
