### PR TITLE
feat: configure per-resource LLM idle timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+### Added
+
+- LLM idle unloading is configurable independently for embedding, reranking,
+  and query generation with `QMD_EMBED_IDLE_TIMEOUT_MINUTES`,
+  `QMD_RERANK_IDLE_TIMEOUT_MINUTES`, and
+  `QMD_GENERATE_IDLE_TIMEOUT_MINUTES`, plus the SDK
+  `llmIdleTimeoutMinutes` option. Each defaults to five minutes, accepts
+  `0..34560`, and uses `0` to keep that resource group warm.
+- `qmd doctor` reports all three effective idle timeouts. Invalid timeout
+  settings are diagnosed without skipping later checks and make Doctor exit
+  nonzero; other CLI, SDK, and MCP startup paths reject them immediately.
+
+### Changed
+
+- Idle cleanup now unloads each resource group's contexts and model
+  independently, resets lazy-load guards for transparent reload, and defers
+  cleanup while that QMD store has an active LLM session or operation. Explicit
+  shutdown still releases all resources regardless of idle-timeout settings.
+
 ## [2.6.3] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -136,7 +136,34 @@ The HTTP server exposes two endpoints:
 - `POST /mcp` — MCP Streamable HTTP (JSON responses, stateless)
 - `GET /health` — liveness check with uptime
 
-LLM models stay loaded in VRAM across requests. Embedding/reranking contexts are disposed after 5 min idle and transparently recreated on the next request (~1s penalty, models remain loaded).
+LLM resources are shared across HTTP requests, but they do not stay in VRAM
+indefinitely by default. Embedding, reranking, and query-generation resources
+each have an independent five-minute idle timeout. When one expires, QMD
+disposes that group's contexts before its model and transparently reloads both
+on the next request.
+
+Configure the three timeouts in minutes:
+
+```sh
+# Keep embeddings permanently warm, use the default for reranking,
+# and unload query generation after 30 minutes.
+export QMD_EMBED_IDLE_TIMEOUT_MINUTES=0
+export QMD_RERANK_IDLE_TIMEOUT_MINUTES=5
+export QMD_GENERATE_IDLE_TIMEOUT_MINUTES=30
+qmd mcp --http
+```
+
+`0` disables idle unloading for that resource group and therefore uses more
+RAM/VRAM. Values may range from `0` through `34560` minutes (24 days). An
+explicit server shutdown still releases every context and model. `qmd doctor`
+shows all three effective values and reports invalid settings while continuing
+the remaining diagnostics.
+
+The CLI `qmd search` command is lexical BM25 search and needs no LLM.
+`qmd vsearch` needs the embedding model and its contexts. `qmd query` can use
+query generation, embedding, and reranking, so each of the three timers may be
+active independently. Retrieved document text comes from the index; holding
+search results or document content does not keep a GPU context alive.
 
 Point any MCP client at `http://localhost:8181/mcp` to connect.
 
