### PR TITLE
fix(db): make concurrent store initialization safe

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -781,90 +781,6 @@ function sanitizeFTS5Phrase(phrase: string): string {
     .join(' ');
 }
 
-function rebuildFTSForCjkNormalization(db: Database): void {
-  const version = db.prepare(`SELECT value FROM store_config WHERE key = 'fts_cjk_normalized_version'`).get() as { value?: string } | undefined;
-  if (version?.value === FTS_CJK_NORMALIZED_VERSION) return;
-
-  // Stream rows from disk and build into a shadow FTS table, committing in
-  // small batches. The previous implementation cleared documents_fts up front
-  // and loaded every body into memory via .all() inside one transaction; on a
-  // large library that OOMs the process AND leaves FTS empty if it crashes
-  // mid-rebuild. Building a separate documents_fts_rebuild table and only
-  // atomically swapping it in at the very end means the live FTS index keeps
-  // serving queries until the new index is complete, and a crash leaves the
-  // old index intact (the half-built shadow table is dropped on next run).
-  const BATCH_SIZE = 500;
-
-  // A shadow table may linger from a prior crashed run — start clean.
-  db.exec(`DROP TABLE IF EXISTS documents_fts_rebuild`);
-  db.exec(`
-    CREATE VIRTUAL TABLE documents_fts_rebuild USING fts5(
-      filepath, title, body,
-      tokenize='porter unicode61'
-    )
-  `);
-
-  type FtsRow = { id: number; collection: string; path: string; title: string; body: string };
-
-  const insert = db.prepare(`INSERT INTO documents_fts_rebuild(rowid, filepath, title, body) VALUES (?, ?, ?, ?)`);
-
-  // The transaction closes over a mutable `batch` buffer rather than taking the
-  // batch as an argument: the wrapper's transaction() type only accepts scalar
-  // SQLiteValue args, and we want each commit to wrap a bounded set of inserts.
-  let batch: FtsRow[] = [];
-  const flushBatch = db.transaction(() => {
-    for (const row of batch) {
-      insert.run(
-        row.id,
-        normalizeCjkForFTS(`${row.collection}/${row.path}`),
-        normalizeCjkForFTS(row.title),
-        normalizeCjkForFTS(row.body)
-      );
-    }
-  });
-
-  // .iterate() pulls rows one at a time from SQLite rather than materializing
-  // the entire result set (every document body) into a JS array up front.
-  const iterator = db.prepare(`
-    SELECT d.id, d.collection, d.path, d.title, content.doc as body
-    FROM documents d
-    JOIN content ON content.hash = d.hash
-    WHERE d.active = 1
-  `).iterate<FtsRow>();
-
-  for (const row of iterator) {
-    batch.push(row);
-    if (batch.length >= BATCH_SIZE) {
-      flushBatch();
-      batch = [];
-    }
-  }
-  if (batch.length > 0) {
-    flushBatch();
-  }
-
-  // Atomic swap: copy the completed shadow index into the live table and drop
-  // the shadow. Using INSERT INTO … SELECT + DROP avoids ALTER TABLE … RENAME,
-  // which on SQLite ≥ 3.25 re-validates every trigger body that references the
-  // renamed table — the documents_ai/documents_au triggers reference
-  // documents_fts by name, so renaming after a DROP fails with
-  // "no such table: main.documents_fts". The copy+drop path leaves the live
-  // table and its triggers untouched until the transaction commits.
-  const swap = db.transaction(() => {
-    db.exec(`DELETE FROM documents_fts`);
-    db.exec(
-      `INSERT INTO documents_fts(rowid, filepath, title, body)
-       SELECT rowid, filepath, title, body FROM documents_fts_rebuild`
-    );
-    db.exec(`DROP TABLE documents_fts_rebuild`);
-    db.prepare(`
-      INSERT OR REPLACE INTO store_config(key, value)
-      VALUES ('fts_cjk_normalized_version', ?)
-    `).run(FTS_CJK_NORMALIZED_VERSION);
-  });
-  swap();
-}
-
 function getUserVersion(db: Database): number {
   const row = db.prepare(`PRAGMA user_version`).get() as Record<string, number> | undefined;
   const value = row ? Object.values(row)[0] : 0;
@@ -932,6 +848,109 @@ function applyFtsSyncTriggers(db: Database): void {
   } catch (err) {
     db.exec(`ROLLBACK`);
     throw err;
+  }
+}
+
+function cjkRebuildVersion(db: Database): string | undefined {
+  const version = db.prepare(`SELECT value FROM store_config WHERE key = 'fts_cjk_normalized_version'`).get() as { value?: string } | undefined;
+  return version?.value;
+}
+
+function quoteSqlIdentifier(identifier: string): string {
+  return `"${identifier.replace(/"/g, '""')}"`;
+}
+
+function dropTableIfExists(db: Database, tableName: string): void {
+  db.exec(`DROP TABLE IF EXISTS ${quoteSqlIdentifier(tableName)}`);
+}
+
+function rebuildFTSForCjkNormalization(db: Database): void {
+  if (cjkRebuildVersion(db) === FTS_CJK_NORMALIZED_VERSION) return;
+
+  // Clean up the legacy fixed-name shadow table left by an interrupted older
+  // rebuild implementation. New concurrent rebuilds use per-process names below.
+  dropTableIfExists(db, "documents_fts_rebuild");
+
+  // Stream rows from disk and build into a per-process shadow FTS table. A fixed
+  // shadow name made concurrent cold opens collide (`database is locked`, then
+  // `no such table: documents_fts_rebuild`) before the schema version could be
+  // stamped. The final live-table swap is protected by BEGIN IMMEDIATE and a
+  // double-checked version read, so only one process publishes the rebuild.
+  const BATCH_SIZE = 500;
+  const rebuildTable = `documents_fts_rebuild_${process.pid}_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+  const quotedRebuildTable = quoteSqlIdentifier(rebuildTable);
+
+  try {
+    db.exec(`
+      CREATE VIRTUAL TABLE ${quotedRebuildTable} USING fts5(
+        filepath, title, body,
+        tokenize='porter unicode61'
+      )
+    `);
+
+    type FtsRow = { id: number; collection: string; path: string; title: string; body: string };
+
+    const insert = db.prepare(`INSERT INTO ${quotedRebuildTable}(rowid, filepath, title, body) VALUES (?, ?, ?, ?)`);
+
+    // The transaction closes over a mutable `batch` buffer rather than taking the
+    // batch as an argument: the wrapper's transaction() type only accepts scalar
+    // SQLiteValue args, and we want each commit to wrap a bounded set of inserts.
+    let batch: FtsRow[] = [];
+    const flushBatch = db.transaction(() => {
+      for (const row of batch) {
+        insert.run(
+          row.id,
+          normalizeCjkForFTS(`${row.collection}/${row.path}`),
+          normalizeCjkForFTS(row.title),
+          normalizeCjkForFTS(row.body)
+        );
+      }
+    });
+
+    // .iterate() pulls rows one at a time from SQLite rather than materializing
+    // the entire result set (every document body) into a JS array up front.
+    const iterator = db.prepare(`
+      SELECT d.id, d.collection, d.path, d.title, content.doc as body
+      FROM documents d
+      JOIN content ON content.hash = d.hash
+      WHERE d.active = 1
+    `).iterate<FtsRow>();
+
+    for (const row of iterator) {
+      batch.push(row);
+      if (batch.length >= BATCH_SIZE) {
+        flushBatch();
+        batch = [];
+      }
+    }
+    if (batch.length > 0) {
+      flushBatch();
+    }
+
+    // Atomic publish: copy the completed shadow index into the live table and
+    // stamp the version while holding the writer lock. If another process won
+    // the race while this one was building its shadow, skip the publish and only
+    // drop this process's private shadow table.
+    db.exec(`BEGIN IMMEDIATE`);
+    try {
+      if (cjkRebuildVersion(db) !== FTS_CJK_NORMALIZED_VERSION) {
+        db.exec(`DELETE FROM documents_fts`);
+        db.exec(
+          `INSERT INTO documents_fts(rowid, filepath, title, body)
+           SELECT rowid, filepath, title, body FROM ${quotedRebuildTable}`
+        );
+        db.prepare(`
+          INSERT OR REPLACE INTO store_config(key, value)
+          VALUES ('fts_cjk_normalized_version', ?)
+        `).run(FTS_CJK_NORMALIZED_VERSION);
+      }
+      db.exec(`COMMIT`);
+    } catch (err) {
+      db.exec(`ROLLBACK`);
+      throw err;
+    }
+  } finally {
+    dropTableIfExists(db, rebuildTable);
   }
 }
 

--- a/test/_helpers/store-init-worker.ts
+++ b/test/_helpers/store-init-worker.ts
@@ -1,10 +1,9 @@
 /**
  * store-init-worker - one subprocess that opens a store and exits.
  *
- * Spawned N-up by store-concurrency.test.ts to reproduce the cross-connection
- * schema-init race. Each worker busy-waits until a shared wall-clock start time
- * so every process hits initializeDatabase at once, then opens the store. Exits
- * 0 on success, 1 if createStore throws (e.g. "trigger already exists").
+ * Spawned N-up by store-concurrency.test.ts to reproduce cross-connection
+ * schema-init races. Each worker busy-waits until a shared wall-clock start
+ * time so every process hits initializeDatabase at once, then opens the store.
  */
 import { createStore } from "../../src/store.ts";
 
@@ -17,7 +16,7 @@ if (!dbPath) {
 }
 
 while (Date.now() < startAtMs) {
-  // Align all workers to the same start so their DROP/CREATE windows overlap.
+  // Align all workers to the same start so their schema-init windows overlap.
 }
 
 try {

--- a/test/store-concurrency.test.ts
+++ b/test/store-concurrency.test.ts
@@ -1,14 +1,8 @@
 /**
  * store-concurrency.test.ts - concurrent schema-init safety
  *
- * Reproduces the cross-connection race where two processes opening the same
- * database interleave the FTS trigger DROP+CREATE and collide with "trigger
- * already exists". JavaScript is single-threaded, so the race only appears
- * across OS processes — each case spawns N workers that open the store at once.
- *
- * Fails against the pre-fix DROP+CREATE-on-every-open code; passes once the
- * trigger rebuild is gated by PRAGMA user_version inside an IMMEDIATE
- * transaction.
+ * Reproduces cross-process races in cold store initialization: WAL migration,
+ * FTS sync trigger rebuild, and CJK FTS normalization shadow-table rebuild.
  */
 import { describe, test, expect } from "vitest";
 import { mkdtemp, rm } from "node:fs/promises";
@@ -24,7 +18,7 @@ const workerScript = join(thisDir, "_helpers", "store-init-worker.ts");
 const tsxCli = join(projectRoot, "node_modules", "tsx", "dist", "cli.mjs");
 const isBunRuntime = typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
 
-const WORKERS = 12;
+const WORKERS = isBunRuntime ? (process.platform === "darwin" ? 16 : 12) : 6;
 
 type WorkerResult = { code: number | null; stderr: string };
 
@@ -69,13 +63,23 @@ function expectSchemaIntact(dbPath: string): void {
 
     const versionRow = db.prepare(`PRAGMA user_version`).get() as Record<string, number>;
     expect(Object.values(versionRow)[0]).toBeGreaterThanOrEqual(1);
+
+    const cjkVersion = db
+      .prepare(`SELECT value FROM store_config WHERE key = 'fts_cjk_normalized_version'`)
+      .get() as { value?: string } | undefined;
+    expect(cjkVersion?.value).toBe("1");
+
+    const leakedShadow = db
+      .prepare(`SELECT name FROM sqlite_master WHERE name LIKE 'documents_fts_rebuild%'`)
+      .all() as { name: string }[];
+    expect(leakedShadow).toHaveLength(0);
   } finally {
     db.close();
   }
 }
 
 describe("concurrent store initialization", () => {
-  test("cold database: N processes initialize without colliding on triggers", async () => {
+  test("cold database: N processes initialize without colliding on FTS setup", async () => {
     const dir = await mkdtemp(join(tmpdir(), "qmd-store-concurrency-"));
     const dbPath = join(dir, "index.sqlite");
     try {
@@ -91,8 +95,6 @@ describe("concurrent store initialization", () => {
     const dir = await mkdtemp(join(tmpdir(), "qmd-store-concurrency-"));
     const dbPath = join(dir, "index.sqlite");
     try {
-      // Stamp the schema once, single-process, so every concurrent reopen takes
-      // the version-gated fast path.
       const [seed] = await openConcurrently(dbPath, 1);
       expect(seed.code).toBe(0);
 


### PR DESCRIPTION
Supersedes draft #744 with the same tested commit, but opened non-draft so it can be merged once checks are green.

## Summary
- make concurrent store initialization safe across processes
- avoid CJK FTS shadow-table collisions by using per-process rebuild tables
- keep cleanup for legacy fixed-name `documents_fts_rebuild` tables
- add process-level concurrency coverage

## Verification
- PR #744 CI passed on commit `b5e0a123bc770351792511d8a8dc754998a609be`
- local targeted Bun concurrency test passed

No squash merge.