### PR TITLE
chore: release v2.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.6.3] - 2026-06-24
+
 ### Added
 
 - `qmd embed --timeout <minutes>` overrides the embed session's max duration

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tobilu/qmd",
-  "version": "2.5.3",
+  "version": "2.6.3",
   "description": "Query Markup Documents - On-device hybrid search for markdown files with BM25, vector search, and LLM reranking",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump package version from 2.5.3 to 2.6.3 (+0.1.0)
- cut the current changelog entries under 2.6.3 dated 2026-06-24

## Verification
- `node -e "const p=require('./package.json'); if(p.version!=='2.6.3') process.exit(1); console.log(p.name, p.version)"`
- `git diff --check`

Full matrix should run on the PR before merge. No squash merge.