@@ -204,6 +231,11 @@ import { createStore } from '@tobilu/qmd'
 // 1. Inline config — no files needed besides the DB
 const store = await createStore({
   dbPath: './index.sqlite',
+  llmIdleTimeoutMinutes: {
+    embed: 0,       // Keep embedding resources warm
+    rerank: 5,      // Default behavior
+    generate: 30,
+  },
   config: {
     collections: {
       docs: { path: '/path/to/docs', pattern: '**/*.md' },
@@ -222,9 +254,18 @@ const store2 = await createStore({
 const store3 = await createStore({ dbPath: './index.sqlite' })
 ```
 
+`llmIdleTimeoutMinutes` follows the same `0..34560` range and per-resource
+semantics as the environment variables. Explicit SDK values take precedence
+over the corresponding environment variables; omitted values use the
+environment and then the five-minute default. `store.close()` always releases
+all LLM resources, including groups configured with `0`.
+
 #### Search
 
-The unified `search()` method handles both simple queries and pre-expanded structured queries:
+The SDK's unified `search()` method handles both simple queries and
+pre-expanded structured queries. Unlike the lexical-only CLI command
+`qmd search`, `store.search()` is a hybrid operation and may use query
+generation, embeddings, and reranking:
 
 ```typescript
 // Simple query — auto-expanded via LLM, then BM25 + vector + reranking
@@ -1071,6 +1112,9 @@ llm_cache       -- Cached LLM responses (query expansion, rerank scores)
 | `QMD_CONFIG_DIR` | unset | Override the config directory outright (takes precedence over `XDG_CONFIG_HOME`) |
 | `QMD_LLAMA_GPU` | `auto` | Force llama.cpp GPU backend (`metal`, `vulkan`, `cuda`) or disable GPU with `false` |
 | `QMD_FORCE_CPU` | unset | Set to `1`/`true` to force CPU mode before any CUDA/Vulkan/Metal probing. Equivalent CLI flag: `--no-gpu`. |
+| `QMD_EMBED_IDLE_TIMEOUT_MINUTES` | `5` | Unload embedding contexts and model after this many idle minutes. `0` keeps them warm; maximum `34560`. |
+| `QMD_RERANK_IDLE_TIMEOUT_MINUTES` | `5` | Unload reranking contexts and model after this many idle minutes. `0` keeps them warm; maximum `34560`. |
+| `QMD_GENERATE_IDLE_TIMEOUT_MINUTES` | `5` | Unload the query-generation model after this many idle minutes. `0` keeps it warm; maximum `34560`. |
 | `QMD_EMBED_PARALLELISM` | automatic | Override embedding/reranking context parallelism (1-8). Windows CUDA defaults to `1` because parallel CUDA contexts can crash with `ggml-cuda.cu:98`; use Vulkan or raise this only if your driver is stable. |
 
 ## How It Works

--- a/skills/qmd/references/mcp-setup.md
+++ b/skills/qmd/references/mcp-setup.md
@@ -47,6 +47,25 @@ qmd mcp --http --daemon     # Background
 qmd mcp stop                # Stop daemon
 ```
 
+Embedding, reranking, and query-generation resources each unload after five
+idle minutes by default. Configure them independently with
+`QMD_EMBED_IDLE_TIMEOUT_MINUTES`, `QMD_RERANK_IDLE_TIMEOUT_MINUTES`, and
+`QMD_GENERATE_IDLE_TIMEOUT_MINUTES`. `0` keeps that resource group warm; the
+maximum is `34560` minutes. For example:
+
+```bash
+QMD_EMBED_IDLE_TIMEOUT_MINUTES=0 QMD_RERANK_IDLE_TIMEOUT_MINUTES=10 QMD_GENERATE_IDLE_TIMEOUT_MINUTES=30 qmd mcp --http
+```
+
+The `query` tool uses embedding resources for `vec`/`hyde` searches and uses
+reranking unless the caller disables it. Its searches are already expanded, so
+the MCP tool does not invoke query generation itself; the CLI `qmd query` and a
+simple SDK `store.search()` can use all three groups. Each group's activity and
+timer are independent. Retrieved Markdown content is index data, not a live GPU
+context. Stopping the server explicitly releases all contexts and models,
+including groups configured with `0`. Use `qmd doctor` to inspect the effective
+values.
+
 ## Tools
 
 ### query

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -80,7 +80,7 @@ import {
   type ReindexResult,
   type ChunkStrategy,
 } from "../store.js";
-import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, setDefaultLlamaCpp, LlamaCpp, withLLMSession, pullModels, DEFAULT_MODEL_CACHE_DIR, resolveEmbedModel, resolveGenerateModel, resolveRerankModel, resolveModels, inspectGgufFile, isDarwinMetalMitigationActive } from "../llm.js";
+import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, setDefaultLlamaCpp, LlamaCpp, withLLMSession, pullModels, DEFAULT_MODEL_CACHE_DIR, resolveEmbedModel, resolveGenerateModel, resolveRerankModel, resolveModels, inspectGgufFile, isDarwinMetalMitigationActive, resolveLlmIdleTimeoutMs, type LlmResourceGroup } from "../llm.js";
 import {
   formatSearchResults,
   formatDocuments,
@@ -125,21 +125,67 @@ let store: ReturnType<typeof createStore> | null = null;
 let storeDbPathOverride: string | undefined;
 let currentIndexName = "index";
 
-function getStore(): ReturnType<typeof createStore> {
+const LLM_IDLE_TIMEOUT_ENV_NAMES: Record<LlmResourceGroup, string> = {
+  embed: "QMD_EMBED_IDLE_TIMEOUT_MINUTES",
+  rerank: "QMD_RERANK_IDLE_TIMEOUT_MINUTES",
+  generate: "QMD_GENERATE_IDLE_TIMEOUT_MINUTES",
+};
+
+type LlmIdleTimeoutDiagnostic = {
+  group: LlmResourceGroup;
+  milliseconds: number;
+  source: string;
+  error?: Error;
+};
+
+function inspectLlmIdleTimeoutConfiguration(): LlmIdleTimeoutDiagnostic[] {
+  return (Object.keys(LLM_IDLE_TIMEOUT_ENV_NAMES) as LlmResourceGroup[]).map((group) => {
+    const envName = LLM_IDLE_TIMEOUT_ENV_NAMES[group];
+    const rawValue = process.env[envName];
+    try {
+      return {
+        group,
+        milliseconds: resolveLlmIdleTimeoutMs(group, undefined, rawValue),
+        source: rawValue === undefined ? "default" : envName,
+      };
+    } catch (error) {
+      return {
+        group,
+        milliseconds: resolveLlmIdleTimeoutMs(group, undefined, undefined),
+        source: envName,
+        error: error instanceof Error ? error : new Error(String(error)),
+      };
+    }
+  });
+}
+
+function validateLlmIdleTimeoutEnvironment(): void {
+  const invalid = inspectLlmIdleTimeoutConfiguration().find((diagnostic) => diagnostic.error);
+  if (invalid?.error) throw invalid.error;
+}
+
+function getStore(idleTimeoutMs?: Record<LlmResourceGroup, number>): ReturnType<typeof createStore> {
   if (!store) {
     store = createStore(storeDbPathOverride);
-    // Sync YAML config into SQLite store_collections so store.ts reads from DB
+    // Sync YAML config into SQLite store_collections so store.ts reads from DB.
+    // Only configuration loading is optional; LLM configuration errors must
+    // remain visible to normal CLI commands.
+    let activeModels: ReturnType<typeof resolveModelsForCli> | undefined;
     try {
-      const activeModels = ensureModelsConfiguredForCli();
+      activeModels = ensureModelsConfiguredForCli();
       const config = loadConfig();
       syncConfigToDb(store.db, config);
+    } catch {
+      // Config may not exist yet — that's fine, DB works without it.
+    }
+
+    if (activeModels) {
       setDefaultLlamaCpp(new LlamaCpp({
         embedModel: activeModels.embed,
         generateModel: activeModels.generate,
         rerankModel: activeModels.rerank,
+        idleTimeoutMs,
       }));
-    } catch {
-      // Config may not exist yet — that's fine, DB works without it
     }
   }
   return store;
@@ -222,6 +268,7 @@ type CliLifecycleWritable = {
 type FinishSuccessfulCliCommandOptions = {
   command: string;
   format?: OutputFormat;
+  exitCode?: number;
   cleanup?: () => Promise<void>;
   exit?: (code: number) => void;
   stdout?: CliLifecycleWritable;
@@ -260,24 +307,26 @@ async function flushWritable(stream: CliLifecycleWritable): Promise<void> {
  */
 export async function finishSuccessfulCliCommand(options: FinishSuccessfulCliCommandOptions): Promise<void> {
   const stderr = options.stderr ?? process.stderr;
+  const exitCode = options.exitCode ?? 0;
 
   await flushWritable(options.stdout ?? process.stdout);
 
   try {
     await (options.cleanup ?? disposeDefaultLlamaCpp)();
   } catch (error) {
+    const outputDescription = exitCode === 0 ? "successful output" : "command output";
     stderr.write(
-      `QMD Warning: cleanup after successful output failed (${error instanceof Error ? error.message : String(error)}); exiting 0 because command output completed.\n`
+      `QMD Warning: cleanup after ${outputDescription} failed (${error instanceof Error ? error.message : String(error)}); exiting ${exitCode} because command output completed.\n`
     );
   }
   await flushWritable(stderr);
 
   if (options.exit) {
-    options.exit(0);
+    options.exit(exitCode);
     return;
   }
 
-  process.exitCode = 0;
+  process.exitCode = exitCode;
 }
 
 // Ensure cursor is restored on exit
@@ -3492,6 +3541,9 @@ function collectEnvironmentOverrides(activeModels: { embed: string; generate: st
   add("QMD_FORCE_CPU", "forces llama.cpp to bypass GPU backends; embeddings/query will be slower but GPU crashes are avoided");
   add("QMD_LLAMA_GPU", "selects llama.cpp GPU backend (metal/cuda/vulkan) or disables GPU when set to false/off/0");
   add("QMD_DOCTOR_DEVICE_PROBE", "controls qmd doctor native device probing; 0/off skips GPU probing");
+  add("QMD_EMBED_IDLE_TIMEOUT_MINUTES", "sets embedding model/context idle unload in minutes; 0 keeps them loaded");
+  add("QMD_RERANK_IDLE_TIMEOUT_MINUTES", "sets reranking model/context idle unload in minutes; 0 keeps them loaded");
+  add("QMD_GENERATE_IDLE_TIMEOUT_MINUTES", "sets generation model idle unload in minutes; 0 keeps it loaded");
   add("QMD_EMBED_PARALLELISM", "overrides embedding parallel context count; too high can exhaust RAM/VRAM");
   add("QMD_EXPAND_CONTEXT_SIZE", "overrides query expansion context size; larger values use more memory");
   add("QMD_RERANK_CONTEXT_SIZE", "overrides reranker context size; larger values use more memory");
@@ -3532,6 +3584,21 @@ function checkDoctorIndexConfig(nextSteps: string[]): DoctorConfigCheck {
     nextSteps.push(`Fix invalid YAML in ${configPath}, then rerun \`qmd doctor\`.`);
     return { config: null, valid: false };
   }
+}
+
+function checkLlmIdleTimeouts(diagnostics: LlmIdleTimeoutDiagnostic[]): boolean {
+  for (const diagnostic of diagnostics) {
+    const label = `LLM idle timeout (${diagnostic.group})`;
+    if (diagnostic.error) {
+      doctorCheck(label, false, diagnostic.error.message);
+      continue;
+    }
+
+    const minutes = diagnostic.milliseconds / 60_000;
+    doctorCheck(label, true, `${minutes} minutes (${diagnostic.source})`);
+  }
+
+  return diagnostics.every((diagnostic) => diagnostic.error === undefined);
 }
 
 function checkEnvironmentOverrides(activeModels: { embed: string; generate: string; rerank: string }, configModels: ModelsConfig = {}): void {
@@ -3823,7 +3890,11 @@ async function runDoctorDeviceChecks(nextSteps: string[]): Promise<void> {
 }
 
 async function showDoctor(): Promise<void> {
-  const storeInstance = getStore();
+  const idleTimeoutDiagnostics = inspectLlmIdleTimeoutConfiguration();
+  const idleTimeoutMs = Object.fromEntries(
+    idleTimeoutDiagnostics.map((diagnostic) => [diagnostic.group, diagnostic.milliseconds]),
+  ) as Record<LlmResourceGroup, number>;
+  const storeInstance = getStore(idleTimeoutMs);
   const db = storeInstance.db;
   const pkg = readPackageJson();
   const activeModels = resolveModelsForCli();
@@ -3841,6 +3912,8 @@ async function showDoctor(): Promise<void> {
   } catch (error) {
     doctorCheck("SQLite runtime", false, error instanceof Error ? error.message : String(error));
   }
+
+  const idleTimeoutsValid = checkLlmIdleTimeouts(idleTimeoutDiagnostics);
 
   const betterSqliteVersion = pkg.dependencies?.["better-sqlite3"] ?? pkg.devDependencies?.["better-sqlite3"] ?? "not declared";
   doctorCheck("better-sqlite3 package", true, String(betterSqliteVersion));
@@ -3940,6 +4013,7 @@ async function showDoctor(): Promise<void> {
   }
 
   closeDb();
+  if (!idleTimeoutsValid) process.exitCode = 1;
 }
 
 function printDoctorHint(): void {
@@ -4021,6 +4095,14 @@ if (isMain) {
   if (!cli.command || cli.values.help) {
     showHelp();
     process.exit(cli.values.help ? 0 : 1);
+  }
+
+  if (cli.command !== "doctor") {
+    try {
+      validateLlmIdleTimeoutEnvironment();
+    } catch (error) {
+      exitWithError(error);
+    }
   }
 
   switch (cli.command) {
@@ -4581,6 +4663,7 @@ if (isMain) {
     await finishSuccessfulCliCommand({
       command: cli.command,
       format: cli.opts.format,
+      exitCode: Number(process.exitCode ?? 0),
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,8 @@ import {
 } from "./store.js";
 import {
   LlamaCpp,
+  resolveLlmIdleTimeoutMs,
+  withLLMSessionForLlm,
 } from "./llm.js";
 import {
   setConfigSource,
@@ -209,6 +211,12 @@ export interface StoreOptions {
   configPath?: string;
   /** Inline collection config (mutually exclusive with `configPath`) */
   config?: CollectionConfig;
+  /** Per-resource LLM idle timeouts in minutes (0..34560). Defaults to 5; `0` keeps that resource warm. */
+  llmIdleTimeoutMinutes?: {
+    embed?: number;
+    rerank?: number;
+    generate?: number;
+  };
 }
 
 /**
@@ -350,6 +358,24 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
     throw new Error("Provide either configPath or config, not both");
   }
 
+  const llmIdleTimeoutMs = {
+    embed: resolveLlmIdleTimeoutMs(
+      "embed",
+      options.llmIdleTimeoutMinutes?.embed,
+      process.env.QMD_EMBED_IDLE_TIMEOUT_MINUTES,
+    ),
+    rerank: resolveLlmIdleTimeoutMs(
+      "rerank",
+      options.llmIdleTimeoutMinutes?.rerank,
+      process.env.QMD_RERANK_IDLE_TIMEOUT_MINUTES,
+    ),
+    generate: resolveLlmIdleTimeoutMs(
+      "generate",
+      options.llmIdleTimeoutMinutes?.generate,
+      process.env.QMD_GENERATE_IDLE_TIMEOUT_MINUTES,
+    ),
+  };
+
   // Create the internal store (opens DB, creates tables)
   const internal = createStoreInternal(options.dbPath);
   const db = internal.db;
@@ -372,14 +398,13 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
   }
   // else: DB-only mode — no external config, use existing store_collections
 
-  // Create a per-store LlamaCpp instance — lazy-loads models on first use,
-  // auto-unloads after 5 min inactivity to free VRAM.
+  // Create a per-store LlamaCpp instance. Each model group lazy-loads on
+  // demand and independently unloads after its configured idle timeout.
   const llm = new LlamaCpp({
     embedModel: config?.models?.embed,
     generateModel: config?.models?.generate,
     rerankModel: config?.models?.rerank,
-    inactivityTimeoutMs: 5 * 60 * 1000,
-    disposeModelsOnInactivity: true,
+    idleTimeoutMs: llmIdleTimeoutMs,
   });
   internal.llm = llm;
 
@@ -388,7 +413,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
     dbPath: internal.dbPath,
 
     // Search
-    search: async (opts) => {
+    search: async (opts) => withLLMSessionForLlm(llm, async () => {
       if (!opts.query && !opts.queries) {
         throw new Error("search() requires either 'query' or 'queries'");
       }
@@ -424,10 +449,16 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
         skipRerank,
         chunkStrategy: opts.chunkStrategy,
       });
-    },
+    }),
     searchLex: async (q, opts) => internal.searchFTS(q, opts?.limit, opts?.collection),
-    searchVector: async (q, opts) => internal.searchVec(q, llm.embedModelName, opts?.limit, opts?.collection),
-    expandQuery: async (q, opts) => internal.expandQuery(q, undefined, opts?.intent),
+    searchVector: async (q, opts) => withLLMSessionForLlm(
+      llm,
+      async (session) => internal.searchVec(q, llm.embedModelName, opts?.limit, opts?.collection, session),
+    ),
+    expandQuery: async (q, opts) => withLLMSessionForLlm(
+      llm,
+      async () => internal.expandQuery(q, undefined, opts?.intent),
+    ),
     get: async (pathOrDocid, opts) => internal.findDocument(pathOrDocid, opts),
     getDocumentBody: async (pathOrDocid, opts) => {
       const result = internal.findDocument(pathOrDocid, { includeBody: false });

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -290,6 +290,37 @@ export function resolveModels(config?: ModelResolutionConfig): Required<ModelRes
   };
 }
 
+
+export type LlmResourceGroup = "embed" | "rerank" | "generate";
+
+export function resolveLlmIdleTimeoutMs(
+  group: LlmResourceGroup,
+  sdkValue: number | undefined,
+  envValue: string | undefined,
+): number {
+  const envNames: Record<LlmResourceGroup, string> = {
+    embed: "QMD_EMBED_IDLE_TIMEOUT_MINUTES",
+    rerank: "QMD_RERANK_IDLE_TIMEOUT_MINUTES",
+    generate: "QMD_GENERATE_IDLE_TIMEOUT_MINUTES",
+  };
+  const optionName = sdkValue === undefined
+    ? envNames[group]
+    : `llmIdleTimeoutMinutes.${group}`;
+  const minutes = sdkValue ?? (
+    envValue === undefined
+      ? 5
+      : envValue.trim() === ""
+        ? Number.NaN
+        : Number(envValue)
+  );
+
+  if (!Number.isFinite(minutes) || minutes < 0 || minutes > 34_560) {
+    throw new Error(`${optionName} must be a finite number between 0 and 34560 minutes`);
+  }
+
+  return minutes * 60 * 1000;
+}
+
 // Local model cache directory
 const MODEL_CACHE_DIR = process.env.XDG_CACHE_HOME
   ? join(process.env.XDG_CACHE_HOME, "qmd", "models")
@@ -566,28 +597,13 @@ export type LlamaCppConfig = {
    * Default: 2048. Can also be set via QMD_EXPAND_CONTEXT_SIZE.
    */
   expandContextSize?: number;
-  /**
-   * Inactivity timeout in ms before unloading contexts (default: 2 minutes, 0 to disable).
-   *
-   * Per node-llama-cpp lifecycle guidance, we prefer keeping models loaded and only disposing
-   * contexts when idle, since contexts (and their sequences) are the heavy per-session objects.
-   * @see https://node-llama-cpp.withcat.ai/guide/objects-lifecycle
-   */
-  inactivityTimeoutMs?: number;
-  /**
-   * Whether to dispose models on inactivity (default: false).
-   *
-   * Keeping models loaded avoids repeated VRAM thrash; set to true only if you need aggressive
-   * memory reclaim.
-   */
-  disposeModelsOnInactivity?: boolean;
+  /** Resolved per-resource idle timeouts in milliseconds. */
+  idleTimeoutMs?: Record<LlmResourceGroup, number>;
 };
 
 /**
  * LLM implementation using node-llama-cpp
  */
-// Default inactivity timeout: 5 minutes (keep models warm during typical search sessions)
-const DEFAULT_INACTIVITY_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_EXPAND_CONTEXT_SIZE = 2048;
 
 export type LlamaGpuMode = "auto" | "metal" | "vulkan" | "cuda" | false;
@@ -709,19 +725,30 @@ export class LlamaCpp implements LLM {
   private embedModelLoadPromise: Promise<LlamaModel> | null = null;
   private generateModelLoadPromise: Promise<LlamaModel> | null = null;
   private rerankModelLoadPromise: Promise<LlamaModel> | null = null;
+  private rerankContextsCreatePromise: Promise<Awaited<ReturnType<LlamaModel["createRankingContext"]>>[]> | null = null;
   // Guard against concurrent ensureLlama() calls creating duplicate Llama
   // instances. Without this, two concurrent callers each build their own
   // runtime and the last write to this.llama wins, leaving models/grammars
   // bound to different Llama instances ("different Llama instance" errors).
   private llamaLoadPromise: Promise<Llama> | null = null;
 
-  // Inactivity timer for auto-unloading models
-  private inactivityTimer: ReturnType<typeof setTimeout> | null = null;
-  private inactivityTimeoutMs: number;
-  private disposeModelsOnInactivity: boolean;
+  // Independent inactivity timers for each resource group.
+  private readonly idleTimers: Record<LlmResourceGroup, ReturnType<typeof setTimeout> | null> = {
+    embed: null,
+    rerank: null,
+    generate: null,
+  };
+  private readonly idleUnloadPromises: Record<LlmResourceGroup, Promise<void> | null> = {
+    embed: null,
+    rerank: null,
+    generate: null,
+  };
+  private readonly idleTimeoutMs: Record<LlmResourceGroup, number>;
 
   // Track disposal state to prevent double-dispose
   private disposed = false;
+  private activeLifecycleSessions = 0;
+  private inFlightLifecycleOperations = 0;
 
 
   constructor(config: LlamaCppConfig = {}) {
@@ -736,8 +763,23 @@ export class LlamaCpp implements LLM {
     this.rerankModelUri = resolveRerankModel({ rerank: config.rerankModel });
     this.modelCacheDir = config.modelCacheDir || MODEL_CACHE_DIR;
     this.expandContextSize = resolveExpandContextSize(config.expandContextSize);
-    this.inactivityTimeoutMs = config.inactivityTimeoutMs ?? DEFAULT_INACTIVITY_TIMEOUT_MS;
-    this.disposeModelsOnInactivity = config.disposeModelsOnInactivity ?? false;
+    this.idleTimeoutMs = config.idleTimeoutMs ?? {
+      embed: resolveLlmIdleTimeoutMs(
+        "embed",
+        undefined,
+        process.env.QMD_EMBED_IDLE_TIMEOUT_MINUTES,
+      ),
+      rerank: resolveLlmIdleTimeoutMs(
+        "rerank",
+        undefined,
+        process.env.QMD_RERANK_IDLE_TIMEOUT_MINUTES,
+      ),
+      generate: resolveLlmIdleTimeoutMs(
+        "generate",
+        undefined,
+        process.env.QMD_GENERATE_IDLE_TIMEOUT_MINUTES,
+      ),
+    };
   }
 
   get embedModelName(): string {
@@ -752,93 +794,139 @@ export class LlamaCpp implements LLM {
     return this.rerankModelUri;
   }
 
-  /**
-   * Reset the inactivity timer. Called after each model operation.
-   * When timer fires, models are unloaded to free memory (if no active sessions).
-   */
-  private touchActivity(): void {
-    // Clear existing timer
-    if (this.inactivityTimer) {
-      clearTimeout(this.inactivityTimer);
-      this.inactivityTimer = null;
-    }
+  acquireLifecycleSession(): void {
+    this.activeLifecycleSessions++;
+  }
 
-    // Only set timer if we have disposable contexts and timeout is enabled
-    if (this.inactivityTimeoutMs > 0 && this.hasLoadedContexts()) {
-      this.inactivityTimer = setTimeout(() => {
-        // Check if session manager allows unloading
-        // canUnloadLLM is defined later in this file - it checks the session manager
-        // We use dynamic import pattern to avoid circular dependency issues
-        if (typeof canUnloadLLM === 'function' && !canUnloadLLM()) {
-          // Active sessions/operations - reschedule timer
-          this.touchActivity();
-          return;
-        }
-        this.unloadIdleResources().catch(err => {
-          console.error("Error unloading idle resources:", err);
-        });
-      }, this.inactivityTimeoutMs);
-      // Don't keep process alive just for this timer
-      this.inactivityTimer.unref();
-    }
+  releaseLifecycleSession(): void {
+    this.activeLifecycleSessions = Math.max(0, this.activeLifecycleSessions - 1);
+  }
+
+  lifecycleOperationStart(): void {
+    this.inFlightLifecycleOperations++;
+  }
+
+  lifecycleOperationEnd(): void {
+    this.inFlightLifecycleOperations = Math.max(0, this.inFlightLifecycleOperations - 1);
+  }
+
+  canUnloadIdleResources(): boolean {
+    return this.activeLifecycleSessions === 0 && this.inFlightLifecycleOperations === 0;
   }
 
   /**
-   * Check if any contexts are currently loaded (and therefore worth unloading on inactivity).
+   * Reset one resource group's inactivity timer after model activity.
+   * The timer unloads that group's contexts and model once the instance is idle.
    */
-  private hasLoadedContexts(): boolean {
-    return !!(this.embedContexts.length > 0 || this.rerankContexts.length > 0);
+  private touchActivity(group: LlmResourceGroup): void {
+    if (this.disposed) return;
+
+    const currentTimer = this.idleTimers[group];
+    if (currentTimer) {
+      clearTimeout(currentTimer);
+      this.idleTimers[group] = null;
+    }
+
+    const timeoutMs = this.idleTimeoutMs[group];
+    if (timeoutMs === 0 || !this.hasLoadedResources(group)) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      if (!this.canUnloadIdleResources()) {
+        this.touchActivity(group);
+        return;
+      }
+      this.startIdleUnload(group);
+    }, timeoutMs);
+    timer.unref();
+    this.idleTimers[group] = timer;
+  }
+
+  private startIdleUnload(group: LlmResourceGroup): void {
+    if (this.idleUnloadPromises[group]) return;
+
+    const unloadPromise = this.unloadIdleResources(group).catch((error) => {
+      console.error(`Error unloading idle ${group} resources:`, error);
+    });
+    this.idleUnloadPromises[group] = unloadPromise;
+    void unloadPromise.finally(() => {
+      if (this.idleUnloadPromises[group] === unloadPromise) {
+        this.idleUnloadPromises[group] = null;
+      }
+    });
+  }
+
+  private async waitForIdleUnload(group: LlmResourceGroup): Promise<void> {
+    const unloadPromise = this.idleUnloadPromises[group];
+    if (unloadPromise) await unloadPromise;
   }
 
   /**
-   * Unload idle resources but keep the instance alive for future use.
-   *
-   * By default, this disposes contexts (and their dependent sequences), while keeping models loaded.
-   * This matches the intended lifecycle: model → context → sequence, where contexts are per-session.
+   * Check whether this resource group currently holds a model or context.
    */
-  async unloadIdleResources(): Promise<void> {
-    // Don't unload if already disposed
+  private hasLoadedResources(group: LlmResourceGroup): boolean {
+    if (group === "embed") {
+      return this.embedModel !== null || this.embedContexts.length > 0;
+    }
+    if (group === "rerank") {
+      return this.rerankModel !== null || this.rerankContexts.length > 0;
+    }
+    return this.generateModel !== null;
+  }
+
+  /**
+   * Unload one idle resource group while keeping the instance reusable.
+   * Contexts are disposed before their owning model; load guards are reset so
+   * the next operation can transparently recreate the complete resource group.
+   */
+  private async unloadIdleResources(group: LlmResourceGroup): Promise<void> {
     if (this.disposed) {
       return;
     }
 
-    // Clear timer
-    if (this.inactivityTimer) {
-      clearTimeout(this.inactivityTimer);
-      this.inactivityTimer = null;
-    }
+    const timer = this.idleTimers[group];
+    if (timer) clearTimeout(timer);
+    this.idleTimers[group] = null;
 
-    // Dispose contexts first
-    for (const ctx of this.embedContexts) {
-      await ctx.dispose();
-    }
-    this.embedContexts = [];
-    for (const ctx of this.rerankContexts) {
-      await ctx.dispose();
-    }
-    this.rerankContexts = [];
-
-    // Optionally dispose models too (opt-in)
-    if (this.disposeModelsOnInactivity) {
-      if (this.embedModel) {
-        await this.embedModel.dispose();
-        this.embedModel = null;
-      }
-      if (this.generateModel) {
-        await this.generateModel.dispose();
-        this.generateModel = null;
-      }
-      if (this.rerankModel) {
-        await this.rerankModel.dispose();
-        this.rerankModel = null;
-      }
-      // Reset load promises so models can be reloaded later
+    if (group === "embed") {
+      const contexts = this.embedContexts;
+      const model = this.embedModel;
+      this.embedContexts = [];
+      this.embedModel = null;
       this.embedModelLoadPromise = null;
-      this.generateModelLoadPromise = null;
-      this.rerankModelLoadPromise = null;
+      this.embedContextsCreatePromise = null;
+      for (const context of contexts) {
+        await disposeWithTimeout("idle embedding context", () => context.dispose());
+      }
+      if (model) {
+        await disposeWithTimeout("idle embedding model", () => model.dispose());
+      }
+      return;
     }
 
-    // Note: We keep llama instance alive - it's lightweight
+    if (group === "rerank") {
+      const contexts = this.rerankContexts;
+      const model = this.rerankModel;
+      this.rerankContexts = [];
+      this.rerankModel = null;
+      this.rerankModelLoadPromise = null;
+      this.rerankContextsCreatePromise = null;
+      for (const context of contexts) {
+        await disposeWithTimeout("idle rerank context", () => context.dispose());
+      }
+      if (model) {
+        await disposeWithTimeout("idle rerank model", () => model.dispose());
+      }
+      return;
+    }
+
+    const model = this.generateModel;
+    this.generateModel = null;
+    this.generateModelLoadPromise = null;
+    if (model) {
+      await disposeWithTimeout("idle generation model", () => model.dispose());
+    }
   }
 
   /**
@@ -991,6 +1079,7 @@ export class LlamaCpp implements LLM {
    * Load embedding model (lazy)
    */
   private async ensureEmbedModel(): Promise<LlamaModel> {
+    await this.waitForIdleUnload("embed");
     if (this.embedModel) {
       return this.embedModel;
     }
@@ -1004,7 +1093,7 @@ export class LlamaCpp implements LLM {
       const model = await llama.loadModel(this.modelLoadOptions(modelPath));
       this.embedModel = model;
       // Model loading counts as activity - ping to keep alive
-      this.touchActivity();
+      this.touchActivity("embed");
       return model;
     })();
 
@@ -1064,8 +1153,9 @@ export class LlamaCpp implements LLM {
   private embedContextsCreatePromise: Promise<LlamaEmbeddingContext[]> | null = null;
 
   private async ensureEmbedContexts(): Promise<LlamaEmbeddingContext[]> {
+    await this.waitForIdleUnload("embed");
     if (this.embedContexts.length > 0) {
-      this.touchActivity();
+      this.touchActivity("embed");
       return this.embedContexts;
     }
 
@@ -1089,7 +1179,7 @@ export class LlamaCpp implements LLM {
           break;
         }
       }
-      this.touchActivity();
+      this.touchActivity("embed");
       return this.embedContexts;
     })();
 
@@ -1112,6 +1202,7 @@ export class LlamaCpp implements LLM {
    * Load generation model (lazy) - context is created fresh per call
    */
   private async ensureGenerateModel(): Promise<LlamaModel> {
+    await this.waitForIdleUnload("generate");
     if (!this.generateModel) {
       if (this.generateModelLoadPromise) {
         return await this.generateModelLoadPromise;
@@ -1131,7 +1222,7 @@ export class LlamaCpp implements LLM {
         this.generateModelLoadPromise = null;
       }
     }
-    this.touchActivity();
+    this.touchActivity("generate");
     if (!this.generateModel) {
       throw new Error("Generate model not loaded");
     }
@@ -1142,6 +1233,7 @@ export class LlamaCpp implements LLM {
    * Load rerank model (lazy)
    */
   private async ensureRerankModel(): Promise<LlamaModel> {
+    await this.waitForIdleUnload("rerank");
     if (this.rerankModel) {
       return this.rerankModel;
     }
@@ -1155,7 +1247,7 @@ export class LlamaCpp implements LLM {
       const model = await llama.loadModel(this.modelLoadOptions(modelPath));
       this.rerankModel = model;
       // Model loading counts as activity - ping to keep alive
-      this.touchActivity();
+      this.touchActivity("rerank");
       return model;
     })();
 
@@ -1192,7 +1284,16 @@ export class LlamaCpp implements LLM {
     return Number.isFinite(v) && v > 0 ? v : 2048;
   })();
   private async ensureRerankContexts(): Promise<Awaited<ReturnType<LlamaModel["createRankingContext"]>>[]> {
-    if (this.rerankContexts.length === 0) {
+    await this.waitForIdleUnload("rerank");
+    if (this.rerankContexts.length > 0) {
+      this.touchActivity("rerank");
+      return this.rerankContexts;
+    }
+    if (this.rerankContextsCreatePromise) {
+      return await this.rerankContextsCreatePromise;
+    }
+
+    this.rerankContextsCreatePromise = (async () => {
       const model = await this.ensureRerankModel();
       // ~960 MB per context with flash attention at contextSize 2048
       const n = Math.min(await this.computeParallelism(1000), 4);
@@ -1205,7 +1306,6 @@ export class LlamaCpp implements LLM {
           }));
         } catch {
           if (this.rerankContexts.length === 0) {
-            // Flash attention might not be supported — retry without it
             try {
               this.rerankContexts.push(await model.createRankingContext({
                 contextSize: LlamaCpp.RERANK_CONTEXT_SIZE,
@@ -1218,9 +1318,15 @@ export class LlamaCpp implements LLM {
           break;
         }
       }
+      this.touchActivity("rerank");
+      return this.rerankContexts;
+    })();
+
+    try {
+      return await this.rerankContextsCreatePromise;
+    } finally {
+      this.rerankContextsCreatePromise = null;
     }
-    this.touchActivity();
-    return this.rerankContexts;
   }
 
   // ==========================================================================
@@ -1296,7 +1402,7 @@ export class LlamaCpp implements LLM {
 
   async embed(text: string, options: EmbedOptions = {}): Promise<EmbeddingResult | null> {
     // Ping activity at start to keep models alive during this operation
-    this.touchActivity();
+    this.touchActivity("embed");
 
     try {
       const context = await this.ensureEmbedContext();
@@ -1316,6 +1422,8 @@ export class LlamaCpp implements LLM {
     } catch (error) {
       console.error("Embedding error:", error);
       return null;
+    } finally {
+      this.touchActivity("embed");
     }
   }
 
@@ -1326,7 +1434,7 @@ export class LlamaCpp implements LLM {
   async embedBatch(texts: string[], options: EmbedOptions = {}): Promise<(EmbeddingResult | null)[]> {
     if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
     // Ping activity at start to keep models alive during this operation
-    this.touchActivity();
+    this.touchActivity("embed");
 
     if (texts.length === 0) return [];
 
@@ -1345,7 +1453,7 @@ export class LlamaCpp implements LLM {
               console.warn(`⚠ Batch text truncated to fit embedding context (${limit} tokens)`);
             }
             const embedding = await context.getEmbeddingFor(safeText);
-            this.touchActivity();
+            this.touchActivity("embed");
             embeddings.push({ embedding: Array.from(embedding.vector), model: options.model ?? this.embedModelUri });
           } catch (err) {
             console.error("Embedding error for text:", err);
@@ -1372,7 +1480,7 @@ export class LlamaCpp implements LLM {
                 console.warn(`⚠ Batch text truncated to fit embedding context (${limit} tokens)`);
               }
               const embedding = await ctx.getEmbeddingFor(safeText);
-              this.touchActivity();
+              this.touchActivity("embed");
               results.push({ embedding: Array.from(embedding.vector), model: options.model ?? this.embedModelUri });
             } catch (err) {
               console.error("Embedding error for text:", err);
@@ -1387,13 +1495,15 @@ export class LlamaCpp implements LLM {
     } catch (error) {
       console.error("Batch embedding error:", error);
       return texts.map(() => null);
+    } finally {
+      this.touchActivity("embed");
     }
   }
 
   async generate(prompt: string, options: GenerateOptions = {}): Promise<GenerateResult | null> {
     if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
     // Ping activity at start to keep models alive during this operation
-    this.touchActivity();
+    this.touchActivity("generate");
 
     // Ensure model is loaded
     await this.ensureGenerateModel();
@@ -1428,7 +1538,11 @@ export class LlamaCpp implements LLM {
       };
     } finally {
       // Dispose context (which disposes dependent sequences/sessions per lifecycle rules)
-      await context.dispose();
+      try {
+        await context.dispose();
+      } finally {
+        this.touchActivity("generate");
+      }
     }
   }
 
@@ -1454,7 +1568,7 @@ export class LlamaCpp implements LLM {
   async expandQuery(query: string, options: { context?: string, includeLexical?: boolean, intent?: string } = {}): Promise<Queryable[]> {
     if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
     // Ping activity at start to keep models alive during this operation
-    this.touchActivity();
+    this.touchActivity("generate");
 
     const llama = await this.ensureLlama();
     await this.ensureGenerateModel();
@@ -1541,7 +1655,11 @@ export class LlamaCpp implements LLM {
       if (includeLexical) fallback.unshift({ type: 'lex', text: query });
       return fallback;
     } finally {
-      if (genContext) await genContext.dispose();
+      try {
+        if (genContext) await genContext.dispose();
+      } finally {
+        this.touchActivity("generate");
+      }
     }
   }
 
@@ -1558,92 +1676,96 @@ export class LlamaCpp implements LLM {
   ): Promise<RerankResult> {
     if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
     // Ping activity at start to keep models alive during this operation
-    this.touchActivity();
+    this.touchActivity("rerank");
 
-    const contexts = await this.ensureRerankContexts();
-    const model = await this.ensureRerankModel();
+    try {
+      const contexts = await this.ensureRerankContexts();
+      const model = await this.ensureRerankModel();
 
-    // Truncate documents that would exceed the rerank context size.
-    // Budget = contextSize - template overhead - query tokens
-    const queryTokens = model.tokenize(query).length;
-    const maxDocTokens = LlamaCpp.RERANK_CONTEXT_SIZE - LlamaCpp.RERANK_TEMPLATE_OVERHEAD - queryTokens;
-    const truncationCache = new Map<string, string>();
+      // Truncate documents that would exceed the rerank context size.
+      // Budget = contextSize - template overhead - query tokens
+      const queryTokens = model.tokenize(query).length;
+      const maxDocTokens = LlamaCpp.RERANK_CONTEXT_SIZE - LlamaCpp.RERANK_TEMPLATE_OVERHEAD - queryTokens;
+      const truncationCache = new Map<string, string>();
 
-    const truncatedDocs = documents.map((doc) => {
-      const cached = truncationCache.get(doc.text);
-      if (cached !== undefined) {
-        return cached === doc.text ? doc : { ...doc, text: cached };
+      const truncatedDocs = documents.map((doc) => {
+        const cached = truncationCache.get(doc.text);
+        if (cached !== undefined) {
+          return cached === doc.text ? doc : { ...doc, text: cached };
+        }
+
+        const tokens = model.tokenize(doc.text);
+        const truncatedText = tokens.length <= maxDocTokens
+          ? doc.text
+          : model.detokenize(tokens.slice(0, maxDocTokens));
+        truncationCache.set(doc.text, truncatedText);
+
+        if (truncatedText === doc.text) return doc;
+        return { ...doc, text: truncatedText };
+      });
+
+      // Deduplicate identical effective texts before scoring.
+      // This avoids redundant work for repeated chunks and fixes collisions where
+      // multiple docs map to the same chunk text.
+      const textToDocs = new Map<string, { file: string; index: number }[]>();
+      truncatedDocs.forEach((doc, index) => {
+        const existing = textToDocs.get(doc.text);
+        if (existing) {
+          existing.push({ file: doc.file, index });
+        } else {
+          textToDocs.set(doc.text, [{ file: doc.file, index }]);
+        }
+      });
+
+      // Extract just the text for ranking
+      const texts = Array.from(textToDocs.keys());
+
+      // Split documents across contexts for parallel evaluation.
+      // Each context has its own sequence with a lock, so parallelism comes
+      // from multiple contexts evaluating different chunks simultaneously.
+      const activeContextCount = Math.max(
+        1,
+        Math.min(
+          contexts.length,
+          Math.ceil(texts.length / LlamaCpp.RERANK_TARGET_DOCS_PER_CONTEXT)
+        )
+      );
+      const activeContexts = contexts.slice(0, activeContextCount);
+      const chunkSize = Math.ceil(texts.length / activeContexts.length);
+      const chunks = Array.from({ length: activeContexts.length }, (_, i) =>
+        texts.slice(i * chunkSize, (i + 1) * chunkSize)
+      ).filter(chunk => chunk.length > 0);
+
+      const allScores = await Promise.all(
+        chunks.map((chunk, i) => activeContexts[i]!.rankAll(query, chunk))
+      );
+
+      // Reassemble scores in original order and sort
+      const flatScores = allScores.flat();
+      const ranked = texts
+        .map((text, i) => ({ document: text, score: flatScores[i]! }))
+        .sort((a, b) => b.score - a.score);
+
+      // Map back to our result format.
+      const results: RerankDocumentResult[] = [];
+      for (const item of ranked) {
+        const docInfos = textToDocs.get(item.document) ?? [];
+        for (const docInfo of docInfos) {
+          results.push({
+            file: docInfo.file,
+            score: item.score,
+            index: docInfo.index,
+          });
+        }
       }
 
-      const tokens = model.tokenize(doc.text);
-      const truncatedText = tokens.length <= maxDocTokens
-        ? doc.text
-        : model.detokenize(tokens.slice(0, maxDocTokens));
-      truncationCache.set(doc.text, truncatedText);
-
-      if (truncatedText === doc.text) return doc;
-      return { ...doc, text: truncatedText };
-    });
-
-    // Deduplicate identical effective texts before scoring.
-    // This avoids redundant work for repeated chunks and fixes collisions where
-    // multiple docs map to the same chunk text.
-    const textToDocs = new Map<string, { file: string; index: number }[]>();
-    truncatedDocs.forEach((doc, index) => {
-      const existing = textToDocs.get(doc.text);
-      if (existing) {
-        existing.push({ file: doc.file, index });
-      } else {
-        textToDocs.set(doc.text, [{ file: doc.file, index }]);
-      }
-    });
-
-    // Extract just the text for ranking
-    const texts = Array.from(textToDocs.keys());
-
-    // Split documents across contexts for parallel evaluation.
-    // Each context has its own sequence with a lock, so parallelism comes
-    // from multiple contexts evaluating different chunks simultaneously.
-    const activeContextCount = Math.max(
-      1,
-      Math.min(
-        contexts.length,
-        Math.ceil(texts.length / LlamaCpp.RERANK_TARGET_DOCS_PER_CONTEXT)
-      )
-    );
-    const activeContexts = contexts.slice(0, activeContextCount);
-    const chunkSize = Math.ceil(texts.length / activeContexts.length);
-    const chunks = Array.from({ length: activeContexts.length }, (_, i) =>
-      texts.slice(i * chunkSize, (i + 1) * chunkSize)
-    ).filter(chunk => chunk.length > 0);
-
-    const allScores = await Promise.all(
-      chunks.map((chunk, i) => activeContexts[i]!.rankAll(query, chunk))
-    );
-
-    // Reassemble scores in original order and sort
-    const flatScores = allScores.flat();
-    const ranked = texts
-      .map((text, i) => ({ document: text, score: flatScores[i]! }))
-      .sort((a, b) => b.score - a.score);
-
-    // Map back to our result format.
-    const results: RerankDocumentResult[] = [];
-    for (const item of ranked) {
-      const docInfos = textToDocs.get(item.document) ?? [];
-      for (const docInfo of docInfos) {
-        results.push({
-          file: docInfo.file,
-          score: item.score,
-          index: docInfo.index,
-        });
-      }
+      return {
+        results,
+        model: this.rerankModelUri,
+      };
+    } finally {
+      this.touchActivity("rerank");
     }
-
-    return {
-      results,
-      model: this.rerankModelUri,
-    };
   }
 
   /**
@@ -1684,9 +1806,16 @@ export class LlamaCpp implements LLM {
     this.disposed = true;
 
     // Clear inactivity timer
-    if (this.inactivityTimer) {
-      clearTimeout(this.inactivityTimer);
-      this.inactivityTimer = null;
+    for (const group of ["embed", "rerank", "generate"] as const) {
+      const timer = this.idleTimers[group];
+      if (timer) clearTimeout(timer);
+      this.idleTimers[group] = null;
+    }
+    await Promise.allSettled(
+      (Object.values(this.idleUnloadPromises).filter(Boolean) as Promise<void>[]),
+    );
+    for (const group of ["embed", "rerank", "generate"] as const) {
+      this.idleUnloadPromises[group] = null;
     }
 
     // Explicitly dispose in dependency order: contexts first, then models, then llama.
@@ -1726,6 +1855,7 @@ export class LlamaCpp implements LLM {
     this.embedContextsCreatePromise = null;
     this.generateModelLoadPromise = null;
     this.rerankModelLoadPromise = null;
+    this.rerankContextsCreatePromise = null;
     this.llamaLoadPromise = null;
   }
 }
@@ -1755,28 +1885,31 @@ class LLMSessionManager {
     return this._inFlightOperations;
   }
 
-  /**
-   * Returns true only when both session count and in-flight operations are 0.
-   * Used by LlamaCpp to determine if idle unload is safe.
-   */
   canUnload(): boolean {
-    return this._activeSessionCount === 0 && this._inFlightOperations === 0;
+    return this.llm.canUnloadIdleResources?.()
+      ?? (this._activeSessionCount === 0 && this._inFlightOperations === 0);
   }
 
   acquire(): void {
     this._activeSessionCount++;
+    this.llm.acquireLifecycleSession?.();
   }
 
   release(): void {
-    this._activeSessionCount = Math.max(0, this._activeSessionCount - 1);
+    if (this._activeSessionCount === 0) return;
+    this._activeSessionCount--;
+    this.llm.releaseLifecycleSession?.();
   }
 
   operationStart(): void {
     this._inFlightOperations++;
+    this.llm.lifecycleOperationStart?.();
   }
 
   operationEnd(): void {
-    this._inFlightOperations = Math.max(0, this._inFlightOperations - 1);
+    if (this._inFlightOperations === 0) return;
+    this._inFlightOperations--;
+    this.llm.lifecycleOperationEnd?.();
   }
 
   getLlamaCpp(): LlamaCpp {

--- a/test/cli-exit-lifecycle.test.ts
+++ b/test/cli-exit-lifecycle.test.ts
@@ -69,6 +69,23 @@ describe("CLI successful-exit lifecycle", () => {
     }
   });
 
+  test("cleans up while preserving a nonzero diagnostic exit code", async () => {
+    const exitCodes: number[] = [];
+    const calls: string[] = [];
+
+    await finishSuccessfulCliCommand({
+      command: "doctor",
+      exitCode: 1,
+      cleanup: async () => { calls.push("cleanup"); },
+      exit: (code) => { exitCodes.push(code); },
+      stdout: { write: (_chunk: string | Uint8Array, cb?: (error?: Error | null) => void) => { calls.push("stdout-flush"); cb?.(); return true; } },
+      stderr: { write: (_chunk: string | Uint8Array, cb?: (error?: Error | null) => void) => { calls.push("stderr-flush"); cb?.(); return true; } },
+    });
+
+    expect(calls).toEqual(["stdout-flush", "cleanup", "stderr-flush"]);
+    expect(exitCodes).toEqual([1]);
+  });
+
   test("darwin Metal mitigation reflects launcher-exported env on darwin", () => {
     // The real mitigation lives in bin/qmd, which sets GGML_METAL_NO_RESIDENCY=1
     // before Node loads the llama.cpp native binding. The JS-side predicate
@@ -98,7 +115,9 @@ describe("CLI successful-exit lifecycle", () => {
 
   test("disposes Llama resources in dependency order before CLI exit", async () => {
     const calls: string[] = [];
-    const llm = new LlamaCpp({ inactivityTimeoutMs: 0 });
+    const llm = new LlamaCpp({
+      idleTimeoutMs: { embed: 0, rerank: 0, generate: 0 },
+    });
     const disposable = (name: string) => ({
       dispose: async () => {
         calls.push(name);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -505,6 +505,56 @@ describe("CLI Status Command", () => {
     await runQmd(["collection", "add", "."]);
   });
 
+  test("qmd doctor lists effective LLM idle timeouts", async () => {
+    const env = await createIsolatedTestEnv("doctor-idle-timeouts");
+    const { stdout, exitCode } = await runQmd(["doctor"], {
+      dbPath: env.dbPath,
+      configDir: env.configDir,
+      env: {
+        QMD_EMBED_IDLE_TIMEOUT_MINUTES: "0",
+        QMD_RERANK_IDLE_TIMEOUT_MINUTES: "0.25",
+        QMD_GENERATE_IDLE_TIMEOUT_MINUTES: "34560",
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("LLM idle timeout (embed): 0 minutes");
+    expect(stdout).toContain("LLM idle timeout (rerank): 0.25 minutes");
+    expect(stdout).toContain("LLM idle timeout (generate): 34560 minutes");
+  }, 20000);
+
+  test("qmd doctor reports an invalid idle timeout, continues diagnostics, and exits nonzero", async () => {
+    const env = await createIsolatedTestEnv("doctor-invalid-idle-timeout");
+    const { stdout, exitCode } = await runQmd(["doctor"], {
+      dbPath: env.dbPath,
+      configDir: env.configDir,
+      env: { QMD_RERANK_IDLE_TIMEOUT_MINUTES: "invalid" },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("QMD Doctor");
+    expect(stdout).toContain("SQLite runtime");
+    expect(stdout).toContain("LLM idle timeout (rerank)");
+    expect(stdout).toContain(
+      "QMD_RERANK_IDLE_TIMEOUT_MINUTES must be a finite number between 0 and 34560 minutes",
+    );
+  }, 20000);
+
+  test("normal commands fail immediately for an invalid idle timeout", async () => {
+    const env = await createIsolatedTestEnv("status-invalid-idle-timeout");
+    const { stdout, stderr, exitCode } = await runQmd(["status"], {
+      dbPath: env.dbPath,
+      configDir: env.configDir,
+      env: { QMD_GENERATE_IDLE_TIMEOUT_MINUTES: "-1" },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stdout).not.toContain("QMD Status");
+    expect(stderr).toContain(
+      "QMD_GENERATE_IDLE_TIMEOUT_MINUTES must be a finite number between 0 and 34560 minutes",
+    );
+  }, 20000);
+
   test("qmd doctor reports core index health checks", async () => {
     const { stdout, exitCode } = await runQmd(["doctor"]);
     expect(exitCode).toBe(0);
@@ -668,6 +718,9 @@ describe("CLI Status Command", () => {
       QMD_DOCTOR_DEVICE_PROBE: "0",
       QMD_FORCE_CPU: "1",
       QMD_LLAMA_GPU: "metal",
+      QMD_EMBED_IDLE_TIMEOUT_MINUTES: "1",
+      QMD_RERANK_IDLE_TIMEOUT_MINUTES: "2",
+      QMD_GENERATE_IDLE_TIMEOUT_MINUTES: "3",
       QMD_EMBED_PARALLELISM: "2",
       QMD_EXPAND_CONTEXT_SIZE: "4096",
       QMD_RERANK_CONTEXT_SIZE: "8192",

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -21,12 +21,531 @@ import {
   resolveGenerateModel,
   resolveRerankModel,
   resolveModels,
+  resolveLlmIdleTimeoutMs,
   withLLMSession,
+  withLLMSessionForLlm,
   canUnloadLLM,
   SessionReleasedError,
   type RerankDocument,
   type ILLMSession,
 } from "../src/llm.js";
+
+describe("LLM idle timeout resolution", () => {
+  test("uses the five-minute default when SDK and environment values are absent", () => {
+    expect(resolveLlmIdleTimeoutMs("embed", undefined, undefined)).toBe(300_000);
+  });
+
+  test("an explicit SDK zero overrides the environment value", () => {
+    expect(resolveLlmIdleTimeoutMs("embed", 0, "12.5")).toBe(0);
+  });
+
+  test("parses a decimal environment value in minutes", () => {
+    expect(resolveLlmIdleTimeoutMs("rerank", undefined, "0.1")).toBe(6_000);
+  });
+
+  test("accepts the documented maximum of 24 days", () => {
+    expect(resolveLlmIdleTimeoutMs("generate", 34_560, undefined)).toBe(2_073_600_000);
+  });
+
+  test.each(["", "-1", "NaN", "Infinity", "abc", "34560.1"])(
+    "rejects invalid embedding environment value %j with an actionable error",
+    (value) => {
+      expect(() => resolveLlmIdleTimeoutMs("embed", undefined, value)).toThrow(
+        "QMD_EMBED_IDLE_TIMEOUT_MINUTES must be a finite number between 0 and 34560 minutes",
+      );
+    },
+  );
+
+  test("LlamaCpp validates timeout environment variables for direct CLI use", () => {
+    const previous = process.env.QMD_RERANK_IDLE_TIMEOUT_MINUTES;
+    process.env.QMD_RERANK_IDLE_TIMEOUT_MINUTES = "invalid";
+    try {
+      expect(() => new LlamaCpp()).toThrow(
+        "QMD_RERANK_IDLE_TIMEOUT_MINUTES must be a finite number between 0 and 34560 minutes",
+      );
+    } finally {
+      if (previous === undefined) delete process.env.QMD_RERANK_IDLE_TIMEOUT_MINUTES;
+      else process.env.QMD_RERANK_IDLE_TIMEOUT_MINUTES = previous;
+    }
+  });
+});
+
+async function advanceFakeTimersByTime(ms: number): Promise<void> {
+  vi.advanceTimersByTime(ms);
+  for (let pendingMicrotask = 0; pendingMicrotask < 10; pendingMicrotask += 1) {
+    await Promise.resolve();
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe("LlamaCpp idle resource timers", () => {
+  test("embedding activity schedules only the embedding timer", async () => {
+    vi.useFakeTimers();
+    const llm = new LlamaCpp({
+      idleTimeoutMs: { embed: 60_000, rerank: 120_000, generate: 180_000 },
+    }) as any;
+    llm._ciMode = false;
+    const context = {
+      getEmbeddingFor: vi.fn().mockResolvedValue({ vector: new Float32Array([0.5]) }),
+      dispose: vi.fn().mockResolvedValue(undefined),
+    };
+    llm.embedContexts = [context];
+    llm.ensureEmbedContext = vi.fn().mockResolvedValue(context);
+
+    try {
+      await llm.embed("timer isolation");
+
+      expect(llm.idleTimers.embed).not.toBeNull();
+      expect(llm.idleTimers.rerank).toBeNull();
+      expect(llm.idleTimers.generate).toBeNull();
+    } finally {
+      await llm.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  test("embedding timeout disposes contexts before its model and leaves other groups warm", async () => {
+    vi.useFakeTimers();
+    const disposalOrder: string[] = [];
+    const llm = new LlamaCpp({
+      idleTimeoutMs: { embed: 100, rerank: 200, generate: 300 },
+    }) as any;
+    llm._ciMode = false;
+    const embedContext = {
+      getEmbeddingFor: vi.fn().mockResolvedValue({ vector: new Float32Array([0.5]) }),
+      dispose: vi.fn(async () => { disposalOrder.push("embed-context"); }),
+    };
+    const embedModel = {
+      tokenize: vi.fn().mockReturnValue([]),
+      detokenize: vi.fn().mockReturnValue(""),
+      dispose: vi.fn(async () => { disposalOrder.push("embed-model"); }),
+    };
+    const rerankContext = { dispose: vi.fn().mockResolvedValue(undefined) };
+    const rerankModel = { dispose: vi.fn().mockResolvedValue(undefined) };
+    const generateModel = { dispose: vi.fn().mockResolvedValue(undefined) };
+    llm.embedContexts = [embedContext];
+    llm.embedModel = embedModel;
+    llm.rerankContexts = [rerankContext];
+    llm.rerankModel = rerankModel;
+    llm.generateModel = generateModel;
+    llm.ensureEmbedContext = vi.fn().mockResolvedValue(embedContext);
+
+    try {
+      await llm.embed("resource isolation");
+      await advanceFakeTimersByTime(100);
+
+      expect(disposalOrder).toEqual(["embed-context", "embed-model"]);
+      expect(rerankContext.dispose).not.toHaveBeenCalled();
+      expect(rerankModel.dispose).not.toHaveBeenCalled();
+      expect(generateModel.dispose).not.toHaveBeenCalled();
+    } finally {
+      await llm.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  test("a per-store session defers idle unload for its own LlamaCpp instance", async () => {
+    vi.useFakeTimers();
+    const llm = new LlamaCpp({
+      idleTimeoutMs: { embed: 100, rerank: 0, generate: 0 },
+    }) as any;
+    llm._ciMode = false;
+    const context = {
+      getEmbeddingFor: vi.fn().mockResolvedValue({ vector: new Float32Array([0.5]) }),
+      dispose: vi.fn().mockResolvedValue(undefined),
+    };
+    const model = {
+      tokenize: vi.fn().mockReturnValue([]),
+      detokenize: vi.fn().mockReturnValue(""),
+      dispose: vi.fn().mockResolvedValue(undefined),
+    };
+    llm.embedContexts = [context];
+    llm.embedModel = model;
+    llm.ensureEmbedContext = vi.fn().mockResolvedValue(context);
+
+    try {
+      await withLLMSessionForLlm(llm, async (session) => {
+        await session.embed("active session");
+        await advanceFakeTimersByTime(100);
+        expect(context.dispose).not.toHaveBeenCalled();
+      });
+
+      await advanceFakeTimersByTime(100);
+      expect(context.dispose).toHaveBeenCalledOnce();
+    } finally {
+      await llm.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  test("a completed operation receives a full idle interval before unloading", async () => {
+    vi.useFakeTimers();
+    const ranking = deferred<number[]>();
+    const llm = new LlamaCpp({
+      idleTimeoutMs: { embed: 0, rerank: 100, generate: 0 },
+    }) as any;
+    llm._ciMode = false;
+    const context = {
+      rankAll: vi.fn(() => ranking.promise),
+      dispose: vi.fn().mockResolvedValue(undefined),
+    };
+    llm.rerankContexts = [context];
+    llm.rerankModel = {
+      tokenize: vi.fn().mockReturnValue([]),
+      detokenize: vi.fn().mockReturnValue(""),
+      dispose: vi.fn().mockResolvedValue(undefined),
+    };
+
+    try {
+      const operation = withLLMSessionForLlm(
+        llm,
+        async (session) => session.rerank("query", [{ file: "doc.md", text: "text" }]),
+      );
+      await advanceFakeTimersByTime(150);
+      expect(context.dispose).not.toHaveBeenCalled();
+
+      ranking.resolve([0.75]);
+      await operation;
+      await advanceFakeTimersByTime(50);
+      expect(context.dispose).not.toHaveBeenCalled();
+
+      await advanceFakeTimersByTime(50);
+      expect(context.dispose).toHaveBeenCalledOnce();
+    } finally {
+      await llm.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  test("a new operation waits for an in-progress idle unload before reloading", async () => {
+    vi.useFakeTimers();
+    const contextDisposal = deferred<void>();
+    const llm = new LlamaCpp({
+      idleTimeoutMs: { embed: 100, rerank: 0, generate: 0 },
+    }) as any;
+    llm._ciMode = false;
+    const oldContext = {
+      getEmbeddingFor: vi.fn().mockResolvedValue({ vector: new Float32Array([0.5]) }),
+      dispose: vi.fn(() => contextDisposal.promise),
+    };
+    const oldModel = {
+      tokenize: vi.fn().mockReturnValue([]),
+      detokenize: vi.fn().mockReturnValue(""),
+      dispose: vi.fn().mockResolvedValue(undefined),
+    };
+    const newModel = { dispose: vi.fn().mockResolvedValue(undefined) };
+    const loadModel = vi.fn().mockResolvedValue(newModel);
+    llm.embedContexts = [oldContext];
+    llm.embedModel = oldModel;
+    llm.llama = { loadModel, dispose: vi.fn().mockResolvedValue(undefined) };
+    llm.resolveModel = vi.fn().mockResolvedValue("/tmp/fake-embed.gguf");
+    llm.ensureEmbedContext = vi.fn().mockResolvedValue(oldContext);
+
+    try {
+      await llm.embed("first operation");
+      await advanceFakeTimersByTime(100);
+      expect(oldContext.dispose).toHaveBeenCalledOnce();
+
+      const reload = llm.ensureEmbedModel();
+      await Promise.resolve();
+      expect(loadModel).not.toHaveBeenCalled();
+
+      contextDisposal.resolve();
+      expect(await reload).toBe(newModel);
+      expect(oldModel.dispose).toHaveBeenCalledOnce();
+      expect(loadModel).toHaveBeenCalledOnce();
+    } finally {
+      contextDisposal.resolve();
+      await llm.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  test("a rejected idle context dispose still releases the model and allows reload", async () => {
+    vi.useFakeTimers();
+    const llm = new LlamaCpp({
+      idleTimeoutMs: { embed: 100, rerank: 0, generate: 0 },
+    }) as any;
+    const oldContext = {
+      dispose: vi.fn().mockRejectedValue(new Error("native context dispose failed")),
+    };
+    const oldModel = {
+      dispose: vi.fn().mockResolvedValue(undefined),
+    };
+    const newModel = { dispose: vi.fn().mockResolvedValue(undefined) };
+    const loadModel = vi.fn().mockResolvedValue(newModel);
+    llm.embedContexts = [oldContext];
+    llm.embedModel = oldModel;
+    llm.llama = { loadModel, dispose: vi.fn().mockResolvedValue(undefined) };
+    llm.resolveModel = vi.fn().mockResolvedValue("/tmp/fake-embed.gguf");
+    llm.touchActivity("embed");
+
+    try {
+      await advanceFakeTimersByTime(100);
+      expect(oldModel.dispose).toHaveBeenCalledOnce();
+      expect(await llm.ensureEmbedModel()).toBe(newModel);
+    } finally {
+      await llm.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  test("a hanging idle context dispose times out without blocking reload", async () => {
+    vi.useFakeTimers();
+    const llm = new LlamaCpp({
+      idleTimeoutMs: { embed: 100, rerank: 0, generate: 0 },
+    }) as any;
+    const oldContext = {
+      dispose: vi.fn(() => new Promise<void>(() => {})),
+    };
+    const oldModel = {
+      dispose: vi.fn().mockResolvedValue(undefined),
+    };
+    const newModel = { dispose: vi.fn().mockResolvedValue(undefined) };
+    const loadModel = vi.fn().mockResolvedValue(newModel);
+    llm.embedContexts = [oldContext];
+    llm.embedModel = oldModel;
+    llm.llama = { loadModel, dispose: vi.fn().mockResolvedValue(undefined) };
+    llm.resolveModel = vi.fn().mockResolvedValue("/tmp/fake-embed.gguf");
+    llm.touchActivity("embed");
+
+    try {
+      await advanceFakeTimersByTime(100);
+      const reload = llm.ensureEmbedModel();
+      await Promise.resolve();
+      expect(loadModel).not.toHaveBeenCalled();
+
+      await advanceFakeTimersByTime(1_000);
+      expect(await reload).toBe(newModel);
+      expect(oldModel.dispose).toHaveBeenCalledOnce();
+    } finally {
+      await llm.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  test("timeout zero keeps embedding resources warm without creating a timer", async () => {
+    vi.useFakeTimers();
+    const llm = new LlamaCpp({
+      idleTimeoutMs: { embed: 0, rerank: 100, generate: 100 },
+    }) as any;
+    llm._ciMode = false;
+    const context = {
+      getEmbeddingFor: vi.fn().mockResolvedValue({ vector: new Float32Array([0.5]) }),
+      dispose: vi.fn().mockResolvedValue(undefined),
+    };
+    const model = {
+      tokenize: vi.fn().mockReturnValue([]),
+      detokenize: vi.fn().mockReturnValue(""),
+      dispose: vi.fn().mockResolvedValue(undefined),
+    };
+    llm.embedContexts = [context];
+    llm.embedModel = model;
+    llm.ensureEmbedContext = vi.fn().mockResolvedValue(context);
+
+    try {
+      await llm.embed("stay warm");
+      await advanceFakeTimersByTime(1_000);
+
+      expect(llm.idleTimers.embed).toBeNull();
+      expect(context.dispose).not.toHaveBeenCalled();
+      expect(model.dispose).not.toHaveBeenCalled();
+    } finally {
+      await llm.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  test("repeated embedding activity resets its idle deadline", async () => {
+    vi.useFakeTimers();
+    const llm = new LlamaCpp({
+      idleTimeoutMs: { embed: 100, rerank: 0, generate: 0 },
+    }) as any;
+    llm._ciMode = false;
+    const context = {
+      getEmbeddingFor: vi.fn().mockResolvedValue({ vector: new Float32Array([0.5]) }),
+      dispose: vi.fn().mockResolvedValue(undefined),
+    };
+    const model = {
+      tokenize: vi.fn().mockReturnValue([]),
+      detokenize: vi.fn().mockReturnValue(""),
+      dispose: vi.fn().mockResolvedValue(undefined),
+    };
+    llm.embedContexts = [context];
+    llm.embedModel = model;
+    llm.ensureEmbedContext = vi.fn().mockResolvedValue(context);
+
+    try {
+      await llm.embed("first");
+      await advanceFakeTimersByTime(50);
+      await llm.embed("second");
+      await advanceFakeTimersByTime(50);
+      expect(context.dispose).not.toHaveBeenCalled();
+
+      await advanceFakeTimersByTime(50);
+      expect(context.dispose).toHaveBeenCalledOnce();
+    } finally {
+      await llm.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  test("reranking and generation unload independently and leave embedding warm", async () => {
+    vi.useFakeTimers();
+    const disposalOrder: string[] = [];
+    const llm = new LlamaCpp({
+      idleTimeoutMs: { embed: 0, rerank: 100, generate: 200 },
+    }) as any;
+    llm._ciMode = false;
+    const embedContext = { dispose: vi.fn().mockResolvedValue(undefined) };
+    const embedModel = { dispose: vi.fn().mockResolvedValue(undefined) };
+    const rerankContext = {
+      rankAll: vi.fn().mockResolvedValue([0.75]),
+      dispose: vi.fn(async () => { disposalOrder.push("rerank-context"); }),
+    };
+    const rerankModel = {
+      tokenize: vi.fn().mockReturnValue([]),
+      detokenize: vi.fn().mockReturnValue(""),
+      dispose: vi.fn(async () => { disposalOrder.push("rerank-model"); }),
+    };
+    const generateModel = {
+      dispose: vi.fn(async () => { disposalOrder.push("generate-model"); }),
+    };
+    llm.embedContexts = [embedContext];
+    llm.embedModel = embedModel;
+    llm.rerankContexts = [rerankContext];
+    llm.rerankModel = rerankModel;
+    llm.generateModel = generateModel;
+
+    try {
+      await llm.rerank("query", [{ file: "doc.md", text: "text" }]);
+      await llm.ensureGenerateModel();
+      await advanceFakeTimersByTime(100);
+
+      expect(disposalOrder).toEqual(["rerank-context", "rerank-model"]);
+      expect(embedContext.dispose).not.toHaveBeenCalled();
+      expect(embedModel.dispose).not.toHaveBeenCalled();
+      expect(generateModel.dispose).not.toHaveBeenCalled();
+
+      await advanceFakeTimersByTime(100);
+      expect(disposalOrder).toEqual([
+        "rerank-context",
+        "rerank-model",
+        "generate-model",
+      ]);
+      expect(embedContext.dispose).not.toHaveBeenCalled();
+      expect(embedModel.dispose).not.toHaveBeenCalled();
+    } finally {
+      await llm.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  test("concurrent rerank requests create one shared context pool", async () => {
+    const llm = new LlamaCpp({
+      idleTimeoutMs: { embed: 0, rerank: 0, generate: 0 },
+    }) as any;
+    const context = {
+      rankAll: vi.fn().mockResolvedValue([0.75]),
+      dispose: vi.fn().mockResolvedValue(undefined),
+    };
+    const createRankingContext = vi.fn().mockResolvedValue(context);
+    llm.ensureRerankModel = vi.fn().mockResolvedValue({ createRankingContext });
+    llm.computeParallelism = vi.fn().mockResolvedValue(1);
+    llm.threadsPerContext = vi.fn().mockResolvedValue(1);
+
+    try {
+      const [first, second] = await Promise.all([
+        llm.ensureRerankContexts(),
+        llm.ensureRerankContexts(),
+      ]);
+
+      expect(createRankingContext).toHaveBeenCalledOnce();
+      expect(first).toBe(second);
+    } finally {
+      await llm.dispose();
+    }
+  });
+
+  test("an embedding model can load again after its idle timeout", async () => {
+    vi.useFakeTimers();
+    const firstModel = { dispose: vi.fn().mockResolvedValue(undefined) };
+    const secondModel = { dispose: vi.fn().mockResolvedValue(undefined) };
+    const loadModel = vi.fn()
+      .mockResolvedValueOnce(firstModel)
+      .mockResolvedValueOnce(secondModel);
+    const llm = new LlamaCpp({
+      idleTimeoutMs: { embed: 100, rerank: 0, generate: 0 },
+    }) as any;
+    llm.llama = { loadModel, dispose: vi.fn().mockResolvedValue(undefined) };
+    llm.resolveModel = vi.fn().mockResolvedValue("/tmp/fake-embed.gguf");
+
+    try {
+      expect(await llm.ensureEmbedModel()).toBe(firstModel);
+      await advanceFakeTimersByTime(100);
+      expect(firstModel.dispose).toHaveBeenCalledOnce();
+
+      expect(await llm.ensureEmbedModel()).toBe(secondModel);
+      expect(loadModel).toHaveBeenCalledTimes(2);
+    } finally {
+      await llm.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  test("explicit dispose releases permanently warm resources and resets lifecycle state", async () => {
+    const disposalOrder: string[] = [];
+    const llm = new LlamaCpp({
+      idleTimeoutMs: { embed: 0, rerank: 0, generate: 0 },
+    }) as any;
+    llm.embedContexts = [{
+      dispose: vi.fn(async () => { disposalOrder.push("embed-context"); }),
+    }];
+    llm.rerankContexts = [{
+      dispose: vi.fn(async () => { disposalOrder.push("rerank-context"); }),
+    }];
+    llm.embedModel = {
+      dispose: vi.fn(async () => { disposalOrder.push("embed-model"); }),
+    };
+    llm.generateModel = {
+      dispose: vi.fn(async () => { disposalOrder.push("generate-model"); }),
+    };
+    llm.rerankModel = {
+      dispose: vi.fn(async () => { disposalOrder.push("rerank-model"); }),
+    };
+    llm.llama = {
+      dispose: vi.fn(async () => { disposalOrder.push("llama"); }),
+    };
+    llm.embedModelLoadPromise = Promise.resolve(llm.embedModel);
+    llm.generateModelLoadPromise = Promise.resolve(llm.generateModel);
+    llm.rerankModelLoadPromise = Promise.resolve(llm.rerankModel);
+    llm.embedContextsCreatePromise = Promise.resolve(llm.embedContexts);
+    llm.rerankContextsCreatePromise = Promise.resolve(llm.rerankContexts);
+
+    await llm.dispose();
+
+    expect(disposalOrder).toEqual([
+      "embed-context",
+      "rerank-context",
+      "embed-model",
+      "generate-model",
+      "rerank-model",
+      "llama",
+    ]);
+    expect(llm.embedModelLoadPromise).toBeNull();
+    expect(llm.generateModelLoadPromise).toBeNull();
+    expect(llm.rerankModelLoadPromise).toBeNull();
+    expect(llm.embedContextsCreatePromise).toBeNull();
+    expect(llm.rerankContextsCreatePromise).toBeNull();
+  });
+});
 
 describe("model name resolution", () => {
   function withModelEnv(env: Record<string, string | undefined>, fn: () => void): void {

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -5,7 +5,7 @@
  * Uses inline config (no YAML files) to verify the SDK works self-contained.
  */
 
-import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
 import { mkdtemp, writeFile, mkdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -104,6 +104,96 @@ describe("createStore", () => {
     await expect(
       createStore({ dbPath: "", config: { collections: {} } })
     ).rejects.toThrow("dbPath is required");
+  });
+
+  test("rejects an invalid SDK idle timeout before opening the database", async () => {
+    const dbPath = freshDbPath();
+
+    await expect(createStore({
+      dbPath,
+      config: { collections: {} },
+      llmIdleTimeoutMinutes: { generate: Number.POSITIVE_INFINITY },
+    })).rejects.toThrow(
+      "llmIdleTimeoutMinutes.generate must be a finite number between 0 and 34560 minutes",
+    );
+    expect(existsSync(dbPath)).toBe(false);
+  });
+
+  test("protects public SDK LLM operations with the store instance lifecycle", async () => {
+    const store = await createStore({
+      dbPath: freshDbPath(),
+      config: { collections: {} },
+      llmIdleTimeoutMinutes: { embed: 0, rerank: 0, generate: 0 },
+    });
+    const llm = store.internal.llm as any;
+    llm.expandQuery = vi.fn(async () => {
+      expect(llm.canUnloadIdleResources()).toBe(false);
+      return [];
+    });
+
+    try {
+      await store.expandQuery("lifecycle protection");
+      expect(llm.expandQuery).toHaveBeenCalledOnce();
+      expect(llm.canUnloadIdleResources()).toBe(true);
+    } finally {
+      await store.close();
+    }
+  });
+
+  test("routes vector search through the store-specific LLM session", async () => {
+    const store = await createStore({
+      dbPath: freshDbPath(),
+      config: { collections: {} },
+      llmIdleTimeoutMinutes: { embed: 0 },
+    });
+    const llm = store.internal.llm as any;
+    const searchVec = vi.fn(async (
+      _query: string,
+      _model: string,
+      _limit?: number,
+      _collection?: string,
+      session?: unknown,
+    ) => {
+      expect(session).toBeDefined();
+      expect(llm.canUnloadIdleResources()).toBe(false);
+      return [];
+    });
+    store.internal.searchVec = searchVec;
+
+    try {
+      await store.searchVector("store-specific embedding");
+      expect(searchVec).toHaveBeenCalledOnce();
+      expect(llm.canUnloadIdleResources()).toBe(true);
+    } finally {
+      await store.close();
+    }
+  });
+
+  test("resolves SDK, environment, and default timeout precedence per resource", async () => {
+    const previousEmbed = process.env.QMD_EMBED_IDLE_TIMEOUT_MINUTES;
+    const previousRerank = process.env.QMD_RERANK_IDLE_TIMEOUT_MINUTES;
+    process.env.QMD_EMBED_IDLE_TIMEOUT_MINUTES = "9";
+    process.env.QMD_RERANK_IDLE_TIMEOUT_MINUTES = "0.25";
+
+    let store: QMDStore | undefined;
+    try {
+      store = await createStore({
+        dbPath: freshDbPath(),
+        config: { collections: {} },
+        llmIdleTimeoutMinutes: { embed: 0 },
+      });
+      expect((store.internal.llm as any).idleTimeoutMs).toEqual({
+        embed: 0,
+        rerank: 15_000,
+        generate: 300_000,
+      });
+    } finally {
+      await store?.close();
+      if (previousEmbed === undefined) delete process.env.QMD_EMBED_IDLE_TIMEOUT_MINUTES;
+      else process.env.QMD_EMBED_IDLE_TIMEOUT_MINUTES = previousEmbed;
+      if (previousRerank === undefined) delete process.env.QMD_RERANK_IDLE_TIMEOUT_MINUTES;
+      else process.env.QMD_RERANK_IDLE_TIMEOUT_MINUTES = previousRerank;
+    }
   });
 
   test("opens with just dbPath (DB-only mode)", async () => {


### PR DESCRIPTION
## Summary

- add independent embedding, reranking, and generation idle timeouts
- support configuration through environment variables and `StoreOptions`
- keep the existing five-minute behavior as the default and use `0` to keep a resource group warm
- unload contexts and models independently while protecting active per-store operations
- report effective values and invalid configuration through `qmd doctor`
- document CLI, SDK, and MCP lifecycle behavior

## Why

Long-lived MCP and SDK processes can sit idle for more than five minutes between searches. Reloading embedding and reranking models after every such pause adds several seconds of avoidable latency. Independent timeouts allow latency-sensitive resources to stay warm while generation can still be released sooner.

## Validation

- `npm test`
  - TypeScript typecheck
  - Node Vitest suite
  - Bun suite: 913 passed, 80 skipped, 0 failed
  - package and compiled CLI smoke tests
- `npm run build`
- manual CUDA lifecycle verification
  - embedding and reranking remained warm with timeout `0`
  - generation loaded on demand and unloaded after its configured timeout
  - explicit store shutdown released the remaining runtime
