### PR TITLE
fix: don't split UTF-16 surrogate pairs at chunk boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `qmd embed` no longer splits a UTF-16 surrogate pair (emoji, etc.) across a
+  chunk boundary. A chunk ending or starting mid-pair produced an unpaired
+  surrogate in the chunk text, which some remote embedding APIs reject as
+  invalid JSON — permanently failing that chunk on every retry, since the
+  boundary calculation is deterministic.
+
 ## [2.6.3] - 2026-06-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@
   chunk boundary. A chunk ending or starting mid-pair produced an unpaired
   surrogate in the chunk text, which some remote embedding APIs reject as
   invalid JSON — permanently failing that chunk on every retry, since the
-  boundary calculation is deterministic.
+  boundary calculation is deterministic. This covers both the character-based
+  chunker and `chunkDocumentByTokens`'s recursive re-splitting for
+  astral-plane-dense content, which could previously drive the char budget
+  low enough to reproduce the same split.
 
 ## [2.6.3] - 2026-06-24
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -282,17 +282,27 @@ function isSurrogatePairBoundary(content: string, pos: number): boolean {
 }
 
 /**
- * Nudges `pos` back by one code unit when it splits a surrogate pair, so a
- * slice ending or starting at `pos` never contains an unpaired surrogate.
- * Returns `pos` unchanged when the adjustment would move at or before
- * `floor` (caller-supplied lower bound, e.g. the previous chunk's start) —
- * preserving forward progress takes priority over the (extremely rare)
- * pathological case where a surrogate pair can't be avoided.
+ * Nudges `pos` off a surrogate-pair boundary so a slice ending or starting
+ * at `pos` never contains an unpaired surrogate. Prefers retreating by one
+ * code unit (excludes the pair from this slice, deferring it to the next
+ * chunk); when that would violate forward progress (`pos - 1 <= floor`,
+ * the caller-supplied lower bound, e.g. the previous chunk's start),
+ * advances by one code unit instead (includes the whole pair in this
+ * slice, slightly exceeding the caller's target width).
+ *
+ * Advancing is always safe: `isSurrogatePairBoundary` only returns true
+ * for `pos < content.length`, so `pos + 1 <= content.length`; and every
+ * call site already guarantees `pos > floor` before calling this function,
+ * so `pos + 1 > floor` too. This means a surrogate pair is never split —
+ * unlike a plain "give up and leave pos unchanged" fallback, which would
+ * let recursive re-chunking (e.g. chunkDocumentByTokens shrinking maxChars
+ * toward 1 for astral-dense content) reproduce the exact bug this exists
+ * to prevent.
  */
 function adjustSurrogateBoundary(content: string, pos: number, floor: number): number {
   if (!isSurrogatePairBoundary(content, pos)) return pos;
-  const adjusted = pos - 1;
-  return adjusted > floor ? adjusted : pos;
+  const retreat = pos - 1;
+  return retreat > floor ? retreat : pos + 1;
 }
 
 /**
@@ -2786,6 +2796,30 @@ export async function chunkDocumentAsync(
 }
 
 /**
+ * Strips a leading lone low surrogate and/or a trailing lone high surrogate
+ * from `text`, so the result is always well-formed UTF-16. Defense-in-depth
+ * for chunkDocumentByTokens: chunkDocumentWithBreakPoints (via chunkDocument)
+ * never itself produces a split surrogate pair (see adjustSurrogateBoundary),
+ * but the tokenizer's detokenize() truncation fallback below reconstructs
+ * text from raw token IDs — a different code path this doesn't cover, since
+ * a tokenizer is free to encode a single astral-plane character as multiple
+ * tokens and truncate between them.
+ */
+function stripUnpairedSurrogates(text: string): string {
+  let start = 0;
+  let end = text.length;
+  if (end > 0) {
+    const first = text.charCodeAt(0);
+    if (first >= 0xdc00 && first <= 0xdfff) start = 1;
+  }
+  if (end > start) {
+    const last = text.charCodeAt(end - 1);
+    if (last >= 0xd800 && last <= 0xdbff) end -= 1;
+  }
+  return start === 0 && end === text.length ? text : text.slice(start, end);
+}
+
+/**
  * Chunk a document by actual token count using the LLM tokenizer.
  * More accurate than character-based chunking but requires async.
  *
@@ -2826,7 +2860,12 @@ export async function chunkDocumentByTokens(
 
     const tokens = await llm.tokenize(text);
     if (tokens.length <= maxTokens || text.length <= 1) {
-      results.push({ text, pos, tokens: tokens.length });
+      // Safety net: text.length <= 1 can only legitimately be a single
+      // BMP character (a well-formed astral character needs 2 code units),
+      // so this only ever strips something for already-malformed input.
+      const safeText = stripUnpairedSurrogates(text);
+      if (safeText.length === 0) return;
+      results.push({ text: safeText, pos, tokens: tokens.length });
       return;
     }
 
@@ -2861,7 +2900,11 @@ export async function chunkDocumentByTokens(
       || subChunks[0]?.text.length === text.length
     ) {
       const fallbackTokens = tokens.slice(0, Math.max(1, maxTokens));
-      const truncatedText = await llm.detokenize(fallbackTokens);
+      // Safety net: detokenize() reconstructs text from raw token IDs, and
+      // a tokenizer can encode a single astral-plane character across
+      // multiple tokens — truncating the token list can land mid-character.
+      const truncatedText = stripUnpairedSurrogates(await llm.detokenize(fallbackTokens));
+      if (truncatedText.length === 0) return;
       results.push({
         text: truncatedText,
         pos,

--- a/src/store.ts
+++ b/src/store.ts
@@ -2796,13 +2796,25 @@ export async function chunkDocumentAsync(
 }
 
 /**
- * Strips a leading lone low surrogate and/or a trailing lone high surrogate
- * from `text`, so the result is always well-formed UTF-16. Defense-in-depth
- * for chunkDocumentByTokens: chunkDocumentWithBreakPoints (via chunkDocument)
- * never itself produces a split surrogate pair (see adjustSurrogateBoundary),
- * but the tokenizer's detokenize() truncation fallback below reconstructs
- * text from raw token IDs — a different code path this doesn't cover, since
- * a tokenizer is free to encode a single astral-plane character as multiple
+ * Strips any unpaired surrogate at the start or end of `text`, so the
+ * result is always well-formed UTF-16. Handles all four ways a lone
+ * surrogate can sit at a boundary:
+ *   - leading lone low surrogate (never valid as the first unit of a pair)
+ *   - leading lone high surrogate NOT followed by a matching low surrogate
+ *     (a leading high surrogate that IS followed by its low surrogate is a
+ *     complete, valid pair and must be left alone)
+ *   - trailing lone high surrogate (never valid as the last unit of a pair)
+ *   - trailing lone low surrogate NOT preceded by a matching high surrogate
+ *     (mirrors the leading-high case)
+ *
+ * Defense-in-depth for chunkDocumentByTokens: chunkDocumentWithBreakPoints
+ * (via chunkDocument) never itself produces a split surrogate pair (see
+ * adjustSurrogateBoundary), but a lone surrogate can already be present in
+ * the source document (unrelated upstream encoding bug) and land at an
+ * ordinary chunk boundary by coincidence, and the tokenizer's detokenize()
+ * truncation fallback below reconstructs text from raw token IDs — a
+ * different code path chunk-boundary adjustment doesn't cover, since a
+ * tokenizer is free to encode a single astral-plane character as multiple
  * tokens and truncate between them.
  */
 function stripUnpairedSurrogates(text: string): string {
@@ -2810,11 +2822,27 @@ function stripUnpairedSurrogates(text: string): string {
   let end = text.length;
   if (end > 0) {
     const first = text.charCodeAt(0);
-    if (first >= 0xdc00 && first <= 0xdfff) start = 1;
+    const firstIsLow = first >= 0xdc00 && first <= 0xdfff;
+    const firstIsHigh = first >= 0xd800 && first <= 0xdbff;
+    if (firstIsLow) {
+      start = 1;
+    } else if (firstIsHigh) {
+      const second = end > 1 ? text.charCodeAt(1) : NaN;
+      const secondIsLow = second >= 0xdc00 && second <= 0xdfff;
+      if (!secondIsLow) start = 1;
+    }
   }
   if (end > start) {
     const last = text.charCodeAt(end - 1);
-    if (last >= 0xd800 && last <= 0xdbff) end -= 1;
+    const lastIsHigh = last >= 0xd800 && last <= 0xdbff;
+    const lastIsLow = last >= 0xdc00 && last <= 0xdfff;
+    if (lastIsHigh) {
+      end -= 1;
+    } else if (lastIsLow) {
+      const prev = end - 1 > start ? text.charCodeAt(end - 2) : NaN;
+      const prevIsHigh = prev >= 0xd800 && prev <= 0xdbff;
+      if (!prevIsHigh) end -= 1;
+    }
   }
   return start === 0 && end === text.length ? text : text.slice(start, end);
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -270,6 +270,32 @@ export function mergeBreakPoints(a: BreakPoint[], b: BreakPoint[]): BreakPoint[]
 }
 
 /**
+ * True if `pos` sits between a UTF-16 high surrogate (at pos-1) and a low
+ * surrogate (at pos) — i.e. slicing at `pos` would split an astral-plane
+ * character (emoji, etc.) into two unpaired surrogates.
+ */
+function isSurrogatePairBoundary(content: string, pos: number): boolean {
+  if (pos <= 0 || pos >= content.length) return false;
+  const high = content.charCodeAt(pos - 1);
+  const low = content.charCodeAt(pos);
+  return high >= 0xd800 && high <= 0xdbff && low >= 0xdc00 && low <= 0xdfff;
+}
+
+/**
+ * Nudges `pos` back by one code unit when it splits a surrogate pair, so a
+ * slice ending or starting at `pos` never contains an unpaired surrogate.
+ * Returns `pos` unchanged when the adjustment would move at or before
+ * `floor` (caller-supplied lower bound, e.g. the previous chunk's start) —
+ * preserving forward progress takes priority over the (extremely rare)
+ * pathological case where a surrogate pair can't be avoided.
+ */
+function adjustSurrogateBoundary(content: string, pos: number, floor: number): number {
+  if (!isSurrogatePairBoundary(content, pos)) return pos;
+  const adjusted = pos - 1;
+  return adjusted > floor ? adjusted : pos;
+}
+
+/**
  * Core chunk algorithm that operates on precomputed break points and code fences.
  * This is the shared implementation used by both regex-only and AST-aware chunking.
  */
@@ -310,6 +336,11 @@ export function chunkDocumentWithBreakPoints(
       endPos = Math.min(charPos + maxChars, content.length);
     }
 
+    // Never slice through the middle of a surrogate pair (e.g. an emoji) —
+    // an unpaired surrogate in the chunk text breaks JSON serialization for
+    // remote embedding APIs.
+    endPos = adjustSurrogateBoundary(content, endPos, charPos);
+
     chunks.push({ text: content.slice(charPos, endPos), pos: charPos });
 
     if (endPos >= content.length) {
@@ -320,6 +351,7 @@ export function chunkDocumentWithBreakPoints(
     if (charPos <= lastChunkPos) {
       charPos = endPos;
     }
+    charPos = adjustSurrogateBoundary(content, charPos, lastChunkPos);
   }
 
   return chunks;

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1046,6 +1046,42 @@ describe("chunkDocumentWithBreakPoints", () => {
       expect(chunksNew[i]!.pos).toBe(chunksOriginal[i]!.pos);
     }
   });
+
+  test("does not split a surrogate pair at the raw chunk boundary", () => {
+    // "🚀" is a two-code-unit surrogate pair (high 0xD83D, low 0xDE80).
+    // Place it so the raw fallback boundary (charPos + maxChars) falls
+    // exactly between the two code units: 99 "x" chars, then the emoji at
+    // indices 99-100, so targetEndPos=100 lands right after the high
+    // surrogate.
+    const maxChars = 100;
+    const overlapChars = 20;
+    const windowChars = 10;
+    const content = "x".repeat(99) + "\u{1F680}" + "y".repeat(50);
+
+    const chunks = chunkDocumentWithBreakPoints(content, [], [], maxChars, overlapChars, windowChars);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.text.isWellFormed()).toBe(true);
+    }
+  });
+
+  test("does not split a surrogate pair at the overlap-derived chunk start", () => {
+    // Place the emoji so the boundary itself (charPos + maxChars = 100) is
+    // clean, but the next chunk's start (endPos - overlapChars = 100 - 20 = 80)
+    // falls between the high surrogate (index 79) and low surrogate (index 80).
+    const maxChars = 100;
+    const overlapChars = 20;
+    const windowChars = 10;
+    const content = "x".repeat(79) + "\u{1F680}" + "y".repeat(69);
+
+    const chunks = chunkDocumentWithBreakPoints(content, [], [], maxChars, overlapChars, windowChars);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.text.isWellFormed()).toBe(true);
+    }
+  });
 });
 
 describe("AST-aware chunkDocumentAsync", () => {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -3690,6 +3690,13 @@ describe("Token chunking guardrails", () => {
     try {
       const chunks = await chunkDocumentByTokens("\u{1F680}", 1, 0, 0);
 
+      // A single emoji at maxTokens=1 has no valid within-budget
+      // representation once the malformed detokenize() output is
+      // stripped, so the safety net drops it entirely rather than
+      // emitting a broken fragment. Asserting the exact count (rather
+      // than leaving it unchecked) makes that intentional outcome
+      // explicit and avoids a vacuous pass on an empty array.
+      expect(chunks.length).toBe(0);
       for (const chunk of chunks) {
         expect(chunk.text.isWellFormed()).toBe(true);
       }
@@ -3716,6 +3723,63 @@ describe("Token chunking guardrails", () => {
       const chunks = await chunkDocumentByTokens("\uD800", 900, 135);
 
       expect(chunks.length).toBe(0);
+    } finally {
+      setDefaultLlamaCpp(null);
+    }
+  });
+
+  test("chunkDocumentByTokens strips a lone high surrogate that lands at an ordinary chunk's leading edge", async () => {
+    // The lone high surrogate is already malformed in the source content
+    // (not produced by chunking) and happens to fall exactly on a normal,
+    // non-degenerate chunk boundary — reached via the plain base case
+    // (tokens.length <= maxTokens on the first try), not the recursive
+    // re-split or single-character-chunk paths already covered above.
+    setDefaultLlamaCpp({
+      async tokenize(text: string) {
+        return Array.from({ length: Math.ceil(text.length / 3) }, () => 1);
+      },
+      async detokenize(tokens: readonly number[]) {
+        return "x".repeat(tokens.length);
+      },
+    } as any);
+
+    try {
+      // maxChars = maxTokens(10) * avgCharsPerToken(3) = 30, so the first
+      // chunk boundary lands at index 30 — exactly where the lone high
+      // surrogate sits, making it the leading character of chunk 2.
+      const content = "x".repeat(30) + "\uD800" + "y".repeat(29);
+      const chunks = await chunkDocumentByTokens(content, 10, 0, 0);
+
+      expect(chunks.length).toBeGreaterThan(1);
+      for (const chunk of chunks) {
+        expect(chunk.text.isWellFormed()).toBe(true);
+      }
+    } finally {
+      setDefaultLlamaCpp(null);
+    }
+  });
+
+  test("chunkDocumentByTokens strips a lone low surrogate that lands at an ordinary chunk's trailing edge", async () => {
+    // Mirror of the leading-high case: a lone low surrogate already
+    // malformed in the source content falls exactly at the end of the
+    // first chunk, reached via the same plain base case.
+    setDefaultLlamaCpp({
+      async tokenize(text: string) {
+        return Array.from({ length: Math.ceil(text.length / 3) }, () => 1);
+      },
+      async detokenize(tokens: readonly number[]) {
+        return "x".repeat(tokens.length);
+      },
+    } as any);
+
+    try {
+      const content = "x".repeat(29) + "\uDC00" + "y".repeat(30);
+      const chunks = await chunkDocumentByTokens(content, 10, 0, 0);
+
+      expect(chunks.length).toBeGreaterThan(1);
+      for (const chunk of chunks) {
+        expect(chunk.text.isWellFormed()).toBe(true);
+      }
     } finally {
       setDefaultLlamaCpp(null);
     }

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -3642,6 +3642,84 @@ describe("Token chunking guardrails", () => {
       setDefaultLlamaCpp(null);
     }
   });
+
+  test("chunkDocumentByTokens keeps surrogate pairs intact when the token budget shrinks the char budget below 2", async () => {
+    // A tokenizer that reports one token per UTF-16 code unit makes
+    // astral-plane content (emoji) look 2x as "expensive" as it actually
+    // is, driving pushChunkWithinTokenLimit's recursive safeMaxChars
+    // calculation down to 1 char — exactly the case that used to make
+    // chunkDocument() slice a surrogate pair in half.
+    setDefaultLlamaCpp({
+      async tokenize(text: string) {
+        return Array.from({ length: text.length }, () => 1);
+      },
+      async detokenize(tokens: readonly number[]) {
+        return "x".repeat(tokens.length);
+      },
+    } as any);
+
+    try {
+      const content = "\u{1F680}".repeat(30); // 30 emoji, 60 UTF-16 code units
+      const chunks = await chunkDocumentByTokens(content, 2, 0, 0);
+
+      expect(chunks.length).toBeGreaterThan(1);
+      for (const chunk of chunks) {
+        expect(chunk.text.isWellFormed()).toBe(true);
+      }
+    } finally {
+      setDefaultLlamaCpp(null);
+    }
+  });
+
+  test("chunkDocumentByTokens drops rather than emits an unpaired surrogate from the detokenize() truncation fallback", async () => {
+    // Simulates a tokenizer that encodes a single astral-plane character
+    // across multiple tokens and, when the truncation fallback slices the
+    // token list down to a single token, detokenizes it back into a lone
+    // high surrogate — the shape a real BPE-style tokenizer can produce.
+    // This exercises the results.push() site fed by llm.detokenize()
+    // rather than by chunkDocument()'s char-slicing.
+    setDefaultLlamaCpp({
+      async tokenize(text: string) {
+        return Array.from({ length: text.length }, () => 1);
+      },
+      async detokenize(tokens: readonly number[]) {
+        return tokens.length === 1 ? "\uD83D" : "\u{1F680}".repeat(Math.ceil(tokens.length / 2));
+      },
+    } as any);
+
+    try {
+      const chunks = await chunkDocumentByTokens("\u{1F680}", 1, 0, 0);
+
+      for (const chunk of chunks) {
+        expect(chunk.text.isWellFormed()).toBe(true);
+      }
+    } finally {
+      setDefaultLlamaCpp(null);
+    }
+  });
+
+  test("chunkDocumentByTokens drops rather than emits an already-malformed lone surrogate from source content", async () => {
+    // Defense-in-depth for the text.length <= 1 base case: a bare lone
+    // surrogate that was already malformed in the source document (e.g.
+    // from an unrelated upstream encoding bug) should never reach the
+    // embedding pipeline as a 1-character chunk.
+    setDefaultLlamaCpp({
+      async tokenize(text: string) {
+        return Array.from({ length: text.length }, () => 1);
+      },
+      async detokenize(tokens: readonly number[]) {
+        return "x".repeat(tokens.length);
+      },
+    } as any);
+
+    try {
+      const chunks = await chunkDocumentByTokens("\uD800", 900, 135);
+
+      expect(chunks.length).toBe(0);
+    } finally {
+      setDefaultLlamaCpp(null);
+    }
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
## Problem

When a document being chunked for embedding has an astral-plane character (an emoji, for instance) sitting right at a chunk boundary, the chunker can cut the raw UTF-16 offset in the middle of that character's surrogate pair. The resulting chunk text then contains an unpaired surrogate, and some OpenAI-compatible remote embedding endpoints reject the JSON payload for it as invalid (`invalid string: surrogate U+DC00..U+DFFF must follow U+D800..U+DBFF`). Because the chunking is deterministic, the same chunk fails the same way on every retry, so the document's embedding gets stuck permanently.

This shows up in two places: `chunkDocumentWithBreakPoints`'s own boundary math, and `chunkDocumentByTokens`'s recursive re-splitting, which shrinks the char budget toward 1 for astral-plane-dense content with a high token/char ratio — small enough that a naive "give up" fallback for the boundary adjustment could reproduce the same split.

## Solution

Adds an `isSurrogatePairBoundary`/`adjustSurrogateBoundary` helper pair and applies it at the two points in `chunkDocumentWithBreakPoints` where a chunk boundary is finalized: the end of the current chunk (right before slicing) and the start of the next chunk (after subtracting the overlap). Both prefer nudging the cut back by one code unit to exclude the pair from this chunk; when that would stall the loop's forward progress (the char budget is too small to retreat), they advance by one code unit instead, including the whole pair rather than splitting it. Advancing is always safe — the pair's low surrogate is never the last character of the document when this fires, and the position is already known to be ahead of the previous chunk's start. This guarantees a pair is never split, regardless of how small the budget gets, and covers `chunkDocument`, `chunkDocumentAsync`, and `chunkDocumentByTokens`'s recursion for free, since they all route through this function.

As defense-in-depth, `chunkDocumentByTokens` also strips any unpaired surrogate immediately before each of its two result-emitting sites, via a small `stripUnpairedSurrogates` helper. This covers two paths the boundary fix above doesn't reach: its token-budget truncation fallback reconstructs text via the tokenizer's `detokenize()`, which can itself land mid-character if a single astral-plane character was encoded across multiple tokens; and a lone surrogate that was already malformed in the source document (an unrelated upstream encoding issue, not something chunking created) can land at an ordinary chunk boundary by coincidence, since chunking only adjusts boundaries that split a pair it can see. The helper checks all four ways a lone surrogate can sit at a boundary — leading lone low, leading lone high not followed by its low, trailing lone high, and trailing lone low not preceded by its high — distinguishing a genuine unpaired surrogate from the edge of a valid, complete pair.

## Tests

Regression tests in `test/store.test.ts`:
- Two tests for `chunkDocumentWithBreakPoints` construct content where an emoji sits exactly on the raw fallback boundary and on the overlap-derived boundary.
- Five tests for `chunkDocumentByTokens` (mocking the tokenizer, following the existing `setDefaultLlamaCpp` pattern used by the neighboring pathological-blob test) cover the recursive re-split path, the `detokenize()` truncation fallback, an already-malformed single-character document, and a lone surrogate landing at the leading/trailing edge of an ordinary (non-degenerate) chunk.

All seven fail on `main` and pass with this change (verified via revert-and-rerun, not just red-then-green ordering). The existing `chunkDocumentWithBreakPoints`/`chunkDocument` equivalence test and the full test suite (vitest + bun) remain green.