### PR TITLE
fix(store): stop legacy path migration from evicting live files (#717)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Files whose names differ only in the characters the legacy slug collapsed to
+  `-` (spaces, underscores) no longer evict each other from the index (#717).
+  The legacy-path migration reconstructs the slug a pre-2.6 index would have
+  stored (`2026_06_16.md` → `2026-06-16.md`) and adopts the matching row — but
+  it did so even when that row belonged to a live file, renaming it onto the new
+  document. Indexing `2026-06-16.md` and `2026_06_16.md` in the same collection
+  silently dropped one of them; a `qmd update` after adding an underscored twin
+  removed the hyphenated file from the index entirely. The migration now skips
+  any row whose path is still owned by a file in the current scan, so it only
+  ever adopts genuinely stale rows. `handelize()` is unchanged — it exists only
+  to reconstruct pre-2.6 paths, and altering its output would strand snake_case
+  corpora on the old index format.
+- `qmd get`, `qmd multi-get` and `qmd ls <prefix>` now match `_` and `%` in
+  paths literally instead of as SQL `LIKE` wildcards (#717). `qmd get
+  2026_06_16.md` could return the contents of a sibling `2026-06-16.md`, and
+  `qmd ls notes/2026_06` listed files it did not match.
+
 ## [2.6.3] - 2026-06-24
 
 ### Added

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -57,7 +57,7 @@ import {
   vacuumDatabase,
   getCollectionsWithoutContext,
   getTopLevelPathsWithoutContext,
-  handelize,
+  escapeLikePattern,
   hybridQuery,
   vectorSearchQuery,
   structuredSearch,
@@ -1122,9 +1122,9 @@ function multiGet(pattern: string, maxLines?: number, maxBytes: number = DEFAULT
               d.path
             FROM documents d
             JOIN content ON content.hash = d.hash
-            WHERE d.path LIKE ? AND d.active = 1
+            WHERE d.path LIKE ? ESCAPE '\\' AND d.active = 1
             LIMIT 1
-          `).get(`%${name}`) as { virtual_path: string; body_length: number; collection: string; path: string } | null;
+          `).get(`%${escapeLikePattern(name)}`) as { virtual_path: string; body_length: number; collection: string; path: string } | null;
         }
       }
 
@@ -1461,10 +1461,10 @@ function listFiles(pathArg?: string): void {
       SELECT d.path, d.title, d.modified_at, LENGTH(ct.doc) as size
       FROM documents d
       JOIN content ct ON d.hash = ct.hash
-      WHERE d.collection = ? AND d.path LIKE ? AND d.active = 1
+      WHERE d.collection = ? AND d.path LIKE ? ESCAPE '\\' AND d.active = 1
       ORDER BY d.path
     `;
-    params = [coll.name, `${pathPrefix}%`];
+    params = [coll.name, `${escapeLikePattern(pathPrefix)}%`];
   } else {
     // List all files in the collection
     query = `
@@ -1693,6 +1693,9 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
 
   let indexed = 0, updated = 0, unchanged = 0, processed = 0;
   const seenPaths = new Set<string>();
+  // Literal paths of every file in this scan. Passed to the legacy-path
+  // migration so it never adopts a row that still belongs to a live file.
+  const livePaths = new Set(files.map(f => f.replace(/\\/g, '/')));
   const startTime = Date.now();
 
   for (const relativeFile of files) {
@@ -1721,7 +1724,7 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
     const title = extractTitle(content, relativeFile);
 
     // Check if document exists (also migrates legacy lowercase paths)
-    const existing = findOrMigrateLegacyDocument(db, collectionName, path);
+    const existing = findOrMigrateLegacyDocument(db, collectionName, path, livePaths);
 
     if (existing) {
       if (existing.hash === hash) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -401,6 +401,17 @@ export function normalizePathSeparators(path: string): string {
 }
 
 /**
+ * Escape a literal string for use inside a SQL LIKE pattern.
+ *
+ * `_` and `%` are LIKE wildcards, and filenames contain both — without this,
+ * looking up "2026_06_16.md" also matches "2026-06-16.md" and can return the
+ * wrong document (issue #717). Queries using this must declare ESCAPE '\'.
+ */
+export function escapeLikePattern(literal: string): string {
+  return literal.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
+
+/**
  * Detect if running inside WSL (Windows Subsystem for Linux).
  * On WSL, paths like /c/work/... are valid drvfs mount points, not Git Bash paths.
  */
@@ -1397,6 +1408,9 @@ export async function reindexCollection(
   const total = files.length;
   let indexed = 0, updated = 0, unchanged = 0, processed = 0;
   const seenPaths = new Set<string>();
+  // Literal paths of every file in this scan. Passed to the legacy-path
+  // migration so it never adopts a row that still belongs to a live file.
+  const livePaths = new Set(files.map(f => normalizePathSeparators(f)));
 
   for (const relativeFile of files) {
     const filepath = getRealPath(resolve(collectionPath, relativeFile));
@@ -1423,7 +1437,7 @@ export async function reindexCollection(
     const hash = await hashContent(content);
     const title = extractTitle(content, relativeFile);
 
-    const existing = findOrMigrateLegacyDocument(db, collectionName, path);
+    const existing = findOrMigrateLegacyDocument(db, collectionName, path, livePaths);
 
     if (existing) {
       if (existing.hash === hash) {
@@ -2062,6 +2076,15 @@ export function getDocid(hash: string): string {
  * - Preserve folder structure (a/b/c/d.md stays structured)
  * - Preserve file extension
  * - Preserve original case (important for case-sensitive filesystems)
+ *
+ * NOT used at index time — documents are stored under their literal
+ * filesystem path. The only remaining caller is
+ * findOrMigrateLegacyDocument(), which uses it to reconstruct the path a
+ * pre-2.6 index would have stored for a given file so that row can be renamed
+ * in place. Its output is therefore fixed by that old format: keeping `_` in
+ * the dash-separated character class (and `___` → `/`) is what lets
+ * snake_case corpora — the ones worst hit by the old slugging — migrate
+ * without losing their rows. Do not "fix" it to preserve underscores.
  */
 /** Replace emoji/symbol codepoints with their hex representation (e.g. 🐘 → 1f418) */
 function emojiToHex(str: string): string {
@@ -2596,39 +2619,56 @@ export function findActiveDocument(
  * FTS entry. Embeddings are keyed by content hash, so the rename is
  * safe — no re-embedding required.
  *
+ * `livePaths`, when given, is the set of literal paths of every file in the
+ * current scan of this collection. A legacy row whose path is in that set
+ * belongs to a *different* file that still exists on disk, so it must never be
+ * adopted — renaming it would evict that file from the index. See the comment
+ * on the legacy lookups below.
+ *
  * @internal Used by reindexCollection and indexFiles during qmd update.
  * Returns null if the document does not exist under either path.
  */
 export function findOrMigrateLegacyDocument(
   db: Database,
   collectionName: string,
-  path: string
+  path: string,
+  livePaths?: ReadonlySet<string>
 ): { id: number; hash: string; title: string } | null {
   const existing = findActiveDocument(db, collectionName, path);
   if (existing) return existing;
 
+  // Both fallbacks below are *lossy inverses*: many literal paths map onto the
+  // same legacy path ("a b.md", "a_b.md" and "a-b.md" all handalize to
+  // "a-b.md"), so a match is only evidence of a legacy row when no live file
+  // already owns that path. Without this guard, indexing "2026_06_16.md" next
+  // to an existing "2026-06-16.md" renames the latter's row and the hyphenated
+  // file silently disappears from the index (issue #717).
+  type LegacyRow = { id: number; hash: string; title: string; path: string };
+  const claimable = (row: LegacyRow | undefined): LegacyRow | undefined =>
+    row && !livePaths?.has(row.path) ? row : undefined;
+
   // Case-insensitive match (legacy normalization: e.g. "README.md" → "readme.md").
-  const legacyCase = db.prepare(`
-    SELECT id, hash, title FROM documents
+  const legacyCase = claimable(db.prepare(`
+    SELECT id, hash, title, path FROM documents
     WHERE collection = ? AND path COLLATE NOCASE = ? AND active = 1
     ORDER BY id
     LIMIT 1
-  `).get(collectionName, path) as { id: number; hash: string; title: string } | undefined;
+  `).get(collectionName, path) as LegacyRow | undefined);
 
   // Handalized-path match: existing DBs indexed with handelize() stored slugged paths
   // like "Budget-Revenue-Q4-2024.md" for a raw path like "Budget & Revenue (Q4) [2024].md".
   // Try matching the handalized form of the incoming raw path against the DB so that
   // qmd update on an old index can rename the row to the literal path.
-  let legacyHandalized: { id: number; hash: string; title: string } | undefined;
+  let legacyHandalized: LegacyRow | undefined;
   try {
     const handleized = handelize(path);
     if (handleized !== path) {
-      legacyHandalized = db.prepare(`
-        SELECT id, hash, title FROM documents
+      legacyHandalized = claimable(db.prepare(`
+        SELECT id, hash, title, path FROM documents
         WHERE collection = ? AND path = ? AND active = 1
         ORDER BY id
         LIMIT 1
-      `).get(collectionName, handleized) as { id: number; hash: string; title: string } | undefined;
+      `).get(collectionName, handleized) as LegacyRow | undefined);
     }
   } catch {
     // handelize throws on invalid paths; just skip
@@ -4217,15 +4257,15 @@ export function findDocument(db: Database, filename: string, options: { includeB
     WHERE 'qmd://' || d.collection || '/' || d.path = ? AND d.active = 1
   `).get(filepath) as DbDocRow | null;
 
-  // Try fuzzy match by virtual path
+  // Try fuzzy match by virtual path (suffix match on the literal path)
   if (!doc) {
     doc = db.prepare(`
       SELECT ${selectCols}
       FROM documents d
       JOIN content ON content.hash = d.hash
-      WHERE 'qmd://' || d.collection || '/' || d.path LIKE ? AND d.active = 1
+      WHERE 'qmd://' || d.collection || '/' || d.path LIKE ? ESCAPE '\\' AND d.active = 1
       LIMIT 1
-    `).get(`%${filepath}`) as DbDocRow | null;
+    `).get(`%${escapeLikePattern(filepath)}`) as DbDocRow | null;
   }
 
   // Try to match by absolute path (requires looking up collection paths from DB)
@@ -4373,9 +4413,9 @@ export function findDocuments(
           SELECT ${selectCols}
           FROM documents d
           JOIN content ON content.hash = d.hash
-          WHERE 'qmd://' || d.collection || '/' || d.path LIKE ? AND d.active = 1
+          WHERE 'qmd://' || d.collection || '/' || d.path LIKE ? ESCAPE '\\' AND d.active = 1
           LIMIT 1
-        `).get(`%${name}`) as DbDocRow | null;
+        `).get(`%${escapeLikePattern(name)}`) as DbDocRow | null;
       }
       if (doc) {
         fileRows.push(doc);

--- a/test/path-fidelity.test.ts
+++ b/test/path-fidelity.test.ts
@@ -333,6 +333,161 @@ describe("Path fidelity — CLI integration", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Separator collisions: files whose names differ only in the characters the
+// legacy slug collapsed to "-" (spaces, underscores) must all survive indexing.
+// Regression for #717 — the legacy-path migration used to adopt the row of a
+// live file, evicting it from the index.
+// ---------------------------------------------------------------------------
+
+// Helper: build an isolated env with an arbitrary set of files.
+async function createCollectionWith(
+  prefix: string,
+  files: Array<{ name: string; content: string }>
+): Promise<{ collectionDir: string; dbPath: string; configDir: string }> {
+  const envDir = join(testDir, prefix);
+  const collectionDir = join(envDir, "corpus");
+  const dbPath = join(envDir, "test.sqlite");
+  const configDir = join(envDir, "config");
+
+  await mkdir(collectionDir, { recursive: true });
+  await mkdir(configDir, { recursive: true });
+  for (const f of files) {
+    await writeFile(join(collectionDir, f.name), f.content);
+  }
+  await writeFile(join(configDir, "index.yml"), "collections: {}\n");
+
+  return { collectionDir: realpathSync(collectionDir), dbPath, configDir };
+}
+
+function activePaths(dbPath: string): string[] {
+  const db = openDatabase(dbPath);
+  const rows = db.prepare(
+    "SELECT path FROM documents WHERE active = 1 ORDER BY path"
+  ).all() as { path: string }[];
+  db.close();
+  return rows.map((r) => r.path);
+}
+
+describe("Path fidelity — separator collisions (#717)", () => {
+  const twins: Array<{ name: string; content: string }> = [
+    { name: "2026-06-16.md", content: "# Hyphen\n\nJournal searchterm-twin hyphenated.\n" },
+    { name: "2026_06_16.md", content: "# Underscore\n\nJournal searchterm-twin underscored.\n" },
+    { name: "my file.md", content: "# Spaced\n\nFile searchterm-twin with spaces.\n" },
+    { name: "my-file.md", content: "# Hyphenated\n\nFile searchterm-twin hyphenated.\n" },
+  ];
+
+  test("a fresh index keeps every file whose name differs only by separators", async () => {
+    const { collectionDir, dbPath, configDir } = await createCollectionWith("collide-fresh", twins);
+
+    const add = await runQmd(
+      ["collection", "add", collectionDir, "--name", "collide"],
+      { cwd: collectionDir, dbPath, configDir }
+    );
+    expect(add.exitCode, `collection add failed: ${add.stderr}`).toBe(0);
+
+    const paths = activePaths(dbPath);
+    for (const f of twins) {
+      expect(paths, `${f.name} missing from index`).toContain(f.name);
+    }
+    expect(paths).toHaveLength(twins.length);
+  });
+
+  test("adding an underscore twin to an indexed collection does not evict the hyphen file", async () => {
+    // Index the hyphenated file on its own first, then add its underscore twin.
+    // handelize("2026_06_16.md") === "2026-06-16.md", so the legacy-path lookup
+    // matches the live hyphen row — it must not be renamed onto the new file.
+    const { collectionDir, dbPath, configDir } = await createCollectionWith(
+      "collide-incremental",
+      [twins[0]!]
+    );
+
+    const add = await runQmd(
+      ["collection", "add", collectionDir, "--name", "collide"],
+      { cwd: collectionDir, dbPath, configDir }
+    );
+    expect(add.exitCode, `collection add failed: ${add.stderr}`).toBe(0);
+    expect(activePaths(dbPath)).toEqual(["2026-06-16.md"]);
+
+    await writeFile(join(collectionDir, twins[1]!.name), twins[1]!.content);
+    const update = await runQmd(["update"], { cwd: collectionDir, dbPath, configDir });
+    expect(update.exitCode, `qmd update failed: ${update.stderr}`).toBe(0);
+
+    expect(activePaths(dbPath)).toEqual(["2026-06-16.md", "2026_06_16.md"]);
+
+    // Each path resolves to its own content — no row was repointed.
+    const hyphen = await runQmd(["get", "2026-06-16.md"], { cwd: collectionDir, dbPath, configDir });
+    expect(hyphen.exitCode, `get hyphen failed: ${hyphen.stderr}`).toBe(0);
+    expect(hyphen.stdout).toContain("hyphenated");
+
+    const underscore = await runQmd(["get", "2026_06_16.md"], { cwd: collectionDir, dbPath, configDir });
+    expect(underscore.exitCode, `get underscore failed: ${underscore.stderr}`).toBe(0);
+    expect(underscore.stdout).toContain("underscored");
+  });
+
+  test("underscores in a path are matched literally, not as LIKE wildcards", async () => {
+    const { collectionDir, dbPath, configDir } = await createCollectionWith("collide-like", twins);
+    const add = await runQmd(
+      ["collection", "add", collectionDir, "--name", "collide"],
+      { cwd: collectionDir, dbPath, configDir }
+    );
+    expect(add.exitCode, `collection add failed: ${add.stderr}`).toBe(0);
+
+    // multi-get by name must return only the underscored file
+    const mg = await runQmd(
+      ["multi-get", "2026_06_16.md", "--format", "files"],
+      { cwd: collectionDir, dbPath, configDir }
+    );
+    expect(mg.exitCode, `multi-get failed: ${mg.stderr}`).toBe(0);
+    expect(mg.stdout).toContain("2026_06_16.md");
+    expect(mg.stdout).not.toContain("2026-06-16.md");
+
+    // `ls <prefix>` must not treat "_" as "any character"
+    const ls = await runQmd(["ls", "collide/2026_06"], { cwd: collectionDir, dbPath, configDir });
+    expect(ls.exitCode, `ls failed: ${ls.stderr}`).toBe(0);
+    expect(ls.stdout).toContain("2026_06_16.md");
+    expect(ls.stdout).not.toContain("2026-06-16.md");
+  });
+
+  test("legacy rows still migrate when a live file shares the slug", async () => {
+    // Old index built by the pre-2.6 slugging code: the underscore file was
+    // stored as "2026-06-16.md". The collection now also contains a real
+    // "2026-06-16.md". After `qmd update`, both files must be present and the
+    // legacy row must not have been renamed away from the file that owns it.
+    const { collectionDir, dbPath, configDir } = await createCollectionWith(
+      "collide-legacy",
+      [twins[0]!, twins[1]!]
+    );
+
+    const store = createStore(dbPath);
+    const now = new Date().toISOString();
+    const legacyYaml = `collections:\n  collide:\n    path: "${collectionDir}"\n    mask: "**/*.md"\n`;
+    await writeFile(join(configDir, "index.yml"), legacyYaml);
+    syncConfigToDb(store.db, YAML.parse(legacyYaml) as CollectionConfig);
+
+    // Only one row exists — the old slugging collapsed both names onto it.
+    const legacyPath = handelize(normalizePathSeparators(twins[1]!.name));
+    expect(legacyPath).toBe("2026-06-16.md");
+    const legacyHash = await hashContent(twins[1]!.content);
+    insertContent(store.db, legacyHash, twins[1]!.content, now);
+    insertDocument(store.db, "collide", legacyPath, "Underscore", legacyHash, now, now);
+    store.close();
+
+    const update = await runQmd(["update"], { cwd: collectionDir, dbPath, configDir });
+    expect(update.exitCode, `qmd update failed: ${update.stderr}`).toBe(0);
+
+    expect(activePaths(dbPath)).toEqual(["2026-06-16.md", "2026_06_16.md"]);
+
+    const hyphen = await runQmd(["get", "2026-06-16.md"], { cwd: collectionDir, dbPath, configDir });
+    expect(hyphen.exitCode).toBe(0);
+    expect(hyphen.stdout).toContain("hyphenated");
+
+    const underscore = await runQmd(["get", "2026_06_16.md"], { cwd: collectionDir, dbPath, configDir });
+    expect(underscore.exitCode).toBe(0);
+    expect(underscore.stdout).toContain("underscored");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Migration test: old handalized DB upgraded by `qmd update`
 // ---------------------------------------------------------------------------
 

--- a/test/store.helpers.unit.test.ts
+++ b/test/store.helpers.unit.test.ts
@@ -16,6 +16,7 @@ import {
   normalizeDocid,
   isDocid,
   handelize,
+  escapeLikePattern,
   cleanupOrphanedVectors,
   sanitizeFTS5Term,
 } from "../src/store";
@@ -218,6 +219,15 @@ describe("handelize", () => {
     expect(handelize("a")).toBe("a");
     expect(handelize("1")).toBe("1");
     expect(handelize("a.md")).toBe("a.md");
+  });
+
+  test("escapes SQL LIKE wildcards in literal paths", () => {
+    // "_" and "%" are LIKE wildcards — filenames containing them must not
+    // match sibling files (issue #717).
+    expect(escapeLikePattern("2026_06_16.md")).toBe("2026\\_06\\_16.md");
+    expect(escapeLikePattern("100%.md")).toBe("100\\%.md");
+    expect(escapeLikePattern("back\\slash.md")).toBe("back\\\\slash.md");
+    expect(escapeLikePattern("plain-file.md")).toBe("plain-file.md");
   });
 
   test("normalizes virtual paths", () => {


### PR DESCRIPTION
Fixes #717 — the parts of it that are still reproducible on `main` (v2.6.3).

Index-time slugging is already gone (070147d stores literal filesystem paths), but two lossy-path bugs survived it, and both still cost snake_case corpora documents today.

## 1. The legacy-path migration evicts live files

`findOrMigrateLegacyDocument()` reconstructs the path a pre-2.6 index would have stored (`handelize("2026_06_16.md")` → `"2026-06-16.md"`) and adopts the row it finds. That inverse is lossy — `a b.md`, `a_b.md` and `a-b.md` all handalize to `a-b.md` — and the lookup never checked whether the row it matched belongs to a file that still exists. So it renames a live file's row onto the new document, and the live file disappears from the index.

On `main` today:

```sh
mkdir -p /tmp/qmd-717 && cd /tmp/qmd-717
echo hyphen     > 2026-06-16.md
echo underscore > 2026_06_16.md
qmd collection add /tmp/qmd-717 --name t717
qmd ls t717
# qmd://t717/2026_06_16.md      <- only one row; 2026-06-16.md is gone
```

The incremental form is worse, because it removes a document that was already indexed and searchable: index `2026-06-16.md` alone, then add `2026_06_16.md` and run `qmd update` — the hyphenated file is dropped. This is the OP's "Only one file is shown", and @manpreetmaso's Logseq journals (`2026_06_16.md`) are the worst case since every filename in that corpus has the collision.

Both legacy lookups now skip a candidate row whose path is still owned by a file in the current scan, so only genuinely stale rows are adopted. Legitimate migration of a pre-2.6 index is unaffected (covered by the existing migration test, plus a new one where the legacy slug collides with a live file).

**`handelize()` is deliberately left alone.** It is no longer a display or index function — its only caller is this migration, where its job is to reproduce the old path format byte for byte. Making it preserve `_` would mean pre-2.6 snake_case indexes stop matching and stop migrating in place — precisely the users this issue is about. Added a doc comment saying so, since "why does this still slugify underscores?" is an obvious next question.

## 2. `_` in a path is a SQL `LIKE` wildcard

Same report, different mechanism, and it returns the *wrong document* rather than none:

```sh
qmd get 2026_06_16.md    # printed the contents of 2026-06-16.md
qmd ls notes/2026_06     # listed notes/2026-06-… too
```

`qmd get`, `qmd multi-get` and `qmd ls <prefix>` interpolate the user's path straight into a `LIKE` pattern, where `_` matches any character and `%` matches anything. Added `escapeLikePattern()` + an `ESCAPE` clause at the four call sites. I found this because the regression test for (1) failed on it.

## Tests

`test/path-fidelity.test.ts` gains a "separator collisions (#717)" block: fresh index keeps all four of `2026-06-16.md` / `2026_06_16.md` / `my file.md` / `my-file.md`; adding an underscored twin to an indexed collection does not evict the hyphenated file (and each path still resolves to its own content); `_` is matched literally by `multi-get` and `ls`; and a legacy row still migrates when a live file shares its slug. Plus a unit test for `escapeLikePattern()`.

Full suite passes (952 passed / 7 skipped). Two pre-existing failures on my machine are unrelated to this change and fail identically on a clean `main`: a batch of `cli.test.ts` cases that assert `stderr === ""` and pick up Node's `DEP0205` warning under this Node version, and `mcp.test.ts > MCP HTTP Transport` (`SqliteError: no such column: T.name`). Both go away with `NODE_OPTIONS=--no-deprecation` / are environmental.

## Not addressed here

`--full-path` still falls back to the `qmd://` URI when a result can't be resolved on disk, and drops the docid while doing it (`get`/`multi-get` keep it). With literal paths stored, that fallback now only fires for files that genuinely no longer exist, so it reads as a stale-index signal rather than a normalization bug — happy to follow up separately if you want it to warn or keep the docid.
