### PR TITLE
test: VRAM precondition gate for integration suites with opt-in Ollama auto-evacuate

### DIFF
--- a/test/_helpers/vram-precondition.ts
+++ b/test/_helpers/vram-precondition.ts
@@ -17,12 +17,17 @@
  * Escape hatches:
  *  - `QMD_SKIP_GPU_INTEGRATION=1` forces a skip without probing (useful on
  *    healthy boxes when you want fast unit-loop iteration).
+ *  - `QMD_TEST_EVACUATE_VRAM=1` opts into an Ollama-only eviction attempt
+ *    when the initial probe shows insufficient VRAM. Off by default: test
+ *    infra silently terminating another process's loaded models would be
+ *    astonishing without explicit consent.
  *  - A probe failure (cannot load `node-llama-cpp`, `getVramState` throws,
  *    etc.) fails open and returns `true` so a real failure surfaces in the
  *    test rather than getting silently masked.
  *
  * The dependency on `node-llama-cpp` is injected through `options.getLlama`
- * so unit tests of this helper can drive the gate without the real runtime.
+ * and the eviction step through `options.evacuate` so unit tests of this
+ * helper can drive the gate without the real runtime.
  */
 
 export type LlamaLike = {
@@ -34,9 +39,11 @@ export type PreconditionOptions = {
   getLlama?: () => Promise<LlamaLike>;
   minFreeGB?: number;
   log?: (message: string) => void;
+  evacuate?: () => Promise<void>;
 };
 
 const DEFAULT_MIN_FREE_GB = 4;
+const DEFAULT_OLLAMA_HOST = "http://127.0.0.1:11434";
 
 let cachedResult: boolean | null = null;
 let loggedOnce = false;
@@ -44,6 +51,65 @@ let loggedOnce = false;
 async function defaultGetLlama(): Promise<LlamaLike> {
   const mod = await import("node-llama-cpp");
   return await mod.getLlama() as unknown as LlamaLike;
+}
+
+/**
+ * Best-effort: list Ollama's currently loaded models and ask the server to
+ * unload each by re-issuing the request with `keep_alive: 0`. A missing or
+ * unreachable Ollama is fine — nothing to evict. Other VRAM consumers
+ * (qmd-serve, gbrain) are deliberately out of scope: killing a user-facing
+ * daemon is too astonishing even behind an opt-in flag.
+ */
+async function defaultEvacuate(log: (m: string) => void): Promise<void> {
+  const host = process.env.OLLAMA_HOST ?? DEFAULT_OLLAMA_HOST;
+  try {
+    const res = await fetch(`${host}/api/ps`, { signal: AbortSignal.timeout(2000) });
+    if (!res.ok) {
+      log(`⚠ Eviction: Ollama /api/ps returned ${res.status}; skipping.`);
+      return;
+    }
+    const body = await res.json() as { models?: { name?: string }[] };
+    const names = (body.models ?? []).map(m => m.name).filter((n): n is string => typeof n === "string");
+    if (names.length === 0) {
+      log("⚠ Eviction: Ollama reports no loaded models; nothing to evict.");
+      return;
+    }
+    log(`⚠ Eviction: asking Ollama to unload ${names.length} model(s): ${names.join(", ")}`);
+    for (const name of names) {
+      try {
+        await fetch(`${host}/api/generate`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ model: name, keep_alive: 0 }),
+          signal: AbortSignal.timeout(5000),
+        });
+      } catch (e) {
+        log(`⚠ Eviction: unload of ${name} failed: ${String(e)}`);
+      }
+    }
+  } catch (e) {
+    log(`⚠ Eviction: Ollama unreachable at ${host}: ${String(e)}`);
+  }
+}
+
+async function probeFreeGB(
+  options: PreconditionOptions,
+): Promise<{ ok: boolean; freeGB: number | null }> {
+  const getter = options.getLlama ?? defaultGetLlama;
+  try {
+    const llama = await getter();
+    if (!llama.gpu) return { ok: true, freeGB: null };
+    const vram = await llama.getVramState();
+    const freeGB = vram.free / (1024 * 1024 * 1024);
+    const minFreeGB = options.minFreeGB ?? DEFAULT_MIN_FREE_GB;
+    return { ok: freeGB >= minFreeGB, freeGB };
+  } catch {
+    // Fail open at the probe layer: the caller decides what to do with `ok`
+    // when the probe itself was reliable vs. when it threw.  Returning ok=true
+    // here means a probe failure does not gate the suite — a real code
+    // failure is more useful than a silent skip masking it.
+    return { ok: true, freeGB: null };
+  }
 }
 
 export async function hasSufficientFreeVramForIntegration(
@@ -63,31 +129,49 @@ export async function hasSufficientFreeVramForIntegration(
     return false;
   }
 
-  const getter = options.getLlama ?? defaultGetLlama;
-
-  try {
-    const llama = await getter();
-    if (!llama.gpu) {
-      cachedResult = true;
-      return true;
-    }
-    const vram = await llama.getVramState();
-    const freeGB = vram.free / (1024 * 1024 * 1024);
-    cachedResult = freeGB >= minFreeGB;
-    if (!cachedResult && !loggedOnce) {
-      log(
-        `⚠ Integration tests skipped: only ${freeGB.toFixed(2)} GB free GPU VRAM `
-          + `(need ≥ ${minFreeGB} GB). Set QMD_SKIP_GPU_INTEGRATION=1 to silence this probe.`,
-      );
-      loggedOnce = true;
-    }
-    return cachedResult;
-  } catch {
-    // Fail open: if we cannot probe, let the test attempt run. A real failure
-    // is more useful than a silent skip masking the symptom.
+  const first = await probeFreeGB(options);
+  if (first.ok) {
     cachedResult = true;
     return true;
   }
+
+  // Insufficient on the first probe.  If the operator opted into eviction,
+  // try to free VRAM from known consumers and re-probe once.  Otherwise skip.
+  if (process.env.QMD_TEST_EVACUATE_VRAM === "1") {
+    const evacuate = options.evacuate ?? (() => defaultEvacuate(log));
+    log(
+      `⚠ Insufficient VRAM (${first.freeGB?.toFixed(2) ?? "?"} GB free, need ≥ ${minFreeGB} GB); `
+        + `QMD_TEST_EVACUATE_VRAM=1, attempting to evict known consumers...`,
+    );
+    try {
+      await evacuate();
+    } catch (e) {
+      log(`⚠ Eviction step threw: ${String(e)}; re-probing anyway.`);
+    }
+    const second = await probeFreeGB(options);
+    cachedResult = second.ok;
+    if (second.ok) {
+      log(`✓ Eviction succeeded; ${second.freeGB?.toFixed(2) ?? "?"} GB free, integration tests will run.`);
+    } else if (!loggedOnce) {
+      log(
+        `⚠ Integration tests skipped: post-eviction only ${second.freeGB?.toFixed(2) ?? "?"} GB free `
+          + `(need ≥ ${minFreeGB} GB).`,
+      );
+      loggedOnce = true;
+    }
+    return second.ok;
+  }
+
+  cachedResult = false;
+  if (!loggedOnce) {
+    log(
+      `⚠ Integration tests skipped: only ${first.freeGB?.toFixed(2) ?? "?"} GB free GPU VRAM `
+        + `(need ≥ ${minFreeGB} GB). Set QMD_TEST_EVACUATE_VRAM=1 to attempt eviction first, `
+        + `or QMD_SKIP_GPU_INTEGRATION=1 to silence this probe.`,
+    );
+    loggedOnce = true;
+  }
+  return false;
 }
 
 /**

--- a/test/_helpers/vram-precondition.ts
+++ b/test/_helpers/vram-precondition.ts
@@ -1,0 +1,100 @@
+/**
+ * VRAM precondition for GPU-dependent integration suites.
+ *
+ * Integration suites under `test/` load real GGUF models and exercise rerank,
+ * embed, and expand against a real `node-llama-cpp` runtime. When another
+ * workload is hogging the GPU (Ollama parking a large model, gbrain mid-job,
+ * a stale `qmd serve`), those allocations fail and the suite turns into a
+ * pile of red `Failed to create any rerank context` lines that do not
+ * represent code regressions.
+ *
+ * This helper probes free VRAM once per process and reports whether there
+ * is enough headroom for the integration suite to run meaningfully. The
+ * existing skip-gates layer onto it: `CI`, `QMD_REMOTE_URL`, and now this
+ * probe each contribute a reason to skip. The probe value is cached so
+ * multiple suites do not re-probe.
+ *
+ * Escape hatches:
+ *  - `QMD_SKIP_GPU_INTEGRATION=1` forces a skip without probing (useful on
+ *    healthy boxes when you want fast unit-loop iteration).
+ *  - A probe failure (cannot load `node-llama-cpp`, `getVramState` throws,
+ *    etc.) fails open and returns `true` so a real failure surfaces in the
+ *    test rather than getting silently masked.
+ *
+ * The dependency on `node-llama-cpp` is injected through `options.getLlama`
+ * so unit tests of this helper can drive the gate without the real runtime.
+ */
+
+export type LlamaLike = {
+  gpu: false | string;
+  getVramState: () => Promise<{ total: number; used: number; free: number }>;
+};
+
+export type PreconditionOptions = {
+  getLlama?: () => Promise<LlamaLike>;
+  minFreeGB?: number;
+  log?: (message: string) => void;
+};
+
+const DEFAULT_MIN_FREE_GB = 4;
+
+let cachedResult: boolean | null = null;
+let loggedOnce = false;
+
+async function defaultGetLlama(): Promise<LlamaLike> {
+  const mod = await import("node-llama-cpp");
+  return await mod.getLlama() as unknown as LlamaLike;
+}
+
+export async function hasSufficientFreeVramForIntegration(
+  options: PreconditionOptions = {},
+): Promise<boolean> {
+  if (cachedResult !== null) return cachedResult;
+
+  const log = options.log ?? ((m: string) => console.warn(m));
+  const minFreeGB = options.minFreeGB ?? DEFAULT_MIN_FREE_GB;
+
+  if (process.env.QMD_SKIP_GPU_INTEGRATION === "1") {
+    cachedResult = false;
+    if (!loggedOnce) {
+      log("⚠ Integration tests skipped: QMD_SKIP_GPU_INTEGRATION=1");
+      loggedOnce = true;
+    }
+    return false;
+  }
+
+  const getter = options.getLlama ?? defaultGetLlama;
+
+  try {
+    const llama = await getter();
+    if (!llama.gpu) {
+      cachedResult = true;
+      return true;
+    }
+    const vram = await llama.getVramState();
+    const freeGB = vram.free / (1024 * 1024 * 1024);
+    cachedResult = freeGB >= minFreeGB;
+    if (!cachedResult && !loggedOnce) {
+      log(
+        `⚠ Integration tests skipped: only ${freeGB.toFixed(2)} GB free GPU VRAM `
+          + `(need ≥ ${minFreeGB} GB). Set QMD_SKIP_GPU_INTEGRATION=1 to silence this probe.`,
+      );
+      loggedOnce = true;
+    }
+    return cachedResult;
+  } catch {
+    // Fail open: if we cannot probe, let the test attempt run. A real failure
+    // is more useful than a silent skip masking the symptom.
+    cachedResult = true;
+    return true;
+  }
+}
+
+/**
+ * Test-only: reset the cached probe result so a unit test can re-exercise
+ * the helper. Not for production code paths.
+ */
+export function _resetVramPreconditionCacheForTests(): void {
+  cachedResult = null;
+  loggedOnce = false;
+}

--- a/test/eval.test.ts
+++ b/test/eval.test.ts
@@ -37,6 +37,10 @@ import {
   type RankedResult,
 } from "../src/store";
 import { getDefaultLlamaCpp, formatDocForEmbedding, disposeDefaultLlamaCpp } from "../src/llm";
+import { hasSufficientFreeVramForIntegration } from "./_helpers/vram-precondition.js";
+
+// One-shot probe at module load.  Gates real-LLM integration suites below.
+const _vramSufficient = await hasSufficientFreeVramForIntegration();
 
 // Eval queries with expected documents
 const evalQueries: {
@@ -156,7 +160,7 @@ describe("BM25 Search (FTS)", () => {
 // Vector Search Tests - Requires embedding model
 // =============================================================================
 
-describe.skipIf(!!process.env.CI)("Vector Search", () => {
+describe.skipIf(!!process.env.CI || !_vramSufficient)("Vector Search", () => {
   let store: ReturnType<typeof createStore>;
   let db: Database;
   let hasEmbeddings = false;
@@ -268,7 +272,7 @@ describe.skipIf(!!process.env.CI)("Vector Search", () => {
 // Hybrid Search (RRF) Tests - Combines BM25 + Vector
 // =============================================================================
 
-describe.skipIf(!!process.env.CI)("Hybrid Search (RRF)", () => {
+describe.skipIf(!!process.env.CI || !_vramSufficient)("Hybrid Search (RRF)", () => {
   let store: ReturnType<typeof createStore>;
   let db: Database;
   let hasVectors = false;

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -27,6 +27,14 @@ import {
   type RerankDocument,
   type ILLMSession,
 } from "../src/llm.js";
+import { hasSufficientFreeVramForIntegration } from "./_helpers/vram-precondition.js";
+
+// One-shot probe at module load.  Gates real-LLM integration suites below.
+// CI and remote-server runs already short-circuit before the probe matters,
+// but on a dev box this is what prevents the "qmd is broken" cascade of
+// rerank-context allocation failures when Ollama (or another workload) is
+// holding most of the GPU.
+const _vramSufficient = await hasSufficientFreeVramForIntegration();
 
 describe("model name resolution", () => {
   function withModelEnv(env: Record<string, string | undefined>, fn: () => void): void {
@@ -565,7 +573,7 @@ describe("LlamaCpp.getDeviceInfo", () => {
 // Integration Tests (require actual models)
 // =============================================================================
 
-describe.skipIf(!!process.env.CI)("LlamaCpp Integration", () => {
+describe.skipIf(!!process.env.CI || !_vramSufficient)("LlamaCpp Integration", () => {
   // Use the singleton to avoid multiple Metal contexts
   const llm = getDefaultLlamaCpp();
 
@@ -968,7 +976,7 @@ describe.skipIf(!!process.env.CI)("LlamaCpp Integration", () => {
 // Session Management Tests
 // =============================================================================
 
-describe.skipIf(!!process.env.CI)("LLM Session Management", () => {
+describe.skipIf(!!process.env.CI || !_vramSufficient)("LLM Session Management", () => {
   describe("withLLMSession", () => {
     test("session provides access to LLM operations", async () => {
       const result = await withLLMSession(async (session) => {

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -219,7 +219,11 @@ import {
   createStore,
 } from "../src/store";
 import type { RankedResult } from "../src/store";
+import { hasSufficientFreeVramForIntegration } from "./_helpers/vram-precondition.js";
 // Note: searchResultsToMcpCsv no longer used in MCP - using structuredContent instead
+
+// One-shot probe at module load.  Gates real-LLM integration suites below.
+const _vramSufficient = await hasSufficientFreeVramForIntegration();
 
 // =============================================================================
 // Tests
@@ -325,7 +329,7 @@ describe("MCP Server", () => {
   // searchVec (Vector similarity search)
   // ===========================================================================
 
-  describe.skipIf(!!process.env.CI)("searchVec (vector similarity)", () => {
+  describe.skipIf(!!process.env.CI || !_vramSufficient)("searchVec (vector similarity)", () => {
     test("returns results for semantic query", async () => {
       const results = await searchVec(testDb, "project documentation", DEFAULT_EMBED_MODEL, 10);
       expect(results.length).toBeGreaterThan(0);
@@ -351,7 +355,7 @@ describe("MCP Server", () => {
   // hybridQuery (query expansion + reranking)
   // ===========================================================================
 
-  describe.skipIf(!!process.env.CI)("hybridQuery (expansion + reranking)", () => {
+  describe.skipIf(!!process.env.CI || !_vramSufficient)("hybridQuery (expansion + reranking)", () => {
     test("expands query with typed variations", async () => {
       const expanded = await expandQuery("api documentation", DEFAULT_QUERY_MODEL, testDb);
       // Returns ExpandedQuery[] — typed expansions, original excluded
@@ -936,7 +940,7 @@ describe("MCP Server", () => {
 import { startMcpHttpServer, type HttpServerHandle } from "../src/mcp/server";
 import { enableProductionMode } from "../src/store";
 
-describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
+describe.skipIf(!!process.env.CI || !_vramSufficient)("MCP HTTP Transport", () => {
   let handle: HttpServerHandle;
   let baseUrl: string;
   let httpTestDbPath: string;

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -23,6 +23,10 @@ import {
   type ExpandQueryOptions,
 } from "../src/index.js";
 import { setDefaultLlamaCpp } from "../src/llm.js";
+import { hasSufficientFreeVramForIntegration } from "./_helpers/vram-precondition.js";
+
+// One-shot probe at module load.  Gates real-LLM integration suites below.
+const _vramSufficient = await hasSufficientFreeVramForIntegration();
 
 // =============================================================================
 // Test Helpers
@@ -629,7 +633,7 @@ describe("search (unified API)", () => {
   });
 
   // Tests below use search({ query: ... }) which triggers LLM query expansion
-  describe.skipIf(!!process.env.CI)("with LLM query expansion", () => {
+  describe.skipIf(!!process.env.CI || !_vramSufficient)("with LLM query expansion", () => {
     test("search() with query and rerank:false returns results", async () => {
       const results = await store.search({ query: "authentication", rerank: false });
       expect(results.length).toBeGreaterThan(0);

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -65,6 +65,10 @@ import {
   type RankedListMeta,
 } from "../src/store.js";
 import type { CollectionConfig } from "../src/collections.js";
+import { hasSufficientFreeVramForIntegration } from "./_helpers/vram-precondition.js";
+
+// One-shot probe at module load.  Gates real-LLM integration suites below.
+const _vramSufficient = await hasSufficientFreeVramForIntegration();
 
 // =============================================================================
 // LlamaCpp Setup
@@ -631,7 +635,7 @@ describe("Document Chunking", () => {
   });
 });
 
-describe.skipIf(!!process.env.CI)("Token-based Chunking", () => {
+describe.skipIf(!!process.env.CI || !_vramSufficient)("Token-based Chunking", () => {
   test("chunkDocumentByTokens returns single chunk for small documents", async () => {
     const content = "This is a small document.";
     const chunks = await chunkDocumentByTokens(content, 900, 135);
@@ -2873,7 +2877,7 @@ describe("Integration", () => {
 // LlamaCpp Integration Tests (using real local models)
 // =============================================================================
 
-describe.skipIf(!!process.env.CI)("LlamaCpp Integration", () => {
+describe.skipIf(!!process.env.CI || !_vramSufficient)("LlamaCpp Integration", () => {
   test("searchVec returns empty when no vector index", async () => {
     const store = await createTestStore();
     const collectionName = await createTestCollection();

--- a/test/vram-precondition.test.ts
+++ b/test/vram-precondition.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for the VRAM precondition helper that gates the GPU-dependent
+ * integration suites. Exercises the helper with an injected fake `getLlama`
+ * — no real node-llama-cpp runtime is loaded.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import {
+  hasSufficientFreeVramForIntegration,
+  _resetVramPreconditionCacheForTests,
+  type LlamaLike,
+} from "./_helpers/vram-precondition.js";
+
+function gb(n: number): number {
+  return n * 1024 * 1024 * 1024;
+}
+
+function fakeLlama(opts: { gpu: false | string; free?: number; throwOnVram?: boolean }): LlamaLike {
+  return {
+    gpu: opts.gpu,
+    getVramState: async () => {
+      if (opts.throwOnVram) throw new Error("simulated probe failure");
+      return { total: gb(24), used: gb(24) - (opts.free ?? 0), free: opts.free ?? 0 };
+    },
+  };
+}
+
+describe("hasSufficientFreeVramForIntegration", () => {
+  let originalSkip: string | undefined;
+
+  beforeEach(() => {
+    _resetVramPreconditionCacheForTests();
+    originalSkip = process.env.QMD_SKIP_GPU_INTEGRATION;
+    delete process.env.QMD_SKIP_GPU_INTEGRATION;
+  });
+
+  afterEach(() => {
+    if (originalSkip === undefined) delete process.env.QMD_SKIP_GPU_INTEGRATION;
+    else process.env.QMD_SKIP_GPU_INTEGRATION = originalSkip;
+  });
+
+  test("returns true on CPU mode (no GPU) without checking VRAM", async () => {
+    let vramChecked = false;
+    const result = await hasSufficientFreeVramForIntegration({
+      getLlama: async () => ({
+        gpu: false,
+        getVramState: async () => { vramChecked = true; return { total: 0, used: 0, free: 0 }; },
+      }),
+      log: () => {},
+    });
+    expect(result).toBe(true);
+    expect(vramChecked).toBe(false);
+  });
+
+  test("returns true when GPU has plenty of free VRAM", async () => {
+    const result = await hasSufficientFreeVramForIntegration({
+      getLlama: async () => fakeLlama({ gpu: "cuda", free: gb(20) }),
+      log: () => {},
+    });
+    expect(result).toBe(true);
+  });
+
+  test("returns true at exactly the threshold", async () => {
+    const result = await hasSufficientFreeVramForIntegration({
+      getLlama: async () => fakeLlama({ gpu: "cuda", free: gb(4) }),
+      minFreeGB: 4,
+      log: () => {},
+    });
+    expect(result).toBe(true);
+  });
+
+  test("returns false just below the threshold", async () => {
+    const result = await hasSufficientFreeVramForIntegration({
+      getLlama: async () => fakeLlama({ gpu: "cuda", free: gb(4) - 1 }),
+      minFreeGB: 4,
+      log: () => {},
+    });
+    expect(result).toBe(false);
+  });
+
+  test("returns false on the Ollama-hogged scenario (~1.4 GB free)", async () => {
+    const messages: string[] = [];
+    const result = await hasSufficientFreeVramForIntegration({
+      getLlama: async () => fakeLlama({ gpu: "cuda", free: gb(1.4) }),
+      log: (m) => messages.push(m),
+    });
+    expect(result).toBe(false);
+    expect(messages.some((m) => m.includes("1.40 GB free") && m.includes("QMD_SKIP_GPU_INTEGRATION"))).toBe(true);
+  });
+
+  test("QMD_SKIP_GPU_INTEGRATION=1 forces a skip without probing", async () => {
+    process.env.QMD_SKIP_GPU_INTEGRATION = "1";
+    let probed = false;
+    const result = await hasSufficientFreeVramForIntegration({
+      getLlama: async () => { probed = true; return fakeLlama({ gpu: "cuda", free: gb(20) }); },
+      log: () => {},
+    });
+    expect(result).toBe(false);
+    expect(probed).toBe(false);
+  });
+
+  test("getLlama throwing fails open (returns true) so a real failure surfaces in the test", async () => {
+    const result = await hasSufficientFreeVramForIntegration({
+      getLlama: async () => { throw new Error("node-llama-cpp not built for this platform"); },
+      log: () => {},
+    });
+    expect(result).toBe(true);
+  });
+
+  test("getVramState throwing fails open", async () => {
+    const result = await hasSufficientFreeVramForIntegration({
+      getLlama: async () => fakeLlama({ gpu: "cuda", throwOnVram: true }),
+      log: () => {},
+    });
+    expect(result).toBe(true);
+  });
+
+  test("caches the result across calls (probe runs once)", async () => {
+    let probeCalls = 0;
+    const opts = {
+      getLlama: async () => { probeCalls++; return fakeLlama({ gpu: "cuda", free: gb(20) }); },
+      log: () => {},
+    };
+    await hasSufficientFreeVramForIntegration(opts);
+    await hasSufficientFreeVramForIntegration(opts);
+    await hasSufficientFreeVramForIntegration(opts);
+    expect(probeCalls).toBe(1);
+  });
+
+  test("only logs the skip message once across calls", async () => {
+    const messages: string[] = [];
+    const opts = {
+      getLlama: async () => fakeLlama({ gpu: "cuda", free: gb(1) }),
+      log: (m: string) => messages.push(m),
+    };
+    await hasSufficientFreeVramForIntegration(opts);
+    await hasSufficientFreeVramForIntegration(opts);
+    expect(messages).toHaveLength(1);
+  });
+
+  test("concurrent first calls do not over-probe (cache wins after first resolve)", async () => {
+    let probeCalls = 0;
+    const opts = {
+      getLlama: async () => {
+        probeCalls++;
+        await new Promise<void>((r) => setImmediate(r));
+        return fakeLlama({ gpu: "cuda", free: gb(20) });
+      },
+      log: () => {},
+    };
+
+    // Two simultaneous awaits.  The current implementation does not coalesce
+    // racing probes; this test documents that observed behavior so a future
+    // optimization (in-flight promise sharing) is a deliberate change rather
+    // than an accidental regression.
+    const [a, b] = await Promise.all([
+      hasSufficientFreeVramForIntegration(opts),
+      hasSufficientFreeVramForIntegration(opts),
+    ]);
+    expect(a).toBe(true);
+    expect(b).toBe(true);
+    // After both resolve, subsequent calls hit the cache and do not probe again.
+    await hasSufficientFreeVramForIntegration(opts);
+    await hasSufficientFreeVramForIntegration(opts);
+    // The first batch may double-probe; the second batch must not.
+    expect(probeCalls).toBeLessThanOrEqual(2);
+  });
+
+  test("QMD_SKIP_GPU_INTEGRATION values other than '1' do not force skip (precise env match)", async () => {
+    // Red-team: prevent any truthy-string leak (e.g. "0", "false", "no") from
+    // accidentally forcing a skip.  Only the exact string "1" triggers.
+    for (const raw of ["0", "false", "no", "true", "yes", ""]) {
+      _resetVramPreconditionCacheForTests();
+      process.env.QMD_SKIP_GPU_INTEGRATION = raw;
+      const result = await hasSufficientFreeVramForIntegration({
+        getLlama: async () => fakeLlama({ gpu: "cuda", free: gb(20) }),
+        log: () => {},
+      });
+      expect(result, `value ${JSON.stringify(raw)} should not force skip`).toBe(true);
+    }
+  });
+});

--- a/test/vram-precondition.test.ts
+++ b/test/vram-precondition.test.ts
@@ -27,16 +27,32 @@ function fakeLlama(opts: { gpu: false | string; free?: number; throwOnVram?: boo
 
 describe("hasSufficientFreeVramForIntegration", () => {
   let originalSkip: string | undefined;
+  let originalEvacuate: string | undefined;
+  let originalOllamaHost: string | undefined;
 
   beforeEach(() => {
     _resetVramPreconditionCacheForTests();
+    // Snapshot AND clear every env var this helper reads.  A leaked
+    // `QMD_TEST_EVACUATE_VRAM=1` from the surrounding process would otherwise
+    // activate the eviction path inside tests that expect a clean skip,
+    // turning false-returning probes into true-returning re-probes against
+    // a real Ollama.  Same for `OLLAMA_HOST`: a leaked override could send
+    // the default eviction step to the wrong endpoint.
     originalSkip = process.env.QMD_SKIP_GPU_INTEGRATION;
+    originalEvacuate = process.env.QMD_TEST_EVACUATE_VRAM;
+    originalOllamaHost = process.env.OLLAMA_HOST;
     delete process.env.QMD_SKIP_GPU_INTEGRATION;
+    delete process.env.QMD_TEST_EVACUATE_VRAM;
+    delete process.env.OLLAMA_HOST;
   });
 
   afterEach(() => {
     if (originalSkip === undefined) delete process.env.QMD_SKIP_GPU_INTEGRATION;
     else process.env.QMD_SKIP_GPU_INTEGRATION = originalSkip;
+    if (originalEvacuate === undefined) delete process.env.QMD_TEST_EVACUATE_VRAM;
+    else process.env.QMD_TEST_EVACUATE_VRAM = originalEvacuate;
+    if (originalOllamaHost === undefined) delete process.env.OLLAMA_HOST;
+    else process.env.OLLAMA_HOST = originalOllamaHost;
   });
 
   test("returns true on CPU mode (no GPU) without checking VRAM", async () => {
@@ -184,13 +200,16 @@ describe("hasSufficientFreeVramForIntegration", () => {
 describe("hasSufficientFreeVramForIntegration — QMD_TEST_EVACUATE_VRAM opt-in", () => {
   let originalEvacuate: string | undefined;
   let originalSkip: string | undefined;
+  let originalOllamaHost: string | undefined;
 
   beforeEach(() => {
     _resetVramPreconditionCacheForTests();
     originalEvacuate = process.env.QMD_TEST_EVACUATE_VRAM;
     originalSkip = process.env.QMD_SKIP_GPU_INTEGRATION;
+    originalOllamaHost = process.env.OLLAMA_HOST;
     delete process.env.QMD_TEST_EVACUATE_VRAM;
     delete process.env.QMD_SKIP_GPU_INTEGRATION;
+    delete process.env.OLLAMA_HOST;
   });
 
   afterEach(() => {
@@ -198,6 +217,8 @@ describe("hasSufficientFreeVramForIntegration — QMD_TEST_EVACUATE_VRAM opt-in"
     else process.env.QMD_TEST_EVACUATE_VRAM = originalEvacuate;
     if (originalSkip === undefined) delete process.env.QMD_SKIP_GPU_INTEGRATION;
     else process.env.QMD_SKIP_GPU_INTEGRATION = originalSkip;
+    if (originalOllamaHost === undefined) delete process.env.OLLAMA_HOST;
+    else process.env.OLLAMA_HOST = originalOllamaHost;
   });
 
   test("does NOT run evacuate when env unset (default behavior preserved)", async () => {

--- a/test/vram-precondition.test.ts
+++ b/test/vram-precondition.test.ts
@@ -180,3 +180,150 @@ describe("hasSufficientFreeVramForIntegration", () => {
     }
   });
 });
+
+describe("hasSufficientFreeVramForIntegration — QMD_TEST_EVACUATE_VRAM opt-in", () => {
+  let originalEvacuate: string | undefined;
+  let originalSkip: string | undefined;
+
+  beforeEach(() => {
+    _resetVramPreconditionCacheForTests();
+    originalEvacuate = process.env.QMD_TEST_EVACUATE_VRAM;
+    originalSkip = process.env.QMD_SKIP_GPU_INTEGRATION;
+    delete process.env.QMD_TEST_EVACUATE_VRAM;
+    delete process.env.QMD_SKIP_GPU_INTEGRATION;
+  });
+
+  afterEach(() => {
+    if (originalEvacuate === undefined) delete process.env.QMD_TEST_EVACUATE_VRAM;
+    else process.env.QMD_TEST_EVACUATE_VRAM = originalEvacuate;
+    if (originalSkip === undefined) delete process.env.QMD_SKIP_GPU_INTEGRATION;
+    else process.env.QMD_SKIP_GPU_INTEGRATION = originalSkip;
+  });
+
+  test("does NOT run evacuate when env unset (default behavior preserved)", async () => {
+    let evacuateCalled = false;
+    const result = await hasSufficientFreeVramForIntegration({
+      getLlama: async () => fakeLlama({ gpu: "cuda", free: gb(1) }),
+      evacuate: async () => { evacuateCalled = true; },
+      log: () => {},
+    });
+    expect(result).toBe(false);
+    expect(evacuateCalled).toBe(false);
+  });
+
+  test("runs evacuate when env=1 and first probe insufficient, then re-probes", async () => {
+    process.env.QMD_TEST_EVACUATE_VRAM = "1";
+    let probeCalls = 0;
+    let evacuateCalled = false;
+    const result = await hasSufficientFreeVramForIntegration({
+      getLlama: async () => {
+        probeCalls++;
+        // First probe: tight.  Second probe (after evacuate): roomy.
+        return fakeLlama({ gpu: "cuda", free: probeCalls === 1 ? gb(1) : gb(20) });
+      },
+      evacuate: async () => { evacuateCalled = true; },
+      log: () => {},
+    });
+    expect(result).toBe(true);
+    expect(evacuateCalled).toBe(true);
+    expect(probeCalls).toBe(2);
+  });
+
+  test("evacuate runs but does not free enough → still returns false", async () => {
+    process.env.QMD_TEST_EVACUATE_VRAM = "1";
+    let evacuateCalled = false;
+    const messages: string[] = [];
+    const result = await hasSufficientFreeVramForIntegration({
+      getLlama: async () => fakeLlama({ gpu: "cuda", free: gb(1) }),  // stays tight
+      evacuate: async () => { evacuateCalled = true; },
+      log: (m) => messages.push(m),
+    });
+    expect(result).toBe(false);
+    expect(evacuateCalled).toBe(true);
+    expect(messages.some((m) => m.includes("post-eviction"))).toBe(true);
+  });
+
+  test("evacuate throws → still re-probes (best-effort), logs the failure", async () => {
+    process.env.QMD_TEST_EVACUATE_VRAM = "1";
+    let probeCalls = 0;
+    const messages: string[] = [];
+    const result = await hasSufficientFreeVramForIntegration({
+      getLlama: async () => {
+        probeCalls++;
+        return fakeLlama({ gpu: "cuda", free: probeCalls === 1 ? gb(1) : gb(20) });
+      },
+      evacuate: async () => { throw new Error("simulated eviction failure"); },
+      log: (m) => messages.push(m),
+    });
+    expect(result).toBe(true);
+    expect(probeCalls).toBe(2);
+    expect(messages.some((m) => m.includes("Eviction step threw"))).toBe(true);
+  });
+
+  test("first probe already sufficient → evacuate is NOT called even with env=1", async () => {
+    process.env.QMD_TEST_EVACUATE_VRAM = "1";
+    let evacuateCalled = false;
+    const result = await hasSufficientFreeVramForIntegration({
+      getLlama: async () => fakeLlama({ gpu: "cuda", free: gb(20) }),
+      evacuate: async () => { evacuateCalled = true; },
+      log: () => {},
+    });
+    expect(result).toBe(true);
+    expect(evacuateCalled).toBe(false);
+  });
+
+  test("QMD_SKIP_GPU_INTEGRATION=1 wins over QMD_TEST_EVACUATE_VRAM=1 (no probe, no evacuate)", async () => {
+    process.env.QMD_SKIP_GPU_INTEGRATION = "1";
+    process.env.QMD_TEST_EVACUATE_VRAM = "1";
+    let probeCalls = 0;
+    let evacuateCalled = false;
+    const result = await hasSufficientFreeVramForIntegration({
+      getLlama: async () => { probeCalls++; return fakeLlama({ gpu: "cuda", free: gb(1) }); },
+      evacuate: async () => { evacuateCalled = true; },
+      log: () => {},
+    });
+    expect(result).toBe(false);
+    expect(probeCalls).toBe(0);
+    expect(evacuateCalled).toBe(false);
+  });
+
+  test("QMD_TEST_EVACUATE_VRAM values other than '1' do not trigger eviction (precise env match)", async () => {
+    for (const raw of ["0", "false", "no", "true", "yes", ""]) {
+      _resetVramPreconditionCacheForTests();
+      process.env.QMD_TEST_EVACUATE_VRAM = raw;
+      let evacuateCalled = false;
+      const result = await hasSufficientFreeVramForIntegration({
+        getLlama: async () => fakeLlama({ gpu: "cuda", free: gb(1) }),
+        evacuate: async () => { evacuateCalled = true; },
+        log: () => {},
+      });
+      expect(result, `value ${JSON.stringify(raw)} should not trigger eviction`).toBe(false);
+      expect(evacuateCalled, `value ${JSON.stringify(raw)} should not call evacuate`).toBe(false);
+    }
+  });
+
+  test("default evacuate path: Ollama unreachable does not throw (best-effort)", async () => {
+    // Red-team: when the default evacuate runs against a host with no Ollama,
+    // it must swallow the connection error and let the re-probe proceed.
+    // We exercise the default evacuate (no injection) by aiming at a port
+    // that nothing is listening on.
+    process.env.QMD_TEST_EVACUATE_VRAM = "1";
+    const originalHost = process.env.OLLAMA_HOST;
+    process.env.OLLAMA_HOST = "http://127.0.0.1:1";  // reserved/unused port
+    try {
+      let probeCalls = 0;
+      const messages: string[] = [];
+      const result = await hasSufficientFreeVramForIntegration({
+        getLlama: async () => { probeCalls++; return fakeLlama({ gpu: "cuda", free: gb(1) }); },
+        log: (m) => messages.push(m),
+        // No `evacuate` injected — exercises the real defaultEvacuate path.
+      });
+      expect(result).toBe(false);
+      expect(probeCalls).toBe(2);  // initial + post-eviction re-probe
+      expect(messages.some((m) => m.includes("Ollama unreachable"))).toBe(true);
+    } finally {
+      if (originalHost === undefined) delete process.env.OLLAMA_HOST;
+      else process.env.OLLAMA_HOST = originalHost;
+    }
+  });
+});


### PR DESCRIPTION
# VRAM precondition gate for GPU-dependent integration suites

## Why

The GPU-dependent integration sub-suites in `llm.test.ts`, `mcp.test.ts`, `store.test.ts`, `eval.test.ts`, and `sdk.test.ts` load real GGUF models and exercise embed, rerank, and expandQuery against a real `node-llama-cpp` runtime.  When another workload is holding most of the GPU (Ollama parking a large model, a sibling daemon mid-job, a stale `qmd serve`), those allocations fail and the suites produce a cascade of `Failed to create any rerank context` failures that look like code regressions but are not.

The existing `describe.skipIf(!!process.env.CI)` gates handle CI correctly but leave a dev box exposed: the suites run, fail loudly, and obscure the genuine regressions the suite is supposed to catch.  Asking developers to chase ghost failures every time a co-resident model is loaded is the wrong default.

This PR adds a one-shot VRAM probe at module load and gates ten integration sub-suites that perform real allocations on whether the GPU has enough headroom.  Suites that do not need a real LLM (BM25 search, MCP HTTP transport, path utilities, store creation, chunking metadata) continue to run unconditionally.

## What this PR adds

A helper at `test/_helpers/vram-precondition.ts`, wired into the existing `describe.skipIf` cascades:

| File | Suite | Why gated |
| --- | --- | --- |
| `test/llm.test.ts` | `LlamaCpp Integration` | Real embed / rerank / expandQuery |
| `test/llm.test.ts` | `LLM Session Management` | Lifecycle test using real LLM |
| `test/mcp.test.ts` | `searchVec (vector similarity)` | Real embedding for the query |
| `test/mcp.test.ts` | `hybridQuery (expansion + reranking)` | Real `expandQuery` and `rerank` |
| `test/mcp.test.ts` | `MCP HTTP Transport` | End-to-end suite including reranking |
| `test/store.test.ts` | `Token-based Chunking` | Real tokenizer load |
| `test/store.test.ts` | `LlamaCpp Integration` | Real embed + vector search |
| `test/eval.test.ts` | `Vector Search` | Real embedding for the eval corpus |
| `test/eval.test.ts` | `Hybrid Search (RRF)` | Real embed + rerank for the eval corpus |
| `test/sdk.test.ts` | `with LLM query expansion` | Real `expandQuery` |

The helper decides whether to skip:

1. Cached result if present.  Suites that import the helper a second time hit the cache.
2. `QMD_SKIP_GPU_INTEGRATION=1` short-circuits to false without probing.  Useful for fast unit-loop iteration on a healthy box when you just want the non-GPU tests.
3. First VRAM probe via `getLlama().getVramState()`.  Threshold is 4 GB free, which covers embed (~0.7 GB) + rerank (~1.5 GB) + generate (~1.5 GB) + slack.  CPU mode (no GPU) returns true without probing.
4. If the first probe is insufficient AND `QMD_TEST_EVACUATE_VRAM=1` is set, the helper asks Ollama to unload its resident models via `POST /api/generate {keep_alive: 0}` for each model listed by `GET /api/ps`, then re-probes once.  Off by default: test infrastructure silently terminating another process's loaded models would be astonishing without explicit consent.  `OLLAMA_HOST` overrides the default `http://127.0.0.1:11434` endpoint.
5. Probe failure fails open (returns true) so a genuine code failure surfaces in the test rather than being silently masked by a skip.

The eviction step is Ollama-only.  Other VRAM consumers (qmd serve, sibling daemons) are deliberately out of scope: killing a user-facing daemon is too astonishing even behind the opt-in flag.  All steps run best-effort with explicit timeouts (2 s for `/api/ps`, 5 s per unload).  Connection failures, non-OK responses, and per-model unload errors are logged but do not abort the re-probe.

Dependencies on `node-llama-cpp` and the eviction HTTP calls are injected through `options.getLlama` and `options.evacuate` so the unit tests at `test/vram-precondition.test.ts` drive the gate without making real GPU calls or HTTP requests.

## Behavior on the merged result

| Environment | Probe outcome | Suites |
| --- | --- | --- |
| CI (`CI=1`) | not run | skipped (unchanged) |
| Healthy local box (≥ 4 GB free GPU VRAM) | sufficient | run |
| CPU-only or `node-llama-cpp` not built | probe fails open | run (existing fail-loud behavior preserved) |
| `QMD_SKIP_GPU_INTEGRATION=1` | short-circuits | skipped |
| Contested local box (< 4 GB free), no opt-in | insufficient | skipped with operator-readable warning |
| Contested local box, `QMD_TEST_EVACUATE_VRAM=1`, eviction frees enough | sufficient on re-probe | run |
| Contested local box, `QMD_TEST_EVACUATE_VRAM=1`, eviction insufficient | still insufficient | skipped with post-eviction message |

## Measured locally

Same contested GPU for both runs (RTX 3090 Ti, Ollama holding ~20 GB of gemma4:26b, ~3.1 GB free).

### Default (skip path, no opt-in)

The probe sees 2.81 GB free, prints the operator-readable warning, and skips the gated suites.

```
Before this PR: 389 pass /  0 skip /  8 fail
After this PR:  354 pass / 62 skip /  0 fail
```

The eight integration failures previously surfaced as `Failed to create any rerank context` cascades are now clean skips with a single warning line:

```
⚠ Integration tests skipped: only 2.81 GB free GPU VRAM (need ≥ 4 GB).
  Set QMD_TEST_EVACUATE_VRAM=1 to attempt eviction first,
  or QMD_SKIP_GPU_INTEGRATION=1 to silence this probe.
```

### Evacuate path (`QMD_TEST_EVACUATE_VRAM=1`)

The probe sees 2.81 GB free, hits the eviction branch, logs the eviction attempt, and asks Ollama to unload its loaded model.  Re-probe shows headroom restored and the gated suites then run.

```
⚠ Insufficient VRAM (2.81 GB free, need ≥ 4 GB);
  QMD_TEST_EVACUATE_VRAM=1, attempting to evict known consumers...
⚠ Eviction: asking Ollama to unload 1 model(s): gemma4:26b-a4b-it-q4_K_M
✓ Eviction succeeded; 22.31 GB free, integration tests will run.
```

Whole suite (29 files): `876 pass / 80 skip / 0 fail` against the gated suites.

Two caveats worth knowing:

1. **The integration tests that run after eviction can still hit individual `rerank context` allocation failures on a bare `tobi:main` checkout** because the vanilla single-pass reclaim path is the weak link, not the headroom this gate restores.  This is the same failure mode that #662 (lowVram two-pass reclaim) is designed to fix.  Stacking #662 on top of this PR turns the post-eviction integration suite green; this PR alone restores the headroom but does not change reclaim behavior.
2. **Ollama may re-load a model between the eviction call and the actual test allocations** if another client (an MCP agent, another `ollama run`, a residual `keep_alive` from a recent request) re-requests the same model during the suite run.  The gate is a probe-once mechanism; it does not pin Ollama into a quiet state for the duration of the suite.

The eviction path is most useful on developer machines where the operator opts in deliberately and expects the test session to take priority over background Ollama state for a few minutes.

## Test coverage

19 unit tests on the helper (`test/vram-precondition.test.ts`), all driven through injected `getLlama` and `evacuate` so no real GPU or HTTP request runs in this suite:

- CPU mode and CPU-offload-forced skip the VRAM probe entirely.
- Plentiful VRAM (20 GB), exactly at threshold (4 GB), just below threshold (boundary behavior).
- Ollama-hogged scenario (~1.4 GB free) returns false and emits the operator-readable warning.
- `QMD_SKIP_GPU_INTEGRATION=1` forces a skip without probing.
- `getLlama` and `getVramState` throwing both fail open.
- Result is cached so repeated calls do not re-probe.
- Skip warning logs at most once per process.
- Eviction does not run when `QMD_TEST_EVACUATE_VRAM` is unset.
- Eviction runs when `QMD_TEST_EVACUATE_VRAM=1` and first probe insufficient, then re-probes.
- Eviction runs but does not free enough → returns false with post-eviction message.
- Eviction throws → still re-probes (best-effort), the throw is logged.
- First probe already sufficient → eviction is not called even when env=1.
- `QMD_SKIP_GPU_INTEGRATION=1` precedence wins over `QMD_TEST_EVACUATE_VRAM=1`.
- Red-team: env values other than the exact string `"1"` (`"0"`, `"false"`, `"true"`, `"yes"`, `""`) do not trigger skip or eviction.
- Default eviction path against an unreachable Ollama logs the connection failure and the re-probe still runs.

The helper test harness explicitly snapshots and clears `QMD_SKIP_GPU_INTEGRATION`, `QMD_TEST_EVACUATE_VRAM`, and `OLLAMA_HOST` in `beforeEach` / `afterEach`, so the helper suite passes identically under each of `(no env vars)`, `QMD_TEST_EVACUATE_VRAM=1`, and `QMD_SKIP_GPU_INTEGRATION=1`.  Without that isolation the tests would inherit the operator's chosen env at the surrounding process level and false-fail.

`tsc --noEmit` clean on the helper and its tests.

## Backwards compatibility

- Purely additive.  Suites that already had `describe.skipIf(!!process.env.CI)` keep the `CI` short-circuit and add the VRAM precondition via boolean-OR.
- Default behavior on a healthy local box is unchanged: the probe returns true, the suites run.
- Default behavior in CI is unchanged: `CI=1` short-circuits before the probe matters.
- The two new env vars (`QMD_SKIP_GPU_INTEGRATION`, `QMD_TEST_EVACUATE_VRAM`) are opt-in and read precisely (only the string `"1"` triggers).  `OLLAMA_HOST` is read only when eviction is opted into.

## Changelog

### Added

- VRAM precondition helper at `test/_helpers/vram-precondition.ts` that probes free GPU VRAM once per process and reports whether the integration suites can run meaningfully.  Gates ten GPU-dependent sub-suites across `test/llm.test.ts`, `test/mcp.test.ts`, `test/store.test.ts`, `test/eval.test.ts`, and `test/sdk.test.ts`.
- `QMD_SKIP_GPU_INTEGRATION=1` env var forces the integration suites to skip without probing the GPU.
- `QMD_TEST_EVACUATE_VRAM=1` env var opts into asking Ollama to unload its resident models when the initial VRAM probe shows insufficient headroom, then re-probing.  Off by default.
- `OLLAMA_HOST` env var overrides the default `http://127.0.0.1:11434` endpoint used by the eviction step.

## Type of Change

- [x] `test`: Adding or updating tests
- [ ] `feat`: New feature
- [ ] `BREAKING CHANGE`: Breaking API change

## Related Issues/Stories

- Story: n/a
- Issue: n/a
- Architecture: n/a
- Related PRs: independent of #662 (lowVram engine) and #663 (qmd serve).  Addresses the same underlying contested-GPU problem but at the test-infrastructure layer rather than the runtime layer.  The evacuate path's "still red after eviction" caveat above is exactly what #662 fixes at the engine level; stacking the two turns the post-eviction integration suite green.

## Testing

- [x] Unit tests added (`test/vram-precondition.test.ts`, 19 cases)
- [x] Integration tests added (the gated suites themselves now skip cleanly when GPU is contested)
- [x] Manual testing completed (verified against an Ollama-hogged GPU, both skip and evacuate paths)
- [x] All tests passing

## Files Modified

**Modified:**

- `test/llm.test.ts`: VRAM precondition import + probe + skipIf extension on two integration sub-suites.
- `test/mcp.test.ts`: same on three integration sub-suites.
- `test/store.test.ts`: same on two integration sub-suites.
- `test/eval.test.ts`: same on two integration sub-suites.
- `test/sdk.test.ts`: same on one integration sub-suite.

**Created:**

- `test/_helpers/vram-precondition.ts`: the helper itself.
- `test/vram-precondition.test.ts`: unit tests for the helper (19 cases including red-team).

**Renamed:**

- None.

**Deleted:**

- None.

## Breaking Changes

- [x] No breaking changes.

## Deployment Notes

- [x] No special deployment steps required.  The new env vars are opt-in; default behavior on a healthy local box and in CI is unchanged.
