### PR TITLE
fix(launcher): detect bun global installs via the install-root lockfile

### DIFF
--- a/bin/qmd
+++ b/bin/qmd
@@ -10,7 +10,7 @@
 
 import { spawn, spawnSync } from "node:child_process";
 import { existsSync, realpathSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 // Resolve symlinks so global installs (npm link / npm install -g) can find
@@ -129,10 +129,31 @@ if (!useSourceMode && !existsSync(jsEntry)) {
 // modules for Node. The repo ships bun.lock, so without this check, source
 // builds that use npm would be incorrectly routed to bun, causing ABI
 // mismatches with better-sqlite3 / sqlite-vec (see #381).
+//
+// Package-manager installs keep their lockfile at the install root, above
+// node_modules/ — never inside the package directory itself. A bun global
+// install writes $BUN_INSTALL/install/global/bun.lock while the package
+// lands in .../install/global/node_modules/@tobilu/qmd/, so the package-dir
+// checks below can't match and qmd would run under whatever node is first
+// on PATH. The native modules were built by the installing runtime; after
+// the next Node major upgrade they fail to load (ERR_DLOPEN_FAILED,
+// NODE_MODULE_VERSION mismatch). Apply the same npm-priority rule at the
+// install root when the package directory itself has no lockfile.
+const pathParts = pkgDir.split(sep);
+const nodeModulesIndex = pathParts.lastIndexOf("node_modules");
+const installRoot = nodeModulesIndex === -1 ? null : pathParts.slice(0, nodeModulesIndex).join(sep);
+const hasRootNpmLock = installRoot !== null && existsSync(resolve(installRoot, "package-lock.json"));
+const hasRootBunLock = installRoot !== null
+  && (existsSync(resolve(installRoot, "bun.lock")) || existsSync(resolve(installRoot, "bun.lockb")));
+
 let runnerName = "node";
 if (existsSync(resolve(pkgDir, "package-lock.json"))) {
   runnerName = "node";
 } else if (existsSync(resolve(pkgDir, "bun.lock")) || existsSync(resolve(pkgDir, "bun.lockb"))) {
+  runnerName = "bun";
+} else if (hasRootNpmLock) {
+  runnerName = "node";
+} else if (hasRootBunLock) {
   runnerName = "bun";
 } else {
   runnerName = "node";

--- a/test/bin-wrapper.test.ts
+++ b/test/bin-wrapper.test.ts
@@ -172,6 +172,31 @@ describe("bin/qmd package wrapper", () => {
     expect(result.scriptPath).toBe(realpathSync(join(packageRoot, "dist", "cli", "qmd.js")));
   });
 
+  test("bun global install with bun.lock at the install root uses bun", () => {
+    const { root, runtimeBin, capturePath } = makeTempFixture();
+    const packageRoot = makePackage(root, "home/user/.bun/install/global/node_modules/@tobilu/qmd");
+    writeFileSync(join(root, "home", "user", ".bun", "install", "global", "bun.lock"), "");
+    const bunBin = join(root, "home", "user", ".bun", "bin", "qmd");
+    symlinkRelative(join(packageRoot, "bin", "qmd"), bunBin);
+
+    const result = runWrapper(bunBin, runtimeBin, capturePath);
+
+    expect(result.runtime).toBe("bun");
+    expect(result.scriptPath).toBe(realpathSync(join(packageRoot, "dist", "cli", "qmd.js")));
+  });
+
+  test("package-lock.json at the install root keeps npm priority", () => {
+    const { root, runtimeBin, capturePath } = makeTempFixture();
+    const packageRoot = makePackage(root, "project/node_modules/@tobilu/qmd");
+    writeFileSync(join(root, "project", "package-lock.json"), "");
+    writeFileSync(join(root, "project", "bun.lock"), "");
+
+    const result = runWrapper(join(packageRoot, "bin", "qmd"), runtimeBin, capturePath);
+
+    expect(result.runtime).toBe("node");
+    expect(result.scriptPath).toBe(realpathSync(join(packageRoot, "dist", "cli", "qmd.js")));
+  });
+
   test("ambient BUN_INSTALL alone does not select bun for an npm-installed package", () => {
     const { root, runtimeBin, capturePath } = makeTempFixture();
     const packageRoot = makePackage(root, "opt/homebrew/lib/node_modules/@tobilu/qmd");

--- a/test/launcher-detection.test.sh
+++ b/test/launcher-detection.test.sh
@@ -24,6 +24,12 @@ detect_runtime() {
     echo "node"
   elif [ -f "$DIR/bun.lock" ] || [ -f "$DIR/bun.lockb" ]; then
     echo "bun"
+  elif [[ "$DIR" == */node_modules/* ]] && [ -f "${DIR%/node_modules/*}/package-lock.json" ]; then
+    # Mirror the install-root fallback: package-manager installs keep their
+    # lockfile above node_modules/, never inside the package directory.
+    echo "node"
+  elif [[ "$DIR" == */node_modules/* ]] && { [ -f "${DIR%/node_modules/*}/bun.lock" ] || [ -f "${DIR%/node_modules/*}/bun.lockb" ]; }; then
+    echo "bun"
   else
     echo "node"
   fi
@@ -91,6 +97,24 @@ touch "$d/package-lock.json"
 touch "$d/bun.lock"
 touch "$d/bun.lockb"
 assert_runtime "all three lockfiles → node (npm priority)" "$d" "node"
+
+# 8. bun global install: bun.lock at the install root, none in the package dir → bun
+d="$TMPDIR_BASE/bun-global/install/global/node_modules/@tobilu/qmd"
+mkdir -p "$d"
+touch "$TMPDIR_BASE/bun-global/install/global/bun.lock"
+assert_runtime "bun.lock at install root → bun" "$d" "bun"
+
+# 9. package-lock.json at the install root wins over bun.lock there → node
+d="$TMPDIR_BASE/npm-project/node_modules/@tobilu/qmd"
+mkdir -p "$d"
+touch "$TMPDIR_BASE/npm-project/package-lock.json"
+touch "$TMPDIR_BASE/npm-project/bun.lock"
+assert_runtime "install-root package-lock.json + bun.lock → node" "$d" "node"
+
+# 10. no lockfiles anywhere (npm/Homebrew global layout) → node
+d="$TMPDIR_BASE/homebrew/lib/node_modules/@tobilu/qmd"
+mkdir -p "$d"
+assert_runtime "no lockfiles anywhere → node" "$d" "node"
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
## Problem

A `bun install -g @tobilu/qmd` runs under whatever `node` is first on PATH, so the install breaks on the next Node major upgrade.

**Root cause:** runtime detection looks for lockfiles inside the package directory (the detection from #361/#381), but package-manager installs never place one there. A bun global install writes:

```
$BUN_INSTALL/install/global/bun.lock                       ← lockfile at the install root
$BUN_INSTALL/install/global/node_modules/@tobilu/qmd/      ← package dir, no lockfile
```

so the bun branch can never match, qmd falls through to PATH node, and better-sqlite3 (built at install time against that Node ABI) stops loading after the next Node major bump:

```
Error: The module ... better_sqlite3.node was compiled against a different
Node.js version using NODE_MODULE_VERSION 131. This version of Node.js
requires NODE_MODULE_VERSION 147. (ERR_DLOPEN_FAILED)
```

We hit this as crashlooping launchd MCP daemons after a routine `brew upgrade` moved node 23 to 26.

## Repro

Any two Node majors, isolated via `BUN_INSTALL`:

```sh
export BUN_INSTALL=/tmp/qmd-mre
PATH="<node23-bin>:$PATH" bun install -g @tobilu/qmd@2.5.3
PATH="<node23-bin>:/usr/bin:/bin" /tmp/qmd-mre/bin/qmd doctor   # runs fine
PATH="<node26-bin>:/usr/bin:/bin" /tmp/qmd-mre/bin/qmd doctor   # ERR_DLOPEN_FAILED, 131 vs 147
```

## Fix

When the package directory has no lockfile, apply the same npm-priority rule one level up, at the install root above `node_modules/`:

1. `package-lock.json` at the install root → node
2. `bun.lock` / `bun.lockb` at the install root → bun
3. nothing at either level → node, as before

npm and Homebrew globals keep no lockfile at either level and still route to node. Bun project-local installs of qmd as a dependency are picked up through the same path.

## Verification

- Confirmed the bun route is sound before changing anything: the unpatched broken install (node-23-built better-sqlite3, node 26 on PATH) runs every `doctor` check green under bun.
- With the patched launcher, the same broken install goes from `ERR_DLOPEN_FAILED` to `doctor` exit 0.
- Two regression tests in `test/bin-wrapper.test.ts` (bun-global install-root layout, install-root npm priority) and three matching cases in `test/launcher-detection.test.sh`: 15/15 and 10/10 passing.

Glad to adjust if you would rather detect this differently.