### PR TITLE
fix: scope plugin source to ./skills so installs ship 50 KB, not 230 MB

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
 	"plugins": [
 		{
 			"name": "qmd",
-			"source": "./",
+			"source": "./skills",
 			"description": "Search and retrieve documents from local markdown files.",
 			"version": "0.1.0",
 			"author": {
@@ -17,7 +17,7 @@
 			"repository": "https://github.com/tobi/qmd",
 			"license": "MIT",
 			"keywords": ["markdown", "search", "qmd"],
-			"skills": ["./skills/"],
+			"skills": ["./qmd", "./release"],
 			"mcpServers": {
 				"qmd": {
 					"command": "qmd",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Fixed
 
+- Claude Code plugin: scope the plugin `source` to `./skills` so installs
+  copy just the skills (~50 KB) instead of the entire repository. Previously a
+  canonical install materialized ~230 MB / 9,000+ items into
+  `~/.claude/plugins/cache/` — including a full npm dependency install
+  triggered by the repo-root `package.json`. Both skills (`qmd` and `release`)
+  still ship, unchanged. (#790)
+
 - `qmd collection add` now rejects missing paths and regular files before
   creating collection configuration or index state. The error reports both the
   received and resolved path so malformed shell arguments can be corrected.


### PR DESCRIPTION
Fixes #790. Related: #789 / PR #794 (same manifest, different lines — the two changes are merge-independent; a three-way merge test of both diffs combines cleanly).

## Problem

The plugin entry in `.claude-plugin/marketplace.json` declares `"source": "./"` — the repository root. Two consequences:

1. **Every install copies the entire repository** into `~/.claude/plugins/cache/`, when the plugin machinery only reads the skill files and the manifest metadata (~50 KB total).
2. **Because the copied plugin root contains a `package.json`, `claude plugin install` also runs a full npm dependency install** inside the cache. On a canonical install (`claude plugin marketplace add tobi/qmd` + `claude plugin install qmd@qmd`) the resulting `~/.claude/plugins/cache/qmd/qmd/0.1.0/` folder is **230 MB with 9,000+ items**, including `node_modules` with native builds — per machine, for a few KB of skills.

## Fix

Scope the plugin source to the skills directory — nothing is added or removed, both skills (`qmd` and `release`) ship exactly as before:

> **Note:** #790 led with the narrower `"source": "./skills/qmd"` as its verified fix, which would also stop shipping the `release` skill. This PR deliberately implements the issue's *other* offered scoping which does not alter which skills are included so there is no disruption to either skill functionalities.

```diff
-			"source": "./",
+			"source": "./skills",
...
-			"skills": ["./skills/"],
+			"skills": ["./qmd", "./release"],
```

The payload drops **230 MB → ~50 KB**, and no dependency install runs (there is no `package.json` anywhere under `skills/`).

The `mcpServers` declaration is untouched and unaffected: `"command": "qmd"` resolves via `PATH`, not relative to the plugin root.

Verified locally with the equivalent scoping (`"source": "./skills/qmd"`): the install snapshot shrinks as described, the skill arrives byte-identical (md5-checked), no dependency install runs, and `claude plugin details` parses the component inventory cleanly.

## Notes

- **Optional further trim**: if you decide the `release` skill is maintainer-only and shouldn't ship to plugin users, `"source": "./skills/qmd"` with `"skills": ["./"]` narrows the payload to just the qmd skill (~24 KB) — that's the variant verified byte-for-byte in #790. Happy to amend this PR or follow up either way.
- **Delivery**: fresh installs benefit immediately. Already-installed plugins only pick up manifest changes after a version bump — that's #789 / PR #794.
- **Changelog**: this and #794 both add an entry under `[Unreleased]`, so whichever merges second will need a trivial changelog rebase — happy to handle that on my side.
