### PR TITLE
feat(mcp): expose explain parameter for retrieval score traces

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -28,6 +28,7 @@ import {
   type QMDStore,
   type ExpandedQuery,
   type IndexStatus,
+  type HybridQueryExplain,
 } from "../index.js";
 import { getConfigPath } from "../collections.js";
 import { enableProductionMode } from "../store.js";
@@ -44,6 +45,7 @@ type SearchResultItem = {
   context: string | null;
   line: number;   // Absolute line in source markdown
   snippet: string;
+  explain?: HybridQueryExplain;  // Retrieval score traces, present only when explain=true
 };
 
 type StatusResult = {
@@ -323,9 +325,13 @@ Intent-aware lex (C++ performance, not sports):
         rerank: z.boolean().optional().default(true).describe(
           "Rerank results using LLM (default: true). Set to false for faster results on CPU-only machines."
         ),
+        explain: z.boolean().optional().default(false).describe(
+          "Include retrieval score traces (FTS/vector scores, RRF fusion breakdown, rerank " +
+          "blend weights) in each result. Useful for debugging query quality and tuning search."
+        ),
       },
     },
-    async ({ query, searches, limit, minScore, candidateLimit, collections, intent, rerank }) => {
+    async ({ query, searches, limit, minScore, candidateLimit, collections, intent, rerank, explain }) => {
       // Require exactly one of `query` (plain text, auto-expanded) or `searches` (typed sub-queries).
       if (!query && (!searches || searches.length === 0)) {
         return {
@@ -357,6 +363,7 @@ Intent-aware lex (C++ performance, not sports):
         candidateLimit,
         rerank,
         intent,
+        explain,
       });
 
       // Use the plain query, or the first lex/vec sub-query, for snippet extraction
@@ -376,6 +383,7 @@ Intent-aware lex (C++ performance, not sports):
           context: r.context,
           line,
           snippet: addLineNumbers(snippet, line),
+          ...(r.explain ? { explain: r.explain } : {}),
         };
       });
 
@@ -749,6 +757,7 @@ export async function startMcpHttpServer(
           candidateLimit: typeof params.candidateLimit === "number" ? params.candidateLimit : undefined,
           intent: typeof params.intent === "string" ? params.intent : undefined,
           rerank: typeof params.rerank === "boolean" ? params.rerank : undefined,
+          explain: typeof params.explain === "boolean" ? params.explain : undefined,
         });
 
         // Use first lex or vec query for snippet extraction
@@ -766,6 +775,7 @@ export async function startMcpHttpServer(
             context: r.context,
             line,
             snippet: addLineNumbers(snippet, line),
+            ...(r.explain ? { explain: r.explain } : {}),
           };
         });
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -25,6 +25,7 @@ import {
   type QMDStore,
   type ExpandedQuery,
   type IndexStatus,
+  type HybridQueryExplain,
 } from "../index.js";
 import { getConfigPath } from "../collections.js";
 import { enableProductionMode } from "../store.js";
@@ -42,6 +43,7 @@ type SearchResultItem = {
   context: string | null;
   line: number;   // Absolute line in source markdown
   snippet: string;
+  explain?: HybridQueryExplain;  // Retrieval score traces, present only when explain=true
 };
 
 type StatusResult = {
@@ -334,9 +336,13 @@ Intent-aware lex (C++ performance, not sports):
         rerank: z.boolean().optional().default(true).describe(
           "Rerank results using LLM (default: true). Set to false for faster results on CPU-only machines."
         ),
+        explain: z.boolean().optional().default(false).describe(
+          "Include retrieval score traces (FTS/vector scores, RRF fusion breakdown, rerank " +
+          "blend weights) in each result. Useful for debugging query quality and tuning search."
+        ),
       }),
     },
-    track(async ({ query, searches, limit, minScore, candidateLimit, collections, intent, rerank }) => {
+    track(async ({ query, searches, limit, minScore, candidateLimit, collections, intent, rerank, explain }) => {
       // Require exactly one of `query` (plain text, auto-expanded) or `searches` (typed sub-queries).
       if (!query && (!searches || searches.length === 0)) {
         return {
@@ -368,6 +374,7 @@ Intent-aware lex (C++ performance, not sports):
         candidateLimit,
         rerank,
         intent,
+        explain,
       });
 
       // Use the plain query, or the first lex/vec sub-query, for snippet extraction
@@ -387,6 +394,7 @@ Intent-aware lex (C++ performance, not sports):
           context: r.context,
           line,
           snippet: addLineNumbers(snippet, line),
+          ...(r.explain ? { explain: r.explain } : {}),
         };
       });
 
@@ -1009,6 +1017,7 @@ export async function startMcpHttpServer(
           candidateLimit: typeof params.candidateLimit === "number" ? params.candidateLimit : undefined,
           intent: typeof params.intent === "string" ? params.intent : undefined,
           rerank: typeof params.rerank === "boolean" ? params.rerank : undefined,
+          explain: typeof params.explain === "boolean" ? params.explain : undefined,
         });
 
         // Use first lex or vec query for snippet extraction
@@ -1026,6 +1035,7 @@ export async function startMcpHttpServer(
             context: r.context,
             line,
             snippet: addLineNumbers(snippet, line),
+            ...(r.explain ? { explain: r.explain } : {}),
           };
         });
 


### PR DESCRIPTION
## What

Adds an optional `explain` boolean to the MCP `query` tool and the REST `/query` (alias `/search`) endpoint. When set, each result carries the retrieval score trace the SDK already computes — per-list FTS and vector scores, the RRF fusion breakdown, and rerank blend weights.

## Why

`SearchOptions.explain` and `HybridQueryResult.explain` already exist in the SDK (`hybridQuery()` / `structuredSearch()` build the trace via `buildRrfTrace`), but there is no way to request it from an MCP client — you have to drop down to the SDK. This plumbs the existing flag through the two MCP-facing surfaces so query quality and ranking can be inspected in place.

## Details

- New `explain` param (default `false`) on the `query` tool schema, forwarded to `store.search`.
- `explain` accepted on the REST `/query` body and forwarded likewise.
- Each result spreads `...(r.explain ? { explain: r.explain } : {})`, typed against the exported `HybridQueryExplain` — no output change when `explain` is unset.
- `tsc --noEmit` clean.

## History

Fresh, focused resubmission of #433, which was closed on 2026-05-20 during a stale-backlog purge with the note to *"open a fresh focused issue if it still reproduces on v2.5.1+"*. No `explain` parameter exists on current `main`, so the gap remains. Rebased onto current `main` (the rerank-aware `query` signature); the change is smaller now because `main` already exports `HybridQueryExplain`.
