### PR TITLE
Fix multi-get docid resolution

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -22,6 +22,7 @@ import {
   renameCollection,
   findSimilarFiles,
   findDocument,
+  findDocumentByDocid,
   matchFilesByGlob,
   getHashesNeedingEmbedding,
   clearAllEmbeddings,
@@ -40,6 +41,7 @@ import {
   parseVirtualPath,
   buildVirtualPath,
   isVirtualPath,
+  isDocid,
   resolveVirtualPath,
   toVirtualPath,
   insertContent,
@@ -1072,19 +1074,24 @@ function multiGet(pattern: string, maxLines?: number, maxBytes: number = DEFAULT
 
   // Check if it's a comma-separated list or a glob pattern
   const isCommaSeparated = pattern.includes(',') && !pattern.includes('*') && !pattern.includes('?') && !pattern.includes('{');
+  const isSingleDocid = isDocid(pattern);
 
   let files: { filepath: string; displayPath: string; bodyLength: number; collection?: string; path?: string }[];
 
-  if (isCommaSeparated) {
+  if (isCommaSeparated || isSingleDocid) {
     // Comma-separated list of files (can be virtual paths or relative paths)
-    const names = pattern.split(',').map(s => s.trim()).filter(Boolean);
+    const names = isCommaSeparated
+      ? pattern.split(',').map(s => s.trim()).filter(Boolean)
+      : [pattern.trim()].filter(Boolean);
     files = [];
     for (const name of names) {
       let doc: { virtual_path: string; body_length: number; collection: string; path: string } | null = null;
+      const docidMatch = isDocid(name) ? findDocumentByDocid(db, name) : null;
+      const lookupName = docidMatch?.filepath ?? name;
 
       // Handle virtual paths
-      if (isVirtualPath(name)) {
-        const parsed = parseVirtualPath(name);
+      if (isVirtualPath(lookupName)) {
+        const parsed = parseVirtualPath(lookupName);
         if (parsed) {
           // Try exact match on collection + path
           doc = db.prepare(`
@@ -1098,7 +1105,7 @@ function multiGet(pattern: string, maxLines?: number, maxBytes: number = DEFAULT
             WHERE d.collection = ? AND d.path = ? AND d.active = 1
           `).get(parsed.collectionName, parsed.path) as typeof doc;
         }
-      } else {
+      } else if (!docidMatch) {
         // Try exact match on path
         doc = db.prepare(`
           SELECT
@@ -1110,7 +1117,7 @@ function multiGet(pattern: string, maxLines?: number, maxBytes: number = DEFAULT
           JOIN content ON content.hash = d.hash
           WHERE d.path = ? AND d.active = 1
           LIMIT 1
-        `).get(name) as { virtual_path: string; body_length: number; collection: string; path: string } | null;
+        `).get(lookupName) as { virtual_path: string; body_length: number; collection: string; path: string } | null;
 
         // Try suffix match
         if (!doc) {
@@ -1124,7 +1131,7 @@ function multiGet(pattern: string, maxLines?: number, maxBytes: number = DEFAULT
             JOIN content ON content.hash = d.hash
             WHERE d.path LIKE ? AND d.active = 1
             LIMIT 1
-          `).get(`%${name}`) as { virtual_path: string; body_length: number; collection: string; path: string } | null;
+          `).get(`%${lookupName}`) as { virtual_path: string; body_length: number; collection: string; path: string } | null;
         }
       }
 
@@ -1139,6 +1146,10 @@ function multiGet(pattern: string, maxLines?: number, maxBytes: number = DEFAULT
       } else {
         console.error(`File not found: ${name}`);
       }
+    }
+    if (isSingleDocid && files.length === 0) {
+      closeDb();
+      process.exit(1);
     }
   } else {
     // Glob pattern - matchFilesByGlob now returns virtual paths

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -152,7 +152,7 @@ async function buildInstructions(store: QMDStore): Promise<string> {
   lines.push("");
   lines.push("Retrieval:");
   lines.push("  - `get` — single document by path or docid (#abc123). Supports a line-range suffix: `file.md:100` (from line 100) or `file.md:100:40` (40 lines from line 100).");
-  lines.push("  - `multi_get` — batch retrieve by glob (`journals/2025-05*.md`) or comma-separated list.");
+  lines.push("  - `multi_get` — batch retrieve by glob (`journals/2025-05*.md`), comma-separated list, or docids (#abc123).");
 
   // --- Non-obvious things that prevent mistakes ---
   lines.push("");
@@ -471,10 +471,10 @@ Intent-aware lex (C++ performance, not sports):
     "multi_get",
     {
       title: "Multi-Get Documents",
-      description: "Retrieve multiple documents by glob pattern (e.g., 'journals/2025-05*.md') or comma-separated list. Skips files larger than maxBytes.",
+      description: "Retrieve multiple documents by glob pattern (e.g., 'journals/2025-05*.md'), comma-separated list, or docids. Skips files larger than maxBytes.",
       annotations: { readOnlyHint: true, openWorldHint: false },
       inputSchema: {
-        pattern: z.string().describe("Glob pattern or comma-separated list of file paths"),
+        pattern: z.string().describe("Glob pattern, docid, or comma-separated list of file paths/docids"),
         maxLines: z.number().optional().describe("Maximum lines per file"),
         maxBytes: z.number().optional().default(DEFAULT_MULTI_GET_MAX_BYTES).describe("Skip files larger than this (default: 65536 = 64KB)"),
         lineNumbers: z.boolean().optional().default(true).describe("Add line numbers to output (format: 'N: content'). On by default; set false for raw content."),

--- a/src/store.ts
+++ b/src/store.ts
@@ -4341,6 +4341,7 @@ export function findDocuments(
   options: { includeBody?: boolean; maxBytes?: number } = {}
 ): { docs: MultiGetResult[]; errors: string[] } {
   const isCommaSeparated = pattern.includes(',') && !pattern.includes('*') && !pattern.includes('?') && !pattern.includes('{');
+  const isSingleDocid = isDocid(pattern);
   const errors: string[] = [];
   const maxBytes = options.maxBytes ?? DEFAULT_MULTI_GET_MAX_BYTES;
 
@@ -4358,24 +4359,28 @@ export function findDocuments(
 
   let fileRows: DbDocRow[];
 
-  if (isCommaSeparated) {
-    const names = pattern.split(',').map(s => s.trim()).filter(Boolean);
+  if (isCommaSeparated || isSingleDocid) {
+    const names = isCommaSeparated
+      ? pattern.split(',').map(s => s.trim()).filter(Boolean)
+      : [pattern.trim()].filter(Boolean);
     fileRows = [];
     for (const name of names) {
+      const docidMatch = isDocid(name) ? findDocumentByDocid(db, name) : null;
+      const lookupName = docidMatch?.filepath ?? name;
       let doc = db.prepare(`
         SELECT ${selectCols}
         FROM documents d
         JOIN content ON content.hash = d.hash
         WHERE 'qmd://' || d.collection || '/' || d.path = ? AND d.active = 1
-      `).get(name) as DbDocRow | null;
-      if (!doc) {
+      `).get(lookupName) as DbDocRow | null;
+      if (!doc && !docidMatch) {
         doc = db.prepare(`
           SELECT ${selectCols}
           FROM documents d
           JOIN content ON content.hash = d.hash
           WHERE 'qmd://' || d.collection || '/' || d.path LIKE ? AND d.active = 1
           LIMIT 1
-        `).get(`%${name}`) as DbDocRow | null;
+        `).get(`%${lookupName}`) as DbDocRow | null;
       }
       if (doc) {
         fileRows.push(doc);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -920,6 +920,46 @@ describe("CLI Multi-Get Command", () => {
     }
   });
 
+  test("retrieves a document by docid", async () => {
+    const lookup = await runQmd(["multi-get", "README.md", "--json"], { dbPath: localDbPath });
+    expect(lookup.exitCode).toBe(0);
+    const [entry] = JSON.parse(lookup.stdout);
+
+    const { stdout, stderr, exitCode } = await runQmd(["multi-get", entry.docid, "--json"], { dbPath: localDbPath });
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toContain("No files matched pattern");
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].docid).toBe(entry.docid);
+    expect(parsed[0].body).toContain("Test Project");
+  });
+
+  test("fails for a missing single docid", async () => {
+    const { stdout, stderr, exitCode } = await runQmd(["multi-get", "#000000", "--json"], { dbPath: localDbPath });
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("File not found: #000000");
+  });
+
+  test("retrieves docids in comma-separated lists", async () => {
+    const lookup = await runQmd(["multi-get", "README.md", "--json"], { dbPath: localDbPath });
+    expect(lookup.exitCode).toBe(0);
+    const [entry] = JSON.parse(lookup.stdout);
+
+    const { stdout, exitCode } = await runQmd([
+      "multi-get",
+      `${entry.docid},notes/meeting.md`,
+      "--json",
+    ], { dbPath: localDbPath });
+    expect(exitCode).toBe(0);
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].docid).toBe(entry.docid);
+    expect(parsed[1].file).toBe("qmd://fixtures/notes/meeting.md");
+  });
+
   test("shows line numbers by default and --no-line-numbers disables them", async () => {
     const withNums = await runQmd(["multi-get", "README.md"], { dbPath: localDbPath });
     expect(withNums.exitCode).toBe(0);

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -760,6 +760,20 @@ describe("get and multiGet", () => {
     }
   });
 
+  test("multiGet retrieves a document by docid", async () => {
+    const doc = await store.get("qmd://docs/readme.md");
+    if (!("error" in doc)) {
+      const { docs, errors } = await store.multiGet(`#${doc.docid}`, { includeBody: true });
+      expect(errors).toHaveLength(0);
+      expect(docs).toHaveLength(1);
+      expect(docs[0]!.doc.docid).toBe(doc.docid);
+      expect(docs[0]!.skipped).toBe(false);
+      if (!docs[0]!.skipped) {
+        expect(docs[0]!.doc.body).toContain("getting started guide");
+      }
+    }
+  });
+
   test("multiGet retrieves multiple documents", async () => {
     const { docs, errors } = await store.multiGet("qmd://docs/*.md");
     expect(docs.length).toBeGreaterThan(0);

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1969,6 +1969,59 @@ describe("Document Retrieval", () => {
       await cleanupTestDb(store);
     });
 
+    test("findDocuments finds by docid", async () => {
+      const store = await createTestStore();
+      const collectionName = await createTestCollection();
+
+      await insertTestDocument(store.db, collectionName, {
+        name: "docid-doc",
+        filepath: "/path/docid-doc.md",
+        displayPath: "docid-doc.md",
+        body: "# Docid Doc\n\nThe content",
+      });
+
+      const doc = store.findDocument("docid-doc.md");
+      expect("error" in doc).toBe(false);
+      if (!("error" in doc)) {
+        const { docs, errors } = store.findDocuments(`#${doc.docid}`);
+        expect(errors).toHaveLength(0);
+        expect(docs).toHaveLength(1);
+        expect(docs[0]!.doc.docid).toBe(doc.docid);
+      }
+
+      await cleanupTestDb(store);
+    });
+
+    test("findDocuments finds docids in a comma-separated list", async () => {
+      const store = await createTestStore();
+      const collectionName = await createTestCollection();
+
+      await insertTestDocument(store.db, collectionName, {
+        name: "doc1",
+        filepath: "/path/doc1.md",
+        displayPath: "doc1.md",
+      });
+      await insertTestDocument(store.db, collectionName, {
+        name: "doc2",
+        filepath: "/path/doc2.md",
+        displayPath: "doc2.md",
+      });
+
+      const doc1 = store.findDocument("doc1.md");
+      expect("error" in doc1).toBe(false);
+      if (!("error" in doc1)) {
+        const { docs, errors } = store.findDocuments(`#${doc1.docid}, doc2.md`);
+        expect(errors).toHaveLength(0);
+        expect(docs).toHaveLength(2);
+        expect(docs.map((result) => result.doc.displayPath)).toEqual([
+          `${collectionName}/doc1.md`,
+          `${collectionName}/doc2.md`,
+        ]);
+      }
+
+      await cleanupTestDb(store);
+    });
+
     test("findDocuments reports errors for not found files", async () => {
       const store = await createTestStore();
       const collectionName = await createTestCollection();


### PR DESCRIPTION
## Summary

- Resolve docids in shared `multi_get` / SDK multiGet lookups, including comma-separated lists.
- Resolve docids in the separate CLI `multi-get` path and keep missing single-docid lookups as failures.
- Update MCP `multi_get` tool text so clients know docids are accepted.

## Why

Fixes #706.

`get` already resolves docids returned by search results, but `multi-get` treated docid inputs as unmatched patterns/paths. The docs advertise docid support for multi-get, so this makes the batch retrieval path match the documented behavior.

## Tests

- `bun test --preload ./src/test-preload.ts test/store.test.ts -t "findDocuments"`
- `bun test --preload ./src/test-preload.ts test/sdk.test.ts -t "multiGet retrieves"`
- `bun test --preload ./src/test-preload.ts test/cli.test.ts -t "retrieves (a document by docid|docids in comma-separated lists)|fails for a missing single docid"`
- `git diff --check`
- `bun run test:types`

## Scope

- In scope: docid resolution for store/SDK/MCP multi-get, CLI multi-get, MCP tool text, and focused regression tests.
- Non-goals: indexing, embedding, model loading, search ranking, database schema, MCP transport behavior, or broader retrieval refactors.

## Caveats

- The broad Bun run for `test/store.test.ts test/sdk.test.ts test/cli.test.ts` hit unrelated local LLM cache and MCP HTTP daemon failures in this sandbox, so I used focused tests for the changed behavior plus typecheck.
