### PR TITLE
fix: prefer Markdown frontmatter titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Markdown title extraction now prefers a non-empty string `title` from leading
+  YAML frontmatter and ignores that metadata when falling back to a heading.
+  The embedding fingerprint is bumped so existing documents are marked pending
+  and re-embedded with their corrected title on the next `qmd embed`.
+
 ## [2.6.3] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -878,7 +878,7 @@ Template placeholders:
 
 - **Path**: Collection-relative path (e.g., `docs/guide.md`)
 - **Docid**: Short hash identifier (e.g., `#a1b2c3`) - use with `qmd get #a1b2c3`
-- **Title**: Extracted from document (first heading or filename)
+- **Title**: Extracted from document (frontmatter `title`, first heading, or filename)
 - **Context**: Path context if configured via `qmd context add`
 - **Score**: Color-coded (green >70%, yellow >40%, dim otherwise)
 - **Snippet**: Context around match with query terms highlighted

--- a/src/store.ts
+++ b/src/store.ts
@@ -18,6 +18,7 @@ import { createHash } from "crypto";
 import { readFileSync, realpathSync, statSync, mkdirSync } from "node:fs";
 // Note: node:path resolve is not imported — we export our own cross-platform resolve()
 import fastGlob from "fast-glob";
+import YAML from "yaml";
 import { qmdHomedir } from "./paths.js";
 import {
   LlamaCpp,
@@ -54,6 +55,9 @@ export const DEFAULT_EMBED_MAX_DURATION_MS = 30 * 60 * 1000; // 30 minutes; see 
 const EMBED_FINGERPRINT_PROBE_QUERY = "__qmd_embedding_query_probe__";
 const EMBED_FINGERPRINT_PROBE_TITLE = "__qmd_embedding_title_probe__";
 const EMBED_FINGERPRINT_PROBE_DOC = "__qmd_embedding_document_probe__";
+// Bump whenever extractTitle changes text that is fed into document embeddings.
+const TITLE_EXTRACTION_VERSION = 2;
+const LEGACY_EMPTY_FINGERPRINT_TITLE_EXTRACTION_VERSION = 1;
 
 // Chunking: 900 tokens per chunk with 15% overlap
 // Increased from 800 to accommodate smart chunking finding natural break points
@@ -71,6 +75,7 @@ export function getEmbeddingFingerprint(model: string = DEFAULT_EMBED_MODEL): st
     `model:${model}`,
     `query:${formatQueryForEmbedding(EMBED_FINGERPRINT_PROBE_QUERY, model)}`,
     `doc:${formatDocForEmbedding(EMBED_FINGERPRINT_PROBE_DOC, EMBED_FINGERPRINT_PROBE_TITLE, model)}`,
+    `title_extraction:${TITLE_EXTRACTION_VERSION}`,
     `chunk_tokens:${CHUNK_SIZE_TOKENS}`,
     `chunk_overlap_tokens:${CHUNK_OVERLAP_TOKENS}`,
   ].join("\n");
