### PR TITLE
fix: make node-llama-cpp an optional dependency with graceful degradation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,6 @@
         "@modelcontextprotocol/sdk": "1.29.0",
         "better-sqlite3": "12.10.0",
         "fast-glob": "3.3.3",
-        "node-llama-cpp": "3.18.1",
         "picomatch": "4.0.4",
         "sqlite-vec": "0.1.9",
         "tree-sitter-go": "0.25.0",
@@ -25,6 +24,7 @@
         "vitest": "3.2.4",
       },
       "optionalDependencies": {
+        "node-llama-cpp": "3.18.1",
         "sqlite-vec-darwin-arm64": "0.1.9",
         "sqlite-vec-darwin-x64": "0.1.9",
         "sqlite-vec-linux-arm64": "0.1.9",
@@ -275,7 +275,7 @@
 
     "chmodrp": ["chmodrp@1.0.2", "", {}, "sha512-TdngOlFV1FLTzU0o1w8MB6/BFywhtLC0SzRTGJU7T9lmdjlCWeMRt1iVo0Ki+ldwNk0BqNiKoc8xpLZEQ8mY1w=="],
 
-    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "ci-info": ["ci-info@4.3.1", "", {}, "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA=="],
 
@@ -787,7 +787,7 @@
 
     "string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
-    "tar/chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+    "tar-fs/chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@modelcontextprotocol/sdk": "1.29.0",
     "better-sqlite3": "12.10.0",
     "fast-glob": "3.3.3",
-    "node-llama-cpp": "3.18.1",
     "picomatch": "4.0.4",
     "sqlite-vec": "0.1.9",
     "tree-sitter-go": "0.25.0",
@@ -71,6 +70,7 @@
     "zod": "4.2.1"
   },
   "optionalDependencies": {
+    "node-llama-cpp": "3.18.1",
     "sqlite-vec-darwin-arm64": "0.1.9",
     "sqlite-vec-darwin-x64": "0.1.9",
     "sqlite-vec-linux-arm64": "0.1.9",

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -80,7 +80,7 @@ import {
   type ReindexResult,
   type ChunkStrategy,
 } from "../store.js";
-import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, setDefaultLlamaCpp, LlamaCpp, withLLMSession, pullModels, DEFAULT_MODEL_CACHE_DIR, resolveEmbedModel, resolveGenerateModel, resolveRerankModel, resolveModels, inspectGgufFile, isDarwinMetalMitigationActive } from "../llm.js";
+import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, setDefaultLlamaCpp, LlamaCpp, withLLMSession, pullModels, DEFAULT_MODEL_CACHE_DIR, resolveEmbedModel, resolveGenerateModel, resolveRerankModel, resolveModels, inspectGgufFile, isDarwinMetalMitigationActive, assertNodeLlamaCppAvailable, isNodeLlamaCppAvailable, NODE_LLAMA_CPP_UNAVAILABLE_MESSAGE } from "../llm.js";
 import {
   formatSearchResults,
   formatDocuments,
@@ -1860,11 +1860,17 @@ function resolveModelsForCli(): { embed: string; generate: string; rerank: strin
   return ensureModelsConfiguredForCli();
 }
 
+export async function assertNodeLlamaCppAvailableForCli(): Promise<void> {
+  await assertNodeLlamaCppAvailable();
+}
+
 async function vectorIndex(
   model: string = resolveEmbedModelForCli(),
   force: boolean = false,
   batchOptions?: { maxDocsPerBatch?: number; maxBatchBytes?: number; chunkStrategy?: ChunkStrategy; collection?: string; maxDurationMs?: number },
 ): Promise<void> {
+  await assertNodeLlamaCppAvailableForCli();
+
   const storeInstance = getStore();
   const db = storeInstance.db;
 
@@ -2522,6 +2528,8 @@ function logExpansionTree(originalQuery: string, expanded: ExpandedQuery[]): voi
 }
 
 async function vectorSearch(query: string, opts: OutputOptions, _model: string = DEFAULT_EMBED_MODEL): Promise<void> {
+  await assertNodeLlamaCppAvailableForCli();
+
   const store = getStore();
 
   // Validate collection filter (supports multiple -c flags)
@@ -2573,6 +2581,8 @@ async function vectorSearch(query: string, opts: OutputOptions, _model: string =
 }
 
 async function querySearch(query: string, opts: OutputOptions, _embedModel: string = DEFAULT_EMBED_MODEL, _rerankModel: string = DEFAULT_RERANK_MODEL): Promise<void> {
+  await assertNodeLlamaCppAvailableForCli();
+
   const store = getStore();
 
   // Validate collection filter (supports multiple -c flags)
@@ -3370,6 +3380,27 @@ function doctorCheck(label: string, ok: boolean, details: string): void {
   console.log(`${mark} ${label}: ${details}`);
 }
 
+export function rosettaNodeDoctorWarning(
+  platform: NodeJS.Platform = process.platform,
+  arch: NodeJS.Architecture = process.arch
+): string | null {
+  if (platform === "darwin" && arch === "x64") {
+    return "x64 Node on macOS detected; on Apple Silicon this is likely Rosetta and node-llama-cpp may fail to install. Install a native arm64 Node from nodejs.org and reinstall: npm install -g @tobilu/qmd";
+  }
+  return null;
+}
+
+function checkNodeArchitecture(nextSteps: string[]): void {
+  const warning = rosettaNodeDoctorWarning();
+  if (!warning) {
+    doctorCheck("node architecture", true, `${process.platform}/${process.arch}`);
+    return;
+  }
+
+  doctorCheck("node architecture", false, warning);
+  nextSteps.push("Install a native arm64 Node from nodejs.org and reinstall: `npm install -g @tobilu/qmd`.");
+}
+
 function formatCount(n: number): string {
   return n.toLocaleString("en-US");
 }
@@ -3644,6 +3675,10 @@ async function checkEmbeddingVectorSamples(db: Database, model: string, fingerpr
     return { ok: false, details: "no current embedded chunks to test; please run qmd embed again" };
   }
 
+  if (!(await isNodeLlamaCppAvailable())) {
+    return { ok: false, details: `${NODE_LLAMA_CPP_UNAVAILABLE_MESSAGE}; skip vector reproduction until node-llama-cpp is available` };
+  }
+
   const threshold = 0.0001;
   const mismatches: string[] = [];
 
@@ -3755,6 +3790,12 @@ async function runDoctorDeviceChecks(nextSteps: string[]): Promise<void> {
     return;
   }
 
+  if (!(await isNodeLlamaCppAvailable())) {
+    doctorCheck("device probe", false, `${NODE_LLAMA_CPP_UNAVAILABLE_MESSAGE}. Next: install native Node and reinstall qmd, or use BM25 commands such as \`qmd search\`.`);
+    nextSteps.push("Install a native arm64 Node from nodejs.org and reinstall: `npm install -g @tobilu/qmd`.");
+    return;
+  }
+
   const crashHint = "Probing native llama backend now. If qmd crashes here, rerun with `QMD_FORCE_CPU=1 qmd doctor` (or `QMD_DOCTOR_DEVICE_PROBE=0 qmd doctor` to skip this probe).";
   if (process.stdout.isTTY) {
     process.stdout.write(`${c.dim}${crashHint}${c.reset}`);
@@ -3834,6 +3875,8 @@ async function showDoctor(): Promise<void> {
   console.log(`${c.bold}QMD Doctor${c.reset}\n`);
   console.log(`Index: ${getDbPath()}`);
   console.log(`Runtime: ${isBun ? "bun:sqlite" : "better-sqlite3"}`);
+
+  checkNodeArchitecture(nextSteps);
 
   try {
     const row = db.prepare(`SELECT sqlite_version() AS version`).get() as { version: string };
@@ -4320,22 +4363,27 @@ if (isMain) {
       break;
 
     case "pull": {
-      const refresh = cli.values.refresh === undefined ? false : Boolean(cli.values.refresh);
-      const activeModels = resolveModelsForCli();
-      const models = [
-        activeModels.embed,
-        activeModels.generate,
-        activeModels.rerank,
-      ];
-      console.log(`${c.bold}Pulling models${c.reset}`);
-      const results = await pullModels(models, {
-        refresh,
-        cacheDir: DEFAULT_MODEL_CACHE_DIR,
-      });
-      for (const result of results) {
-        const size = formatBytes(result.sizeBytes);
-        const note = result.refreshed ? "refreshed" : "cached/checked";
-        console.log(`- ${result.model} -> ${result.path} (${size}, ${note})`);
+      try {
+        await assertNodeLlamaCppAvailableForCli();
+        const refresh = cli.values.refresh === undefined ? false : Boolean(cli.values.refresh);
+        const activeModels = resolveModelsForCli();
+        const models = [
+          activeModels.embed,
+          activeModels.generate,
+          activeModels.rerank,
+        ];
+        console.log(`${c.bold}Pulling models${c.reset}`);
+        const results = await pullModels(models, {
+          refresh,
+          cacheDir: DEFAULT_MODEL_CACHE_DIR,
+        });
+        for (const result of results) {
+          const size = formatBytes(result.sizeBytes);
+          const note = result.refreshed ? "refreshed" : "cached/checked";
+          console.log(`- ${result.model} -> ${result.path} (${size}, ${note})`);
+        }
+      } catch (error) {
+        exitWithError(error);
       }
       break;
     }
@@ -4358,7 +4406,11 @@ if (isMain) {
       if (!cli.values["min-score"]) {
         cli.opts.minScore = 0.3;
       }
-      await vectorSearch(cli.query, cli.opts);
+      try {
+        await vectorSearch(cli.query, cli.opts);
+      } catch (error) {
+        exitWithError(error);
+      }
       break;
 
     case "query":
@@ -4367,7 +4419,11 @@ if (isMain) {
         console.error("Usage: qmd query [options] <query>");
         process.exit(1);
       }
-      await querySearch(cli.query, cli.opts);
+      try {
+        await querySearch(cli.query, cli.opts);
+      } catch (error) {
+        exitWithError(error);
+      }
       break;
 
     case "bench": {

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -24,16 +24,35 @@ type NodeLlamaCppModule = {
   LlamaLogLevel: { error: unknown };
 };
 
-let nodeLlamaCppImport: Promise<NodeLlamaCppModule> | null = null;
-async function loadNodeLlamaCpp(): Promise<NodeLlamaCppModule> {
+export const NODE_LLAMA_CPP_UNAVAILABLE_MESSAGE =
+  "node-llama-cpp is not available (postinstall failed -- likely Rosetta/x64 Node on Apple Silicon). Install a native arm64 Node from nodejs.org and reinstall: npm install -g @tobilu/qmd";
+
+let nodeLlamaCppImport: Promise<NodeLlamaCppModule | null> | null = null;
+async function loadNodeLlamaCpp(): Promise<NodeLlamaCppModule | null> {
   nodeLlamaCppImport ??= withNativeStdoutRedirectedToStderr(
     () => import("node-llama-cpp") as Promise<NodeLlamaCppModule>
-  );
+  ).catch(() => null);
   return nodeLlamaCppImport;
 }
 
+export async function isNodeLlamaCppAvailable(): Promise<boolean> {
+  return (await loadNodeLlamaCpp()) !== null;
+}
+
+export async function assertNodeLlamaCppAvailable(): Promise<void> {
+  if (await isNodeLlamaCppAvailable()) return;
+  throw new Error(NODE_LLAMA_CPP_UNAVAILABLE_MESSAGE);
+}
+
 export function setNodeLlamaCppModuleForTest(module: NodeLlamaCppModule | null): void {
-  nodeLlamaCppImport = module ? Promise.resolve(module) : null;
+  nodeLlamaCppImport = Promise.resolve(module);
+  failedGpuInitModes.clear();
+  noGpuAccelerationWarningShown = false;
+  cpuForcedPrebuiltFallbackWarningShown = false;
+}
+
+export function resetNodeLlamaCppModuleForTest(): void {
+  nodeLlamaCppImport = null;
   failedGpuInitModes.clear();
   noGpuAccelerationWarningShown = false;
   cpuForcedPrebuiltFallbackWarningShown = false;
@@ -495,7 +514,9 @@ export async function pullModels(
       }
     }
 
-    const { resolveModelFile } = await loadNodeLlamaCpp();
+    const llamaModule = await loadNodeLlamaCpp();
+    if (!llamaModule) throw new Error(NODE_LLAMA_CPP_UNAVAILABLE_MESSAGE);
+    const { resolveModelFile } = llamaModule;
     const path = await resolveModelFile(model, cacheDir);
     validateGgufFile(path, model);
     const sizeBytes = existsSync(path) ? statSync(path).size : 0;
@@ -872,7 +893,9 @@ export class LlamaCpp implements LLM {
     if (!this.llama) {
       const gpuMode = resolveLlamaGpuMode();
 
-      const { getLlama, getLlamaGpuTypes, LlamaLogLevel } = await loadNodeLlamaCpp();
+      const llamaModule = await loadNodeLlamaCpp();
+      if (!llamaModule) throw new Error(NODE_LLAMA_CPP_UNAVAILABLE_MESSAGE);
+      const { getLlama, getLlamaGpuTypes, LlamaLogLevel } = llamaModule;
       const loadLlama = async (gpu: LlamaGpuMode, sourceBuildAllowed = allowBuild, buildOverride?: "auto" | "never") =>
         await withNativeStdoutRedirectedToStderr(() => getLlama({
           // Prefer packaged prebuilt bindings before compiling llama.cpp locally.
@@ -981,7 +1004,9 @@ export class LlamaCpp implements LLM {
   private async resolveModel(modelUri: string): Promise<string> {
     this.ensureModelCacheDir();
     // resolveModelFile handles HF URIs and downloads to the cache dir
-    const { resolveModelFile } = await loadNodeLlamaCpp();
+    const llamaModule = await loadNodeLlamaCpp();
+    if (!llamaModule) throw new Error(NODE_LLAMA_CPP_UNAVAILABLE_MESSAGE);
+    const { resolveModelFile } = llamaModule;
     const modelPath = await resolveModelFile(modelUri, this.modelCacheDir);
     validateGgufFile(modelPath, modelUri);
     return modelPath;
@@ -1401,7 +1426,9 @@ export class LlamaCpp implements LLM {
     // Create fresh context -> sequence -> session for each call
     const context = await this.generateModel!.createContext();
     const sequence = context.getSequence();
-    const { LlamaChatSession } = await loadNodeLlamaCpp();
+    const llamaModule = await loadNodeLlamaCpp();
+    if (!llamaModule) throw new Error(NODE_LLAMA_CPP_UNAVAILABLE_MESSAGE);
+    const { LlamaChatSession } = llamaModule;
     const session = new LlamaChatSession({ contextSequence: sequence });
 
     const maxTokens = options.maxTokens ?? 150;
@@ -1486,7 +1513,9 @@ export class LlamaCpp implements LLM {
         contextSize: this.expandContextSize,
       });
       const sequence = genContext.getSequence();
-      const { LlamaChatSession } = await loadNodeLlamaCpp();
+      const llamaModule = await loadNodeLlamaCpp();
+      if (!llamaModule) throw new Error(NODE_LLAMA_CPP_UNAVAILABLE_MESSAGE);
+      const { LlamaChatSession } = llamaModule;
       const session = new LlamaChatSession({ contextSequence: sequence });
 
       // Qwen3 recommended settings for non-thinking mode:

--- a/test/cli-lazy-llm-import.test.ts
+++ b/test/cli-lazy-llm-import.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "vitest";
 import { readFileSync } from "fs";
 import { join } from "path";
+import {
+  NODE_LLAMA_CPP_UNAVAILABLE_MESSAGE,
+  resetNodeLlamaCppModuleForTest,
+  setNodeLlamaCppModuleForTest,
+} from "../src/llm.js";
 
 describe("LLM module loading", () => {
   test("node-llama-cpp is only dynamically imported by LLM operations", () => {
@@ -16,5 +21,32 @@ describe("LLM module loading", () => {
       buildEditorUri: expect.any(Function),
       termLink: expect.any(Function),
     });
+  });
+
+  test("package declares node-llama-cpp only as an optional dependency", () => {
+    const pkg = JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf-8"));
+
+    expect(pkg.dependencies).not.toHaveProperty("node-llama-cpp");
+    expect(pkg.optionalDependencies).toMatchObject({
+      "node-llama-cpp": "3.18.1",
+    });
+  });
+
+  test("CLI LLM availability guard reports the actionable optional dependency error", async () => {
+    const { assertNodeLlamaCppAvailableForCli } = await import("../src/cli/qmd.ts");
+    setNodeLlamaCppModuleForTest(null);
+    try {
+      await expect(assertNodeLlamaCppAvailableForCli()).rejects.toThrow(NODE_LLAMA_CPP_UNAVAILABLE_MESSAGE);
+    } finally {
+      resetNodeLlamaCppModuleForTest();
+    }
+  });
+
+  test("doctor warns for darwin x64 Node and not for native arm64 or non-darwin", async () => {
+    const { rosettaNodeDoctorWarning } = await import("../src/cli/qmd.ts");
+
+    expect(rosettaNodeDoctorWarning("darwin", "x64")).toContain("native arm64 Node");
+    expect(rosettaNodeDoctorWarning("darwin", "arm64")).toBeNull();
+    expect(rosettaNodeDoctorWarning("linux", "x64")).toBeNull();
   });
 });

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -14,6 +14,10 @@ import {
   disposeDefaultLlamaCpp,
   resolveLlamaGpuMode,
   setNodeLlamaCppModuleForTest,
+  resetNodeLlamaCppModuleForTest,
+  isNodeLlamaCppAvailable,
+  assertNodeLlamaCppAvailable,
+  NODE_LLAMA_CPP_UNAVAILABLE_MESSAGE,
   withNativeStdoutRedirectedToStderr,
   resolveParallelismOverride,
   resolveSafeParallelism,
@@ -177,6 +181,16 @@ describe("QMD_LLAMA_GPU resolution", () => {
 });
 
 describe("native llama stdout containment", () => {
+  test("treats a null node-llama-cpp test module as unavailable", async () => {
+    setNodeLlamaCppModuleForTest(null);
+    try {
+      await expect(isNodeLlamaCppAvailable()).resolves.toBe(false);
+      await expect(assertNodeLlamaCppAvailable()).rejects.toThrow(NODE_LLAMA_CPP_UNAVAILABLE_MESSAGE);
+    } finally {
+      resetNodeLlamaCppModuleForTest();
+    }
+  });
+
   test("redirects native stdout noise to stderr while JSON callers are initializing llama", async () => {
     const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
     const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
@@ -232,7 +246,7 @@ describe("native llama stdout containment", () => {
     } finally {
       stdoutSpy.mockRestore();
       stderrSpy.mockRestore();
-      setNodeLlamaCppModuleForTest(null);
+      resetNodeLlamaCppModuleForTest();
       if (prevGpu === undefined) delete process.env.QMD_LLAMA_GPU;
       else process.env.QMD_LLAMA_GPU = prevGpu;
       if (prevForceCpu === undefined) delete process.env.QMD_FORCE_CPU;
@@ -267,7 +281,7 @@ describe("native llama stdout containment", () => {
       expect(stderr).not.toContain("QMD_STATUS_DEVICE_PROBE");
     } finally {
       stderrSpy.mockRestore();
-      setNodeLlamaCppModuleForTest(null);
+      resetNodeLlamaCppModuleForTest();
       if (prevGpu === undefined) delete process.env.QMD_LLAMA_GPU;
       else process.env.QMD_LLAMA_GPU = prevGpu;
       if (prevForceCpu === undefined) delete process.env.QMD_FORCE_CPU;
@@ -324,7 +338,7 @@ describe("native llama stdout containment", () => {
     } finally {
       await llm.dispose();
       stderrSpy.mockRestore();
-      setNodeLlamaCppModuleForTest(null);
+      resetNodeLlamaCppModuleForTest();
       if (prevGpu === undefined) delete process.env.QMD_LLAMA_GPU;
       else process.env.QMD_LLAMA_GPU = prevGpu;
       if (prevForceCpu === undefined) delete process.env.QMD_FORCE_CPU;


### PR DESCRIPTION
## Summary

Make node-llama-cpp an optional dependency with graceful degradation

## Why this matters

`npm install -g @tobilu/qmd` aborts on Apple Silicon Macs running an x64 (Rosetta) Node, because `node-llama-cpp`'s own postinstall hard-fails with "llama.cpp is not supported under Rosetta on Apple Silicone Macs." Since `node-llama-cpp` is a hard `dependency`, its failed postinstall takes down the entire qmd install with a bare `npm error code 1` and no path forward. The maintainer (tobi, OWNER) posted a complete decision comment on 2026-06-06 selecting "option (b): make node-llama-cpp an optional dependency with graceful degradation" and spelled out the exact mechanism and behavioral contract. This plan implements that decision verbatim.

## Changes

Per tobi's spec: (1) move `node-llama-cpp` from `dependencies` to the existing `optionalDependencies` block in `package.json` so npm/pnpm treat its failed postinstall as non-fatal and qmd still installs. (2) In `src/llm.ts`, wrap the `loadNodeLlamaCpp()` dynamic import (the `withNativeStdoutRedirectedToStderr(() => import("node-llama-cpp"))` call around line 28) in a try/catch that returns `null` when the module is absent or its postinstall errored, instead of throwing. (3) In the LLM-requiring callers in `src/cli/qmd.ts` (`embed`, `query` expansion/reranking, `vsearch`, `pull`), detect the null module and throw the exact actionable error tobi specified: `node-llama-cpp is not available (postinstall failed -- likely Rosetta/x64 Node on Apple Silicon). Install a native arm64 Node from nodejs.org and reinstall: npm install -g @tobilu/qmd`. (4) Add the bonus `qmd doctor` arch check: if `process.platform === 'darwin' && process.arch === 'x64'`, emit a warning pointing users to native arm64 Node. The no-llama contract from the comment is load-bearing: `search`, `ls`, `get`, `multi-get`, `collection *`, `context *`, `status`, `doctor`, `mcp` (BM25 tools), and `update` (re-index without embedding) must all keep working when the module is null; only `embed`, `query`, `vsearch`, `pull` should fail with the clear error.

## Testing

- Happy path (module present): `embed`/`query`/`vsearch`/`pull` work unchanged; existing `test/llm.test.ts` and `test/cli-lazy-llm-import.test.ts` still pass.
- Module absent (simulate null via `setNodeLlamaCppModuleForTest(null)`): `search`, `ls`, `status`, `doctor` succeed; the four LLM commands throw the exact actionable error string, not an uncaught crash or raw module-resolution stack.
- Doctor arch check: on darwin+x64 the warning is emitted; on darwin+arm64 (and non-darwin) it is not.
- Install-level: confirm `package.json` move keeps the module in `optionalDependencies` only (no duplicate entry in `dependencies`) so a failed native postinstall no longer fails the top-level install.

Fixes #699
