### PR TITLE
docs: rename MCP search tool heading `structured_search` -> `query`

### DIFF
--- a/skills/qmd/references/mcp-setup.md
+++ b/skills/qmd/references/mcp-setup.md
@@ -49,7 +49,7 @@ qmd mcp stop                # Stop daemon
 
 ## Tools
 
-### structured_search
+### query
 
 Search with pre-expanded queries.
 


### PR DESCRIPTION
## What

Renames the MCP search tool heading in `skills/qmd/references/mcp-setup.md` from `structured_search` to `query`.

## Why

The tool was renamed `structured_search` → `query` (documented in the CHANGELOG, present at/before 2.1.0 and still in 2.5.3), but this setup reference was never updated. The binary exposes `query`, and `skills/qmd/SKILL.md` already documents it as `query` — only `mcp-setup.md` lagged.

The parameter shape (`searches[]`, `limit`, `collection`, `minScore`) is unchanged, so only the heading needed updating.

Closes #741
