### PR TITLE
fix(mcp): reap idle HTTP sessions

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -32,6 +32,9 @@ import {
 import { getConfigPath } from "../collections.js";
 import { enableProductionMode } from "../store.js";
 
+const DEFAULT_MCP_HTTP_SESSION_TTL_MS = 10 * 60 * 1000;
+const DEFAULT_MCP_HTTP_MAX_SESSIONS = 64;
+
 // =============================================================================
 // Types for structured content
 // =============================================================================
@@ -70,6 +73,16 @@ type StatusResult = {
 function encodeQmdPath(path: string): string {
   // Encode each path segment separately to preserve slashes
   return path.split('/').map(segment => encodeURIComponent(segment)).join('/');
+}
+
+function readNonNegativeIntegerEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) return fallback;
+
+  return parsed;
 }
 
 /**
@@ -602,9 +615,62 @@ export async function startMcpHttpServer(
   // Pre-fetch default collection names for REST endpoint
   const defaultCollectionNames = await store.getDefaultCollectionNames();
 
+  const sessionTtlMs = readNonNegativeIntegerEnv("QMD_MCP_SESSION_TTL_MS", DEFAULT_MCP_HTTP_SESSION_TTL_MS);
+  const maxSessions = readNonNegativeIntegerEnv("QMD_MCP_MAX_SESSIONS", DEFAULT_MCP_HTTP_MAX_SESSIONS);
+  const startTime = Date.now();
+  const quiet = options?.quiet ?? false;
+
+  /** Format timestamp for request logging */
+  function ts(): string {
+    return new Date().toISOString().slice(11, 23); // HH:mm:ss.SSS
+  }
+
+  function log(msg: string): void {
+    if (!quiet) console.error(msg);
+  }
+
   // Session map: each client gets its own McpServer + Transport pair (MCP spec requirement).
   // The store is shared — it's stateless SQLite, safe for concurrent access.
   const sessions = new Map<string, WebStandardStreamableHTTPServerTransport>();