@@ -2037,7 +2042,7 @@ export function createStore(dbPath?: string): Store {
 export type DocumentResult = {
   filepath: string;           // Full filesystem path
   displayPath: string;        // Short display path (e.g., "docs/readme.md")
-  title: string;              // Document title (from first heading or filename)
+  title: string;              // Document title (from frontmatter, first heading, or filename)
   context: string | null;     // Folder context description if configured
   hash: string;               // Content hash for caching/change detection
   docid: string;              // Short docid (first 6 chars of hash) for quick reference
@@ -2273,6 +2278,13 @@ export async function maybeAdoptLegacyEmbeddingFingerprint(store: Store, model: 
   if (legacyCount === 0) {
     return { checked: false, adopted: 0, reason: "no legacy empty-fingerprint embeddings" };
   }
+  if (TITLE_EXTRACTION_VERSION > LEGACY_EMPTY_FINGERPRINT_TITLE_EXTRACTION_VERSION) {
+    return {
+      checked: true,
+      adopted: 0,
+      reason: `legacy empty fingerprints predate title extraction version ${TITLE_EXTRACTION_VERSION}`,
+    };
+  }
 
   const sample = withLazyContentVectorMigration(db, () => db.prepare(`
     SELECT cv.hash, cv.seq, cv.pos, cv.total_chunks, c.doc AS body, MIN(d.path) AS path
@@ -2482,6 +2494,36 @@ export async function hashContent(content: string): Promise<string> {
   return hash.digest("hex");
 }
 
+type MarkdownFrontmatter = {
+  body: string;
+  data: Record<string, unknown> | null;
+};
+
+function splitMarkdownFrontmatter(content: string): MarkdownFrontmatter | null {
+  const withoutBom = content.startsWith("\uFEFF") ? content.slice(1) : content;
+  const opening = withoutBom.match(/^---[ \t]*\r?\n/);
+  if (!opening) return null;
+  const remainder = withoutBom.slice(opening[0].length);
+  const closing = remainder.match(/^(?:---|\.\.\.)[ \t]*(?:\r?\n|$)/m);
+  if (closing?.index === undefined) return null;
+  const raw = remainder.slice(0, closing.index);
+
+  let data: Record<string, unknown> | null = null;
+  try {
+    const parsed = YAML.parse(raw) as unknown;
+    if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+      data = parsed as Record<string, unknown>;
+    }
+  } catch {
+    // A malformed metadata block must not hide a valid body heading.
+  }
+
+  return {
+    body: remainder.slice(closing.index + closing[0].length),
+    data,
+  };
+}
+
 const titleExtractors: Record<string, (content: string) => string | null> = {
   '.md': (content) => {
     const match = content.match(/^##?\s+(.+)$/m);
@@ -2506,9 +2548,16 @@ const titleExtractors: Record<string, (content: string) => string | null> = {
 
 export function extractTitle(content: string, filename: string): string {
   const ext = filename.slice(filename.lastIndexOf('.')).toLowerCase();
+  const frontmatter = ext === '.md' ? splitMarkdownFrontmatter(content) : null;
+  const frontmatterTitle = frontmatter?.data?.title;
+  if (typeof frontmatterTitle === "string") {
+    const normalizedTitle = frontmatterTitle.trim().replace(/\s+/g, " ");
+    if (normalizedTitle) return normalizedTitle;
+  }
+
   const extractor = titleExtractors[ext];
   if (extractor) {
-    const title = extractor(content);
+    const title = extractor(frontmatter?.body ?? content);
     if (title) return title;
   }
   return filename.replace(/\.[^.]+$/, "").split("/").pop() || filename;

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -12,6 +12,7 @@ import type { Database } from "../src/db.js";
 import { unlink, mkdtemp, rmdir, writeFile, rm, mkdir, rename } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createHash } from "node:crypto";
 import YAML from "yaml";
 import * as llmModule from "../src/llm.js";
 import { disposeDefaultLlamaCpp, setDefaultLlamaCpp } from "../src/llm.js";
@@ -27,6 +28,9 @@ import {
   formatQueryForEmbedding,
   formatDocForEmbedding,
   getEmbeddingFingerprint,
+  maybeAdoptLegacyEmbeddingFingerprint,
+  CHUNK_SIZE_TOKENS,
+  CHUNK_OVERLAP_TOKENS,
   chunkDocument,
   chunkDocumentByTokens,
   chunkDocumentAsync,
@@ -507,6 +511,249 @@ describe("Document Helpers", () => {
   test("extractTitle extracts H1 heading", () => {
     const content = "# My Title\n\nSome content here.";
     expect(extractTitle(content, "file.md")).toBe("My Title");
+  });
+
+  test("extractTitle prefers a string title from leading YAML frontmatter", () => {
+    const content = `---
+title: "Frontmatter: Canonical Title"
+---
+
+# Heading Title
+`;
+    expect(extractTitle(content, "file.md")).toBe("Frontmatter: Canonical Title");
+  });
+
+  test("extractTitle accepts the YAML document end marker", () => {
+    const content = `---
+title: Dotted End Marker
+...
+
+# Heading Title
+`;
+    expect(extractTitle(content, "file.md")).toBe("Dotted End Marker");
+  });
+
+  test("extractTitle normalizes multiline YAML titles to one line", () => {
+    const literal = `---
+title: |
+  Canonical
+  Score: 100%
+---
+
+# Heading Title
+`;
+    const folded = `---
+title: >
+  Folded
+  Canonical Title
+---
+`;
+
+    expect(extractTitle(literal, "literal.md")).toBe("Canonical Score: 100%");
+    expect(extractTitle(folded, "folded.md")).toBe("Folded Canonical Title");
+  });
+
+  test("extractTitle ignores frontmatter while falling back to a heading", () => {
+    const content = `---
+# This metadata comment is not the title
+summary: No explicit title
+---
+
+# Actual Title
+`;
+    expect(extractTitle(content, "file.md")).toBe("Actual Title");
+  });
+
+  test("extractTitle ignores empty and non-string frontmatter titles", () => {
+    const emptyTitle = `---
+title: "   "
+---
+
+# Empty Title Fallback
+`;
+    const nonStringTitle = `---
+title:
+  - not
+  - a string
+---
+
+# Non-string Title Fallback
+`;
+
+    expect(extractTitle(emptyTitle, "file.md")).toBe("Empty Title Fallback");
+    expect(extractTitle(nonStringTitle, "file.md")).toBe("Non-string Title Fallback");
+  });
+
+  test("extractTitle falls back safely when leading YAML is malformed", () => {
+    const content = `---
+title: [unterminated
+---
+
+# Valid Body Heading
+`;
+    expect(extractTitle(content, "file.md")).toBe("Valid Body Heading");
+  });
+
+  test("extractTitle does not treat a later thematic break as frontmatter", () => {
+    const content = `Introductory prose.
+
+---
+title: Not Frontmatter
+---
+
+# Real Heading
+`;
+    expect(extractTitle(content, "file.md")).toBe("Real Heading");
+  });
+
+  test("frontmatter title extraction invalidates legacy embedding fingerprints", async () => {
+    const store = await createTestStore();
+    const collectionDir = await mkdtemp(join(testDir, "title-fingerprint-"));
+    const collectionName = await createTestCollection({
+      pwd: collectionDir,
+      name: "title-fingerprint",
+    });
+    const body = `---
+title: Frontmatter Title
+---
+
+# Heading Title
+
+Body text.
+`;
+    const model = "hf:test/embed-model.gguf";
+    const legacySignificant = [
+      `model:${model}`,
+      `query:${formatQueryForEmbedding("__qmd_embedding_query_probe__", model)}`,
+      `doc:${formatDocForEmbedding("__qmd_embedding_document_probe__", "__qmd_embedding_title_probe__", model)}`,
+      `chunk_tokens:${CHUNK_SIZE_TOKENS}`,
+      `chunk_overlap_tokens:${CHUNK_OVERLAP_TOKENS}`,
+    ].join("\n");
+    const legacyFingerprint = createHash("sha256")
+      .update(legacySignificant)
+      .digest("hex")
+      .slice(0, 6);
+
+    try {
+      await writeFile(join(collectionDir, "doc.md"), body);
+      const hash = await hashContent(body);
+      await insertTestDocument(store.db, collectionName, {
+        displayPath: "doc.md",
+        title: "Heading Title",
+        hash,
+        body,
+      });
+      store.llm = { embedModelName: model } as any;
+      store.ensureVecTable(3);
+      store.insertEmbedding(
+        hash,
+        0,
+        0,
+        new Float32Array([1, 2, 3]),
+        model,
+        new Date().toISOString(),
+        1,
+        legacyFingerprint,
+      );
+
+      const result = await reindexCollection(
+        store,
+        collectionDir,
+        "**/*.md",
+        collectionName,
+      );
+      const indexed = store.findDocument("title-fingerprint/doc.md");
+
+      expect(result.updated).toBe(1);
+      expect("title" in indexed && indexed.title).toBe("Frontmatter Title");
+      expect(getEmbeddingFingerprint(model)).not.toBe(legacyFingerprint);
+      expect(store.getHashesNeedingEmbedding()).toBe(1);
+    } finally {
+      await rm(collectionDir, { recursive: true, force: true });
+      await cleanupTestDb(store);
+    }
+  });
+
+  test("legacy empty fingerprints stay pending across heterogeneous titles", async () => {
+    const store = await createTestStore();
+    const model = "hf:test/embed-model.gguf";
+    const frontmatterBody = `---
+title: Frontmatter Title
+---
+
+# Heading Title
+
+Frontmatter body.
+`;
+    const frontmatterHash = await hashContent(frontmatterBody);
+    let plainBody = "# Plain Title\n\nPlain body.";
+    let plainHash = await hashContent(plainBody);
+    let suffix = 0;
+    while (plainHash >= frontmatterHash) {
+      plainBody += `\n${suffix++}`;
+      plainHash = await hashContent(plainBody);
+    }
+
+    setDefaultLlamaCpp({
+      async tokenize(_text: string) { return [1]; },
+      async detokenize(_tokens: readonly number[]) { return plainBody; },
+    } as any);
+    store.llm = {
+      embedModelName: model,
+      async embed(_text: string) {
+        return { embedding: [1, 0, 0], model };
+      },
+    } as any;
+
+    try {
+      await insertTestDocument(store.db, "legacy-mixed", {
+        displayPath: "plain.md",
+        title: "Plain Title",
+        hash: plainHash,
+        body: plainBody,
+      });
+      await insertTestDocument(store.db, "legacy-mixed", {
+        displayPath: "frontmatter.md",
+        title: "Heading Title",
+        hash: frontmatterHash,
+        body: frontmatterBody,
+      });
+      store.ensureVecTable(3);
+      const embeddedAt = new Date().toISOString();
+      store.insertEmbedding(
+        plainHash,
+        0,
+        0,
+        new Float32Array([1, 0, 0]),
+        model,
+        embeddedAt,
+        1,
+        "",
+      );
+      store.insertEmbedding(
+        frontmatterHash,
+        0,
+        0,
+        new Float32Array([0, 1, 0]),
+        model,
+        embeddedAt,
+        1,
+        "",
+      );
+
+      expect(store.getHashesNeedingEmbedding()).toBe(2);
+      const adoption = await maybeAdoptLegacyEmbeddingFingerprint(store, model);
+
+      expect(adoption).toEqual({
+        checked: true,
+        adopted: 0,
+        reason: "legacy empty fingerprints predate title extraction version 2",
+      });
+      expect(store.getHashesNeedingEmbedding()).toBe(2);
+    } finally {
+      setDefaultLlamaCpp(null);
+      await cleanupTestDb(store);
+    }
   });
 
   test("extractTitle extracts H2 heading if no H1", () => {


### PR DESCRIPTION
## Summary

- prefer a non-empty string `title` from leading YAML frontmatter
- keep heading and filename fallbacks, excluding the metadata block from heading detection
- support YAML `---` and `...` end markers, BOM/CRLF, malformed metadata fallback, and single-line title normalization
- version title extraction in the embedding fingerprint so corrected titles are embedded on the next `qmd embed`
- keep legacy empty-fingerprint vectors pending instead of bulk-adopting heterogeneous documents from one matching sample

## Why this is separate from #551

#551 combines frontmatter title extraction with frontmatter-as-a-separate-chunk behavior and a new parser dependency. This PR is intentionally title-only: it uses the existing pinned `yaml` dependency and does not change chunk content, boundaries, or constants.

A downstream 62-case retrieval evaluation did not support changing frontmatter chunking: the stripped projection changed MRR by -0.0385 with paired p=0.810602. Keeping the concerns separate therefore makes the title correction independently reviewable and avoids bundling an unproven chunking change.

## Migration behavior

Existing embeddings have old title semantics. The fingerprint bump marks named legacy vectors pending. Empty pre-fingerprint rows also remain pending because one matching sample cannot prove that documents with different frontmatter titles are current. `qmd doctor` reports the pending documents and the next `qmd embed` refreshes them.

## Tests

- full Node unit suite
- full Bun unit suite: 890 passed, 42 skipped
- Node and Bun store suites: 232 passed each
- TypeScript typecheck
- production build
- `git diff --check`