### PR TITLE
fix: bump plugin version on every release so installed plugins receive updates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
 			"name": "qmd",
 			"source": "./skills",
 			"description": "Search and retrieve documents from local markdown files.",
-			"version": "0.1.0",
+			"version": "2.6.3",
 			"author": {
 				"name": "tobi",
 				"email": "tobi@lutke.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Fixed
 
+- Claude Code plugin: releases now bump the plugin version in
+  `.claude-plugin/marketplace.json` in lockstep with `package.json`. The
+  plugin cache is keyed on this version, and it had been stuck at `0.1.0`
+  since February — so installed plugins never received skill updates
+  (users who installed in February are still being served that snapshot
+  today, despite the qmd skill nearly tripling in size since). Also bumps
+  the plugin to `2.6.3` as a one-time catch-up so existing installs pick
+  up the current skill on their next `claude plugin update`.
+
 - `qmd doctor` no longer false-positives `.etag` HTTP sidecars (written by
   `qmd pull` next to each download) as invalid GGUF models. The model-cache
   check now only inspects real `.gguf` files, so a sidecar that happens to

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -108,7 +108,18 @@ awk '
 
 jq --arg v "$NEW" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
 
-git add package.json CHANGELOG.md
+# Keep the Claude Code plugin version in lockstep with the package version.
+# The plugin cache is keyed on this version: if it never changes, installed
+# plugins never pick up skill updates shipped in this release. (sed, not jq,
+# to preserve the file's formatting; the file has a single "version" key.)
+# The grep guard fails the release if the stamp didn't land (a non-matching
+# sed exits 0, which set -e would never catch).
+sed 's/"version": "[^"]*"/"version": "'"$NEW"'"/' \
+  .claude-plugin/marketplace.json > .claude-plugin/marketplace.json.tmp
+grep -qF "\"version\": \"$NEW\"" .claude-plugin/marketplace.json.tmp
+mv .claude-plugin/marketplace.json.tmp .claude-plugin/marketplace.json
+
+git add package.json CHANGELOG.md .claude-plugin/marketplace.json
 git commit -m "release: v$NEW"
 git tag -a "v$NEW" -m "v$NEW"
 

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -31,7 +31,9 @@ When the user triggers `/release <version>`:
 
 4. **Cut the release** — run `scripts/release.sh <version>`. This renames
    `[Unreleased]` → `[X.Y.Z] - date`, inserts a fresh `[Unreleased]`,
-   bumps `package.json`, commits, and tags.
+   bumps `package.json` and the plugin version in
+   `.claude-plugin/marketplace.json` (so installed plugins see the update),
+   commits, and tags.
 
 5. **Show the final changelog** — print the full `[Unreleased]` +
    minor series rollup via `scripts/extract-changelog.sh <version>`.


### PR DESCRIPTION
Fixes #789. Related: #790 (same neglected manifest — the scoping fix there composes cleanly with this one).

## Problem

Claude Code's plugin cache is keyed on the plugin `version` declared in `.claude-plugin/marketplace.json` — and that version has been `0.1.0` since the plugin was introduced in February. `claude plugin update` compares version strings, sees `0.1.0 == 0.1.0`, and reports "already at the latest version" no matter how much the plugin's content has changed.

The consequence: **no installed plugin has ever received a skill update.** Every user is permanently pinned to whatever `skills/` contained on the day they first installed:

- A February installer is still served the February snapshot of `skills/qmd/SKILL.md` (internal metadata `1.1.1`, titled "Quick Markdown Search", ~151 lines).
- Today's `skills/qmd/SKILL.md` is at metadata `2.2.0`, ~295 lines — the structured `intent:`/`lex:`/`vec:`/`hyde:` query guidance, the `:from:count` line-range workflow, `--full-path`, the pitfalls section: none of it reaches previously-installed users.
- The only escape hatch is a manual `claude plugin uninstall` + `install` (there is no `--force` refresh), which nothing prompts users to do.

Verified on a long-standing install: the cached copy at `~/.claude/plugins/cache/qmd/qmd/0.1.0/skills/qmd/SKILL.md` was dated Feb 20 and differed from the repo's current file, while the marketplace clone was fully up to date — the version gate was the only thing holding the update back. Bumping the version and running `claude plugin update` immediately delivered the current skill.

## Fix

Two parts:

1. **`scripts/release.sh` now stamps the plugin version in lockstep with `package.json`** — cache invalidation becomes a free side effect of every release, with no new manual step to remember. `sed` rather than `jq` so the file's formatting is preserved (a `jq` round-trip reformats the inline arrays; the file has a single `"version"` key so the substitution is unambiguous). A `grep` guard fails the release if the stamp didn't land — a non-matching `sed` exits 0, which `set -e` alone would never catch.

2. **One-time catch-up: plugin version `0.1.0` → `2.6.3`** (the current package version), so existing installs pick up the current skill on their next `claude plugin update` instead of staying stranded.

Also documents the extra bump in the release skill (`skills/release/SKILL.md`) and adds a changelog entry under `[Unreleased]`.

After this, the plugin version tracks the package version (`2.6.4`, `2.7.0`, …) automatically on every `scripts/release.sh` run.

## Notes

- No MCP/runtime behavior change for the plugin; the release-skill docs are updated to mention the extra bump, and the version metadata and release tooling change.
- Existing installs still need one `claude plugin update qmd@qmd` (or reinstall) after this lands to cross the gap; from then on updates flow normally.
