### PR TITLE
chore: make tsc --noEmit (nearly) clean over the test suite

### DIFF
--- a/src/bench-rerank.ts
+++ b/src/bench-rerank.ts
@@ -17,6 +17,7 @@ import {
   LlamaLogLevel,
   type Llama,
   type LlamaModel,
+  type LlamaRankingContext,
 } from "node-llama-cpp";
 import { homedir } from "os";
 import { join } from "path";
@@ -109,7 +110,7 @@ async function benchmarkConfig(
 
   // Create contexts. On CPU, split threads evenly across contexts.
   const cpuThreads = !llama.gpu ? Math.floor(llama.cpuMathCores / parallelism) : 0;
-  const contexts = [];
+  const contexts: LlamaRankingContext[] = [];
   for (let i = 0; i < parallelism; i++) {
     try {
       contexts.push(await model.createRankingContext({

--- a/src/test-preload.ts
+++ b/src/test-preload.ts
@@ -16,7 +16,7 @@
  * See CLAUDE.md for invoking `bun test` manually on darwin.
  */
 import { afterAll } from "bun:test";
-import { disposeDefaultLlamaCpp } from "./llm";
+import { disposeDefaultLlamaCpp } from "./llm.js";
 
 // Global afterAll runs after all test files complete
 afterAll(async () => {

--- a/test/cli-exit-lifecycle.test.ts
+++ b/test/cli-exit-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
-import { finishSuccessfulCliCommand } from "../src/cli/qmd.ts";
-import { LlamaCpp, isDarwinMetalMitigationActive } from "../src/llm.ts";
+import { finishSuccessfulCliCommand } from "../src/cli/qmd.js";
+import { LlamaCpp, isDarwinMetalMitigationActive } from "../src/llm.js";
 
 describe("CLI successful-exit lifecycle", () => {
   test("exits 0 after successful output when post-output LLM cleanup fails", async () => {

--- a/test/cli-lazy-llm-import.test.ts
+++ b/test/cli-lazy-llm-import.test.ts
@@ -11,7 +11,7 @@ describe("LLM module loading", () => {
   });
 
   test("importing the CLI for lightweight commands succeeds", async () => {
-    const mod = await import("../src/cli/qmd.ts");
+    const mod = await import("../src/cli/qmd.js");
     expect(mod).toMatchObject({
       buildEditorUri: expect.any(Function),
       termLink: expect.any(Function),

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -13,10 +13,10 @@ import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { spawn } from "child_process";
 import { setTimeout as sleep } from "timers/promises";
-import { buildEditorUri, termLink, resolveEmbedModelForCli } from "../src/cli/qmd.ts";
-import { openDatabase } from "../src/db.ts";
-import { DEFAULT_EMBED_MODEL_URI, DEFAULT_GENERATE_MODEL_URI, DEFAULT_RERANK_MODEL_URI } from "../src/llm.ts";
-import { setConfigSource } from "../src/collections.ts";
+import { buildEditorUri, termLink, resolveEmbedModelForCli } from "../src/cli/qmd.js";
+import { openDatabase } from "../src/db.js";
+import { DEFAULT_EMBED_MODEL_URI, DEFAULT_GENERATE_MODEL_URI, DEFAULT_RERANK_MODEL_URI } from "../src/llm.js";
+import { setConfigSource } from "../src/collections.js";
 
 // Test fixtures directory and database path
 let testDir: string;

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2150,7 +2150,7 @@ describe("mcp http daemon", () => {
 
       const res = await fetch(`http://localhost:${port}/health`);
       expect(res.status).toBe(200);
-      const body = await res.json();
+      const body = await res.json() as { status: string };
       expect(body.status).toBe("ok");
     } finally {
       const closed = new Promise(r => proc.once("close", r));
@@ -2212,7 +2212,7 @@ describe("mcp http daemon", () => {
         body: JSON.stringify({ searches: [{ type: "lex", query: "authentication" }], limit: 5, rerank: false }),
       });
       expect(res.status).toBe(200);
-      const body = await res.json();
+      const body = await res.json() as { results: { file: string }[] };
       const files = body.results.map((r: { file: string }) => r.file);
       expect(files.some((file: string) => file.includes("mcp-fixtures/notes/meeting.md"))).toBe(true);
     } finally {

--- a/test/eval-bm25.test.ts
+++ b/test/eval-bm25.test.ts
@@ -17,7 +17,7 @@ import {
   searchFTS,
   insertDocument,
   insertContent,
-} from "../src/store";
+} from "../src/store.js";
 
 // Set INDEX_PATH before importing store to prevent using global index
 const tempDir = mkdtempSync(join(tmpdir(), "qmd-eval-unit-"));

--- a/test/eval.test.ts
+++ b/test/eval.test.ts
@@ -35,8 +35,8 @@ import {
   reciprocalRankFusion,
   DEFAULT_EMBED_MODEL,
   type RankedResult,
-} from "../src/store";
-import { getDefaultLlamaCpp, formatDocForEmbedding, disposeDefaultLlamaCpp } from "../src/llm";
+} from "../src/store.js";
+import { getDefaultLlamaCpp, formatDocForEmbedding, disposeDefaultLlamaCpp } from "../src/llm.js";
 
 // Eval queries with expected documents
 const evalQueries: {

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -25,6 +25,7 @@ import {
   canUnloadLLM,
   SessionReleasedError,
   type RerankDocument,
+  type RerankDocumentResult,
   type ILLMSession,
 } from "../src/llm.js";
 
@@ -528,7 +529,7 @@ describe("LlamaCpp rerank deduping", () => {
     expect(rankAll).toHaveBeenCalledWith("query", ["shared chunk", "different chunk"]);
     expect(result.results).toHaveLength(3);
 
-    const scoreByFile = new Map(result.results.map((item) => [item.file, item.score]));
+    const scoreByFile = new Map(result.results.map((item: RerankDocumentResult) => [item.file, item.score]));
     expect(scoreByFile.get("a.md")).toBe(0.9);
     expect(scoreByFile.get("b.md")).toBe(0.9);
     expect(scoreByFile.get("c.md")).toBe(0.2);

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -10,15 +10,15 @@ import { openDatabase, loadSqliteVec } from "../src/db.js";
 import type { Database } from "../src/db.js";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getDefaultLlamaCpp, disposeDefaultLlamaCpp } from "../src/llm";
+import { getDefaultLlamaCpp, disposeDefaultLlamaCpp } from "../src/llm.js";
 import { unlinkSync } from "node:fs";
 import { mkdtemp, writeFile, readdir, unlink, rmdir } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import YAML from "yaml";
-import type { CollectionConfig } from "../src/collections";
-import { setConfigIndexName } from "../src/collections";
-import { syncConfigToDb } from "../src/store";
+import type { CollectionConfig } from "../src/collections.js";
+import { setConfigIndexName } from "../src/collections.js";
+import { syncConfigToDb } from "../src/store.js";
 
 // =============================================================================
 // Test Database Setup
@@ -217,8 +217,8 @@ import {
   DEFAULT_RERANK_MODEL,
   DEFAULT_MULTI_GET_MAX_BYTES,
   createStore,
-} from "../src/store";
-import type { RankedResult } from "../src/store";
+} from "../src/store.js";
+import type { RankedResult } from "../src/store.js";
 // Note: searchResultsToMcpCsv no longer used in MCP - using structuredContent instead
 
 // =============================================================================
@@ -923,8 +923,8 @@ describe("MCP Server", () => {
 // HTTP Transport Tests
 // =============================================================================
 
-import { startMcpHttpServer, type HttpServerHandle } from "../src/mcp/server";
-import { enableProductionMode } from "../src/store";
+import { startMcpHttpServer, type HttpServerHandle } from "../src/mcp/server.js";
+import { enableProductionMode } from "../src/store.js";
 
 describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
   let handle: HttpServerHandle;

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1009,7 +1009,7 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
     const res = await fetch(`${baseUrl}/health`);
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("application/json");
-    const body = await res.json();
+    const body = await res.json() as { status: string; uptime: number };
     expect(body.status).toBe("ok");
     expect(typeof body.uptime).toBe("number");
   });

--- a/test/multi-collection-filter.test.ts
+++ b/test/multi-collection-filter.test.ts
@@ -78,7 +78,7 @@ describe("filterByCollections", () => {
     const filtered = filterByCollections(mixedResults, ["docs", "notes"]);
     expect(filtered).toHaveLength(1);
     // Should match via filepath (docs), not file (notes)
-    expect(filtered[0].filepath).toBe("qmd://docs/readme.md");
+    expect(filtered[0]!.filepath).toBe("qmd://docs/readme.md");
   });
 });
 

--- a/test/rrf-trace.test.ts
+++ b/test/rrf-trace.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { buildRrfTrace, reciprocalRankFusion, type RankedResult } from "../src/store";
+import { buildRrfTrace, reciprocalRankFusion, type RankedResult } from "../src/store.js";
 
 describe("buildRrfTrace", () => {
   test("matches reciprocalRankFusion totals and records per-list contributions", () => {

--- a/test/store.helpers.unit.test.ts
+++ b/test/store.helpers.unit.test.ts
@@ -18,7 +18,7 @@ import {
   handelize,
   cleanupOrphanedVectors,
   sanitizeFTS5Term,
-} from "../src/store";
+} from "../src/store.js";
 
 // =============================================================================
 // Path Utilities


### PR DESCRIPTION
## What

`npx tsc --noEmit` on main currently reports 51 errors, almost all in test files. This brings it to 3 with zero behavior change: type annotations, import-specifier extensions, and narrowing only. No tsconfig, package.json, or runtime logic touched.

- 21 import specifiers: added the explicit `.js` extensions ESM resolution wants (14 missing, 7 written as `.ts`), matching the convention the rest of the codebase already uses.
- 20 implicit-any parameters: 19 cleared as a cascade of the import fixes (the broken specifiers were erasing the imported types), 1 explicit `RerankDocumentResult` annotation.
- 4 `unknown` narrows on `res.json()` in cli/mcp tests, 2 typed locals in `src/bench-rerank.ts` (annotation only), 1 non-null assert after a length assertion.

## The 3 left

- `migrate-schema.ts` and `src/test-preload.ts`: `bun:sqlite` / `bun:test` have no installed types. Adding `@types/bun` to devDependencies would clear both; left out since it touches package.json, happy to add it here if you want.
- `src/bench-rerank.ts`: passing `flashAttention` into `createRankingContext` is runtime-intentional (the catch block probes for support and recovers), and the installed node-llama-cpp typings do not declare it. Typing around it would change what the bench exercises, so it stays.

## Why

Every open PR rebases onto this baseline; with the noise gone, a new red `tsc` line means the PR actually introduced it (#663's branch, for example, currently carries 6 new ones that are invisible against the 51).

## Tests

Fast subset (no local models): 200/200 pass, twice (independent reruns). Baseline comparison on main showed the same single pre-existing model-dependent timeout in `mcp.test.ts` before and after.