### PR TITLE
feat: add per-collection allowDotDirs to index hidden directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- `allowDotDirs` per-collection config: opt specific dot-prefixed directories
+  (e.g. `.aidocs`) back into indexing. Hidden files/dirs are skipped by default;
+  list the dot-dirs you want indexed and everything else dot-prefixed (`.git`,
+  `.cache`, …) stays excluded. YAML-only; defaults to none, so existing setups
+  are unaffected.
+
 ## [2.6.3] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -694,6 +694,7 @@ collections:
     ignore:                      # glob patterns to exclude from indexing
       - "Archive/**"
       - "**/drafts/**"
+    allowDotDirs: [".aidocs"]    # dot-dirs to index (hidden dirs are skipped by default)
     update: "git pull --rebase"  # bash command run before each `qmd update`
     includeByDefault: true       # include in unscoped queries (default: true)
     context:                     # path prefix → description; longest match wins
@@ -709,6 +710,7 @@ collections:
 | `collections.<name>.path` | per-collection | Absolute directory to index. |
 | `collections.<name>.pattern` | per-collection | Glob mask. Set via `qmd collection add --mask`. Default `**/*.md`. |
 | `collections.<name>.ignore` | per-collection | Glob patterns excluded from indexing — useful to stop nested collections double-indexing. **YAML-only — no CLI command sets this.** Additive with QMD's built-in exclusions (`node_modules`, `.git`, `.cache`, `vendor`, `dist`, `build`), which you cannot un-ignore. |
+| `collections.<name>.allowDotDirs` | per-collection | Dot-prefixed directory names to index even though hidden files/dirs are skipped by default (e.g. `[".aidocs"]`). Every other dot-prefixed segment (`.git`, `.cache`, …) stays excluded. **YAML-only.** Default: none (no dot-dirs indexed — unchanged behavior). |
 | `collections.<name>.update` | per-collection | Bash command run before `qmd update` re-indexes this collection. Set via `qmd collection update-cmd`. |
 | `collections.<name>.includeByDefault` | per-collection | Whether unscoped queries search it. Toggle with `qmd collection include`/`exclude`. Default `true`. |
 | `collections.<name>.context` | per-collection | Path-prefix → description map; the most specific (longest) matching prefix wins. Set via `qmd context add`. |

--- a/example-index.yml
+++ b/example-index.yml
@@ -76,6 +76,18 @@ collections:
       "/api": "API reference and endpoint docs"
       "/guides": "How-to guides and tutorials"
 