+  const sessionLastSeen = new Map<string, number>();
+
+  async function closeSession(sessionId: string, reason: string): Promise<void> {
+    const transport = sessions.get(sessionId);
+    sessions.delete(sessionId);
+    sessionLastSeen.delete(sessionId);
+
+    if (!transport) return;
+
+    try {
+      await transport.close();
+    } catch (err) {
+      log(`${ts()} Failed to close session ${sessionId} (${reason}): ${String(err)}`);
+    }
+  }
+
+  async function reapSessions(reserveSlot: boolean): Promise<void> {
+    const now = Date.now();
+
+    if (sessionTtlMs > 0) {
+      for (const [sessionId, lastSeen] of sessionLastSeen) {
+        if (now - lastSeen >= sessionTtlMs) {
+          await closeSession(sessionId, "idle-timeout");
+        }
+      }
+    }
+
+    if (maxSessions <= 0) return;
+
+    const targetSize = reserveSlot ? Math.max(maxSessions - 1, 0) : maxSessions;
+    while (sessions.size > targetSize) {
+      const oldest = [...sessionLastSeen.entries()]
+        .filter(([sessionId]) => sessions.has(sessionId))
+        .sort((a, b) => a[1] - b[1])[0];
+
+      if (!oldest) return;
+      await closeSession(oldest[0], "max-sessions");
+    }
+  }
 
   async function createSession(): Promise<WebStandardStreamableHTTPServerTransport> {
     const transport = new WebStandardStreamableHTTPServerTransport({
@@ -612,6 +678,7 @@ export async function startMcpHttpServer(
       enableJsonResponse: true,
       onsessioninitialized: (sessionId: string) => {
         sessions.set(sessionId, transport);
+        sessionLastSeen.set(sessionId, Date.now());
         log(`${ts()} New session ${sessionId} (${sessions.size} active)`);
       },
     });
@@ -621,18 +688,11 @@ export async function startMcpHttpServer(
     transport.onclose = () => {
       if (transport.sessionId) {
         sessions.delete(transport.sessionId);
+        sessionLastSeen.delete(transport.sessionId);
       }
     };
 
     return transport;
-  }
-
-  const startTime = Date.now();
-  const quiet = options?.quiet ?? false;
-
-  /** Format timestamp for request logging */
-  function ts(): string {
-    return new Date().toISOString().slice(11, 23); // HH:mm:ss.SSS
   }
 
   type JsonRpcLikeBody = {
@@ -663,10 +723,6 @@ export async function startMcpHttpServer(
       return `tools/call ${tool}`;
     }
     return method;
-  }
-
-  function log(msg: string): void {
-    if (!quiet) console.error(msg);
   }
 
   // Helper to collect request body
@@ -758,6 +814,7 @@ export async function startMcpHttpServer(
 
         // Route to existing session or create new one on initialize
         const sessionId = headers["mcp-session-id"];
+        await reapSessions(!sessionId && isInitializeRequest(body));
         let transport: WebStandardStreamableHTTPServerTransport;
 
         if (sessionId) {
@@ -772,6 +829,7 @@ export async function startMcpHttpServer(
             return;
           }
           transport = existing;
+          sessionLastSeen.set(sessionId, Date.now());
         } else if (isInitializeRequest(body)) {
           transport = await createSession();
         } else {
@@ -801,6 +859,7 @@ export async function startMcpHttpServer(
 
         // GET/DELETE must have a valid session
         const sessionId = headers["mcp-session-id"];
+        await reapSessions(false);
         if (!sessionId) {
           nodeRes.writeHead(400, { "Content-Type": "application/json" });
           nodeRes.end(JSON.stringify({
@@ -820,6 +879,7 @@ export async function startMcpHttpServer(
           }));
           return;
         }
+        sessionLastSeen.set(sessionId, Date.now());
 
         const url = `http://localhost:${port}${pathname}`;
         const rawBody = nodeReq.method !== "GET" && nodeReq.method !== "HEAD" ? await collectBody(nodeReq) : undefined;
@@ -850,10 +910,11 @@ export async function startMcpHttpServer(
   const stop = async () => {
     if (stopping) return;
     stopping = true;
-    for (const transport of sessions.values()) {
-      await transport.close();
+    for (const sessionId of [...sessions.keys()]) {
+      await closeSession(sessionId, "shutdown");
     }
     sessions.clear();
+    sessionLastSeen.clear();
     httpServer.close();
     await store.close();
   };

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1049,6 +1049,83 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
     return { status: res.status, json, contentType: res.headers.get("content-type") };
   }
 
+  type McpHttpResponse = {
+    status: number;
+    json: unknown;
+    contentType: string | null;
+    sessionId: string | null;
+  };
+
+  function initializeRequest(id: number): object {
+    return {
+      jsonrpc: "2.0",
+      id,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "test-client", version: "1.0.0" },
+      },
+    };
+  }
+
+  function toolsListRequest(id: number): object {
+    return {
+      jsonrpc: "2.0",
+      id,
+      method: "tools/list",
+      params: {},
+    };
+  }
+
+  function expectSessionId(value: string | null): asserts value is string {
+    expect(value).toEqual(expect.any(String));
+  }
+
+  async function mcpRequestTo(targetBaseUrl: string, body: object, requestSessionId?: string): Promise<McpHttpResponse> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "Accept": "application/json, text/event-stream",
+    };
+    if (requestSessionId) headers["mcp-session-id"] = requestSessionId;
+
+    const res = await fetch(`${targetBaseUrl}/mcp`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    return {
+      status: res.status,
+      json: await res.json(),
+      contentType: res.headers.get("content-type"),
+      sessionId: res.headers.get("mcp-session-id"),
+    };
+  }
+
+  async function withMcpHttpEnv(
+    env: Record<string, string>,
+    fn: (targetBaseUrl: string) => Promise<void>,
+  ): Promise<void> {
+    const previous = new Map<string, string | undefined>();
+    for (const key of Object.keys(env)) {
+      previous.set(key, process.env[key]);
+      process.env[key] = env[key];
+    }
+
+    let scopedHandle: HttpServerHandle | null = null;
+    try {
+      scopedHandle = await startMcpHttpServer(0, { quiet: true });
+      await fn(`http://localhost:${scopedHandle.port}`);
+    } finally {
+      if (scopedHandle) await scopedHandle.stop();
+      for (const [key, value] of previous) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  }
+
   test("POST /mcp initialize returns 200 JSON (not SSE)", async () => {
     const { status, json, contentType } = await mcpRequest({
       jsonrpc: "2.0",
@@ -1065,6 +1142,47 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
     expect(json.jsonrpc).toBe("2.0");
     expect(json.id).toBe(1);
     expect(json.result.serverInfo.name).toBe("qmd");
+  });
+
+  test("POST /mcp reaps idle sessions that clients never delete", async () => {
+    await withMcpHttpEnv({ QMD_MCP_SESSION_TTL_MS: "1" }, async (targetBaseUrl) => {
+      const first = await mcpRequestTo(targetBaseUrl, initializeRequest(1));
+      expectSessionId(first.sessionId);
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const second = await mcpRequestTo(targetBaseUrl, initializeRequest(2));
+      expectSessionId(second.sessionId);
+
+      const stale = await mcpRequestTo(targetBaseUrl, toolsListRequest(3), first.sessionId);
+      expect(stale.status).toBe(404);
+      expect(stale.json).toMatchObject({
+        jsonrpc: "2.0",
+        error: { code: -32001, message: "Session not found" },
+      });
+    });
+  });
+
+  test("POST /mcp caps active sessions and evicts the oldest", async () => {
+    await withMcpHttpEnv({ QMD_MCP_MAX_SESSIONS: "2" }, async (targetBaseUrl) => {
+      const first = await mcpRequestTo(targetBaseUrl, initializeRequest(1));
+      expectSessionId(first.sessionId);
+      const second = await mcpRequestTo(targetBaseUrl, initializeRequest(2));
+      expectSessionId(second.sessionId);
+      const third = await mcpRequestTo(targetBaseUrl, initializeRequest(3));
+      expectSessionId(third.sessionId);
+
+      const evicted = await mcpRequestTo(targetBaseUrl, toolsListRequest(4), first.sessionId);
+      expect(evicted.status).toBe(404);
+      expect(evicted.json).toMatchObject({
+        jsonrpc: "2.0",
+        error: { code: -32001, message: "Session not found" },
+      });
+
+      const stillActive = await mcpRequestTo(targetBaseUrl, toolsListRequest(5), second.sessionId);
+      expect(stillActive.status).toBe(200);
+      expect(stillActive.contentType).toContain("application/json");
+    });
   });
 
   test("POST /mcp tools/list returns registered tools", async () => {


### PR DESCRIPTION
## Summary
- Add idle-session cleanup for Streamable HTTP MCP clients that do not send `DELETE /mcp`.
- Add a configurable active-session cap to prevent unbounded session growth.
- Cover both idle cleanup and oldest-session eviction with HTTP transport regression tests.

## Changes
- Tracks `lastSeen` timestamps for MCP HTTP sessions.
- Reaps idle sessions using `QMD_MCP_SESSION_TTL_MS` (default: 10 minutes, `0` disables).
- Caps active sessions using `QMD_MCP_MAX_SESSIONS` (default: 64, `0` disables).
- Clears tracking state when sessions close or the server shuts down.

## Testing
- `bun run test:types`
- `env -u CI node ./node_modules/vitest/vitest.mjs run --reporter=verbose --testTimeout 60000 test/mcp.test.ts -t "MCP HTTP Transport"`
- `bun run build`
