### PR TITLE
Expose reranker score in MCP/REST explain output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+
+- MCP `query` and HTTP REST `/query`/`/search` accept `explain: true` and expose
+  a top-level `rerankScore` per result: the raw LLM reranker relevance score from
+  `explain.rerankScore` (or `null` when reranking is disabled). Default responses
+  are unchanged unless `explain` is requested.
+
 ## [2.6.3] - 2026-06-24
 
 ### Added

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -26,6 +26,7 @@ import {
   getDefaultDbPath,
   DEFAULT_MULTI_GET_MAX_BYTES,
   type QMDStore,
+  type HybridQueryResult,
   type ExpandedQuery,
   type IndexStatus,
 } from "../index.js";
@@ -44,6 +45,8 @@ type SearchResultItem = {
   context: string | null;
   line: number;   // Absolute line in source markdown
   snippet: string;
+  rerankScore?: number | null;
+  explain?: HybridQueryResult["explain"] | null;
 };
 
 type StatusResult = {
@@ -84,6 +87,16 @@ function formatSearchSummary(results: SearchResultItem[], query: string): string
     lines.push(`${r.docid} ${Math.round(r.score * 100)}% ${r.file} - ${r.title}`);
   }
   return lines.join('\n');
+}
+
+export function semanticRerankScoreOrNull(result: Pick<HybridQueryResult, "explain">, rerankArg?: boolean): number | null {
+  if (rerankArg === false) return null;
+  const score = result.explain?.rerankScore;
+  if (typeof score !== "number") return null;
+  // skipRerank uses explain.rerankScore=0 as an internal sentinel with rrf.weight=1.0;
+  // do not expose that as a semantic relevance score.
+  if (score === 0 && result.explain?.rrf?.weight === 1.0) return null;
+  return score;
 }
 
 function getPackageVersion(): string {
@@ -323,9 +336,12 @@ Intent-aware lex (C++ performance, not sports):
         rerank: z.boolean().optional().default(true).describe(
           "Rerank results using LLM (default: true). Set to false for faster results on CPU-only machines."
         ),
+        explain: z.boolean().optional().default(false).describe(
+          "Include per-result RRF/blend traces plus top-level rerankScore (the pure reranker relevance score, or null when reranking is disabled). Off by default."
+        ),
       },
     },
-    async ({ query, searches, limit, minScore, candidateLimit, collections, intent, rerank }) => {
+    async ({ query, searches, limit, minScore, candidateLimit, collections, intent, rerank, explain }) => {
       // Require exactly one of `query` (plain text, auto-expanded) or `searches` (typed sub-queries).
       if (!query && (!searches || searches.length === 0)) {
         return {
@@ -356,6 +372,7 @@ Intent-aware lex (C++ performance, not sports):
         minScore,
         candidateLimit,
         rerank,
+        explain,
         intent,
       });
 
@@ -376,6 +393,7 @@ Intent-aware lex (C++ performance, not sports):
           context: r.context,
           line,
           snippet: addLineNumbers(snippet, line),
+          ...(explain ? { rerankScore: semanticRerankScoreOrNull(r, rerank), explain: r.explain ?? null } : {}),
         };
       });
 
@@ -749,6 +767,7 @@ export async function startMcpHttpServer(
           candidateLimit: typeof params.candidateLimit === "number" ? params.candidateLimit : undefined,
           intent: typeof params.intent === "string" ? params.intent : undefined,
           rerank: typeof params.rerank === "boolean" ? params.rerank : undefined,
+          ...(params.explain === true ? { explain: true } : {}),
         });
 
         // Use first lex or vec query for snippet extraction
@@ -766,6 +785,10 @@ export async function startMcpHttpServer(
             context: r.context,
             line,
             snippet: addLineNumbers(snippet, line),
+            ...(params.explain === true ? {
+              rerankScore: semanticRerankScoreOrNull(r, typeof params.rerank === "boolean" ? params.rerank : undefined),
+              explain: r.explain ?? null,
+            } : {}),
           };
         });
 

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -900,6 +900,56 @@ describe("MCP Server", () => {
       }
     });
 
