### PR TITLE
feat(cli): support -c/--collection filter for qmd update

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -656,7 +656,7 @@ async function showStatus(): Promise<void> {
   closeDb();
 }
 
-async function updateCollections(): Promise<void> {
+async function updateCollections(only: string[] = []): Promise<void> {
   const db = getDb();
   const storeInstance = getStore();
   // Collections are defined in YAML; no duplicate cleanup needed.
@@ -664,7 +664,14 @@ async function updateCollections(): Promise<void> {
   // Clear Ollama cache on update
   clearCache(db);
 
-  const collections = listCollections(db);
+  let collections = listCollections(db);
+
+  // Filter to specific collections when requested via -c / --collection
+  // (names are pre-validated by resolveCollectionFilter).
+  if (only.length > 0) {
+    const nameSet = new Set(only);
+    collections = collections.filter((col) => nameSet.has(col.name));
+  }
 
   if (collections.length === 0) {
     console.log(`${c.dim}No collections found. Run 'qmd collection add .' to index markdown files.${c.reset}`);
@@ -3284,7 +3291,7 @@ function showHelp(): void {
   console.log("Maintenance:");
   console.log("  qmd init                      - Create a project-local .qmd index");
   console.log("  qmd status                    - View index + collection health");
-  console.log("  qmd update [--pull]           - Re-index collections (optionally git pull first)");
+  console.log("  qmd update [--pull] [-c name] - Re-index collections (optionally git pull first)");
   console.log("  qmd embed [-f] [-c <name>]    - Generate/refresh vector embeddings");
   console.log("    --max-docs-per-batch <n>    - Cap docs loaded into memory per embedding batch");
   console.log("    --max-batch-mb <n>          - Cap UTF-8 MB loaded into memory per embedding batch");
@@ -4292,7 +4299,7 @@ if (isMain) {
       break;
 
     case "update":
-      await updateCollections();
+      await updateCollections(resolveCollectionFilter(cli.opts.collection, false));
       break;
 
     case "embed":

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1019,6 +1019,31 @@ ${token}
     const after = await runQmd(["get", "qmd://empty-check/only.md"], { dbPath, configDir });
     expect(after.exitCode).toBe(1);
   });
+
+  test("updates only the collection named with -c", async () => {
+    const { dbPath, configDir } = await createIsolatedTestEnv("update-filter");
+    const dirA = join(testDir, `update-filter-a-${Date.now()}`);
+    const dirB = join(testDir, `update-filter-b-${Date.now()}`);
+    await mkdir(dirA, { recursive: true });
+    await mkdir(dirB, { recursive: true });
+    await writeFile(join(dirA, "a.md"), "# Collection A\n");
+    await writeFile(join(dirB, "b.md"), "# Collection B\n");
+
+    expect((await runQmd(["collection", "add", dirA, "--name", "col-a"], { dbPath, configDir })).exitCode).toBe(0);
+    expect((await runQmd(["collection", "add", dirB, "--name", "col-b"], { dbPath, configDir })).exitCode).toBe(0);
+
+    const { stdout, exitCode } = await runQmd(["update", "-c", "col-b"], { dbPath, configDir });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Updating 1 collection(s)");
+    expect(stdout).toContain("col-b");
+    expect(stdout).not.toContain("col-a");
+  });
+
+  test("rejects -c with an unknown collection name", async () => {
+    const { stderr, exitCode } = await runQmd(["update", "-c", "no-such-collection"], { dbPath: localDbPath });
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Collection not found: no-such-collection");
+  });
 });
 
 describe("CLI Add-Context Command", () => {


### PR DESCRIPTION
## Problem

`qmd update` always reindexes every collection. With many or large collections (tens of thousands of docs), refreshing a single collection you just changed means paying for a full reindex of everything.

The CLI already parses a global `-c/--collection` flag (`multiple: true`) and validates it via `resolveCollectionFilter()` for `search`, `query`, `embed`, and `bench` — but the `update` command ignores it.

## Change

Wire the existing flag into `update`:

```
qmd update -c notes            # reindex only "notes"
qmd update -c notes -c work    # reindex several
qmd update                     # unchanged: all collections
```

- `updateCollections(only: string[] = [])` filters the collection list when names are given; names are pre-validated by `resolveCollectionFilter(cli.opts.collection, false)`, so unknown names error-exit exactly like they do for `search`/`embed` (`Collection not found: <name>`, exit 1).
- No flag → empty filter → identical update-all behavior.
- Help text updated: `qmd update [--pull] [-c name]`.

## Tests

Two new integration tests in the existing `CLI Update Command` suite:

- `updates only the collection named with -c` — two collections; asserts `Updating 1 collection(s)`, the named collection is updated, and the other isn't mentioned.
- `rejects -c with an unknown collection name` — asserts exit 1 and `Collection not found: no-such-collection`.

`vitest run test/cli.test.ts -t "Update Command"` → 4 passed (2 pre-existing + 2 new). `tsc -p tsconfig.build.json --noEmit` clean.