+  # ── Index hidden (dot-prefixed) directories ────────────────────────────────
+  # Hidden files/dirs are skipped by default. List the dot-dirs you want indexed
+  # via `allowDotDirs`; everything else dot-prefixed (.git, .cache, …) stays
+  # excluded. Useful for agent/tooling dirs like .aidocs that hold real docs.
+  agent-notes:
+    path: ~/work/project
+    pattern: "**/*.md"
+    allowDotDirs:
+      - ".aidocs"             # index .aidocs/ (AI session notes, plans, research)
+    context:
+      "/": "Project docs including .aidocs/ agent notes"
+
   # ── Exclude from default searches ──────────────────────────────────────────
   # includeByDefault: false → skipped unless you name it: qmd query -c vendor "..."
   # Set via CLI: qmd collection exclude vendor

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -721,6 +721,7 @@ async function updateCollections(): Promise<void> {
 
     const result = await reindexCollection(storeInstance, col.pwd, col.glob_pattern, col.name, {
       ignorePatterns: yamlCol?.ignore,
+      allowDotDirs: yamlCol?.allowDotDirs,
       onProgress: (info) => {
         progress.set((info.current / info.total) * 100);
         const elapsed = (Date.now() - startTime) / 1000;
@@ -1596,7 +1597,7 @@ async function collectionAdd(pwd: string, globPattern: string, name?: string): P
   // Create the collection and index files
   console.log(`Creating collection '${collName}'...`);
   const newColl = getCollectionFromYaml(collName);
-  await indexFiles(pwd, globPattern, collName, false, newColl?.ignore);
+  await indexFiles(pwd, globPattern, collName, false, newColl?.ignore, newColl?.allowDotDirs);
   console.log(`${c.green}✓${c.reset} Collection '${collName}' created successfully`);
 }
 
@@ -1649,7 +1650,7 @@ function collectionRename(oldName: string, newName: string): void {
   console.log(`  Virtual paths updated: ${c.cyan}qmd://${oldName}/${c.reset} → ${c.cyan}qmd://${newName}/${c.reset}`);
 }
 
-async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, collectionName?: string, suppressEmbedNotice: boolean = false, ignorePatterns?: string[]): Promise<void> {
+async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, collectionName?: string, suppressEmbedNotice: boolean = false, ignorePatterns?: string[], allowDotDirs?: string[]): Promise<void> {
   const db = getDb();
   const resolvedPwd = pwd || getPwd();
   const now = new Date().toISOString();
@@ -1670,17 +1671,18 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
     ...excludeDirs.map(d => `**/${d}/**`),
     ...(ignorePatterns || []),
   ];
+  const allowedDotDirs = allowDotDirs ?? [];
   const allFiles: string[] = await fastGlob(globPattern, {
     cwd: resolvedPwd,
     onlyFiles: true,
     followSymbolicLinks: false,
-    dot: false,
+    dot: allowedDotDirs.length > 0,
     ignore: allIgnore,
   });
-  // Filter hidden files/folders (dot: false handles top-level but not nested)
+  // Filter hidden files/folders, except dot-dirs explicitly allowed by the collection
   const files = allFiles.filter(file => {
     const parts = file.split("/");
-    return !parts.some(part => part.startsWith("."));
+    return !parts.some(part => part.startsWith(".") && !allowedDotDirs.includes(part));
   });
 
   const total = files.length;

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -28,6 +28,7 @@ export interface Collection {
   path: string;              // Absolute path to index
   pattern: string;           // Glob pattern (e.g., "**/*.md")
   ignore?: string[];         // Glob patterns to exclude (e.g., ["Sessions/**"])
+  allowDotDirs?: string[];   // Dot-prefixed dir segments to index despite the default hidden-file skip (e.g., [".aidocs"])
   context?: ContextMap;      // Optional context definitions
   update?: string;           // Optional bash command to run during qmd update
   includeByDefault?: boolean; // Include in queries by default (default: true)

--- a/src/index.ts
+++ b/src/index.ts
@@ -501,6 +501,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
       for (const col of filtered) {
         const result = await reindexCollection(internal, col.path, col.pattern || "**/*.md", col.name, {
           ignorePatterns: col.ignore,
+          allowDotDirs: col.allowDotDirs,
           onProgress: updateOpts?.onProgress
             ? (info) => updateOpts.onProgress!({ collection: col.name, ...info })
             : undefined,

--- a/src/store.ts
+++ b/src/store.ts
@@ -1033,11 +1033,19 @@ function initializeDatabase(db: Database): void {
       path TEXT NOT NULL,
       pattern TEXT NOT NULL DEFAULT '**/*.md',
       ignore_patterns TEXT,
+      allow_dot_dirs TEXT,
       include_by_default INTEGER DEFAULT 1,
       update_command TEXT,
       context TEXT
     )
   `);
+  // Migrate older DBs that predate the allow_dot_dirs column (idempotent).
+  try {
+    db.exec(`ALTER TABLE store_collections ADD COLUMN allow_dot_dirs TEXT`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes("duplicate column name")) throw error;
+  }
 
   // Store config — key-value metadata (e.g. config_hash for sync optimization)
   db.exec(`
@@ -1069,6 +1077,7 @@ type StoreCollectionRow = {
   path: string;
   pattern: string;
   ignore_patterns: string | null;
+  allow_dot_dirs: string | null;
   include_by_default: number;
   update_command: string | null;
   context: string | null;
@@ -1080,6 +1089,7 @@ function rowToNamedCollection(row: StoreCollectionRow): NamedCollection {
     path: row.path,
     pattern: row.pattern,
     ...(row.ignore_patterns ? { ignore: JSON.parse(row.ignore_patterns) as string[] } : {}),
+    ...(row.allow_dot_dirs ? { allowDotDirs: JSON.parse(row.allow_dot_dirs) as string[] } : {}),
     ...(row.include_by_default === 0 ? { includeByDefault: false } : {}),
     ...(row.update_command ? { update: row.update_command } : {}),
     ...(row.context ? { context: JSON.parse(row.context) as ContextMap } : {}),
@@ -1126,12 +1136,13 @@ export function getStoreContexts(db: Database): Array<{ collection: string; path
 
 export function upsertStoreCollection(db: Database, name: string, collection: Omit<Collection, 'pattern'> & { pattern?: string }): void {
   db.prepare(`
-    INSERT INTO store_collections (name, path, pattern, ignore_patterns, include_by_default, update_command, context)
-    VALUES (?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO store_collections (name, path, pattern, ignore_patterns, allow_dot_dirs, include_by_default, update_command, context)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(name) DO UPDATE SET
       path = excluded.path,
       pattern = excluded.pattern,
       ignore_patterns = excluded.ignore_patterns,
+      allow_dot_dirs = excluded.allow_dot_dirs,
       include_by_default = excluded.include_by_default,
       update_command = excluded.update_command,
       context = excluded.context
@@ -1140,6 +1151,7 @@ export function upsertStoreCollection(db: Database, name: string, collection: Om
     collection.path,
     collection.pattern || '**/*.md',
     collection.ignore ? JSON.stringify(collection.ignore) : null,
+    collection.allowDotDirs ? JSON.stringify(collection.allowDotDirs) : null,
     collection.includeByDefault === false ? 0 : 1,
     collection.update || null,
     collection.context ? JSON.stringify(collection.context) : null,
@@ -1370,6 +1382,7 @@ export async function reindexCollection(
   collectionName: string,
   options?: {
     ignorePatterns?: string[];
+    allowDotDirs?: string[];
     onProgress?: (info: ReindexProgress) => void;
   }
 ): Promise<ReindexResult> {
@@ -1381,17 +1394,21 @@ export async function reindexCollection(
     ...excludeDirs.map(d => `**/${d}/**`),
     ...(options?.ignorePatterns || []),
   ];
+  // Hidden (dot-prefixed) files/dirs are skipped by default. A collection can opt
+  // specific dot-dirs back in via `allowDotDirs` (e.g. [".aidocs"]); every other
+  // dot-prefixed segment (.git, .cache, …) stays excluded.
+  const allowDotDirs = options?.allowDotDirs ?? [];
   const allFiles: string[] = await fastGlob(globPattern, {
     cwd: collectionPath,
     onlyFiles: true,
     followSymbolicLinks: false,
-    dot: false,
+    dot: allowDotDirs.length > 0,
     ignore: allIgnore,
   });
-  // Filter hidden files/folders
+  // Filter hidden files/folders, except dot-dirs explicitly allowed by the collection
   const files = allFiles.filter(file => {
     const parts = file.split("/");
-    return !parts.some(part => part.startsWith("."));
+    return !parts.some(part => part.startsWith(".") && !allowDotDirs.includes(part));
   });
 
   const total = files.length;

--- a/test/allow-dot-dirs.test.ts
+++ b/test/allow-dot-dirs.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Integration tests for the per-collection `allowDotDirs` config.
+ *
+ * Hidden (dot-prefixed) files/dirs are skipped by default. `allowDotDirs` opts
+ * specific dot-dirs back into indexing, while every other dot-prefixed segment
+ * (.git, .cache, …) stays excluded.
+ */
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, writeFile, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createStore } from "../src/index.js";
+
+let root: string;
+
+beforeAll(async () => {
+  root = await mkdtemp(join(tmpdir(), "qmd-allow-dot-dirs-"));
+  await mkdir(join(root, "docs"), { recursive: true });
+  await mkdir(join(root, ".aidocs", "sessions"), { recursive: true });
+  await mkdir(join(root, ".git"), { recursive: true });
+  await writeFile(join(root, "docs", "readme.md"), "# Readme\n\nPublic guide.\n");
+  await writeFile(join(root, ".aidocs", "sessions", "agentnote.md"), "# Session note\n\nAgent session summary.\n");
+  await writeFile(join(root, ".git", "gitinternal.md"), "# Git internals\n\nShould never be indexed.\n");
+});
+
+afterAll(async () => {
+  try {
+    await rm(root, { recursive: true, force: true });
+  } catch {
+    // ignore cleanup errors
+  }
+});
+
+function freshDb(): string {
+  return join(root, `idx-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+}
+
+async function indexedPaths(allowDotDirs?: string[]): Promise<string> {
+  const store = await createStore({
+    dbPath: freshDb(),
+    config: {
+      collections: {
+        proj: { path: root, pattern: "**/*.md", ...(allowDotDirs ? { allowDotDirs } : {}) },
+      },
+    },
+  });
+  await store.update();
+  const rows = (store.internal as { db: { prepare(sql: string): { all(): unknown[] } } }).db
+    .prepare("SELECT path FROM documents WHERE active = 1")
+    .all() as { path: string }[];
+  await store.close();
+  return rows.map(r => r.path).join("\n");
+}
+
+describe("allowDotDirs", () => {
+  test("dot-dirs are skipped by default (unchanged behavior)", async () => {
+    const paths = await indexedPaths();
+    expect(paths).toContain("readme");
+    expect(paths).not.toContain("agentnote"); // .aidocs/ not indexed
+    expect(paths).not.toContain("gitinternal"); // .git/ not indexed
+  });
+
+  test("listed dot-dirs are indexed; other dot-dirs stay excluded", async () => {
+    const paths = await indexedPaths([".aidocs"]);
+    expect(paths).toContain("readme");
+    expect(paths).toContain("agentnote"); // .aidocs/sessions/agentnote.md indexed
+    expect(paths).not.toContain("gitinternal"); // .git/ still excluded
+  });
+});


### PR DESCRIPTION
## Problem

Hidden (dot-prefixed) files and directories are skipped unconditionally during indexing — `reindexCollection` walks with `dot: false` and then filters out any path segment starting with `.`. That's the right default, but it also excludes dot-dirs that hold real, indexable docs.

The case that motivated this: an `.aidocs/` directory holding agent session notes, plans, and research that I genuinely want searchable, kept out of the visible tree via the leading dot. Today the only workaround is patching `node_modules`, which gets wiped on every `npm install`.

## Solution

A per-collection opt-in whitelist, `allowDotDirs`:

```yaml
collections:
  project:
    path: ~/work/project
    pattern: "**/*.md"
    allowDotDirs: [".aidocs"]   # index .aidocs/; .git, .cache, … stay excluded
```

When set, the walk uses `dot: true` and the hidden-file filter keeps only the listed dot-dir segments; every other dot-prefixed segment (`.git`, `.cache`, …) — and the hardcoded `excludeDirs` — still get excluded.

**Backward compatible:** defaults to none, so unconfigured collections behave exactly as before (all dot-dirs skipped).

## Scope

- `Collection.allowDotDirs?: string[]` config field.
- Honored by `reindexCollection` (the `qmd update` path) and the CLI `indexFiles` (the `qmd collection add` initial index).
- Persisted to `store_collections` (new nullable `allow_dot_dirs` column + idempotent migration), so the SDK `store.update()` — which reads collections from SQLite — honors it too.
- Docs: README config table + `example-index.yml` + CHANGELOG.

## Tests

`test/allow-dot-dirs.test.ts` verifies that dot-dirs are skipped by default, and that a listed dot-dir (`.aidocs`) gets indexed while `.git` stays excluded. Full suite green locally (`store.test.ts`, `sdk.test.ts`, type-check).

Happy to adjust the field name or split the persistence out if you'd prefer a smaller surface.
