### PR TITLE
fix: query references dropped table, cache miss on empty string

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
       "esbuild",
       "node-llama-cpp",
       "tree-sitter-go",
-      "tree-sitter-javascript",
       "tree-sitter-python",
       "tree-sitter-rust",
       "tree-sitter-typescript"

--- a/src/store.ts
+++ b/src/store.ts
@@ -2357,7 +2357,7 @@ export function getCacheKey(url: string, body: object): string {
 
 export function getCachedResult(db: Database, cacheKey: string): string | null {
   const row = db.prepare(`SELECT result FROM llm_cache WHERE hash = ?`).get(cacheKey) as { result: string } | null;
-  return row?.result || null;
+  return row?.result ?? null;
 }
 
 export function setCachedResult(db: Database, cacheKey: string, result: string): void {
@@ -3199,7 +3199,7 @@ export function renameCollection(db: Database, oldName: string, newName: string)
  */
 export function insertContext(db: Database, collectionId: number, pathPrefix: string, context: string): void {
   // Get collection name from ID
-  const coll = db.prepare(`SELECT name FROM collections WHERE id = ?`).get(collectionId) as { name: string } | null;
+  const coll = db.prepare(`SELECT name FROM store_collections WHERE id = ?`).get(collectionId) as { name: string } | null;
   if (!coll) {
     throw new Error(`Collection with id ${collectionId} not found`);
   }


### PR DESCRIPTION
Two bugs I ran into while reading the store code:

- \`insertContext\` queries \`SELECT name FROM collections WHERE id = ?\` but the \`collections\` table gets explicitly dropped during DB init. Changed to \`store_collections\` which is the actual table that exists.
- \`getCachedResult\` used \`row?.result || null\` which means an empty string cached result gets treated as a cache miss (empty string is falsy). Changed to \`?? null\` so legitimate empty results are returned correctly without re-computation.

Also cleaned up a stale \`tree-sitter-javascript\` entry in \`pnpm.onlyBuiltDependencies\` — it's not in any dependency list.