### PR TITLE
feat(store): set busy_timeout on sqlite connections to avoid SQLITE_BUSY race

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -63,9 +63,17 @@ if (isBun) {
 
 /**
  * Open a SQLite database. Works with both bun:sqlite and better-sqlite3.
+ *
+ * Sets PRAGMA busy_timeout = 10000 (10s) on every connection so that two
+ * processes sharing the same store — e.g. the long-running MCP daemon and a
+ * `qmd` CLI invocation (often driven from cron) — wait-and-retry instead of
+ * failing immediately with SQLITE_BUSY when one holds a write lock the other
+ * needs. 10s comfortably covers the typical write window of either side.
  */
 export function openDatabase(path: string): Database {
-  return new _Database(path) as Database;
+  const db = new _Database(path) as Database;
+  db.exec("PRAGMA busy_timeout = 10000");
+  return db;
 }
 
 /**


### PR DESCRIPTION
## What

Sets `PRAGMA busy_timeout = 10000` (10s) on every SQLite connection qmd opens, at the single `openDatabase()` choke point in `src/db.ts`.

## Why

When two processes share the same qmd store — e.g. a long-running MCP daemon and a `qmd` CLI invocation (often driven from a short-interval cron) — the second writer hits `SQLITE_BUSY` immediately and aborts, because SQLite's default is to error rather than wait on a locked database:

```
SQLiteError: database is locked
  code: "SQLITE_BUSY"
  at clearCache (.../store.js) ... at updateCollections (.../cli/qmd.js)
```

`busy_timeout` makes SQLite wait-and-retry for up to the timeout before giving up — the standard pattern for short-lived multi-process contention. 10s comfortably covers the typical write window of either side.

## Details

- One-line change in `openDatabase()`, the only place qmd creates a connection (verified — the sole other open site routes through it). Applies uniformly under both `bun:sqlite` and `better-sqlite3`.
- No behaviour change for single-process use.
- `tsc --noEmit` clean.