+    test("semantic rerank score helper exposes pure reranker score only when meaningful", () => {
+      const explain = {
+        ftsScores: [0.4],
+        vectorScores: [0.5],
+        rrf: { rank: 2, positionScore: 0.5, weight: 0.6, baseScore: 0.1, topRankBonus: 0, totalScore: 0.1, contributions: [] },
+        rerankScore: 0.734567,
+        blendedScore: 0.593827,
+      };
+      expect(semanticRerankScoreOrNull({ explain }, true)).toBe(0.734567);
+      expect(semanticRerankScoreOrNull({ explain }, undefined)).toBe(0.734567);
+      expect(semanticRerankScoreOrNull({ explain }, false)).toBeNull();
+      expect(semanticRerankScoreOrNull({})).toBeNull();
+      expect(semanticRerankScoreOrNull({ explain: { ...explain, rrf: { ...explain.rrf, weight: 1.0 }, rerankScore: 0 } }, true)).toBeNull();
+    });
+
+    test("rerankScore response fields are default-off and full-precision when explain is true", () => {
+      const result = {
+        docid: "abc123",
+        displayPath: "docs/readme.md",
+        title: "Project README",
+        score: 0.876543,
+        context: null,
+        explain: {
+          ftsScores: [],
+          vectorScores: [],
+          rrf: { rank: 1, positionScore: 1, weight: 0.75, baseScore: 0.1, topRankBonus: 0.05, totalScore: 0.15, contributions: [] },
+          rerankScore: 0.503212345,
+          blendedScore: 0.876543,
+        },
+      };
+      const base = {
+        docid: `#${result.docid}`,
+        file: result.displayPath,
+        title: result.title,
+        score: Math.round(result.score * 100) / 100,
+        context: result.context,
+        line: 1,
+        snippet: "1: readme",
+      };
+      expect(base).not.toHaveProperty("rerankScore");
+      const explained = {
+        ...base,
+        rerankScore: semanticRerankScoreOrNull(result, true),
+        explain: result.explain,
+      };
+      expect(explained.score).toBe(0.88);                 // display score stays rounded
+      expect(explained.rerankScore).toBe(0.503212345);    // pure relevance score is raw
+      expect(explained.rerankScore).toBe(explained.explain.rerankScore);
+    });
+
     test("REST /query and /search file field uses qmd:// URI prefix (#576)", () => {
       // Regression test: the HTTP REST endpoint was returning r.displayPath (e.g.
       // "docs/readme.md") instead of "qmd://docs/readme.md", while the CLI and MCP
@@ -933,7 +983,7 @@ describe("MCP Server", () => {
 // HTTP Transport Tests
 // =============================================================================
 
-import { startMcpHttpServer, type HttpServerHandle } from "../src/mcp/server";
+import { startMcpHttpServer, type HttpServerHandle, semanticRerankScoreOrNull } from "../src/mcp/server";
 import { enableProductionMode } from "../src/store";
 
 describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {


### PR DESCRIPTION
## Summary

- Adds optional `explain: true` support to the MCP `query` tool and HTTP REST `/query`/`/search` path.
- Exposes a top-level `rerankScore` per result when explain output is requested.
- Keeps default responses unchanged: no `explain`, no `rerankScore` unless `explain: true` is supplied.
- Maps disabled-rerank sentinel behavior to `null` instead of exposing `0` as a semantic relevance score.

## Why

QMD already computes a pure semantic reranker score inside `HybridQueryExplain.rerankScore`, but callers at the MCP/HTTP boundary only receive the blended display `score`. That blended score includes RRF/position signal, so it is useful for ranking but not for applying a semantic relevance floor.

This exposes the existing pure reranker signal without changing the default response shape.

## Test plan

- `bun install`
- `bun run test:types`
- `CI=true bunx vitest run test/mcp.test.ts --reporter=verbose --testTimeout 60000`
- `bun run build`
- `NODE_NO_WARNINGS=1 bun run test:unit`

Note: `bun run test:unit` without `NODE_NO_WARNINGS=1` failed locally only on pre-existing `test/cli.test.ts` stderr-empty assertions due to Node DEP0205 `module.register()` deprecation warnings; rerunning with warnings suppressed produced `883 pass / 80 skip / 0 fail`.