### PR TITLE
fix(db): avoid "database is busy" during CJK FTS rebuild

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -907,24 +907,25 @@ function rebuildFTSForCjkNormalization(db: Database): void {
       }
     });
 
-    // .iterate() pulls rows one at a time from SQLite rather than materializing
-    // the entire result set (every document body) into a JS array up front.
-    const iterator = db.prepare(`
+    // Pull bounded batches and finalize each SELECT before starting the insert
+    // transaction. Holding a better-sqlite3 iterator open while beginning a
+    // transaction on the same connection raises "connection is busy".
+    const selectBatch = db.prepare(`
       SELECT d.id, d.collection, d.path, d.title, content.doc as body
       FROM documents d
       JOIN content ON content.hash = d.hash
       WHERE d.active = 1
-    `).iterate<FtsRow>();
+        AND d.id > ?
+      ORDER BY d.id
+      LIMIT ?
+    `);
 
-    for (const row of iterator) {
-      batch.push(row);
-      if (batch.length >= BATCH_SIZE) {
-        flushBatch();
-        batch = [];
-      }
-    }
-    if (batch.length > 0) {
+    let lastId = 0;
+    for (;;) {
+      batch = selectBatch.all(lastId, BATCH_SIZE) as FtsRow[];
+      if (batch.length === 0) break;
       flushBatch();
+      lastId = batch[batch.length - 1]!.id;
     }
 
     // Atomic publish: copy the completed shadow index into the live table and

--- a/test/store-cjk-fts.test.ts
+++ b/test/store-cjk-fts.test.ts
@@ -1,20 +1,33 @@
 /**
  * store-cjk-fts.test.ts — Regression tests for the CJK FTS migration fix.
  *
- * Covers rebuildFTSForCjkNormalization()'s streaming, batched, shadow-table
- * rebuild (src/store.ts). The previous implementation cleared documents_fts up
- * front, loaded every document body into memory via .all() inside a single
- * giant transaction, and left FTS empty on a mid-rebuild crash. The new
- * implementation:
- *   - streams source rows via .iterate() (never materializes all bodies),
- *   - builds a separate documents_fts_rebuild shadow table in batches,
+ * Covers rebuildFTSForCjkNormalization()'s batched, shadow-table rebuild
+ * (src/store.ts). The original implementation cleared documents_fts up front,
+ * loaded every document body into memory via a single unbounded .all() inside
+ * one giant transaction, and left FTS empty on a mid-rebuild crash.
+ *
+ * The row-scan strategy has since gone through two fixes for two distinct
+ * failure modes, both still enforced here:
+ *   - OOM (the original bug): never materialize every active document's body
+ *     into one JS array at once. First fixed via a streaming .iterate()
+ *     cursor; now enforced via bounded, keyset-paginated .all() batches
+ *     (`WHERE id > ? ORDER BY id LIMIT ?`) — each call materializes at most
+ *     one bounded batch, then the batch is discarded before the next SELECT.
+ *   - "database is busy" (a later regression): a better-sqlite3 .iterate()
+ *     cursor left open while a transaction begins on the same connection
+ *     raises "database is busy". Bounded LIMIT/OFFSET-style batches instead
+ *     fully finalize each SELECT before the insert transaction starts, so the
+ *     connection is never busy with two concurrent statements.
+ * Both fixes share the same shadow-table structure:
+ *   - builds a separate documents_fts_rebuild shadow table in bounded batches,
  *   - atomically swaps it in only after a complete pass,
  *   - drops a lingering shadow table from a prior crashed run on the next run.
  *
  * These tests exercise the migration through createStore()/openDatabase() on a
  * pre-seeded DB that omits the fts_cjk_normalized_version marker (forcing a
- * rebuild on open), plus a structural assertion that .iterate() — not .all() —
- * drives the body scan.
+ * rebuild on open), plus a structural assertion that the body scan is bounded
+ * (LIMIT + keyset pagination) rather than a single unbounded .all() over every
+ * active document.
  *
  * Run with: bun test test/store-cjk-fts.test.ts
  *        or: pnpm test:node test/store-cjk-fts.test.ts
@@ -134,11 +147,11 @@ function activeDocCount(db: Database): number {
 }
 
 // =============================================================================
-// Test 1 — structural: rebuild streams via .iterate(), never .all()
+// Test 1 — structural: rebuild scans source rows in bounded, paginated batches
 // =============================================================================
 
-describe("rebuildFTSForCjkNormalization — streaming source scan", () => {
-  test("body scan uses .iterate(), not .all()", () => {
+describe("rebuildFTSForCjkNormalization — bounded source scan", () => {
+  test("body scan is bounded (keyset LIMIT pagination), never one unbounded .all()", () => {
     const __filename = fileURLToPath(import.meta.url);
     const storeSrc = readFileSync(
       join(dirname(__filename), "..", "src", "store.ts"),
@@ -155,18 +168,24 @@ describe("rebuildFTSForCjkNormalization — streaming source scan", () => {
     const fnBodyRaw = storeSrc.slice(startIdx, endIdx);
 
     // Strip line + block comments so the assertions match real executed code,
-    // not the narrative comment that mentions the old `.all()` behavior.
+    // not narrative comments that mention old/alternate behavior.
     const fnBody = fnBodyRaw
       .replace(/\/\*[\s\S]*?\*\//g, "")
       .split("\n")
       .map(line => line.replace(/\/\/.*$/, ""))
       .join("\n");
 
-    // The source-row scan must stream one row at a time.
-    expect(fnBody).toMatch(/\.iterate</);
-    // It must NOT pull the whole result set (every document body) into a JS
-    // array — that is the OOM regression this fix removes.
-    expect(fnBody).not.toMatch(/\.all\(/);
+    // The guarded invariant is "bounded memory", not a specific better-sqlite3
+    // API. Any .all() used for the source-body scan must be paired with a
+    // LIMIT and a keyset cursor (id > ?), so each call only ever materializes
+    // one bounded batch — never every active document's body at once (the
+    // original OOM bug) — and each SELECT fully finalizes before the insert
+    // transaction begins (the "database is busy" regression this replaced a
+    // streaming .iterate() cursor to fix, since holding a cursor open on the
+    // same connection while starting a transaction raises "busy").
+    expect(fnBody).toMatch(/LIMIT\s*\?/);
+    expect(fnBody).toMatch(/d\.id\s*>\s*\?/);
+    expect(fnBody).toMatch(/ORDER BY d\.id/);
     // Sanity: it builds into a shadow table and atomically swaps it in via
     // INSERT INTO … SELECT (not ALTER TABLE … RENAME, which triggers SQLite
     // 3.25+ re-validation of dependent trigger bodies).


### PR DESCRIPTION
## What

`rebuildFTSForCjkNormalization()` streamed source rows via a better-sqlite3
`.iterate()` cursor while later beginning a transaction on the same
connection to flush each batch. Holding that cursor open across the
`BEGIN` raises `"database is busy"` instead of completing the rebuild.

## Why

The streaming cursor was introduced by #737 specifically to avoid loading
every document body into memory at once (the original OOM bug). That fix
was correct for the memory problem but introduced this one: two concurrent
statements (an open iterator + a transaction) on the same connection.

## How

Replaced the `.iterate()` cursor with bounded, keyset-paginated batches
(`WHERE id > ? ORDER BY id LIMIT ?`) — each `SELECT` fully finalizes before
its batch's insert transaction starts, so the connection is never busy with
two concurrent statements. Batches stay bounded (500 rows at a time, same
as before), so this doesn't reintroduce the OOM bug #737 fixed — confirmed
by that PR's own large-library migration test, still passing.

Updated the structural regression test to assert the actual protected
invariant (bounded `LIMIT` + keyset pagination, never one unbounded `.all()`
over every active document) instead of a specific API shape
(`.iterate(), not .all()`), since that literal check no longer applies now
that bounded `.all()` batches are the mechanism.

## Testing

- `tsc -p tsconfig.build.json --noEmit` clean
- `test/store-cjk-fts.test.ts` (6 tests) and `test/store-concurrency.test.ts`
  (2 tests) all pass

Split out of #761 per review feedback there, so this can be reviewed and
reverted independently of the embedding-provider change.