### PR TITLE
feat(mcp): add update and embed maintenance tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+### Added
+
+- The MCP server now exposes `update` and `embed` through the same central tool
+  registration for stdio and Streamable HTTP. The documented maintenance flow
+  is `update`, inspect `status.needsEmbedding`, then `embed` only when work is
+  pending. Both tools report progress when the client supplies a progress
+  token, return structured counters, and write only to QMD's derived index.
+  Progress delivery is best-effort and cannot change a successful tool result.
+  `update` never modifies source files or executes configured update commands;
+  `embed` uses only the centrally configured model and defaults to a 30-minute
+  runtime limit. Values above the documented safe Node timer maximum are
+  rejected; `0` remains unlimited. A per-process, per-store fail-fast lock
+  permits one maintenance writer while reads remain available, and
+  cancellation/error paths release the lock. Separate processes continue to
+  rely on SQLite/WAL/busy-timeout. Busy, cancelled, failed, and partial
+  embedding results are surfaced with `isError` without adding REST maintenance
+  endpoints. MCP failure details preserve known safe Store categories and
+  sanitize raw backend, model, download, and database error text.
+
 ## [2.6.3] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Although the tool works perfectly fine when you just tell your agent to use it o
 - `get` — Retrieve a document by path or docid (with fuzzy matching suggestions)
 - `multi_get` — Batch retrieve by glob pattern, comma-separated list, or docids
 - `status` — Index health and collection info
+- `update` — Synchronize configured collections into QMD's derived index
+- `embed` — Generate pending vector embeddings with QMD's configured model
 
 **Claude Desktop configuration** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
 
@@ -139,6 +141,7 @@ The HTTP server exposes two endpoints:
 LLM models stay loaded in VRAM across requests. Embedding/reranking contexts are disposed after 5 min idle and transparently recreated on the next request (~1s penalty, models remain loaded).
 
 Point any MCP client at `http://localhost:8181/mcp` to connect.
+The stdio and HTTP transports expose the same centrally registered tools.
 
 #### MCP Tool Parameters
 
@@ -159,6 +162,29 @@ Point any MCP client at `http://localhost:8181/mcp` to connect.
 | `multi_get` | `maxBytes` | number | Skip files larger than N (default 10240) |
 | `multi_get` | `maxLines` | number | Limit lines per file |
 | `multi_get` | `lineNumbers` | boolean | Prefix lines with numbers (default **true**) |
+| `update` | `collections` | string[] | Optional non-empty list of configured collections; omit to update all |
+| `embed` | `collection` | string | Optional configured collection; omit to process all pending collections |
+| `embed` | `force` | boolean | Rebuild existing embeddings in scope (default **false**) |
+| `embed` | `chunkStrategy` | `"auto"` or `"regex"` | Optional chunking strategy; omit to use QMD's configured default |
+| `embed` | `maxDocsPerBatch` | positive integer | Optional document limit per embedding batch |
+| `embed` | `maxBatchMiB` | positive number | Optional embedding batch-size limit in MiB |
+| `embed` | `timeoutMinutes` | non-negative number | Runtime limit (default **30**, maximum **35791**); use `0` for no runtime limit |
+
+For safe maintenance, call `update`, then call `status` and inspect
+`needsEmbedding`. Call `embed` only when that count is greater than zero. Both
+tools write only to QMD's derived index; `update` does not modify source files
+or execute configured collection update commands. If the request includes an
+MCP progress token, `update` reports file progress and `embed` reports chunk,
+byte, and error counters. Only one `update` or `embed` operation can run for a
+shared store within one MCP server process/store instance at a time; another
+writer fails immediately as busy while read tools remain available. Separate
+CLI or server processes rely on SQLite/WAL/busy-timeout instead of this
+fail-fast lock. Busy, cancelled, and failed calls set `isError`.
+`embed` also sets `isError` for partial failures while retaining its result
+counters and a bounded failure list. Failure reasons in that list are sanitized
+MCP categories, not raw model, download, backend, or database error messages.
+The 30-minute default embed limit provides a final safety boundary when an
+active native model computation cannot stop immediately.
 
 Unknown parameters are silently ignored (not rejected) — double-check names if
 results seem unscoped. The HTTP `/query` and `/search` endpoints return

--- a/src/index.ts
+++ b/src/index.ts
@@ -300,6 +300,11 @@ export interface QMDStore {
     maxDocsPerBatch?: number;
     maxBatchBytes?: number;
     chunkStrategy?: ChunkStrategy;
+    /**
+     * Maximum wall-clock duration for the embed run, in milliseconds.
+     * Defaults to 30 minutes; 0 disables the runtime limit.
+     */
+    maxDurationMs?: number;
     onProgress?: (info: EmbedProgress) => void;
   }): Promise<EmbedResult>;
 
@@ -529,6 +534,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
         maxDocsPerBatch: embedOpts?.maxDocsPerBatch,
         maxBatchBytes: embedOpts?.maxBatchBytes,
         chunkStrategy: embedOpts?.chunkStrategy,
+        maxDurationMs: embedOpts?.maxDurationMs,
         onProgress: embedOpts?.onProgress,
       });
     },

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -26,11 +26,20 @@ import {
   getDefaultDbPath,
   DEFAULT_MULTI_GET_MAX_BYTES,
   type QMDStore,
+  type EmbedProgress,
+  type UpdateProgress,
   type ExpandedQuery,
   type IndexStatus,
 } from "../index.js";
 import { getConfigPath } from "../collections.js";
-import { enableProductionMode } from "../store.js";
+import {
+  EMBED_FAILURE_BATCH_NO_VECTOR_REASON,
+  EMBED_FAILURE_BATCH_SESSION_EXPIRED_PREFIX,
+  EMBED_FAILURE_ERROR_RATE_REASON,
+  EMBED_FAILURE_NO_VECTOR_REASON,
+  EMBED_FAILURE_SESSION_EXPIRED_REASON,
+  enableProductionMode,
+} from "../store.js";
 
 // =============================================================================
 // Types for structured content
