### PR TITLE
fix(doctor): skip `.etag` sidecars when validating the model cache

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -3546,7 +3546,11 @@ function findCachedModelInspection(model: string): CachedModelInspection {
     if (!filename || !existsSync(DEFAULT_MODEL_CACHE_DIR)) return { path: null, invalid };
     const entries = readdirSync(DEFAULT_MODEL_CACHE_DIR, { withFileTypes: true });
     for (const entry of entries) {
-      if (!entry.isFile() || !entry.name.includes(filename)) continue;
+      // Skip the `<filename>.etag` HTTP sidecar that `qmd pull` writes next to
+      // each blob. It satisfies `includes(filename)` but is not a GGUF, so
+      // inspecting it as one surfaces a spurious "invalid" model in `qmd
+      // doctor` whenever readdir happens to yield the sidecar before the blob.
+      if (!entry.isFile() || entry.name.endsWith(".etag") || !entry.name.includes(filename)) continue;
       const candidate = pathJoin(DEFAULT_MODEL_CACHE_DIR, entry.name);
       const inspection = inspectGgufFile(candidate);
       if (inspection.valid) return { path: candidate, invalid };

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -591,6 +591,41 @@ describe("CLI Status Command", () => {
     expect(stdout).toContain("qmd pull --refresh");
   }, 20000);
 
+  test("qmd doctor ignores .etag sidecars beside a valid cached model", async () => {
+    // `qmd pull` writes a `<filename>.etag` HTTP sidecar next to each model
+    // blob. That sidecar matches the model-cache lookup's `includes(filename)`
+    // test, so a naive scan inspects it as a GGUF and reports the model
+    // "invalid" — order-dependently, whenever readdir yields the sidecar
+    // before the blob. The sidecar must be skipped.
+    const env = await createIsolatedTestEnv("doctor-etag-sidecar");
+    const model = "hf:example/custom-model/custom.gguf";
+    await writeFile(join(env.configDir, "index.yml"), `collections: {}\nmodels:\n  embed: ${model}\n  generate: ${model}\n  rerank: ${model}\n`);
+    const cacheRoot = join(env.configDir, "cache");
+    const modelCacheDir = join(cacheRoot, "qmd", "models");
+    await mkdir(modelCacheDir, { recursive: true });
+    // Create the sidecar first so readdir is more likely to surface it before
+    // the blob on order-preserving filesystems (the bug's trigger condition).
+    await writeFile(join(modelCacheDir, "custom.gguf.etag"), '"a1b2c3d4e5"\n');
+    // A real blob: node-llama-cpp stores it `hf_<org>_<filename>`. Any name
+    // containing the filename works; it just needs the GGUF magic to be valid.
+    await writeFile(join(modelCacheDir, "hf_example_custom.gguf"), Buffer.concat([Buffer.from("GGUF"), Buffer.alloc(60)]));
+
+    const { stdout, exitCode } = await runQmd(["doctor"], {
+      dbPath: env.dbPath,
+      configDir: env.configDir,
+      env: {
+        XDG_CACHE_HOME: cacheRoot,
+        QMD_DOCTOR_DEVICE_PROBE: "0",
+      },
+    });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("model cache");
+    expect(stdout).toContain("downloaded and valid GGUF");
+    // The sidecar must not be reported as a bad model.
+    expect(stdout).not.toContain("not valid GGUF");
+    expect(stdout).not.toContain(".etag");
+  }, 20000);
+
   test("qmd doctor says when models are overridden by env", async () => {
     const env = await createIsolatedTestEnv("doctor-env-models");
     await writeFile(join(env.configDir, "index.yml"), "collections: {}\n");


### PR DESCRIPTION
## Problem

`qmd doctor` can report a downloaded, fully working model as **invalid**:

```
⚠ model cache: invalid 1: generation: hf:tobil/qmd-query-expansion-1.7B-gguf/qmd-query-expansion-1.7B-q4_k_m.gguf
  (~/.cache/qmd/models/qmd-query-expansion-1.7B-q4_k_m.gguf.etag: not valid GGUF
   (expected magic "GGUF", got "\"c38", 0 KB)). Next: run `qmd pull --refresh` (or remove the bad cached file)
```

The model itself is fine — `qmd query`/`qmd embed` work — and `qmd pull --refresh` does **not** clear the warning.

## Root cause

`findCachedModelInspection()` scans the model-cache dir for every entry whose name `includes(filename)` and inspects each as a GGUF:

```ts
const filename = model.split("/").pop();        // "…q4_k_m.gguf"
for (const entry of entries) {
  if (!entry.isFile() || !entry.name.includes(filename)) continue;
  const inspection = inspectGgufFile(pathJoin(DEFAULT_MODEL_CACHE_DIR, entry.name));
  ...
}
```

`qmd pull` writes a `<filename>.etag` HTTP sidecar next to each blob (`pullModels`, `llm.ts`). That sidecar's name also contains `filename`, so it gets inspected — and a ~67-byte etag has no `GGUF` magic, so it's flagged invalid.

The loop `return`s on the first **valid** GGUF it finds, so the false positive only surfaces when `readdir` happens to yield the `.etag` before the blob. That explains the otherwise-puzzling symptoms:

- **Order-dependent** — hits some models/filesystems and not others (e.g. only the generation model on a given box, while embedding/reranking pass).
- **`qmd pull --refresh` doesn't help** — it re-downloads the blob and re-writes the same sidecar.
- **Invisible to most users** — only `qmd pull` writes the `.etag`; lazy first-use downloads via `resolveModelFile` don't, so the file doctor trips over isn't even present.

## Fix

Skip `*.etag` entries in the scan — one line in `findCachedModelInspection`. The same `includes(filename)` match in `pullModels` is harmless (it only deletes/refreshes), so the validity check is the only place that needs it.

## Test

Adds a regression test that stages a valid GGUF blob plus a garbage `.etag` sidecar in the model cache and asserts `qmd doctor` reports the model valid. Verified it **fails on the prior code** (reproduces `invalid 1: … .etag: not valid GGUF`) and **passes with the fix**. `tsc -p tsconfig.build.json --noEmit` and `bun run build` are clean.