@@ -62,6 +71,9 @@ type StatusResult = {
 // =============================================================================
 // Helper functions
 // =============================================================================
+
+const MAX_NODE_TIMER_MS = 2_147_483_647;
+const MAX_EMBED_TIMEOUT_MINUTES = Math.floor(MAX_NODE_TIMER_MS / 60_000);
 
 /**
  * Encode a path for use in qmd:// URIs.
@@ -124,13 +136,20 @@ async function buildInstructions(store: QMDStore): Promise<string> {
     lines.push("Call the `status` tool for collection descriptions, paths, and per-collection doc counts.");
   }
 
+  // --- Maintenance workflow ---
+  lines.push("");
+  lines.push("Maintenance:");
+  lines.push("  - Call the `update` MCP tool to synchronize configured collections into the derived index.");
+  lines.push("  - After update, call `status` and inspect `needsEmbedding`.");
+  lines.push("  - Call the `embed` MCP tool only when `needsEmbedding` is greater than 0.");
+
   // --- Capability gaps ---
   if (!status.hasVectorIndex) {
     lines.push("");
-    lines.push("Note: No vector embeddings yet. Run `qmd embed` to enable semantic search (vec/hyde).");
+    lines.push("Note: No vector embeddings yet; semantic search (vec/hyde) remains unavailable until pending embeddings are generated.");
   } else if (status.needsEmbedding > 0) {
     lines.push("");
-    lines.push(`Note: ${status.needsEmbedding} documents need embedding. Run \`qmd embed\` to update.`);
+    lines.push(`Note: ${status.needsEmbedding} documents currently need embedding.`);
   }
 
   // --- Search tool ---
@@ -168,7 +187,90 @@ async function buildInstructions(store: QMDStore): Promise<string> {
  * Create an MCP server with all QMD tools, resources, and prompts registered.
  * Shared by both stdio and HTTP transports.
  */
-async function createMcpServer(store: QMDStore): Promise<McpServer> {
+type MaintenanceOperation = "update" | "embed";
+
+type MaintenanceLease =
+  | { acquired: true; release: () => void }
+  | { acquired: false; active: MaintenanceOperation };
+
+class MaintenanceCancelledError extends Error {}
+
+const maintenanceStates = new WeakMap<
+  QMDStore,
+  { active?: { operation: MaintenanceOperation; leaseId: symbol } }
+>();
+
+function throwIfMaintenanceAborted(signal: AbortSignal): void {
+  if (signal.aborted) {
+    throw new MaintenanceCancelledError();
+  }
+}
+
+function acquireMaintenance(
+  store: QMDStore,
+  operation: MaintenanceOperation
+): MaintenanceLease {
+  let state = maintenanceStates.get(store);
+  if (!state) {
+    state = {};
+    maintenanceStates.set(store, state);
+  }
+
+  if (state.active) {
+    return { acquired: false, active: state.active.operation };
+  }
+
+  const leaseId = Symbol(operation);
+  state.active = { operation, leaseId };
+  return {
+    acquired: true,
+    release: () => {
+      if (state.active?.leaseId === leaseId) {
+        state.active = undefined;
+      }
+    },
+  };
+}
+
+function enqueueBestEffortNotification(
+  pendingNotifications: Set<Promise<void>>,
+  send: () => Promise<void>
+): void {
+  const pendingNotification = (async () => {
+    try {
+      await send();
+    } catch {
+      // Progress notifications are best-effort and never change tool results.
+    }
+  })();
+  pendingNotifications.add(pendingNotification);
+  void pendingNotification.then(() => {
+    pendingNotifications.delete(pendingNotification);
+  });
+}
+
+const SAFE_EMBED_FAILURE_REASONS = new Set([
+  EMBED_FAILURE_NO_VECTOR_REASON,
+  EMBED_FAILURE_SESSION_EXPIRED_REASON,
+  EMBED_FAILURE_ERROR_RATE_REASON,
+  EMBED_FAILURE_BATCH_NO_VECTOR_REASON,
+]);
+
+function sanitizeEmbedFailureReason(reason: string): string {
+  if (SAFE_EMBED_FAILURE_REASONS.has(reason)) {
+    return reason;
+  }
+
+  if (
+    reason.startsWith(`${EMBED_FAILURE_BATCH_SESSION_EXPIRED_PREFIX}: `)
+  ) {
+    return EMBED_FAILURE_BATCH_SESSION_EXPIRED_PREFIX;
+  }
+
+  return "embedding backend or index write failed";
+}
+
+export async function createMcpServer(store: QMDStore): Promise<McpServer> {
   const server = new McpServer(
     { name: "qmd", version: getPackageVersion() },
     { instructions: await buildInstructions(store) },
@@ -533,6 +635,340 @@ Intent-aware lex (C++ performance, not sports):
       }
 
       return { content };
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Tool: update (Synchronize configured collections into the derived index)
+  // ---------------------------------------------------------------------------
+
+  server.registerTool(
+    "update",
+    {
+      title: "Update Index",
+      description: "Synchronize configured Markdown collections into the derived index. Omit collections to update all configured collections. This writes only to QMD's index; source files are unchanged and configured update commands are not executed. With an MCP progress token it reports file progress. Progress notifications are best-effort and never change the tool result. Busy, cancelled, and failed runs return isError. Inspect the structured needsEmbedding count afterward and call embed only when it is greater than 0.",
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      inputSchema: {
+        collections: z.array(z.string()).min(1).optional().describe(
+          "Optional non-empty list of configured collection names. Omit to update all collections."
+        ),
+      },
+    },
+    async ({ collections }, extra) => {
+      if (extra.signal.aborted) {
+        return {
+          content: [{
+            type: "text",
+            text: "Update cancelled by the MCP client. Retry when ready.",
+          }],
+          isError: true,
+        };
+      }
+
+      const maintenance = acquireMaintenance(store, "update");
+      if (!maintenance.acquired) {
+        return {
+          content: [{
+            type: "text",
+            text: `QMD maintenance is busy with ${maintenance.active}. Retry after it finishes.`,
+          }],
+          isError: true,
+        };
+      }
+
+      try {
+        throwIfMaintenanceAborted(extra.signal);
+
+        if (collections) {
+          const configuredNames = new Set(
+            (await store.listCollections()).map(collection => collection.name)
+          );
+          throwIfMaintenanceAborted(extra.signal);
+          const unknownCollections = collections.filter(
+            name => !configuredNames.has(name)
+          );
+
+          if (unknownCollections.length > 0) {
+            return {
+              content: [{
+                type: "text",
+                text: `Unknown collection(s): ${unknownCollections.join(", ")}. Call status to list configured collections.`,
+              }],
+              isError: true,
+            };
+          }
+        }
+
+        const progressToken = extra._meta?.progressToken;
+        const pendingNotifications = new Set<Promise<void>>();
+        let activeCollection: string | undefined;
+        let completedFiles = 0;
+        let activeCollectionTotal = 0;
+        let lastProgress = 0;
+        let lastTotal = 0;
+
+        const onProgress = (info: UpdateProgress) => {
+          throwIfMaintenanceAborted(extra.signal);
+
+          if (progressToken === undefined) {
+            return;
+          }
+
+          if (
+            activeCollection !== undefined &&
+            activeCollection !== info.collection
+          ) {
+            completedFiles += activeCollectionTotal;
+          }
+          activeCollection = info.collection;
+          activeCollectionTotal = info.total;
+
+          const progress = Math.max(lastProgress, completedFiles + info.current);
+          const total = Math.max(
+            lastTotal,
+            completedFiles + info.total,
+            progress
+          );
+          lastProgress = progress;
+          lastTotal = total;
+
+          enqueueBestEffortNotification(pendingNotifications, () =>
+            extra.sendNotification({
+              method: "notifications/progress",
+              params: {
+                progressToken,
+                progress,
+                total,
+                message: `${info.collection}/${info.file}`,
+              },
+            })
+          );
+        };
+
+        const result = await store.update({
+          ...(collections === undefined ? {} : { collections }),
+          onProgress,
+        });
+        await Promise.all(pendingNotifications);
+        throwIfMaintenanceAborted(extra.signal);
+
+        const summary =
+          `Updated ${result.collections} collection(s): ${result.indexed} indexed, ` +
+          `${result.updated} updated, ${result.unchanged} unchanged, ${result.removed} removed. ` +
+          `${result.needsEmbedding} document(s) need embedding.`;
+
+        return {
+          content: [{ type: "text", text: summary }],
+          structuredContent: result,
+        };
+      } catch (error) {
+        if (error instanceof MaintenanceCancelledError || extra.signal.aborted) {
+          return {
+            content: [{
+              type: "text",
+              text: "Update cancelled by the MCP client. Retry when ready.",
+            }],
+            isError: true,
+          };
+        }
+
+        return {
+          content: [{
+            type: "text",
+            text: "Update failed. Check QMD status and server logs, then retry.",
+          }],
+          isError: true,
+        };
+      } finally {
+        maintenance.release();
+      }
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Tool: embed (Generate vector embeddings for the derived index)
+  // ---------------------------------------------------------------------------
+
+  server.registerTool(
+    "embed",
+    {
+      title: "Embed Documents",
+      description: "Generate vector embeddings for pending indexed documents using QMD's centrally configured model. Defaults: force false and a runtime limit of 30 minutes; omit collection to process all pending collections. This writes only to the derived index and may download the configured model if it is not cached. With an MCP progress token it reports chunks, bytes, and errors. Busy, cancelled, failed, and partial-error runs return isError while preserving available counters. Per-document failure reasons are sanitized at the MCP boundary; they are categories, not raw backend errors.",
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      inputSchema: {
+        collection: z.string().min(1).optional().describe(
+          "Optional configured collection name. Omit to embed pending documents from all collections."
+        ),
+        force: z.boolean().optional().default(false).describe(
+          "Rebuild existing embeddings in the selected scope (default: false)."
+        ),
+        chunkStrategy: z.enum(["auto", "regex"]).optional().describe(
+          "Chunking strategy. Omit to use QMD's configured default."
+        ),
+        maxDocsPerBatch: z.number().int().positive().optional().describe(
+          "Maximum documents per embedding batch."
+        ),
+        maxBatchMiB: z.number().positive().optional().describe(
+          "Maximum embedding batch size in MiB."
+        ),
+        timeoutMinutes: z.number()
+          .nonnegative()
+          .max(
+            MAX_EMBED_TIMEOUT_MINUTES,
+            `timeoutMinutes must be at most ${MAX_EMBED_TIMEOUT_MINUTES} minutes. Use 0 for no runtime limit.`
+          )
+          .optional()
+          .default(30)
+          .describe(
+            `Maximum runtime in minutes (default: 30, maximum: ${MAX_EMBED_TIMEOUT_MINUTES}). Use 0 for no runtime limit.`
+          ),
+      },
+    },
+    async ({
+      collection,
+      force,
+      chunkStrategy,
+      maxDocsPerBatch,
+      maxBatchMiB,
+      timeoutMinutes,
+    }, extra) => {
+      if (extra.signal.aborted) {
+        return {
+          content: [{
+            type: "text",
+            text: "Embedding cancelled by the MCP client. Retry when ready.",
+          }],
+          isError: true,
+        };
+      }
+
+      const maintenance = acquireMaintenance(store, "embed");
+      if (!maintenance.acquired) {
+        return {
+          content: [{
+            type: "text",
+            text: `QMD maintenance is busy with ${maintenance.active}. Retry after it finishes.`,
+          }],
+          isError: true,
+        };
+      }
+
+      try {
+        throwIfMaintenanceAborted(extra.signal);
+
+        if (collection !== undefined) {
+          const configuredNames = new Set(
+            (await store.listCollections()).map(configured => configured.name)
+          );
+          throwIfMaintenanceAborted(extra.signal);
+
+          if (!configuredNames.has(collection)) {
+            return {
+              content: [{
+                type: "text",
+                text: `Unknown collection: ${collection}. Call status to list configured collections.`,
+              }],
+              isError: true,
+            };
+          }
+        }
+
+        const progressToken = extra._meta?.progressToken;
+        const pendingNotifications = new Set<Promise<void>>();
+        let lastProgress = 0;
+        let lastTotal = 0;
+        const onProgress = (info: EmbedProgress) => {
+          throwIfMaintenanceAborted(extra.signal);
+
+          if (progressToken === undefined) {
+            return;
+          }
+
+          const progress = Math.max(lastProgress, info.chunksEmbedded);
+          const total = Math.max(lastTotal, info.totalChunks, progress);
+          lastProgress = progress;
+          lastTotal = total;
+
+          enqueueBestEffortNotification(pendingNotifications, () =>
+            extra.sendNotification({
+              method: "notifications/progress",
+              params: {
+                progressToken,
+                progress,
+                total,
+                message:
+                  `${info.chunksEmbedded}/${info.totalChunks} chunks; ` +
+                  `${info.bytesProcessed}/${info.totalBytes} bytes; ` +
+                  `${info.errors} errors`,
+              },
+            })
+          );
+        };
+
+        const embedOptions: NonNullable<Parameters<QMDStore["embed"]>[0]> = {
+          force,
+          maxDurationMs: Math.round(timeoutMinutes * 60 * 1000),
+          ...(collection === undefined ? {} : { collection }),
+          ...(chunkStrategy === undefined ? {} : { chunkStrategy }),
+          ...(maxDocsPerBatch === undefined ? {} : { maxDocsPerBatch }),
+          ...(maxBatchMiB === undefined
+            ? {}
+            : { maxBatchBytes: maxBatchMiB * 1024 * 1024 }),
+          onProgress,
+        };
+        const result = await store.embed(embedOptions);
+        await Promise.all(pendingNotifications);
+        throwIfMaintenanceAborted(extra.signal);
+        const failures = result.failures ?? [];
+        const structured = {
+          ...result,
+          failureCount: result.errors,
+          failures: failures.slice(0, 20).map(failure => ({
+            ...failure,
+            reason: sanitizeEmbedFailureReason(failure.reason),
+          })),
+          failuresTruncated: failures.length > 20,
+        };
+        const summary =
+          `Embedded ${result.docsProcessed} document(s) into ${result.chunksEmbedded} chunk(s) ` +
+          `in ${result.durationMs}ms with ${result.errors} error(s).`;
+
+        return {
+          content: [{ type: "text", text: summary }],
+          structuredContent: structured,
+          isError: result.errors > 0,
+        };
+      } catch (error) {
+        if (error instanceof MaintenanceCancelledError || extra.signal.aborted) {
+          return {
+            content: [{
+              type: "text",
+              text: "Embedding cancelled by the MCP client. Retry when ready.",
+            }],
+            isError: true,
+          };
+        }
+
+        return {
+          content: [{
+            type: "text",
+            text: "Embedding failed. Check QMD status and server logs, then retry.",
+          }],
+          isError: true,
+        };
+      } finally {
+        maintenance.release();
+      }
     }
   );
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -50,6 +50,16 @@ export const DEFAULT_MULTI_GET_MAX_BYTES = 64 * 1024; // 64KB
 export const DEFAULT_EMBED_MAX_DOCS_PER_BATCH = 64;
 export const DEFAULT_EMBED_MAX_BATCH_BYTES = 64 * 1024 * 1024; // 64MB
 export const DEFAULT_EMBED_MAX_DURATION_MS = 30 * 60 * 1000; // 30 minutes; see EmbedOptions.maxDurationMs
+export const EMBED_FAILURE_NO_VECTOR_REASON =
+  "embedding returned no vector";
+export const EMBED_FAILURE_SESSION_EXPIRED_REASON =
+  "LLM session expired before embedding chunk";
+export const EMBED_FAILURE_ERROR_RATE_REASON =
+  "embedding aborted because error rate was too high";
+export const EMBED_FAILURE_BATCH_NO_VECTOR_REASON =
+  "batch embedding returned no vector";
+export const EMBED_FAILURE_BATCH_SESSION_EXPIRED_PREFIX =
+  "batch failed and session expired";
 
 const EMBED_FINGERPRINT_PROBE_QUERY = "__qmd_embedding_query_probe__";
 const EMBED_FINGERPRINT_PROBE_TITLE = "__qmd_embedding_title_probe__";
@@ -1748,7 +1758,7 @@ export async function generateEmbeddings(
         const text = formatDocForEmbedding(chunk.text, chunk.title, embedModelUri);
         const result = await session.embed(text, { model });
         if (!result) {
-          recordFailure(chunk, "embedding returned no vector");
+          recordFailure(chunk, EMBED_FAILURE_NO_VECTOR_REASON);
           return false;
         }
         insertEmbedding(db, chunk.hash, chunk.seq, chunk.pos, new Float32Array(result.embedding), model, now, chunk.expectedTotalChunks, fingerprint);
@@ -1852,7 +1862,9 @@ export async function generateEmbeddings(
         // Abort early if session has been invalidated (e.g. max duration exceeded)
         if (!session.isValid) {
           const remainingChunks = batchChunks.slice(batchStart);
-          for (const chunk of remainingChunks) recordFailure(chunk, "LLM session expired before embedding chunk");
+          for (const chunk of remainingChunks) {
+            recordFailure(chunk, EMBED_FAILURE_SESSION_EXPIRED_REASON);
+          }
           console.warn(`⚠ Session expired — skipping ${remainingChunks.length} remaining chunks`);
           break;
         }
@@ -1861,7 +1873,9 @@ export async function generateEmbeddings(
         const processed = chunksEmbedded + activeErrorCount();
         if (processed >= BATCH_SIZE && activeErrorCount() > processed * 0.8) {
           const remainingChunks = batchChunks.slice(batchStart);
-          for (const chunk of remainingChunks) recordFailure(chunk, "embedding aborted because error rate was too high");
+          for (const chunk of remainingChunks) {
+            recordFailure(chunk, EMBED_FAILURE_ERROR_RATE_REASON);
+          }
           console.warn(`⚠ Error rate too high (${activeErrorCount()}/${processed}) — aborting embedding`);
           break;
         }
@@ -1881,7 +1895,7 @@ export async function generateEmbeddings(
               successesSinceRetry++;
               clearFailure(chunk);
             } else {
-              recordFailure(chunk, "batch embedding returned no vector");
+              recordFailure(chunk, EMBED_FAILURE_BATCH_NO_VECTOR_REASON);
             }
             batchChunkBytesProcessed += chunk.bytes;
           }
@@ -1892,7 +1906,12 @@ export async function generateEmbeddings(
           // cleared, so the visible error count reflects outstanding failures.
           const batchReason = reasonFromError(error);
           if (!session.isValid) {
-            for (const chunk of chunkBatch) recordFailure(chunk, `batch failed and session expired: ${batchReason}`);
+            for (const chunk of chunkBatch) {
+              recordFailure(
+                chunk,
+                `${EMBED_FAILURE_BATCH_SESSION_EXPIRED_PREFIX}: ${batchReason}`
+              );
+            }
             batchChunkBytesProcessed += chunkBatch.reduce((sum, c) => sum + c.bytes, 0);
           } else {
             for (const chunk of chunkBatch) {

--- a/test/mcp-maintenance.test.ts
+++ b/test/mcp-maintenance.test.ts
@@ -1,0 +1,1292 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+  getDefaultEnvironment,
+  StdioClientTransport,
+} from "@modelcontextprotocol/sdk/client/stdio.js";
+import {
+  ProgressNotificationSchema,
+  type ProgressNotification,
+} from "@modelcontextprotocol/sdk/types.js";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { QMDStore } from "../src/index.js";
+import { createMcpServer } from "../src/mcp/server.js";
+
+const openHarnesses: Array<{
+  client: Client;
+  server: Awaited<ReturnType<typeof createMcpServer>>;
+}> = [];
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function createStoreDouble(
+  updateImplementation?: (
+    options?: Parameters<QMDStore["update"]>[0]
+  ) => ReturnType<QMDStore["update"]>,
+  embedImplementation?: (
+    options?: Parameters<QMDStore["embed"]>[0]
+  ) => ReturnType<QMDStore["embed"]>,
+) {
+  const update = vi.fn(updateImplementation ?? (async () => ({
+    collections: 2,
+    indexed: 3,
+    updated: 4,
+    unchanged: 5,
+    removed: 6,
+    needsEmbedding: 7,
+  })));
+  const embed = vi.fn(embedImplementation ?? (async () => ({
+    docsProcessed: 3,
+    chunksEmbedded: 4,
+    errors: 0,
+    durationMs: 5,
+    failures: [],
+  })));
+
+  const store = {
+    getStatus: async () => ({
+      totalDocuments: 0,
+      needsEmbedding: 0,
+      hasVectorIndex: false,
+      collections: [
+        {
+          name: "docs",
+          path: "/docs",
+          pattern: "**/*.md",
+          documents: 0,
+          lastUpdated: "",
+        },
+        {
+          name: "notes",
+          path: "/notes",
+          pattern: "**/*.md",
+          documents: 0,
+          lastUpdated: "",
+        },
+      ],
+    }),
+    getGlobalContext: async () => undefined,
+    getDefaultCollectionNames: async () => ["docs", "notes"],
+    listCollections: async () => [
+      {
+        name: "docs",
+        pwd: "/docs",
+        glob_pattern: "**/*.md",
+        doc_count: 0,
+        active_count: 0,
+        last_modified: null,
+        includeByDefault: true,
+      },
+      {
+        name: "notes",
+        pwd: "/notes",
+        glob_pattern: "**/*.md",
+        doc_count: 0,
+        active_count: 0,
+        last_modified: null,
+        includeByDefault: true,
+      },
+    ],
+    update,
+    embed,
+  } as unknown as QMDStore;
+
+  return { store, update, embed };
+}
+
+async function createHarness(store: QMDStore) {
+  const server = await createMcpServer(store);
+  const client = new Client({ name: "qmd-maintenance-test", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  openHarnesses.push({ client, server });
+  return { client, server, serverTransport };
+}
+
+function rejectProgressNotifications(serverTransport: InMemoryTransport): void {
+  const originalSend = serverTransport.send.bind(serverTransport);
+  serverTransport.send = async (message, options) => {
+    if (
+      "method" in message &&
+      message.method === "notifications/progress"
+    ) {
+      throw new Error("progress transport unavailable");
+    }
+
+    await originalSend(message, options);
+  };
+}
+
+function getFirstText(result: unknown): string {
+  const content = (result as {
+    content: Array<{ type: string; text?: string }>;
+  }).content;
+  expect(content[0]?.type).toBe("text");
+  return content[0]?.text ?? "";
+}
+
+afterEach(async () => {
+  await Promise.all(openHarnesses.splice(0).map(async ({ client, server }) => {
+    await client.close();
+    await server.close();
+  }));
+});
+
+describe("MCP maintenance tools", () => {
+  test("stdio tools/list exposes both maintenance tools", async () => {
+    const testDir = await mkdtemp(join(tmpdir(), "qmd-mcp-stdio-"));
+    const client = new Client({
+      name: "qmd-stdio-maintenance-test",
+      version: "1.0.0",
+    });
+    const transport = new StdioClientTransport({
+      command: "node",
+      args: ["--import", "tsx", "src/cli/qmd.ts", "mcp"],
+      cwd: process.cwd(),
+      env: {
+        ...getDefaultEnvironment(),
+        INDEX_PATH: join(testDir, "index.sqlite"),
+        QMD_CONFIG_DIR: testDir,
+        LLAMA_LOG_LEVEL: "error",
+        GGML_LOG_LEVEL: "error",
+        GGML_BACKEND_SILENT: "1",
+      },
+      stderr: "pipe",
+    });
+
+    try {
+      await client.connect(transport);
+      const { tools } = await client.listTools();
+      const toolNames = tools.map(tool => tool.name);
+
+      expect(toolNames).toContain("update");
+      expect(toolNames).toContain("embed");
+    } finally {
+      await client.close();
+      await rm(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test("server instructions recommend the safe MCP maintenance workflow", async () => {
+    const { store } = createStoreDouble();
+    store.getStatus = async () => ({
+      totalDocuments: 3,
+      needsEmbedding: 2,
+      hasVectorIndex: true,
+      collections: [],
+    });
+    const { client } = await createHarness(store);
+
+    const instructions = client.getInstructions() ?? "";
+
+    expect(instructions).toContain("Call the `update` MCP tool");
+    expect(instructions).toContain("inspect `needsEmbedding`");
+    expect(instructions).toContain(
+      "Call the `embed` MCP tool only when `needsEmbedding` is greater than 0"
+    );
+    expect(instructions).not.toContain("qmd embed");
+  });
+
+  test("tools/list exposes update as a local idempotent write", async () => {
+    const { store } = createStoreDouble();
+    const { client } = await createHarness(store);
+
+    const { tools } = await client.listTools();
+    const updateTool = tools.find((tool) => tool.name === "update");
+
+    expect(updateTool).toBeDefined();
+    expect(updateTool?.annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+    expect(updateTool?.inputSchema.properties).toHaveProperty("collections");
+    expect(
+      (updateTool?.inputSchema.properties?.collections as { minItems?: number })
+        .minItems
+    ).toBe(1);
+    expect(updateTool?.description).toMatch(/derived index/i);
+    expect(updateTool?.description).toMatch(/progress/i);
+    expect(updateTool?.description).toMatch(/best-effort/i);
+    expect(updateTool?.description).toMatch(/never change the tool result/i);
+    expect(updateTool?.description).toMatch(/busy|cancel/i);
+    expect(updateTool?.description).toMatch(/needsEmbedding/);
+  });
+
+  test("tools/list exposes embed without caller-controlled model or paths", async () => {
+    const { store } = createStoreDouble();
+    const { client } = await createHarness(store);
+
+    const { tools } = await client.listTools();
+    const embedTool = tools.find((tool) => tool.name === "embed");
+
+    expect(embedTool).toBeDefined();
+    expect(embedTool?.annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    });
+    expect(embedTool?.inputSchema.properties).not.toHaveProperty("model");
+    expect(embedTool?.inputSchema.properties).not.toHaveProperty("dbPath");
+    expect(embedTool?.inputSchema.properties).not.toHaveProperty("configPath");
+    expect(embedTool?.inputSchema.properties).not.toHaveProperty("path");
+    expect(embedTool?.description).toMatch(/derived index/i);
+    expect(embedTool?.description).toMatch(/30 minutes/i);
+    expect(embedTool?.description).toMatch(/progress/i);
+    expect(embedTool?.description).toMatch(/partial|busy|cancel/i);
+  });
+
+  test("embed validates and converts every supported option for the Store", async () => {
+    const { store, embed } = createStoreDouble();
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "embed",
+      arguments: {
+        collection: "docs",
+        force: true,
+        chunkStrategy: "regex",
+        maxDocsPerBatch: 12,
+        maxBatchMiB: 1.5,
+        timeoutMinutes: 0.25,
+      },
+    });
+
+    expect(embed).toHaveBeenCalledWith({
+      collection: "docs",
+      force: true,
+      chunkStrategy: "regex",
+      maxDocsPerBatch: 12,
+      maxBatchBytes: 1.5 * 1024 * 1024,
+      maxDurationMs: 0.25 * 60 * 1000,
+      onProgress: expect.any(Function),
+    });
+    expect(result.structuredContent).toMatchObject({
+      docsProcessed: 3,
+      chunksEmbedded: 4,
+      errors: 0,
+      durationMs: 5,
+      failureCount: 0,
+      failures: [],
+      failuresTruncated: false,
+    });
+  });
+
+  test("embed rejects an unknown collection before calling the Store", async () => {
+    const { store, embed } = createStoreDouble();
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "embed",
+      arguments: { collection: "missing" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(getFirstText(result)).toContain("missing");
+    expect(embed).not.toHaveBeenCalled();
+  });
+
+  test("embed forwards chunk progress with bytes, errors, and the MCP token", async () => {
+    const { store } = createStoreDouble(undefined, async (options) => {
+      options?.onProgress?.({
+        chunksEmbedded: 1,
+        totalChunks: 3,
+        bytesProcessed: 100,
+        totalBytes: 300,
+        errors: 0,
+        failures: [],
+      });
+      options?.onProgress?.({
+        chunksEmbedded: 2,
+        totalChunks: 3,
+        bytesProcessed: 200,
+        totalBytes: 300,
+        errors: 1,
+        failures: [],
+      });
+
+      return {
+        docsProcessed: 2,
+        chunksEmbedded: 2,
+        errors: 1,
+        durationMs: 10,
+        failures: [],
+      };
+    });
+    const { client } = await createHarness(store);
+    const progress: ProgressNotification["params"][] = [];
+
+    client.setNotificationHandler(ProgressNotificationSchema, (notification) => {
+      progress.push(notification.params);
+    });
+
+    await client.callTool({
+      name: "embed",
+      arguments: {},
+      _meta: { progressToken: 42 },
+    });
+
+    expect(progress.map(item => item.progressToken)).toEqual([42, 42]);
+    expect(progress.map(item => item.progress)).toEqual([1, 2]);
+    expect(progress.map(item => item.total)).toEqual([3, 3]);
+    expect(progress.map(item => item.message)).toEqual([
+      "1/3 chunks; 100/300 bytes; 0 errors",
+      "2/3 chunks; 200/300 bytes; 1 errors",
+    ]);
+  });
+
+  test("embed ignores rejected progress notifications after Store success", async () => {
+    const { store } = createStoreDouble(undefined, async (options) => {
+      options?.onProgress?.({
+        chunksEmbedded: 2,
+        totalChunks: 3,
+        bytesProcessed: 200,
+        totalBytes: 300,
+        errors: 0,
+        failures: [],
+      });
+
+      return {
+        docsProcessed: 2,
+        chunksEmbedded: 2,
+        errors: 0,
+        durationMs: 10,
+        failures: [],
+      };
+    });
+    const { client, serverTransport } = await createHarness(store);
+    rejectProgressNotifications(serverTransport);
+
+    const result = await client.callTool({
+      name: "embed",
+      arguments: {},
+      _meta: { progressToken: "rejected-embed-progress" },
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      docsProcessed: 2,
+      chunksEmbedded: 2,
+      errors: 0,
+      durationMs: 10,
+      failureCount: 0,
+      failures: [],
+      failuresTruncated: false,
+    });
+  });
+
+  test("embed handles rejected progress notifications when the Store throws", async () => {
+    const { store } = createStoreDouble(undefined, async (options) => {
+      options?.onProgress?.({
+        chunksEmbedded: 1,
+        totalChunks: 2,
+        bytesProcessed: 100,
+        totalBytes: 200,
+        errors: 0,
+        failures: [],
+      });
+      throw new Error("embedding failed");
+    });
+    const { client, serverTransport } = await createHarness(store);
+    rejectProgressNotifications(serverTransport);
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+
+    try {
+      const result = await client.callTool({
+        name: "embed",
+        arguments: {},
+        _meta: { progressToken: "rejected-embed-progress" },
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(result.isError).toBe(true);
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
+
+  test("embed converts Store exceptions into a safe tool error", async () => {
+    const { store, update } = createStoreDouble(undefined, async () => {
+      throw new Error("model failed with SECRET_MODEL_KEY\ninternal stack detail");
+    });
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "embed",
+      arguments: {},
+    });
+    const text = getFirstText(result);
+
+    expect(result.isError).toBe(true);
+    expect(text).toContain("Embedding failed");
+    expect(text).not.toContain("SECRET_MODEL_KEY");
+    expect(text).not.toContain("stack");
+
+    const afterError = await client.callTool({
+      name: "update",
+      arguments: {},
+    });
+    expect(afterError.isError).not.toBe(true);
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  test("embed applies the 30-minute default and preserves zero as unlimited", async () => {
+    const { store, embed } = createStoreDouble();
+    const { client } = await createHarness(store);
+
+    await client.callTool({ name: "embed", arguments: {} });
+    await client.callTool({
+      name: "embed",
+      arguments: { timeoutMinutes: 0 },
+    });
+
+    expect(embed.mock.calls[0]?.[0]).toEqual({
+      force: false,
+      maxDurationMs: 30 * 60 * 1000,
+      onProgress: expect.any(Function),
+    });
+    expect(embed.mock.calls[1]?.[0]).toEqual({
+      force: false,
+      maxDurationMs: 0,
+      onProgress: expect.any(Function),
+    });
+  });
+
+  test("embed treats a zero-work result as success", async () => {
+    const { store } = createStoreDouble(undefined, async () => ({
+      docsProcessed: 0,
+      chunksEmbedded: 0,
+      errors: 0,
+      durationMs: 0,
+      failures: [],
+    }));
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "embed",
+      arguments: {},
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toMatchObject({
+      docsProcessed: 0,
+      chunksEmbedded: 0,
+      errors: 0,
+      durationMs: 0,
+      failureCount: 0,
+      failures: [],
+      failuresTruncated: false,
+    });
+  });
+
+  test("embed masks raw failure reasons while preserving diagnostic fields", async () => {
+    const { store } = createStoreDouble(undefined, async () => ({
+      docsProcessed: 1,
+      chunksEmbedded: 0,
+      errors: 1,
+      durationMs: 5,
+      failures: [{
+        path: "docs/private.md",
+        hash: "hash-private",
+        seq: 7,
+        attempts: 3,
+        reason: "https://user:SECRET_TOKEN@example.test/model failed",
+      }],
+    }));
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "embed",
+      arguments: {},
+    });
+    const text = getFirstText(result);
+    const structuredText = JSON.stringify(result.structuredContent);
+
+    expect(text).not.toContain("SECRET_TOKEN");
+    expect(text).not.toContain("example.test");
+    expect(structuredText).not.toContain("SECRET_TOKEN");
+    expect(structuredText).not.toContain("example.test");
+    expect(result.structuredContent).toMatchObject({
+      failures: [{
+        path: "docs/private.md",
+        hash: "hash-private",
+        seq: 7,
+        attempts: 3,
+        reason: "embedding backend or index write failed",
+      }],
+    });
+  });
+
+  test("embed preserves safe Store reasons and sanitizes an expired batch detail", async () => {
+    const safeReasons = [
+      "embedding returned no vector",
+      "LLM session expired before embedding chunk",
+      "embedding aborted because error rate was too high",
+      "batch embedding returned no vector",
+    ];
+    const failures = [
+      ...safeReasons.map((reason, index) => ({
+        path: `docs/safe-${index}.md`,
+        hash: `hash-safe-${index}`,
+        seq: index,
+        attempts: 1,
+        reason,
+      })),
+      {
+        path: "docs/expired-batch.md",
+        hash: "hash-expired-batch",
+        seq: 4,
+        attempts: 3,
+        reason:
+          "batch failed and session expired: https://user:SECRET_TOKEN@example.test/model",
+      },
+    ];
+    const { store } = createStoreDouble(undefined, async () => ({
+      docsProcessed: 5,
+      chunksEmbedded: 0,
+      errors: 5,
+      durationMs: 5,
+      failures,
+    }));
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "embed",
+      arguments: {},
+    });
+    const structured = result.structuredContent as {
+      failures: Array<{ reason: string }>;
+    };
+
+    expect(structured.failures.map(failure => failure.reason)).toEqual([
+      ...safeReasons,
+      "batch failed and session expired",
+    ]);
+    expect(JSON.stringify(result.structuredContent)).not.toContain("SECRET_TOKEN");
+    expect(JSON.stringify(result.structuredContent)).not.toContain("example.test");
+  });
+
+  test("embed derives truncation only from available failure details", async () => {
+    const { store: shortStore } = createStoreDouble(undefined, async () => ({
+      docsProcessed: 25,
+      chunksEmbedded: 0,
+      errors: 25,
+      durationMs: 5,
+      failures: [{
+        path: "docs/only-detail.md",
+        hash: "hash-only",
+        seq: 1,
+        attempts: 3,
+        reason: "failed",
+      }],
+    }));
+    const { client: shortClient } = await createHarness(shortStore);
+    const shortResult = await shortClient.callTool({
+      name: "embed",
+      arguments: {},
+    });
+
+    expect(shortResult.structuredContent).toMatchObject({
+      failureCount: 25,
+      failuresTruncated: false,
+    });
+    expect(
+      (shortResult.structuredContent as { failures: unknown[] }).failures
+    ).toHaveLength(1);
+
+    const { store: missingStore } = createStoreDouble(undefined, async () => ({
+      docsProcessed: 25,
+      chunksEmbedded: 0,
+      errors: 25,
+      durationMs: 5,
+    }));
+    const { client: missingClient } = await createHarness(missingStore);
+    const missingResult = await missingClient.callTool({
+      name: "embed",
+      arguments: {},
+    });
+
+    expect(missingResult.structuredContent).toMatchObject({
+      failureCount: 25,
+      failures: [],
+      failuresTruncated: false,
+    });
+  });
+
+  test("embed keeps partial results while limiting failure details to 20", async () => {
+    const failures = Array.from({ length: 25 }, (_, index) => ({
+      path: `doc-${index}.md`,
+      hash: `hash-${index}`,
+      seq: index,
+      attempts: 3,
+      reason: "failed",
+    }));
+    const { store, update } = createStoreDouble(undefined, async () => ({
+      docsProcessed: 25,
+      chunksEmbedded: 10,
+      errors: 25,
+      durationMs: 50,
+      failures,
+    }));
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "embed",
+      arguments: {},
+    });
+    const structured = result.structuredContent as {
+      docsProcessed: number;
+      chunksEmbedded: number;
+      failureCount: number;
+      failures: unknown[];
+      failuresTruncated: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(structured.docsProcessed).toBe(25);
+    expect(structured.chunksEmbedded).toBe(10);
+    expect(structured.failureCount).toBe(25);
+    expect(structured.failures).toHaveLength(20);
+    expect(structured.failuresTruncated).toBe(true);
+
+    const afterPartialFailure = await client.callTool({
+      name: "update",
+      arguments: {},
+    });
+    expect(afterPartialFailure.isError).not.toBe(true);
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  test("embed rejects timer overflow and accepts the maximum safe duration", async () => {
+    const maxTimerMinutes = 35_791;
+    const { store, embed } = createStoreDouble();
+    const { client } = await createHarness(store);
+
+    const overflow = await client.callTool({
+      name: "embed",
+      arguments: { timeoutMinutes: maxTimerMinutes + 0.25 },
+    });
+
+    expect(overflow.isError).toBe(true);
+    expect(getFirstText(overflow)).toContain("Use 0 for no runtime limit");
+    expect(embed).not.toHaveBeenCalled();
+
+    const boundary = await client.callTool({
+      name: "embed",
+      arguments: { timeoutMinutes: maxTimerMinutes },
+    });
+
+    expect(boundary.isError).not.toBe(true);
+    expect(embed).toHaveBeenCalledOnce();
+    expect(embed.mock.calls[0]?.[0]).toEqual({
+      force: false,
+      maxDurationMs: 2_147_460_000,
+      onProgress: expect.any(Function),
+    });
+  });
+
+  test("embed rejects invalid numeric and chunk options before calling the Store", async () => {
+    const { store, embed } = createStoreDouble();
+    const { client } = await createHarness(store);
+    const invalidArguments = [
+      { maxDocsPerBatch: 0 },
+      { maxDocsPerBatch: 1.5 },
+      { maxBatchMiB: 0 },
+      { maxBatchMiB: Number.POSITIVE_INFINITY },
+      { timeoutMinutes: -1 },
+      { chunkStrategy: "semantic" },
+    ];
+
+    for (const arguments_ of invalidArguments) {
+      const result = await client.callTool({
+        name: "embed",
+        arguments: arguments_,
+      });
+      expect(result.isError).toBe(true);
+    }
+
+    expect(embed).not.toHaveBeenCalled();
+  });
+
+  test("a running update blocks embed across sessions but not read tools", async () => {
+    const started = deferred();
+    const release = deferred();
+    const { store, embed } = createStoreDouble(async () => {
+      started.resolve();
+      await release.promise;
+      return {
+        collections: 2,
+        indexed: 0,
+        updated: 0,
+        unchanged: 0,
+        removed: 0,
+        needsEmbedding: 0,
+      };
+    });
+    const first = await createHarness(store);
+    const second = await createHarness(store);
+
+    const updateCall = first.client.callTool({
+      name: "update",
+      arguments: {},
+    });
+    await started.promise;
+
+    try {
+      const statusResult = await second.client.callTool({
+        name: "status",
+        arguments: {},
+      });
+      const busyResult = await second.client.callTool({
+        name: "embed",
+        arguments: {},
+      });
+
+      expect(statusResult.isError).not.toBe(true);
+      expect(busyResult.isError).toBe(true);
+      expect(getFirstText(busyResult)).toContain("busy");
+      expect(embed).not.toHaveBeenCalled();
+    } finally {
+      release.resolve();
+      await updateCall;
+    }
+
+    const afterRelease = await second.client.callTool({
+      name: "embed",
+      arguments: {},
+    });
+    expect(afterRelease.isError).toBe(false);
+    expect(embed).toHaveBeenCalledOnce();
+  });
+
+  test("a running embed blocks update across sessions and releases afterward", async () => {
+    const started = deferred();
+    const release = deferred();
+    const { store, update } = createStoreDouble(undefined, async () => {
+      started.resolve();
+      await release.promise;
+      return {
+        docsProcessed: 0,
+        chunksEmbedded: 0,
+        errors: 0,
+        durationMs: 0,
+        failures: [],
+      };
+    });
+    const first = await createHarness(store);
+    const second = await createHarness(store);
+
+    const embedCall = first.client.callTool({
+      name: "embed",
+      arguments: {},
+    });
+    await started.promise;
+
+    try {
+      const busyResult = await second.client.callTool({
+        name: "update",
+        arguments: {},
+      });
+
+      expect(busyResult.isError).toBe(true);
+      expect(getFirstText(busyResult)).toContain("busy");
+      expect(update).not.toHaveBeenCalled();
+    } finally {
+      release.resolve();
+      await embedCall;
+    }
+
+    const afterRelease = await second.client.callTool({
+      name: "update",
+      arguments: {},
+    });
+    expect(afterRelease.isError).not.toBe(true);
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  test("an MCP abort without a progress token stops embed and sends no notification", async () => {
+    const started = deferred();
+    const continueWork = deferred();
+    const finished = deferred();
+    let continuedPastBoundary = false;
+    const { store, update } = createStoreDouble(undefined, async (options) => {
+      started.resolve();
+      try {
+        await continueWork.promise;
+        options?.onProgress?.({
+          chunksEmbedded: 1,
+          totalChunks: 2,
+          bytesProcessed: 100,
+          totalBytes: 200,
+          errors: 0,
+          failures: [],
+        });
+        continuedPastBoundary = true;
+        return {
+          docsProcessed: 1,
+          chunksEmbedded: 1,
+          errors: 0,
+          durationMs: 1,
+          failures: [],
+        };
+      } finally {
+        finished.resolve();
+      }
+    });
+    const first = await createHarness(store);
+    const second = await createHarness(store);
+    const progress: ProgressNotification["params"][] = [];
+    first.client.setNotificationHandler(ProgressNotificationSchema, (notification) => {
+      progress.push(notification.params);
+    });
+    const abortController = new AbortController();
+
+    const embedCall = first.client.callTool(
+      { name: "embed", arguments: {} },
+      undefined,
+      { signal: abortController.signal },
+    ).then(
+      () => ({ resolved: true }),
+      () => ({ resolved: false }),
+    );
+
+    await started.promise;
+    abortController.abort();
+    continueWork.resolve();
+    await finished.promise;
+
+    expect((await embedCall).resolved).toBe(false);
+    expect(continuedPastBoundary).toBe(false);
+    expect(progress).toEqual([]);
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const afterAbort = await second.client.callTool({
+      name: "update",
+      arguments: {},
+    });
+    expect(afterAbort.isError).not.toBe(true);
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  test("an MCP abort without a progress token stops update and sends no notification", async () => {
+    const started = deferred();
+    const continueWork = deferred();
+    const finished = deferred();
+    let continuedPastBoundary = false;
+    const { store, embed } = createStoreDouble(async (options) => {
+      started.resolve();
+      try {
+        await continueWork.promise;
+        options?.onProgress?.({
+          collection: "docs",
+          current: 1,
+          total: 2,
+          file: "first.md",
+        });
+        continuedPastBoundary = true;
+        return {
+          collections: 1,
+          indexed: 1,
+          updated: 0,
+          unchanged: 0,
+          removed: 0,
+          needsEmbedding: 1,
+        };
+      } finally {
+        finished.resolve();
+      }
+    });
+    const first = await createHarness(store);
+    const second = await createHarness(store);
+    const progress: ProgressNotification["params"][] = [];
+    first.client.setNotificationHandler(ProgressNotificationSchema, (notification) => {
+      progress.push(notification.params);
+    });
+    const abortController = new AbortController();
+
+    const updateCall = first.client.callTool(
+      { name: "update", arguments: {} },
+      undefined,
+      { signal: abortController.signal },
+    ).then(
+      () => ({ resolved: true }),
+      () => ({ resolved: false }),
+    );
+
+    await started.promise;
+    abortController.abort();
+    continueWork.resolve();
+    await finished.promise;
+
+    expect((await updateCall).resolved).toBe(false);
+    expect(continuedPastBoundary).toBe(false);
+    expect(progress).toEqual([]);
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const afterAbort = await second.client.callTool({
+      name: "embed",
+      arguments: {},
+    });
+    expect(afterAbort.isError).not.toBe(true);
+    expect(embed).toHaveBeenCalledOnce();
+  });
+
+  test("an MCP abort stops embed at the next progress boundary and releases the lock", async () => {
+    const started = deferred();
+    const continueWork = deferred();
+    const finished = deferred();
+    let continuedPastBoundary = false;
+    const { store, update } = createStoreDouble(undefined, async (options) => {
+      started.resolve();
+      try {
+        await continueWork.promise;
+        options?.onProgress?.({
+          chunksEmbedded: 1,
+          totalChunks: 2,
+          bytesProcessed: 100,
+          totalBytes: 200,
+          errors: 0,
+          failures: [],
+        });
+        continuedPastBoundary = true;
+        return {
+          docsProcessed: 1,
+          chunksEmbedded: 1,
+          errors: 0,
+          durationMs: 1,
+          failures: [],
+        };
+      } finally {
+        finished.resolve();
+      }
+    });
+    const first = await createHarness(store);
+    const second = await createHarness(store);
+    const abortController = new AbortController();
+
+    const embedCall = first.client.callTool(
+      {
+        name: "embed",
+        arguments: {},
+        _meta: { progressToken: "cancelled-embed" },
+      },
+      undefined,
+      { signal: abortController.signal },
+    ).then(
+      () => ({ resolved: true }),
+      () => ({ resolved: false }),
+    );
+
+    await started.promise;
+    abortController.abort();
+    continueWork.resolve();
+    await finished.promise;
+
+    const callResult = await embedCall;
+    expect(callResult.resolved).toBe(false);
+    expect(continuedPastBoundary).toBe(false);
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const afterAbort = await second.client.callTool({
+      name: "update",
+      arguments: {},
+    });
+    expect(afterAbort.isError).not.toBe(true);
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  test("an MCP abort during validation prevents the Store write and releases the lock", async () => {
+    const validationStarted = deferred();
+    const continueValidation = deferred();
+    const validationReturned = deferred();
+    const { store, update } = createStoreDouble();
+    store.listCollections = async () => {
+      validationStarted.resolve();
+      await continueValidation.promise;
+      validationReturned.resolve();
+      return [{
+        name: "docs",
+        pwd: "/docs",
+        glob_pattern: "**/*.md",
+        doc_count: 0,
+        active_count: 0,
+        last_modified: null,
+        includeByDefault: true,
+      }];
+    };
+    const first = await createHarness(store);
+    const second = await createHarness(store);
+    const abortController = new AbortController();
+
+    const updateCall = first.client.callTool(
+      {
+        name: "update",
+        arguments: { collections: ["docs"] },
+      },
+      undefined,
+      { signal: abortController.signal },
+    ).catch(() => undefined);
+
+    await validationStarted.promise;
+    abortController.abort();
+    continueValidation.resolve();
+    await validationReturned.promise;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(update).not.toHaveBeenCalled();
+    await updateCall;
+
+    const afterAbort = await second.client.callTool({
+      name: "embed",
+      arguments: {},
+    });
+    expect(afterAbort.isError).not.toBe(true);
+  });
+
+  test("update rejects every unknown collection before calling the store", async () => {
+    const { store, update } = createStoreDouble();
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "update",
+      arguments: { collections: ["missing", "also-missing"] },
+    });
+
+    expect(result.isError).toBe(true);
+    const text = getFirstText(result);
+    expect(text).toContain("also-missing");
+    expect(text).toContain("missing");
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  test("update forwards file progress with the original MCP token", async () => {
+    const { store } = createStoreDouble(async (options) => {
+      options?.onProgress?.({
+        collection: "docs",
+        current: 1,
+        total: 2,
+        file: "first.md",
+      });
+      options?.onProgress?.({
+        collection: "docs",
+        current: 2,
+        total: 2,
+        file: "second.md",
+      });
+
+      return {
+        collections: 1,
+        indexed: 2,
+        updated: 0,
+        unchanged: 0,
+        removed: 0,
+        needsEmbedding: 2,
+      };
+    });
+    const { client } = await createHarness(store);
+    const progress: ProgressNotification["params"][] = [];
+
+    client.setNotificationHandler(ProgressNotificationSchema, (notification) => {
+      progress.push(notification.params);
+    });
+
+    await client.callTool({
+      name: "update",
+      arguments: {},
+      _meta: { progressToken: "update-progress" },
+    });
+
+    expect(progress.map(item => item.progressToken)).toEqual([
+      "update-progress",
+      "update-progress",
+    ]);
+    expect(progress.map(item => item.progress)).toEqual([1, 2]);
+    expect(progress.map(item => item.total)).toEqual([2, 2]);
+    expect(progress.map(item => item.message)).toEqual([
+      "docs/first.md",
+      "docs/second.md",
+    ]);
+  });
+
+  test("update ignores rejected progress notifications after Store success", async () => {
+    const { store } = createStoreDouble(async (options) => {
+      options?.onProgress?.({
+        collection: "docs",
+        current: 1,
+        total: 1,
+        file: "first.md",
+      });
+
+      return {
+        collections: 1,
+        indexed: 1,
+        updated: 2,
+        unchanged: 3,
+        removed: 4,
+        needsEmbedding: 5,
+      };
+    });
+    const { client, serverTransport } = await createHarness(store);
+    rejectProgressNotifications(serverTransport);
+
+    const result = await client.callTool({
+      name: "update",
+      arguments: {},
+      _meta: { progressToken: "rejected-update-progress" },
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(result.structuredContent).toEqual({
+      collections: 1,
+      indexed: 1,
+      updated: 2,
+      unchanged: 3,
+      removed: 4,
+      needsEmbedding: 5,
+    });
+  });
+
+  test("update handles rejected progress notifications when the Store throws", async () => {
+    const { store } = createStoreDouble(async (options) => {
+      options?.onProgress?.({
+        collection: "docs",
+        current: 1,
+        total: 1,
+        file: "first.md",
+      });
+      throw new Error("update failed");
+    });
+    const { client, serverTransport } = await createHarness(store);
+    rejectProgressNotifications(serverTransport);
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+
+    try {
+      const result = await client.callTool({
+        name: "update",
+        arguments: {},
+        _meta: { progressToken: "rejected-update-progress" },
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(result.isError).toBe(true);
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
+
+  test("update converts Store exceptions into a safe tool error", async () => {
+    const { store, embed } = createStoreDouble(async () => {
+      throw new Error("database failed with SECRET_TOKEN\ninternal stack detail");
+    });
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "update",
+      arguments: {},
+    });
+    const text = getFirstText(result);
+
+    expect(result.isError).toBe(true);
+    expect(text).toContain("Update failed");
+    expect(text).not.toContain("SECRET_TOKEN");
+    expect(text).not.toContain("stack");
+
+    const afterError = await client.callTool({
+      name: "embed",
+      arguments: {},
+    });
+    expect(afterError.isError).toBe(false);
+    expect(embed).toHaveBeenCalledOnce();
+  });
+
+  test("update forwards an explicit collection selection unchanged", async () => {
+    const { store, update } = createStoreDouble();
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "update",
+      arguments: { collections: ["notes", "docs"] },
+    });
+
+    expect(update).toHaveBeenCalledWith({
+      collections: ["notes", "docs"],
+      onProgress: expect.any(Function),
+    });
+    expect(result.structuredContent).toEqual({
+      collections: 2,
+      indexed: 3,
+      updated: 4,
+      unchanged: 5,
+      removed: 6,
+      needsEmbedding: 7,
+    });
+    expect(getFirstText(result)).toContain("7 document(s) need embedding");
+  });
+
+  test("update without collections updates all and emits no unsolicited progress", async () => {
+    const { store, update } = createStoreDouble();
+    const { client } = await createHarness(store);
+    const progress: ProgressNotification["params"][] = [];
+
+    client.setNotificationHandler(ProgressNotificationSchema, (notification) => {
+      progress.push(notification.params);
+    });
+
+    const result = await client.callTool({
+      name: "update",
+      arguments: {},
+    });
+
+    expect(update).toHaveBeenCalledWith({
+      onProgress: expect.any(Function),
+    });
+    expect(result.structuredContent).toMatchObject({
+      collections: 2,
+      indexed: 3,
+      updated: 4,
+      unchanged: 5,
+      removed: 6,
+      needsEmbedding: 7,
+    });
+    expect(progress).toEqual([]);
+  });
+
+  test("update rejects an explicitly empty collection list before calling the store", async () => {
+    const { store, update } = createStoreDouble();
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "update",
+      arguments: { collections: [] },
+    });
+    const text = getFirstText(result);
+
+    expect(result.isError).toBe(true);
+    expect(text).toContain("collections");
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -88,17 +88,15 @@ function initTestDatabase(db: Database): void {
 
   db.exec(`
     CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(
-      name, body,
-      content='documents',
-      content_rowid='id',
+      filepath, title, body,
       tokenize='porter unicode61'
     )
   `);
 
   db.exec(`
     CREATE TRIGGER IF NOT EXISTS documents_ai AFTER INSERT ON documents BEGIN
-      INSERT INTO documents_fts(rowid, name, body)
-      SELECT new.id, new.path, content.doc
+      INSERT INTO documents_fts(rowid, filepath, title, body)
+      SELECT new.id, new.collection || '/' || new.path, new.title, content.doc
       FROM content
       WHERE content.hash = new.hash;
     END
@@ -946,10 +944,15 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
   const origConfigDir = process.env.QMD_CONFIG_DIR;
 
   beforeAll(async () => {
-    // Create isolated test database with seeded data
+    // Initialize the HTTP fixture through the production schema and triggers.
     httpTestDbPath = `/tmp/qmd-mcp-http-test-${Date.now()}.sqlite`;
+    const schemaStore = createStore(httpTestDbPath);
+    schemaStore.ensureVecTable(768);
+    schemaStore.close();
+
+    // Reopen only after production initialization, then seed through its triggers.
     const db = openDatabase(httpTestDbPath);
-    initTestDatabase(db);
+    loadSqliteVec(db);
     seedTestData(db);
 
     // 300 pad lines (37 chars each = 11100 chars) puts the marker past the
@@ -1094,6 +1097,8 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
     expect(toolNames).toContain("query");
     expect(toolNames).toContain("get");
     expect(toolNames).toContain("status");
+    expect(toolNames).toContain("update");
+    expect(toolNames).toContain("embed");
   });
 
   test("POST /mcp tools/call query returns results", async () => {

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -5,7 +5,16 @@
  * Uses inline config (no YAML files) to verify the SDK works self-contained.
  */
 
-import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
 import { mkdtemp, writeFile, mkdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -23,6 +32,7 @@ import {
   type ExpandQueryOptions,
 } from "../src/index.js";
 import { setDefaultLlamaCpp } from "../src/llm.js";
+import * as llmModule from "../src/llm.js";
 
 // =============================================================================
 // Test Helpers
@@ -991,6 +1001,117 @@ describe("embed", () => {
       expect(result.docsProcessed).toBe(3);
       expect(result.chunksEmbedded).toBe(3);
     } finally {
+      setDefaultLlamaCpp(null);
+      await store.close();
+    }
+  });
+
+  test("store.embed forwards the max runtime budget", async () => {
+    const store = await createStore({
+      dbPath: freshDbPath(),
+      config: {
+        collections: {
+          docs: { path: docsDir, pattern: "**/*.md" },
+        },
+      },
+    });
+
+    const embedBatchCalls: string[][] = [];
+    const slowLlm = {
+      async embed() {
+        return { embedding: [0.1, 0.2, 0.3], model: "fake-embed" };
+      },
+      async embedBatch(texts: string[]) {
+        embedBatchCalls.push([...texts]);
+        await new Promise((resolve) => setTimeout(resolve, 80));
+        return texts.map((_text, index) => ({
+          embedding: [index + 1, index + 2, index + 3],
+          model: "fake-embed",
+        }));
+      },
+    };
+    const sessionSpy = vi.spyOn(llmModule, "withLLMSessionForLlm");
+
+    setDefaultLlamaCpp(createFakeTokenizer() as any);
+    store.internal.llm = slowLlm as any;
+
+    try {
+      await store.update();
+      const result = await store.embed({
+        maxDocsPerBatch: 1,
+        maxBatchBytes: 1024 * 1024,
+        maxDurationMs: 10,
+      });
+
+      expect(embedBatchCalls.length).toBeGreaterThanOrEqual(1);
+      expect(sessionSpy).toHaveBeenCalledWith(
+        slowLlm,
+        expect.any(Function),
+        { maxDuration: 10, name: "generateEmbeddings" },
+      );
+      expect(result.chunksEmbedded).toBeLessThan(3);
+    } finally {
+      sessionSpy.mockRestore();
+      setDefaultLlamaCpp(null);
+      await store.close();
+    }
+  });
+
+  test("store.embed preserves zero as an unlimited runtime budget", async () => {
+    const store = await createStore({
+      dbPath: freshDbPath(),
+      config: {
+        collections: {
+          docs: { path: docsDir, pattern: "**/*.md" },
+        },
+      },
+    });
+    const fakeLlm = createFakeEmbedLlm();
+    const sessionSpy = vi.spyOn(llmModule, "withLLMSessionForLlm");
+    setDefaultLlamaCpp(createFakeTokenizer() as any);
+    store.internal.llm = fakeLlm as any;
+
+    try {
+      await store.update();
+      await store.embed({ maxDurationMs: 0 });
+
+      expect(sessionSpy).toHaveBeenCalledWith(
+        fakeLlm,
+        expect.any(Function),
+        { maxDuration: 0, name: "generateEmbeddings" },
+      );
+    } finally {
+      sessionSpy.mockRestore();
+      setDefaultLlamaCpp(null);
+      await store.close();
+    }
+  });
+
+  test("store.embed applies the default runtime budget when omitted", async () => {
+    const store = await createStore({
+      dbPath: freshDbPath(),
+      config: {
+        collections: {
+          docs: { path: docsDir, pattern: "**/*.md" },
+        },
+      },
+    });
+    const fakeLlm = createFakeEmbedLlm();
+    const sessionSpy = vi.spyOn(llmModule, "withLLMSessionForLlm");
+    setDefaultLlamaCpp(createFakeTokenizer() as any);
+    store.internal.llm = fakeLlm as any;
+
+    try {
+      await store.update();
+      await store.embed();
+
+      expect(sessionSpy).toHaveBeenCalledWith(
+        fakeLlm,
+        expect.any(Function),
+        { maxDuration: 30 * 60 * 1000, name: "generateEmbeddings" },
+      );
+    } finally {
+      sessionSpy.mockRestore();
       setDefaultLlamaCpp(null);
       await store.close();
     }


### PR DESCRIPTION
## Problem

MCP clients can already see a stale index via `status`, but they cannot do
anything about it. Re-indexing and embedding require leaving the MCP connection
and running `qmd update` / `qmd embed` in a shell — impossible in environments
without shell access. The dynamic server instructions even pointed at
`qmd embed`, a command the connected client has no way to call.

## What this adds

Two tools, `update` and `embed`, registered in the shared server factory so
stdio and Streamable HTTP expose the same implementation. Both call existing
store methods only — no CLI subprocess, no shell command, no source file is
modified, and configured collection update commands are never executed.

**`update`** syncs all configured collections or an explicit non-empty subset
and returns `collections`, `indexed`, `updated`, `unchanged`, `removed` and
`needsEmbedding`. Unknown names and an explicitly empty list are rejected
before the store is called, so a typo cannot look like a successful no-op.

**`embed`** supports scope, `force`, chunk strategy, batch bounds and a runtime
limit (default 30 minutes, `0` disables it, values above the safe Node timer
are rejected rather than silently overflowing to an immediate abort). The model
is never a client input.

## Safety boundaries

- Progress is emitted as MCP notifications only when the caller supplies a
  progress token. Delivery is best-effort and never changes the tool result.
- A per-process, per-store fail-fast lock permits one maintenance writer while
  read tools stay available; every exit path releases it. Separate processes
  keep relying on SQLite/WAL/busy-timeout.
- Cancellation is checked before the run and at the store's own progress
  boundaries, independent of whether a progress token was supplied.
- Failure details are capped at 20 entries and sanitized at the MCP boundary:
  known store categories pass through, raw backend, model, download and
  database error text does not.
- No new REST endpoints, no schema change, no migration. Existing search,
  retrieval, resource and status contracts are unchanged.

The embed runtime budget became part of the public SDK contract so the MCP
layer can pass it through without reimplementing batching.

## Tests

Protocol-level tests drive real `tools/list` and `tools/call` messages over an
in-memory transport against a controlled store double — no model, no GPU, no
filesystem scan. Covered: schema and annotations, option validation and
conversion, structured results, safe errors, progress with and without a token,
cross-session busy behaviour, lock release after success/error/cancellation,
bounded failure details, and transport parity for stdio and HTTP.

`test/mcp-maintenance.test.ts` (new) plus additions to `test/sdk.test.ts` and
`test/mcp.test.ts`. Node 175 passed, Bun 175 passed, `npm run test:types`,
`npm run build` and `npm run test:package` green.