### PR TITLE
feat(mcp): add collection management tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Added
 
+- MCP now exposes read-only `collection_list` and `collection_show` tools on
+  both transports. Trusted local stdio clients can explicitly enable
+  `collection_add`, `collection_rename`, and destructive `collection_remove`
+  with `qmd mcp --enable-collection-management`. The writing tools are
+  deliberately excluded from HTTP, validate names and local paths, return
+  structured results, preserve source files, and share the fail-fast Store
+  maintenance lock with `update` and `embed`. The documented add workflow is
+  `collection_add`, `update`, inspect `needsEmbedding`, then `embed` only when
+  needed. Ignore patterns can be supplied during add but are not returned by
+  collection read tools.
 - The MCP server now exposes `update` and `embed` through the same central tool
   registration for stdio and Streamable HTTP. The documented maintenance flow
   is `update`, inspect `status.needsEmbedding`, then `embed` only when work is
@@ -20,6 +30,17 @@
   embedding results are surfaced with `isError` without adding REST maintenance
   endpoints. MCP failure details preserve known safe Store categories and
   sanitize raw backend, model, download, and database error text.
+
+### Fixed
+
+- SDK `removeCollection` now removes the collection's indexed documents,
+  transactionally cleans globally orphaned content hashes, and reports
+  `{ removed, deletedDocs, cleanedHashes }`. Previously it removed only the
+  Store/config entry and left documents searchable.
+- SDK `renameCollection` now transactionally renames both the configured
+  collection and its indexed documents, so search, status, and `qmd://` paths
+  follow the new name. Previously indexed documents remained under the old
+  collection name.
 
 ## [2.6.3] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+### Added
+
+- The MCP server now exposes `update` and `embed` through the same central tool
+  registration for stdio and Streamable HTTP. The documented maintenance flow
+  is `update`, inspect `status.needsEmbedding`, then `embed` only when work is
+  pending. Both tools report progress when the client supplies a progress
+  token, return structured counters, and write only to QMD's derived index.
+  Progress delivery is best-effort and cannot change a successful tool result.
+  `update` never modifies source files or executes configured update commands;
+  `embed` uses only the centrally configured model and defaults to a 30-minute
+  runtime limit. Values above the documented safe Node timer maximum are
+  rejected; `0` remains unlimited. A per-process, per-store fail-fast lock
+  permits one maintenance writer while reads remain available, and
+  cancellation/error paths release the lock. Separate processes continue to
+  rely on SQLite/WAL/busy-timeout. Busy, cancelled, failed, and partial
+  embedding results are surfaced with `isError` without adding REST maintenance
+  endpoints. MCP failure details preserve known safe Store categories and
+  sanitize raw backend, model, download, and database error text.
+
 ## [2.6.3] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Although the tool works perfectly fine when you just tell your agent to use it o
 - `get` — Retrieve a document by path or docid (with fuzzy matching suggestions)
 - `multi_get` — Batch retrieve by glob pattern, comma-separated list, or docids
 - `status` — Index health and collection info
+- `update` — Synchronize configured collections into QMD's derived index
+- `embed` — Generate pending vector embeddings with QMD's configured model
 
 **Claude Desktop configuration** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
 
@@ -139,6 +141,7 @@ The HTTP server exposes two endpoints:
 LLM models stay loaded in VRAM across requests. Embedding/reranking contexts are disposed after 5 min idle and transparently recreated on the next request (~1s penalty, models remain loaded).
 
 Point any MCP client at `http://localhost:8181/mcp` to connect.
+The stdio and HTTP transports expose the same centrally registered tools.
 
 #### MCP Tool Parameters
 
@@ -159,6 +162,29 @@ Point any MCP client at `http://localhost:8181/mcp` to connect.
 | `multi_get` | `maxBytes` | number | Skip files larger than N (default 10240) |
 | `multi_get` | `maxLines` | number | Limit lines per file |
 | `multi_get` | `lineNumbers` | boolean | Prefix lines with numbers (default **true**) |
+| `update` | `collections` | string[] | Optional non-empty list of configured collections; omit to update all |
+| `embed` | `collection` | string | Optional configured collection; omit to process all pending collections |
+| `embed` | `force` | boolean | Rebuild existing embeddings in scope (default **false**) |
+| `embed` | `chunkStrategy` | `"auto"` or `"regex"` | Optional chunking strategy; omit to use QMD's configured default |
+| `embed` | `maxDocsPerBatch` | positive integer | Optional document limit per embedding batch |
+| `embed` | `maxBatchMiB` | positive number | Optional embedding batch-size limit in MiB |
+| `embed` | `timeoutMinutes` | non-negative number | Runtime limit (default **30**, maximum **35791**); use `0` for no runtime limit |
+
+For safe maintenance, call `update`, then call `status` and inspect
+`needsEmbedding`. Call `embed` only when that count is greater than zero. Both
+tools write only to QMD's derived index; `update` does not modify source files
+or execute configured collection update commands. If the request includes an
+MCP progress token, `update` reports file progress and `embed` reports chunk,
+byte, and error counters. Only one `update` or `embed` operation can run for a
+shared store within one MCP server process/store instance at a time; another
+writer fails immediately as busy while read tools remain available. Separate
+CLI or server processes rely on SQLite/WAL/busy-timeout instead of this
+fail-fast lock. Busy, cancelled, and failed calls set `isError`.
+`embed` also sets `isError` for partial failures while retaining its result
+counters and a bounded failure list. Failure reasons in that list are sanitized
+MCP categories, not raw model, download, backend, or database error messages.
+The 30-minute default embed limit provides a final safety boundary when an
+active native model computation cannot stop immediately.
 
 Unknown parameters are silently ignored (not rejected) — double-check names if
 results seem unscoped. The HTTP `/query` and `/search` endpoints return

--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ Although the tool works perfectly fine when you just tell your agent to use it o
 - `status` — Index health and collection info
 - `update` — Synchronize configured collections into QMD's derived index
 - `embed` — Generate pending vector embeddings with QMD's configured model
+- `collection_list` — List configured collections, including ones not indexed yet
+- `collection_show` — Show one configured collection
+
+Local stdio servers can additionally opt in to three collection configuration
+writes with `qmd mcp --enable-collection-management`:
+
+- `collection_add` — Register a local directory without indexing it
+- `collection_rename` — Rename a collection and its indexed paths
+- `collection_remove` — Remove a collection and its indexed data; source files remain unchanged
 
 **Claude Desktop configuration** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
 
@@ -141,7 +150,34 @@ The HTTP server exposes two endpoints:
 LLM models stay loaded in VRAM across requests. Embedding/reranking contexts are disposed after 5 min idle and transparently recreated on the next request (~1s penalty, models remain loaded).
 
 Point any MCP client at `http://localhost:8181/mcp` to connect.
-The stdio and HTTP transports expose the same centrally registered tools.
+The stdio and HTTP transports expose the same centrally registered search,
+retrieval, status, collection-read, update, and embed tools. The deliberate
+transport-parity exception is limited to the three writing collection tools:
+they are never registered over HTTP.
+
+#### Collection Management
+
+Collection configuration writes are disabled by default. Enable them only for a
+trusted local stdio client:
+
+```sh
+qmd mcp --enable-collection-management
+```
+
+For client configuration, add the flag after `mcp`, for example
+`"args": ["mcp", "--enable-collection-management"]`. The flag cannot be combined
+with `--http`; QMD rejects that startup combination. These tools accept local
+filesystem paths, change collection configuration, and can rename or remove
+indexed data. Keeping them off the shared HTTP transport avoids turning a
+network-facing search service into a remote filesystem/configuration
+administration API. There is intentionally no environment-variable or config
+file equivalent for this opt-in.
+
+The safe add workflow is `collection_add`, then `update`, then inspect
+`status.needsEmbedding`; call `embed` only when that value is greater than zero.
+All collection writes share the same per-process, per-store fail-fast lock as
+`update` and `embed`. Concurrent writers return busy immediately, while read
+tools remain available.
 
 #### MCP Tool Parameters
 
@@ -169,6 +205,15 @@ The stdio and HTTP transports expose the same centrally registered tools.
 | `embed` | `maxDocsPerBatch` | positive integer | Optional document limit per embedding batch |
 | `embed` | `maxBatchMiB` | positive number | Optional embedding batch-size limit in MiB |
 | `embed` | `timeoutMinutes` | non-negative number | Runtime limit (default **30**, maximum **35791**); use `0` for no runtime limit |
+| `collection_list` | — | — | Read-only; returns configured collections sorted by name, including zero-document collections |
+| `collection_show` | `name` | string | **Required.** Read-only lookup using the same collection result shape as list/add/rename |
+| `collection_add` | `path` | string | **Required.** Existing local directory; resolved to its real path. Registers only, without update/embed |
+| `collection_add` | `name` | string | Optional; defaults to the resolved directory basename |
+| `collection_add` | `pattern` | string | Optional Markdown glob; defaults to `**/*.md` |
+| `collection_add` | `ignore` | string[] | Optional exclusion globs. Forwarded to the Store, but not returned by collection read tools |
+| `collection_rename` | `oldName` | string | **Required.** Existing collection name |
+| `collection_rename` | `newName` | string | **Required.** Unused name; existing indexed `qmd://` paths follow the rename |
+| `collection_remove` | `name` | string | **Required.** Removes collection config and indexed documents, then cleans globally orphaned content rows; source files remain unchanged |
 
 For safe maintenance, call `update`, then call `status` and inspect
 `needsEmbedding`. Call `embed` only when that count is greater than zero. Both
@@ -176,8 +221,10 @@ tools write only to QMD's derived index; `update` does not modify source files
 or execute configured collection update commands. If the request includes an
 MCP progress token, `update` reports file progress and `embed` reports chunk,
 byte, and error counters. Only one `update` or `embed` operation can run for a
-shared store within one MCP server process/store instance at a time; another
-writer fails immediately as busy while read tools remain available. Separate
+shared store within one MCP server process/store instance at a time; this lock
+also covers enabled `collection_add`, `collection_rename`, and
+`collection_remove` calls. Another writer fails immediately as busy while read
+tools remain available. Separate
 CLI or server processes rely on SQLite/WAL/busy-timeout instead of this
 fail-fast lock. Busy, cancelled, and failed calls set `isError`.
 `embed` also sets `isError` for partial failures while retaining its result

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -2767,7 +2767,8 @@ function parseCLI() {
       intent: { type: "string" },
       // Chunking options
       "chunk-strategy": { type: "string" },  // "regex" (default) or "auto" (AST for code files)
-      // MCP HTTP transport options
+      // MCP transport options
+      "enable-collection-management": { type: "boolean" },
       http: { type: "boolean" },
       daemon: { type: "boolean" },
       port: { type: "string" },
@@ -3274,6 +3275,7 @@ function showHelp(): void {
   console.log("  qmd skills list/get/path      - List and retrieve bundled runtime skills");
   console.log("  qmd skill show/install        - Show or install the QMD skill");
   console.log("  qmd mcp                       - Start the MCP server (stdio transport for AI agents)");
+  console.log("    --enable-collection-management - Enable collection write tools over stdio only");
   console.log("  qmd bench <fixture.json>      - Run search quality benchmarks against a fixture file");
   console.log("");
   console.log("Collections & context:");
@@ -4418,6 +4420,18 @@ if (isMain) {
         process.exit(0);
       }
 
+      const enableCollectionManagement = Boolean(
+        cli.values["enable-collection-management"]
+      );
+      if (cli.values.http && enableCollectionManagement) {
+        console.error(
+          "--enable-collection-management is not supported with --http: " +
+          "the HTTP transport has no authentication, so collection management " +
+          "is only available over stdio. Start without --http to use it."
+        );
+        process.exit(1);
+      }
+
       if (cli.values.http) {
         const port = Number(cli.values.port) || 8181;
         // --host overrides the default localhost bind; QMD_HOST env is the
@@ -4477,7 +4491,10 @@ if (isMain) {
       } else {
         // Default: stdio transport
         const { startMcpServer } = await import("../mcp/server.js");
-        await startMcpServer({ dbPath: getDbPath() });
+        await startMcpServer({
+          dbPath: getDbPath(),
+          enableCollectionManagement,
+        });
       }
       break;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,8 +33,8 @@ import {
   getStoreGlobalContext,
   getStoreContexts,
   upsertStoreCollection,
-  deleteStoreCollection,
-  renameStoreCollection,
+  removeCollection as removeStoreCollection,
+  renameCollection as renameCollectionInStore,
   updateStoreContext,
   removeStoreContext,
   setStoreGlobalContext,
@@ -211,6 +211,13 @@ export interface StoreOptions {
   config?: CollectionConfig;
 }
 
+export interface RemoveCollectionResult {
+  removed: boolean;
+  deletedDocs: number;
+  /** Number of globally orphaned content hashes cleaned up by the removal. */
+  cleanedHashes: number;
+}
+
 /**
  * The QMD SDK store — provides search, retrieval, collection management,
  * context management, and indexing operations.
@@ -254,8 +261,8 @@ export interface QMDStore {
   /** Add or update a collection */
   addCollection(name: string, opts: { path: string; pattern?: string; ignore?: string[] }): Promise<void>;
 
-  /** Remove a collection */
-  removeCollection(name: string): Promise<boolean>;
+  /** Remove a collection and report its indexing impact */
+  removeCollection(name: string): Promise<RemoveCollectionResult>;
 
   /** Rename a collection */
   renameCollection(oldName: string, newName: string): Promise<boolean>;
@@ -449,14 +456,18 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
       }
     },
     removeCollection: async (name) => {
-      const result = deleteStoreCollection(db, name);
+      if (!getStoreCollection(db, name)) {
+        return { removed: false, deletedDocs: 0, cleanedHashes: 0 };
+      }
+
+      const result = removeStoreCollection(db, name);
       if (hasYamlConfig || options.config) {
         collectionsRemoveCollection(name);
       }
-      return result;
+      return { removed: true, ...result };
     },
     renameCollection: async (oldName, newName) => {
-      const result = renameStoreCollection(db, oldName, newName);
+      const result = renameCollectionInStore(db, oldName, newName);
       if (hasYamlConfig || options.config) {
         collectionsRenameCollection(oldName, newName);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -300,6 +300,11 @@ export interface QMDStore {
     maxDocsPerBatch?: number;
     maxBatchBytes?: number;
     chunkStrategy?: ChunkStrategy;
+    /**
+     * Maximum wall-clock duration for the embed run, in milliseconds.
+     * Defaults to 30 minutes; 0 disables the runtime limit.
+     */
+    maxDurationMs?: number;
     onProgress?: (info: EmbedProgress) => void;
   }): Promise<EmbedResult>;
 
@@ -529,6 +534,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
         maxDocsPerBatch: embedOpts?.maxDocsPerBatch,
         maxBatchBytes: embedOpts?.maxBatchBytes,
         chunkStrategy: embedOpts?.chunkStrategy,
+        maxDurationMs: embedOpts?.maxDurationMs,
         onProgress: embedOpts?.onProgress,
       });
     },

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -26,11 +26,20 @@ import {
   getDefaultDbPath,
   DEFAULT_MULTI_GET_MAX_BYTES,
   type QMDStore,
+  type EmbedProgress,
+  type UpdateProgress,
   type ExpandedQuery,
   type IndexStatus,
 } from "../index.js";
 import { getConfigPath } from "../collections.js";
-import { enableProductionMode } from "../store.js";
+import {
+  EMBED_FAILURE_BATCH_NO_VECTOR_REASON,
+  EMBED_FAILURE_BATCH_SESSION_EXPIRED_PREFIX,
+  EMBED_FAILURE_ERROR_RATE_REASON,
+  EMBED_FAILURE_NO_VECTOR_REASON,
+  EMBED_FAILURE_SESSION_EXPIRED_REASON,
+  enableProductionMode,
+} from "../store.js";
 
 // =============================================================================
 // Types for structured content
@@ -62,6 +71,9 @@ type StatusResult = {
 // =============================================================================
 // Helper functions
 // =============================================================================
+
+const MAX_NODE_TIMER_MS = 2_147_483_647;
+const MAX_EMBED_TIMEOUT_MINUTES = Math.floor(MAX_NODE_TIMER_MS / 60_000);
 
 /**
  * Encode a path for use in qmd:// URIs.
@@ -124,13 +136,20 @@ async function buildInstructions(store: QMDStore): Promise<string> {
     lines.push("Call the `status` tool for collection descriptions, paths, and per-collection doc counts.");
   }
 
+  // --- Maintenance workflow ---
+  lines.push("");
+  lines.push("Maintenance:");
+  lines.push("  - Call the `update` MCP tool to synchronize configured collections into the derived index.");
+  lines.push("  - After update, call `status` and inspect `needsEmbedding`.");
+  lines.push("  - Call the `embed` MCP tool only when `needsEmbedding` is greater than 0.");
+
   // --- Capability gaps ---
   if (!status.hasVectorIndex) {
     lines.push("");
-    lines.push("Note: No vector embeddings yet. Run `qmd embed` to enable semantic search (vec/hyde).");
+    lines.push("Note: No vector embeddings yet; semantic search (vec/hyde) remains unavailable until pending embeddings are generated.");
   } else if (status.needsEmbedding > 0) {
     lines.push("");
-    lines.push(`Note: ${status.needsEmbedding} documents need embedding. Run \`qmd embed\` to update.`);
+    lines.push(`Note: ${status.needsEmbedding} documents currently need embedding.`);
   }
 
   // --- Search tool ---
@@ -168,7 +187,90 @@ async function buildInstructions(store: QMDStore): Promise<string> {
  * Create an MCP server with all QMD tools, resources, and prompts registered.
  * Shared by both stdio and HTTP transports.
  */
-async function createMcpServer(store: QMDStore): Promise<McpServer> {
+type MaintenanceOperation = "update" | "embed";
+
+type MaintenanceLease =
+  | { acquired: true; release: () => void }
+  | { acquired: false; active: MaintenanceOperation };
+
+class MaintenanceCancelledError extends Error {}
+
+const maintenanceStates = new WeakMap<
+  QMDStore,
+  { active?: { operation: MaintenanceOperation; leaseId: symbol } }
+>();
+
+function throwIfMaintenanceAborted(signal: AbortSignal): void {
+  if (signal.aborted) {
+    throw new MaintenanceCancelledError();
+  }
+}
+
+function acquireMaintenance(
+  store: QMDStore,
+  operation: MaintenanceOperation
+): MaintenanceLease {
+  let state = maintenanceStates.get(store);
+  if (!state) {
+    state = {};
+    maintenanceStates.set(store, state);
+  }
+
+  if (state.active) {
+    return { acquired: false, active: state.active.operation };
+  }
+
+  const leaseId = Symbol(operation);
+  state.active = { operation, leaseId };
+  return {
+    acquired: true,
+    release: () => {
+      if (state.active?.leaseId === leaseId) {
+        state.active = undefined;
+      }
+    },
+  };
+}
+
+function enqueueBestEffortNotification(
+  pendingNotifications: Set<Promise<void>>,
+  send: () => Promise<void>
+): void {
+  const pendingNotification = (async () => {
+    try {
+      await send();
+    } catch {
+      // Progress notifications are best-effort and never change tool results.
+    }
+  })();
+  pendingNotifications.add(pendingNotification);
+  void pendingNotification.then(() => {
+    pendingNotifications.delete(pendingNotification);
+  });
+}
+
+const SAFE_EMBED_FAILURE_REASONS = new Set([
+  EMBED_FAILURE_NO_VECTOR_REASON,
+  EMBED_FAILURE_SESSION_EXPIRED_REASON,
+  EMBED_FAILURE_ERROR_RATE_REASON,
+  EMBED_FAILURE_BATCH_NO_VECTOR_REASON,
+]);
+
+function sanitizeEmbedFailureReason(reason: string): string {
+  if (SAFE_EMBED_FAILURE_REASONS.has(reason)) {
+    return reason;
+  }
+
+  if (
+    reason.startsWith(`${EMBED_FAILURE_BATCH_SESSION_EXPIRED_PREFIX}: `)
+  ) {
+    return EMBED_FAILURE_BATCH_SESSION_EXPIRED_PREFIX;
+  }
+
+  return "embedding backend or index write failed";
+}
+
+export async function createMcpServer(store: QMDStore): Promise<McpServer> {
   const server = new McpServer(
     { name: "qmd", version: getPackageVersion() },
     { instructions: await buildInstructions(store) },
@@ -533,6 +635,340 @@ Intent-aware lex (C++ performance, not sports):
       }
 
       return { content };
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Tool: update (Synchronize configured collections into the derived index)
+  // ---------------------------------------------------------------------------
+
+  server.registerTool(
+    "update",
+    {
+      title: "Update Index",
+      description: "Synchronize configured Markdown collections into the derived index. Omit collections to update all configured collections. This writes only to QMD's index; source files are unchanged and configured update commands are not executed. With an MCP progress token it reports file progress. Progress notifications are best-effort and never change the tool result. Busy, cancelled, and failed runs return isError. Inspect the structured needsEmbedding count afterward and call embed only when it is greater than 0.",
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      inputSchema: {
+        collections: z.array(z.string()).min(1).optional().describe(
+          "Optional non-empty list of configured collection names. Omit to update all collections."
+        ),
+      },
+    },
+    async ({ collections }, extra) => {
+      if (extra.signal.aborted) {
+        return {
+          content: [{
+            type: "text",
+            text: "Update cancelled by the MCP client. Retry when ready.",
+          }],
+          isError: true,
+        };
+      }
+
+      const maintenance = acquireMaintenance(store, "update");
+      if (!maintenance.acquired) {
+        return {
+          content: [{
+            type: "text",
+            text: `QMD maintenance is busy with ${maintenance.active}. Retry after it finishes.`,
+          }],
+          isError: true,
+        };
+      }
+
+      try {
+        throwIfMaintenanceAborted(extra.signal);
+
+        if (collections) {
+          const configuredNames = new Set(
+            (await store.listCollections()).map(collection => collection.name)
+          );
+          throwIfMaintenanceAborted(extra.signal);
+          const unknownCollections = collections.filter(
+            name => !configuredNames.has(name)
+          );
+
+          if (unknownCollections.length > 0) {
+            return {
+              content: [{
+                type: "text",
+                text: `Unknown collection(s): ${unknownCollections.join(", ")}. Call status to list configured collections.`,
+              }],
+              isError: true,
+            };
+          }
+        }
+
+        const progressToken = extra._meta?.progressToken;
+        const pendingNotifications = new Set<Promise<void>>();
+        let activeCollection: string | undefined;
+        let completedFiles = 0;
+        let activeCollectionTotal = 0;
+        let lastProgress = 0;
+        let lastTotal = 0;
+
+        const onProgress = (info: UpdateProgress) => {
+          throwIfMaintenanceAborted(extra.signal);
+
+          if (progressToken === undefined) {
+            return;
+          }
+
+          if (
+            activeCollection !== undefined &&
+            activeCollection !== info.collection
+          ) {
+            completedFiles += activeCollectionTotal;
+          }
+          activeCollection = info.collection;
+          activeCollectionTotal = info.total;
+
+          const progress = Math.max(lastProgress, completedFiles + info.current);
+          const total = Math.max(
+            lastTotal,
+            completedFiles + info.total,
+            progress
+          );
+          lastProgress = progress;
+          lastTotal = total;
+
+          enqueueBestEffortNotification(pendingNotifications, () =>
+            extra.sendNotification({
+              method: "notifications/progress",
+              params: {
+                progressToken,
+                progress,
+                total,
+                message: `${info.collection}/${info.file}`,
+              },
+            })
+          );
+        };
+
+        const result = await store.update({
+          ...(collections === undefined ? {} : { collections }),
+          onProgress,
+        });
+        await Promise.all(pendingNotifications);
+        throwIfMaintenanceAborted(extra.signal);
+
+        const summary =
+          `Updated ${result.collections} collection(s): ${result.indexed} indexed, ` +
+          `${result.updated} updated, ${result.unchanged} unchanged, ${result.removed} removed. ` +
+          `${result.needsEmbedding} document(s) need embedding.`;
+
+        return {
+          content: [{ type: "text", text: summary }],
+          structuredContent: result,
+        };
+      } catch (error) {
+        if (error instanceof MaintenanceCancelledError || extra.signal.aborted) {
+          return {
+            content: [{
+              type: "text",
+              text: "Update cancelled by the MCP client. Retry when ready.",
+            }],
+            isError: true,
+          };
+        }
+
+        return {
+          content: [{
+            type: "text",
+            text: "Update failed. Check QMD status and server logs, then retry.",
+          }],
+          isError: true,
+        };
+      } finally {
+        maintenance.release();
+      }
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Tool: embed (Generate vector embeddings for the derived index)
+  // ---------------------------------------------------------------------------
+
+  server.registerTool(
+    "embed",
+    {
+      title: "Embed Documents",
+      description: "Generate vector embeddings for pending indexed documents using QMD's centrally configured model. Defaults: force false and a runtime limit of 30 minutes; omit collection to process all pending collections. This writes only to the derived index and may download the configured model if it is not cached. With an MCP progress token it reports chunks, bytes, and errors. Busy, cancelled, failed, and partial-error runs return isError while preserving available counters. Per-document failure reasons are sanitized at the MCP boundary; they are categories, not raw backend errors.",
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      inputSchema: {
+        collection: z.string().min(1).optional().describe(
+          "Optional configured collection name. Omit to embed pending documents from all collections."
+        ),
+        force: z.boolean().optional().default(false).describe(
+          "Rebuild existing embeddings in the selected scope (default: false)."
+        ),
+        chunkStrategy: z.enum(["auto", "regex"]).optional().describe(
+          "Chunking strategy. Omit to use QMD's configured default."
+        ),
+        maxDocsPerBatch: z.number().int().positive().optional().describe(
+          "Maximum documents per embedding batch."
+        ),
+        maxBatchMiB: z.number().positive().optional().describe(
+          "Maximum embedding batch size in MiB."
+        ),
+        timeoutMinutes: z.number()
+          .nonnegative()
+          .max(
+            MAX_EMBED_TIMEOUT_MINUTES,
+            `timeoutMinutes must be at most ${MAX_EMBED_TIMEOUT_MINUTES} minutes. Use 0 for no runtime limit.`
+          )
+          .optional()
+          .default(30)
+          .describe(
+            `Maximum runtime in minutes (default: 30, maximum: ${MAX_EMBED_TIMEOUT_MINUTES}). Use 0 for no runtime limit.`
+          ),
+      },
+    },
+    async ({
+      collection,
+      force,
+      chunkStrategy,
+      maxDocsPerBatch,
+      maxBatchMiB,
+      timeoutMinutes,
+    }, extra) => {
+      if (extra.signal.aborted) {
+        return {
+          content: [{
+            type: "text",
+            text: "Embedding cancelled by the MCP client. Retry when ready.",
+          }],
+          isError: true,
+        };
+      }
+
+      const maintenance = acquireMaintenance(store, "embed");
+      if (!maintenance.acquired) {
+        return {
+          content: [{
+            type: "text",
+            text: `QMD maintenance is busy with ${maintenance.active}. Retry after it finishes.`,
+          }],
+          isError: true,
+        };
+      }
+
+      try {
+        throwIfMaintenanceAborted(extra.signal);
+
+        if (collection !== undefined) {
+          const configuredNames = new Set(
+            (await store.listCollections()).map(configured => configured.name)
+          );
+          throwIfMaintenanceAborted(extra.signal);
+
+          if (!configuredNames.has(collection)) {
+            return {
+              content: [{
+                type: "text",
+                text: `Unknown collection: ${collection}. Call status to list configured collections.`,
+              }],
+              isError: true,
+            };
+          }
+        }
+
+        const progressToken = extra._meta?.progressToken;
+        const pendingNotifications = new Set<Promise<void>>();
+        let lastProgress = 0;
+        let lastTotal = 0;
+        const onProgress = (info: EmbedProgress) => {
+          throwIfMaintenanceAborted(extra.signal);
+
+          if (progressToken === undefined) {
+            return;
+          }
+
+          const progress = Math.max(lastProgress, info.chunksEmbedded);
+          const total = Math.max(lastTotal, info.totalChunks, progress);
+          lastProgress = progress;
+          lastTotal = total;
+
+          enqueueBestEffortNotification(pendingNotifications, () =>
+            extra.sendNotification({
+              method: "notifications/progress",
+              params: {
+                progressToken,
+                progress,
+                total,
+                message:
+                  `${info.chunksEmbedded}/${info.totalChunks} chunks; ` +
+                  `${info.bytesProcessed}/${info.totalBytes} bytes; ` +
+                  `${info.errors} errors`,
+              },
+            })
+          );
+        };
+
+        const embedOptions: NonNullable<Parameters<QMDStore["embed"]>[0]> = {
+          force,
+          maxDurationMs: Math.round(timeoutMinutes * 60 * 1000),
+          ...(collection === undefined ? {} : { collection }),
+          ...(chunkStrategy === undefined ? {} : { chunkStrategy }),
+          ...(maxDocsPerBatch === undefined ? {} : { maxDocsPerBatch }),
+          ...(maxBatchMiB === undefined
+            ? {}
+            : { maxBatchBytes: maxBatchMiB * 1024 * 1024 }),
+          onProgress,
+        };
+        const result = await store.embed(embedOptions);
+        await Promise.all(pendingNotifications);
+        throwIfMaintenanceAborted(extra.signal);
+        const failures = result.failures ?? [];
+        const structured = {
+          ...result,
+          failureCount: result.errors,
+          failures: failures.slice(0, 20).map(failure => ({
+            ...failure,
+            reason: sanitizeEmbedFailureReason(failure.reason),
+          })),
+          failuresTruncated: failures.length > 20,
+        };
+        const summary =
+          `Embedded ${result.docsProcessed} document(s) into ${result.chunksEmbedded} chunk(s) ` +
+          `in ${result.durationMs}ms with ${result.errors} error(s).`;
+
+        return {
+          content: [{ type: "text", text: summary }],
+          structuredContent: structured,
+          isError: result.errors > 0,
+        };
+      } catch (error) {
+        if (error instanceof MaintenanceCancelledError || extra.signal.aborted) {
+          return {
+            content: [{
+              type: "text",
+              text: "Embedding cancelled by the MCP client. Retry when ready.",
+            }],
+            isError: true,
+          };
+        }
+
+        return {
+          content: [{
+            type: "text",
+            text: "Embedding failed. Check QMD status and server logs, then retry.",
+          }],
+          isError: true,
+        };
+      } finally {
+        maintenance.release();
+      }
     }
   );
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -10,7 +10,8 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { realpath, stat } from "node:fs/promises";
+import { basename, join, dirname } from "node:path";
 import { fileURLToPath } from "url";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -33,6 +34,7 @@ import {
 } from "../index.js";
 import { getConfigPath } from "../collections.js";
 import {
+  DEFAULT_GLOB,
   EMBED_FAILURE_BATCH_NO_VECTOR_REASON,
   EMBED_FAILURE_BATCH_SESSION_EXPIRED_PREFIX,
   EMBED_FAILURE_ERROR_RATE_REASON,
@@ -53,6 +55,16 @@ type SearchResultItem = {
   context: string | null;
   line: number;   // Absolute line in source markdown
   snippet: string;
+};
+
+type CollectionResult = {
+  name: string;
+  path: string;
+  pattern: string;
+  documents: number;
+  indexedDocuments: number;
+  lastUpdated: string | null;
+  includeByDefault: boolean;
 };
 
 type StatusResult = {
@@ -98,6 +110,20 @@ function formatSearchSummary(results: SearchResultItem[], query: string): string
   return lines.join('\n');
 }
 
+function toCollectionResult(
+  collection: Awaited<ReturnType<QMDStore["listCollections"]>>[number]
+): CollectionResult {
+  return {
+    name: collection.name,
+    path: collection.pwd,
+    pattern: collection.glob_pattern,
+    documents: collection.active_count,
+    indexedDocuments: collection.doc_count,
+    lastUpdated: collection.last_modified,
+    includeByDefault: collection.includeByDefault,
+  };
+}
+
 function getPackageVersion(): string {
   try {
     const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "../../package.json");
@@ -117,7 +143,10 @@ function getPackageVersion(): string {
  * Injected into the LLM's system prompt via MCP initialize response —
  * gives the LLM immediate context about what's searchable without a tool call.
  */
-async function buildInstructions(store: QMDStore): Promise<string> {
+async function buildInstructions(
+  store: QMDStore,
+  collectionManagementEnabled: boolean,
+): Promise<string> {
   const status = await store.getStatus();
   const globalCtx = await store.getGlobalContext();
   const lines: string[] = [];
@@ -134,6 +163,16 @@ async function buildInstructions(store: QMDStore): Promise<string> {
     const names = status.collections.map(c => c.name).join(", ");
     lines.push(`Collections (scope with \`collections\` parameter): ${names}`);
     lines.push("Call the `status` tool for collection descriptions, paths, and per-collection doc counts.");
+  }
+
+  if (collectionManagementEnabled) {
+    lines.push("");
+    lines.push("Collection management is enabled for this local stdio session:");
+    lines.push("  - Use `collection_list` and `collection_show` to inspect configured collections.");
+    lines.push("  - To register a directory, call `collection_add`, then `update`, inspect `needsEmbedding`, and call `embed` only when `needsEmbedding` is greater than 0.");
+    lines.push("  - Use `collection_rename` to rename a collection and its indexed paths.");
+    lines.push("  - Use destructive `collection_remove` to delete a collection from QMD's index; source files stay unchanged.");
+    lines.push("  - Ignore patterns can be supplied to `collection_add`, but collection read tools cannot return configured ignore patterns.");
   }
 
   // --- Maintenance workflow ---
@@ -187,7 +226,12 @@ async function buildInstructions(store: QMDStore): Promise<string> {
  * Create an MCP server with all QMD tools, resources, and prompts registered.
  * Shared by both stdio and HTTP transports.
  */
-type MaintenanceOperation = "update" | "embed";
+type MaintenanceOperation =
+  | "update"
+  | "embed"
+  | "collection_add"
+  | "collection_rename"
+  | "collection_remove";
 
 type MaintenanceLease =
   | { acquired: true; release: () => void }
@@ -270,10 +314,26 @@ function sanitizeEmbedFailureReason(reason: string): string {
   return "embedding backend or index write failed";
 }
 
-export async function createMcpServer(store: QMDStore): Promise<McpServer> {
+export type McpServerOptions = {
+  transport: "stdio" | "http";
+  enableCollectionManagement?: boolean;
+};
+
+export async function createMcpServer(
+  store: QMDStore,
+  options: McpServerOptions,
+): Promise<McpServer> {
+  const collectionManagementEnabled =
+    options.transport === "stdio" &&
+    options.enableCollectionManagement === true;
   const server = new McpServer(
     { name: "qmd", version: getPackageVersion() },
-    { instructions: await buildInstructions(store) },
+    {
+      instructions: await buildInstructions(
+        store,
+        collectionManagementEnabled,
+      ),
+    },
   );
 
   // Pre-fetch default collection names for search tools
@@ -973,6 +1033,454 @@ Intent-aware lex (C++ performance, not sports):
   );
 
   // ---------------------------------------------------------------------------
+  // Tool: collection_add (Opt-in stdio-only collection configuration write)
+  // ---------------------------------------------------------------------------
+
+  if (collectionManagementEnabled) {
+    server.registerTool(
+      "collection_add",
+      {
+        title: "Add Collection",
+        description: "Register a local directory as a QMD collection without indexing it. Call update afterward, then embed if documents need embeddings.",
+        annotations: {
+          readOnlyHint: false,
+          destructiveHint: false,
+          idempotentHint: false,
+          openWorldHint: false,
+        },
+        inputSchema: {
+          path: z.string().min(1).describe(
+            "Existing local directory to register. Absolute paths are recommended; relative paths resolve against the server process working directory."
+          ),
+          name: z.string().min(1).optional().describe(
+            "Optional collection name; defaults to the resolved directory basename"
+          ),
+          pattern: z.string().min(1).optional().default(DEFAULT_GLOB).describe(
+            `Markdown glob pattern (default: ${DEFAULT_GLOB})`
+          ),
+          ignore: z.array(z.string().min(1)).optional().describe(
+            "Optional glob patterns to exclude"
+          ),
+        },
+      },
+      async ({ path, name, pattern, ignore }) => {
+        const maintenance = acquireMaintenance(store, "collection_add");
+        if (!maintenance.acquired) {
+          return {
+            content: [{
+              type: "text",
+              text: `QMD maintenance is busy with ${maintenance.active}. Retry after it finishes.`,
+            }],
+            isError: true,
+          };
+        }
+
+        try {
+          let resolvedPath: string;
+          try {
+            resolvedPath = await realpath(path);
+          } catch (error) {
+            if (
+              typeof error === "object" &&
+              error !== null &&
+              "code" in error
+            ) {
+              if (error.code === "ENOENT") {
+                return {
+                  content: [{
+                    type: "text",
+                    text: `Collection path does not exist: ${path}. Check the path and retry.`,
+                  }],
+                  isError: true,
+                };
+              }
+              if (error.code === "EACCES") {
+                return {
+                  content: [{
+                    type: "text",
+                    text: `Collection path is not accessible: ${path}. Check directory permissions and retry.`,
+                  }],
+                  isError: true,
+                };
+              }
+              if (error.code === "ENOTDIR") {
+                return {
+                  content: [{
+                    type: "text",
+                    text: `A collection path component is not a directory: ${path}. Check the path and retry.`,
+                  }],
+                  isError: true,
+                };
+              }
+            }
+            return {
+              content: [{
+                type: "text",
+                text: "Could not resolve the collection path. Check access and server logs, then retry.",
+              }],
+              isError: true,
+            };
+          }
+
+          try {
+            if (!(await stat(resolvedPath)).isDirectory()) {
+              return {
+                content: [{
+                  type: "text",
+                  text: `Collection path is not a directory: ${path}. Choose a directory and retry.`,
+                }],
+                isError: true,
+              };
+            }
+
+            const collectionName = (name ?? basename(resolvedPath)) || "root";
+            const collections = await store.listCollections();
+            if (collections.some(collection => collection.name === collectionName)) {
+              return {
+                content: [{
+                  type: "text",
+                  text: `Collection '${collectionName}' already exists. Choose a different name.`,
+                }],
+                isError: true,
+              };
+            }
+
+            const duplicate = collections.find(collection =>
+              collection.pwd === resolvedPath && collection.glob_pattern === pattern
+            );
+            if (duplicate) {
+              return {
+                content: [{
+                  type: "text",
+                  text: `Collection '${duplicate.name}' already uses this path and pattern. Call update for it or remove it first.`,
+                }],
+                isError: true,
+              };
+            }
+
+            await store.addCollection(collectionName, {
+              path: resolvedPath,
+              pattern,
+              ...(ignore === undefined ? {} : { ignore }),
+            });
+
+            const created = (await store.listCollections()).find(
+              collection => collection.name === collectionName
+            );
+            if (!created) {
+              return {
+                content: [{
+                  type: "text",
+                  text: "Collection may have been registered but could not be read back. Call collection_list to check before retrying.",
+                }],
+                isError: true,
+              };
+            }
+
+            return {
+              content: [{
+                type: "text",
+                text: `Added collection '${collectionName}' without indexing. Call update next, then call embed if documents need embeddings.`,
+              }],
+              structuredContent: { collection: toCollectionResult(created) },
+            };
+          } catch {
+            return {
+              content: [{
+                type: "text",
+                text: "Could not add the collection. Check QMD status and server logs, then retry.",
+              }],
+              isError: true,
+            };
+          }
+        } finally {
+          maintenance.release();
+        }
+      }
+    );
+
+    server.registerTool(
+      "collection_rename",
+      {
+        title: "Rename Collection",
+        description: "Rename a configured QMD collection and its existing indexed document paths.",
+        annotations: {
+          readOnlyHint: false,
+          destructiveHint: true,
+          idempotentHint: false,
+          openWorldHint: false,
+        },
+        inputSchema: {
+          oldName: z.string().min(1).describe("Existing collection name"),
+          newName: z.string().min(1).describe("New, unused collection name"),
+        },
+      },
+      async ({ oldName, newName }) => {
+        const maintenance = acquireMaintenance(store, "collection_rename");
+        if (!maintenance.acquired) {
+          return {
+            content: [{
+              type: "text",
+              text: `QMD maintenance is busy with ${maintenance.active}. Retry after it finishes.`,
+            }],
+            isError: true,
+          };
+        }
+
+        try {
+          let collections: Awaited<ReturnType<QMDStore["listCollections"]>>;
+          try {
+            collections = await store.listCollections();
+          } catch {
+            return {
+              content: [{
+                type: "text",
+                text: "Could not read the configured collections. Check QMD status and server logs, then retry.",
+              }],
+              isError: true,
+            };
+          }
+
+          if (!collections.some(collection => collection.name === oldName)) {
+            return {
+              content: [{
+                type: "text",
+                text: `Collection '${oldName}' does not exist. Call collection_list to check the current names.`,
+              }],
+              isError: true,
+            };
+          }
+          if (collections.some(collection => collection.name === newName)) {
+            return {
+              content: [{
+                type: "text",
+                text: `Collection '${newName}' already exists. Choose a different name.`,
+              }],
+              isError: true,
+            };
+          }
+
+          try {
+            const renamedSuccessfully = await store.renameCollection(oldName, newName);
+            if (!renamedSuccessfully) {
+              return {
+                content: [{
+                  type: "text",
+                  text: "No collection was renamed. Call collection_list to check the current names.",
+                }],
+                isError: true,
+              };
+            }
+
+            const renamed = (await store.listCollections()).find(
+              collection => collection.name === newName
+            );
+            if (!renamed) {
+              return {
+                content: [{
+                  type: "text",
+                  text: "Collection may have been renamed but could not be read back. Call collection_show to verify the new name before retrying.",
+                }],
+                isError: true,
+              };
+            }
+
+            return {
+              content: [{
+                type: "text",
+                text: `Renamed collection '${oldName}' to '${newName}'. Existing indexed documents now use qmd://${newName}/... paths.`,
+              }],
+              structuredContent: { collection: toCollectionResult(renamed) },
+            };
+          } catch {
+            return {
+              content: [{
+                type: "text",
+                text: "Collection may have been renamed. Call collection_show to verify the new name before retrying.",
+              }],
+              isError: true,
+            };
+          }
+        } finally {
+          maintenance.release();
+        }
+      }
+    );
+
+    server.registerTool(
+      "collection_remove",
+      {
+        title: "Remove Collection",
+        description: "Remove a QMD collection and its indexed data. Also cleans up content rows that no document references anymore, across all collections. Source files remain unchanged.",
+        annotations: {
+          readOnlyHint: false,
+          destructiveHint: true,
+          idempotentHint: false,
+          openWorldHint: false,
+        },
+        inputSchema: {
+          name: z.string().min(1).describe("Existing collection name"),
+        },
+      },
+      async ({ name }) => {
+        const maintenance = acquireMaintenance(store, "collection_remove");
+        if (!maintenance.acquired) {
+          return {
+            content: [{
+              type: "text",
+              text: `QMD maintenance is busy with ${maintenance.active}. Retry after it finishes.`,
+            }],
+            isError: true,
+          };
+        }
+
+        try {
+          let collections: Awaited<ReturnType<QMDStore["listCollections"]>>;
+          try {
+            collections = await store.listCollections();
+          } catch {
+            return {
+              content: [{
+                type: "text",
+                text: "Could not read the configured collections. Check QMD status and server logs, then retry.",
+              }],
+              isError: true,
+            };
+          }
+
+          if (!collections.some(collection => collection.name === name)) {
+            return {
+              content: [{
+                type: "text",
+                text: `Collection '${name}' does not exist. Call collection_list to check the current names.`,
+              }],
+              isError: true,
+            };
+          }
+
+          try {
+            const result = await store.removeCollection(name);
+            if (!result.removed) {
+              return {
+                content: [{
+                  type: "text",
+                  text: "No collection was removed. Call collection_list to check the current names.",
+                }],
+                isError: true,
+              };
+            }
+
+            return {
+              content: [{
+                type: "text",
+                text: `Removed collection '${name}': deleted ${result.deletedDocs} indexed documents and cleaned ${result.cleanedHashes} globally orphaned content hashes. Source files remain unchanged.`,
+              }],
+              structuredContent: {
+                removed: result.removed,
+                deletedDocs: result.deletedDocs,
+                cleanedHashes: result.cleanedHashes,
+              },
+            };
+          } catch {
+            return {
+              content: [{
+                type: "text",
+                text: "Collection may have been removed. Call collection_list to verify before retrying.",
+              }],
+              isError: true,
+            };
+          }
+        } finally {
+          maintenance.release();
+        }
+      }
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tools: collection_list and collection_show (Read-only collection state)
+  // ---------------------------------------------------------------------------
+
+  server.registerTool(
+    "collection_list",
+    {
+      title: "List Collections",
+      description: "List all configured QMD collections, including ones not indexed yet; status only reports collections with active documents. Each result includes active documents and all indexed documents (active plus inactive), paths, glob patterns, last changes, and unscoped-search defaults.",
+      annotations: { readOnlyHint: true, openWorldHint: false },
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const collections = (await store.listCollections())
+          .map(toCollectionResult)
+          .sort((left, right) =>
+            left.name < right.name ? -1 : left.name > right.name ? 1 : 0
+          );
+        return {
+          content: [{
+            type: "text",
+            text: `${collections.length} configured ${collections.length === 1 ? "collection" : "collections"}.`,
+          }],
+          structuredContent: { collections },
+        };
+      } catch {
+        return {
+          content: [{
+            type: "text",
+            text: "Could not list collections. Check QMD status and server logs, then retry.",
+          }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.registerTool(
+    "collection_show",
+    {
+      title: "Show Collection",
+      description: "Show configuration and index counts for one configured QMD collection, including active documents and all indexed documents (active plus inactive).",
+      annotations: { readOnlyHint: true, openWorldHint: false },
+      inputSchema: {
+        name: z.string().min(1).describe("Configured collection name"),
+      },
+    },
+    async ({ name }) => {
+      try {
+        const collection = (await store.listCollections()).find(
+          configured => configured.name === name
+        );
+        if (!collection) {
+          return {
+            content: [{
+              type: "text",
+              text: `Unknown collection: ${name}. Call collection_list to list configured collections.`,
+            }],
+            isError: true,
+          };
+        }
+
+        const result = toCollectionResult(collection);
+        return {
+          content: [{
+            type: "text",
+            text: `Collection ${result.name}: ${result.path} (${result.documents} active of ${result.indexedDocuments} indexed documents).`,
+          }],
+          structuredContent: { collection: result },
+        };
+      } catch {
+        return {
+          content: [{
+            type: "text",
+            text: "Could not show the collection. Check QMD status and server logs, then retry.",
+          }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // ---------------------------------------------------------------------------
   // Tool: qmd_status (Index status)
   // ---------------------------------------------------------------------------
 
@@ -1015,6 +1523,7 @@ Intent-aware lex (C++ performance, not sports):
 
 export type McpStartupOptions = {
   dbPath?: string;
+  enableCollectionManagement?: boolean;
 };
 
 export async function startMcpServer(options: McpStartupOptions = {}): Promise<void> {
@@ -1029,7 +1538,10 @@ export async function startMcpServer(options: McpStartupOptions = {}): Promise<v
     dbPath: options.dbPath ?? getDefaultDbPath(),
     ...(existsSync(configPath) ? { configPath } : {}),
   });
-  const server = await createMcpServer(store);
+  const server = await createMcpServer(store, {
+    transport: "stdio",
+    enableCollectionManagement: options.enableCollectionManagement,
+  });
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }
@@ -1080,7 +1592,10 @@ export async function startMcpHttpServer(
         log(`${ts()} New session ${sessionId} (${sessions.size} active)`);
       },
     });
-    const server = await createMcpServer(store);
+    const server = await createMcpServer(store, {
+      transport: "http",
+      enableCollectionManagement: options.enableCollectionManagement,
+    });
     await server.connect(transport);
 
     transport.onclose = () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -50,6 +50,16 @@ export const DEFAULT_MULTI_GET_MAX_BYTES = 64 * 1024; // 64KB
 export const DEFAULT_EMBED_MAX_DOCS_PER_BATCH = 64;
 export const DEFAULT_EMBED_MAX_BATCH_BYTES = 64 * 1024 * 1024; // 64MB
 export const DEFAULT_EMBED_MAX_DURATION_MS = 30 * 60 * 1000; // 30 minutes; see EmbedOptions.maxDurationMs
+export const EMBED_FAILURE_NO_VECTOR_REASON =
+  "embedding returned no vector";
+export const EMBED_FAILURE_SESSION_EXPIRED_REASON =
+  "LLM session expired before embedding chunk";
+export const EMBED_FAILURE_ERROR_RATE_REASON =
+  "embedding aborted because error rate was too high";
+export const EMBED_FAILURE_BATCH_NO_VECTOR_REASON =
+  "batch embedding returned no vector";
+export const EMBED_FAILURE_BATCH_SESSION_EXPIRED_PREFIX =
+  "batch failed and session expired";
 
 const EMBED_FINGERPRINT_PROBE_QUERY = "__qmd_embedding_query_probe__";
 const EMBED_FINGERPRINT_PROBE_TITLE = "__qmd_embedding_title_probe__";
@@ -1748,7 +1758,7 @@ export async function generateEmbeddings(
         const text = formatDocForEmbedding(chunk.text, chunk.title, embedModelUri);
         const result = await session.embed(text, { model });
         if (!result) {
-          recordFailure(chunk, "embedding returned no vector");
+          recordFailure(chunk, EMBED_FAILURE_NO_VECTOR_REASON);
           return false;
         }
         insertEmbedding(db, chunk.hash, chunk.seq, chunk.pos, new Float32Array(result.embedding), model, now, chunk.expectedTotalChunks, fingerprint);
@@ -1852,7 +1862,9 @@ export async function generateEmbeddings(
         // Abort early if session has been invalidated (e.g. max duration exceeded)
         if (!session.isValid) {
           const remainingChunks = batchChunks.slice(batchStart);
-          for (const chunk of remainingChunks) recordFailure(chunk, "LLM session expired before embedding chunk");
+          for (const chunk of remainingChunks) {
+            recordFailure(chunk, EMBED_FAILURE_SESSION_EXPIRED_REASON);
+          }
           console.warn(`⚠ Session expired — skipping ${remainingChunks.length} remaining chunks`);
           break;
         }
@@ -1861,7 +1873,9 @@ export async function generateEmbeddings(
         const processed = chunksEmbedded + activeErrorCount();
         if (processed >= BATCH_SIZE && activeErrorCount() > processed * 0.8) {
           const remainingChunks = batchChunks.slice(batchStart);
-          for (const chunk of remainingChunks) recordFailure(chunk, "embedding aborted because error rate was too high");
+          for (const chunk of remainingChunks) {
+            recordFailure(chunk, EMBED_FAILURE_ERROR_RATE_REASON);
+          }
           console.warn(`⚠ Error rate too high (${activeErrorCount()}/${processed}) — aborting embedding`);
           break;
         }
@@ -1881,7 +1895,7 @@ export async function generateEmbeddings(
               successesSinceRetry++;
               clearFailure(chunk);
             } else {
-              recordFailure(chunk, "batch embedding returned no vector");
+              recordFailure(chunk, EMBED_FAILURE_BATCH_NO_VECTOR_REASON);
             }
             batchChunkBytesProcessed += chunk.bytes;
           }
@@ -1892,7 +1906,12 @@ export async function generateEmbeddings(
           // cleared, so the visible error count reflects outstanding failures.
           const batchReason = reasonFromError(error);
           if (!session.isValid) {
-            for (const chunk of chunkBatch) recordFailure(chunk, `batch failed and session expired: ${batchReason}`);
+            for (const chunk of chunkBatch) {
+              recordFailure(
+                chunk,
+                `${EMBED_FAILURE_BATCH_SESSION_EXPIRED_PREFIX}: ${batchReason}`
+              );
+            }
             batchChunkBytesProcessed += chunkBatch.reduce((sum, c) => sum + c.bytes, 0);
           } else {
             for (const chunk of chunkBatch) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -2395,6 +2395,13 @@ export function clearCache(db: Database): void {
 // Cleanup and maintenance operations
 // =============================================================================
 
+// Inactive documents are soft-deleted tombstones. Treating only active
+// documents as references would delete their content and cascade-delete the
+// tombstones through content(hash) -> documents(hash).
+const orphanedContentWhere = `
+  hash NOT IN (SELECT DISTINCT hash FROM documents)
+`;
+
 /**
  * Delete cached LLM API responses.
  * Returns the number of cached responses deleted.
@@ -2409,8 +2416,19 @@ export function deleteLLMCache(db: Database): number {
  * Returns the number of inactive documents deleted.
  */
 export function deleteInactiveDocuments(db: Database): number {
-  const result = db.prepare(`DELETE FROM documents WHERE active = 0`).run();
-  return result.changes;
+  return db.transaction(() => {
+    // Count explicitly instead of using `.changes`: Bun includes changes made
+    // by the documents FTS triggers in the DELETE result.
+    const { count } = db.prepare(`
+      SELECT COUNT(*) AS count
+      FROM documents
+      WHERE active = 0
+    `).get() as { count: number };
+
+    db.prepare(`DELETE FROM documents WHERE active = 0`).run();
+
+    return count;
+  })();
 }
 
 /**
@@ -2422,7 +2440,7 @@ export function deleteInactiveDocuments(db: Database): number {
 export function cleanupOrphanedContent(db: Database): number {
   const result = db.prepare(`
     DELETE FROM content
-    WHERE hash NOT IN (SELECT DISTINCT hash FROM documents)
+    WHERE ${orphanedContentWhere}
   `).run();
   return result.changes;
 }
@@ -3174,39 +3192,56 @@ export function listCollections(db: Database): { name: string; pwd: string; glob
 }
 
 /**
- * Remove a collection and clean up its documents.
- * Uses collections.ts to remove from YAML config and cleans up database.
+ * Transactionally remove a collection's documents and store configuration,
+ * then clean up globally orphaned content hashes.
  */
 export function removeCollection(db: Database, collectionName: string): { deletedDocs: number; cleanedHashes: number } {
-  // Delete documents from database
-  const docResult = db.prepare(`DELETE FROM documents WHERE collection = ?`).run(collectionName);
+  return db.transaction(() => {
+    // Count explicitly instead of using `.changes`: Bun's SQLite result can
+    // include changes made by the documents FTS triggers.
+    const { count: deletedDocs } = db.prepare(`
+      SELECT COUNT(*) AS count
+      FROM documents
+      WHERE collection = ?
+    `).get(collectionName) as { count: number };
 
-  // Clean up orphaned content hashes
-  const cleanupResult = db.prepare(`
-    DELETE FROM content
-    WHERE hash NOT IN (SELECT DISTINCT hash FROM documents WHERE active = 1)
-  `).run();
+    db.prepare(`DELETE FROM documents WHERE collection = ?`).run(collectionName);
 
-  // Remove from store_collections
-  deleteStoreCollection(db, collectionName);
+    // Measure the global orphan cleanup explicitly for the same reason.
+    const { count: cleanedHashes } = db.prepare(`
+      SELECT COUNT(*) AS count
+      FROM content
+      WHERE ${orphanedContentWhere}
+    `).get() as { count: number };
 
-  return {
-    deletedDocs: docResult.changes,
-    cleanedHashes: cleanupResult.changes
-  };
+    db.prepare(`
+      DELETE FROM content
+      WHERE ${orphanedContentWhere}
+    `).run();
+
+    // Remove from store_collections
+    deleteStoreCollection(db, collectionName);
+
+    return {
+      deletedDocs,
+      cleanedHashes
+    };
+  })();
 }
 
 /**
- * Rename a collection.
- * Updates both YAML config and database documents table.
+ * Transactionally rename a collection in indexed documents and
+ * store_collections. Returns whether the source collection existed.
  */
-export function renameCollection(db: Database, oldName: string, newName: string): void {
-  // Update all documents with the new collection name in database
-  db.prepare(`UPDATE documents SET collection = ? WHERE collection = ?`)
-    .run(newName, oldName);
+export function renameCollection(db: Database, oldName: string, newName: string): boolean {
+  return db.transaction(() => {
+    // Update all documents with the new collection name in database
+    db.prepare(`UPDATE documents SET collection = ? WHERE collection = ?`)
+      .run(newName, oldName);
 
-  // Rename in store_collections
-  renameStoreCollection(db, oldName, newName);
+    // Rename in store_collections
+    return renameStoreCollection(db, oldName, newName);
+  })();
 }
 
 // =============================================================================

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2142,6 +2142,22 @@ describe("status and collection list hide filesystem paths", () => {
 // =============================================================================
 
 describe("mcp http daemon", () => {
+  test("rejects collection management over unauthenticated HTTP before startup", async () => {
+    const result = await runQmd([
+      "mcp",
+      "--http",
+      "--enable-collection-management",
+      "--port",
+      "0",
+    ]);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toMatch(
+      /enable-collection-management.*not supported with --http.*no authentication.*stdio/is
+    );
+  });
+
   let daemonTestDir: string;
   let daemonCacheDir: string; // XDG_CACHE_HOME value (the qmd/ subdir is created automatically)
   let daemonDbPath: string;

--- a/test/mcp-maintenance.test.ts
+++ b/test/mcp-maintenance.test.ts
@@ -9,7 +9,7 @@ import {
   ProgressNotificationSchema,
   type ProgressNotification,
 } from "@modelcontextprotocol/sdk/types.js";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { QMDStore } from "../src/index.js";
@@ -51,6 +51,20 @@ function createStoreDouble(
     durationMs: 5,
     failures: [],
   })));
+
+  const addCollection = vi.fn(async (
+    _name: string,
+    _options: { path: string; pattern?: string; ignore?: string[] },
+  ) => undefined);
+  const renameCollection = vi.fn(async (
+    _oldName: string,
+    _newName: string,
+  ) => true);
+  const removeCollection = vi.fn(async (_name: string) => ({
+    removed: true,
+    deletedDocs: 3,
+    cleanedHashes: 2,
+  }));
 
   const store = {
     getStatus: async () => ({
@@ -96,15 +110,31 @@ function createStoreDouble(
         includeByDefault: true,
       },
     ],
+    addCollection,
+    renameCollection,
+    removeCollection,
     update,
     embed,
   } as unknown as QMDStore;
 
-  return { store, update, embed };
+  return {
+    store,
+    addCollection,
+    renameCollection,
+    removeCollection,
+    update,
+    embed,
+  };
 }
 
-async function createHarness(store: QMDStore) {
-  const server = await createMcpServer(store);
+async function createHarness(
+  store: QMDStore,
+  options: {
+    transport: "stdio" | "http";
+    enableCollectionManagement?: boolean;
+  } = { transport: "stdio" },
+) {
+  const server = await createMcpServer(store, options);
   const client = new Client({ name: "qmd-maintenance-test", version: "1.0.0" });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
@@ -145,6 +175,723 @@ afterEach(async () => {
 });
 
 describe("MCP maintenance tools", () => {
+  test("collection management registration preserves the transport security boundary", async () => {
+    const namesFor = async (options: {
+      transport: "stdio" | "http";
+      enableCollectionManagement?: boolean;
+    }) => {
+      const { store } = createStoreDouble();
+      const { client } = await createHarness(store, options);
+      return (await client.listTools()).tools.map(tool => tool.name).sort();
+    };
+
+    const httpDisabled = await namesFor({ transport: "http" });
+    const httpEnabled = await namesFor({
+      transport: "http",
+      enableCollectionManagement: true,
+    });
+    const stdioDisabled = await namesFor({ transport: "stdio" });
+    const stdioEnabled = await namesFor({
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
+
+    expect(httpEnabled).toEqual(httpDisabled);
+    expect(stdioDisabled).toEqual(httpDisabled);
+    expect(stdioEnabled.filter(name => !stdioDisabled.includes(name))).toEqual([
+      "collection_add",
+      "collection_remove",
+      "collection_rename",
+    ]);
+  });
+
+  test("tools/list exposes collection_add as an opt-in local non-destructive write", async () => {
+    const { store } = createStoreDouble();
+    const { client } = await createHarness(store, {
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
+
+    const tool = (await client.listTools()).tools.find(
+      candidate => candidate.name === "collection_add"
+    );
+
+    expect(tool?.annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    });
+    expect(Object.keys(tool?.inputSchema.properties ?? {}).sort()).toEqual([
+      "ignore",
+      "name",
+      "path",
+      "pattern",
+    ]);
+    expect(tool?.inputSchema.required).toEqual(["path"]);
+    expect(tool?.description).toMatch(/without indexing.*update.*embed/i);
+  });
+
+  test("collection_add resolves paths, persists options, and returns the show contract", async () => {
+    const testDir = await mkdtemp(join(tmpdir(), "qmd-collection-add-"));
+    const realDirectory = join(testDir, "docs");
+    const linkedDirectory = join(testDir, "linked-docs");
+    await mkdir(realDirectory);
+    await symlink(realDirectory, linkedDirectory);
+    const { store, addCollection, update, embed } = createStoreDouble();
+    const configured: Awaited<ReturnType<QMDStore["listCollections"]>> = [];
+    store.listCollections = async () => configured;
+    addCollection.mockImplementation(async (name, options) => {
+      configured.push({
+        name,
+        pwd: options.path,
+        glob_pattern: options.pattern ?? "**/*.md",
+        doc_count: 0,
+        active_count: 0,
+        last_modified: null,
+        includeByDefault: true,
+      });
+    });
+    const { client } = await createHarness(store, {
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
+
+    try {
+      const addResult = await client.callTool({
+        name: "collection_add",
+        arguments: {
+          path: linkedDirectory,
+          name: "manual",
+          pattern: "guides/**/*.md",
+          ignore: ["drafts/**", "private/**"],
+        },
+      });
+      const showResult = await client.callTool({
+        name: "collection_show",
+        arguments: { name: "manual" },
+      });
+
+      expect(addResult.structuredContent).toEqual(showResult.structuredContent);
+      expect(addResult.structuredContent).toEqual({
+        collection: {
+          name: "manual",
+          path: realDirectory,
+          pattern: "guides/**/*.md",
+          documents: 0,
+          indexedDocuments: 0,
+          lastUpdated: null,
+          includeByDefault: true,
+        },
+      });
+      expect(addCollection).toHaveBeenCalledWith("manual", {
+        path: realDirectory,
+        pattern: "guides/**/*.md",
+        ignore: ["drafts/**", "private/**"],
+      });
+      expect(getFirstText(addResult)).toMatch(/without indexing.*update.*embed/i);
+      expect(update).not.toHaveBeenCalled();
+      expect(embed).not.toHaveBeenCalled();
+    } finally {
+      await rm(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test("collection_add derives the CLI name and default pattern", async () => {
+    const testDir = await mkdtemp(join(tmpdir(), "qmd-collection-defaults-"));
+    const directory = join(testDir, "docs");
+    await mkdir(directory);
+    const { store, addCollection } = createStoreDouble();
+    const configured: Awaited<ReturnType<QMDStore["listCollections"]>> = [];
+    store.listCollections = async () => configured;
+    addCollection.mockImplementation(async (name, options) => {
+      configured.push({
+        name,
+        pwd: options.path,
+        glob_pattern: options.pattern ?? "**/*.md",
+        doc_count: 0,
+        active_count: 0,
+        last_modified: null,
+        includeByDefault: true,
+      });
+    });
+    const { client } = await createHarness(store, {
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
+
+    try {
+      const result = await client.callTool({
+        name: "collection_add",
+        arguments: { path: directory },
+      });
+
+      expect(result.structuredContent).toMatchObject({
+        collection: {
+          name: "docs",
+          path: directory,
+          pattern: "**/*.md",
+        },
+      });
+      expect(addCollection).toHaveBeenCalledWith("docs", {
+        path: directory,
+        pattern: "**/*.md",
+      });
+    } finally {
+      await rm(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test("collection_add rejects invalid paths and collisions before the Store write", async () => {
+    const testDir = await mkdtemp(join(tmpdir(), "qmd-collection-add-errors-"));
+    const directory = join(testDir, "docs");
+    const file = join(testDir, "file.md");
+    await mkdir(directory);
+    await writeFile(file, "not a directory");
+    const { store, addCollection } = createStoreDouble();
+    store.listCollections = async () => [{
+      name: "existing",
+      pwd: directory,
+      glob_pattern: "**/*.md",
+      doc_count: 0,
+      active_count: 0,
+      last_modified: null,
+      includeByDefault: true,
+    }];
+    const { client } = await createHarness(store, {
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
+
+    try {
+      const missing = await client.callTool({
+        name: "collection_add",
+        arguments: { path: join(testDir, "missing") },
+      });
+      const notDirectory = await client.callTool({
+        name: "collection_add",
+        arguments: { path: file },
+      });
+      const nameCollision = await client.callTool({
+        name: "collection_add",
+        arguments: { path: directory, name: "existing", pattern: "other/*.md" },
+      });
+      const pathCollision = await client.callTool({
+        name: "collection_add",
+        arguments: { path: directory, name: "other" },
+      });
+
+      expect(getFirstText(missing)).toMatch(/does not exist.*check.*retry/i);
+      expect(getFirstText(notDirectory)).toMatch(/not a directory.*choose.*retry/i);
+      expect(getFirstText(nameCollision)).toMatch(/existing.*already exists.*different name/i);
+      expect(getFirstText(pathCollision)).toMatch(/existing.*path and pattern.*update.*remove/i);
+      expect([missing, notDirectory, nameCollision, pathCollision])
+        .toSatisfy(results => results.every(result => result.isError === true));
+      expect(addCollection).not.toHaveBeenCalled();
+    } finally {
+      await rm(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test("collection_add warns against blind retry when read-back fails", async () => {
+    const testDir = await mkdtemp(join(tmpdir(), "qmd-collection-readback-"));
+    const { store, addCollection } = createStoreDouble();
+    store.listCollections = async () => [];
+    const { client } = await createHarness(store, {
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
+
+    try {
+      const result = await client.callTool({
+        name: "collection_add",
+        arguments: { path: testDir, name: "unconfirmed" },
+      });
+
+      expect(addCollection).toHaveBeenCalledOnce();
+      expect(result.isError).toBe(true);
+      expect(getFirstText(result)).toMatch(/may have been registered.*collection_list.*before retrying/i);
+    } finally {
+      await rm(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test("collection_add is not callable without explicit enablement", async () => {
+    const { store } = createStoreDouble();
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "collection_add",
+      arguments: { path: "/docs" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(getFirstText(result)).toMatch(/tool collection_add not found/i);
+  });
+
+  test("tools/list exposes collection_rename as an opt-in destructive local write", async () => {
+    const { store } = createStoreDouble();
+    const { client } = await createHarness(store, {
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
+
+    const tool = (await client.listTools()).tools.find(
+      candidate => candidate.name === "collection_rename"
+    );
+
+    expect(tool?.annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+    });
+    expect(Object.keys(tool?.inputSchema.properties ?? {}).sort()).toEqual([
+      "newName",
+      "oldName",
+    ]);
+    expect(tool?.inputSchema.required).toEqual(["oldName", "newName"]);
+  });
+
+  test("collection_rename updates indexed paths and returns the show contract", async () => {
+    const { store, renameCollection } = createStoreDouble();
+    const configured: Awaited<ReturnType<QMDStore["listCollections"]>> = [{
+      name: "old-name",
+      pwd: "/docs",
+      glob_pattern: "**/*.md",
+      doc_count: 3,
+      active_count: 3,
+      last_modified: "2026-07-29T12:00:00.000Z",
+      includeByDefault: true,
+    }];
+    store.listCollections = async () => configured;
+    renameCollection.mockImplementation(async (oldName, newName) => {
+      const collection = configured.find(candidate => candidate.name === oldName);
+      if (!collection) return false;
+      collection.name = newName;
+      return true;
+    });
+    const { client } = await createHarness(store, {
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
+
+    const result = await client.callTool({
+      name: "collection_rename",
+      arguments: { oldName: "old-name", newName: "new-name" },
+    });
+
+    expect(renameCollection).toHaveBeenCalledWith("old-name", "new-name");
+    expect(result.structuredContent).toEqual({
+      collection: {
+        name: "new-name",
+        path: "/docs",
+        pattern: "**/*.md",
+        documents: 3,
+        indexedDocuments: 3,
+        lastUpdated: "2026-07-29T12:00:00.000Z",
+        includeByDefault: true,
+      },
+    });
+    expect(getFirstText(result)).toMatch(/old-name.*new-name.*qmd:\/\/new-name\//i);
+  });
+
+  test("collection_rename rejects unknown sources and occupied targets before the Store write", async () => {
+    const { store, renameCollection } = createStoreDouble();
+    const { client } = await createHarness(store, {
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
+
+    const unknown = await client.callTool({
+      name: "collection_rename",
+      arguments: { oldName: "missing", newName: "new-name" },
+    });
+    const occupied = await client.callTool({
+      name: "collection_rename",
+      arguments: { oldName: "docs", newName: "notes" },
+    });
+
+    expect(unknown.isError).toBe(true);
+    expect(getFirstText(unknown)).toMatch(/missing.*does not exist.*collection_list/i);
+    expect(occupied.isError).toBe(true);
+    expect(getFirstText(occupied)).toMatch(/notes.*already exists.*different name/i);
+    expect(renameCollection).not.toHaveBeenCalled();
+  });
+
+  test("collection_rename reports unconfirmed outcomes without recommending a blind retry", async () => {
+    const { store, renameCollection } = createStoreDouble();
+    const { client } = await createHarness(store, {
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
+
+    renameCollection.mockResolvedValueOnce(false);
+    const unchanged = await client.callTool({
+      name: "collection_rename",
+      arguments: { oldName: "docs", newName: "manual" },
+    });
+
+    renameCollection.mockResolvedValueOnce(true);
+    const unreadable = await client.callTool({
+      name: "collection_rename",
+      arguments: { oldName: "docs", newName: "manual" },
+    });
+
+    renameCollection.mockRejectedValueOnce(new Error("sensitive store failure"));
+    const ambiguous = await client.callTool({
+      name: "collection_rename",
+      arguments: { oldName: "docs", newName: "manual" },
+    });
+
+    expect(getFirstText(unchanged)).toMatch(/no collection was renamed.*collection_list/i);
+    expect(getFirstText(unreadable)).toMatch(/may have been renamed.*collection_show.*before retrying/i);
+    expect(getFirstText(ambiguous)).toMatch(/may have been renamed.*collection_show.*before retrying/i);
+    expect(getFirstText(ambiguous)).not.toContain("sensitive store failure");
+    expect([unchanged, unreadable, ambiguous])
+      .toSatisfy(results => results.every(result => result.isError === true));
+  });
+
+  test("collection_rename reports a prevalidation read failure as safe to retry", async () => {
+    const { store, renameCollection } = createStoreDouble();
+    store.listCollections = vi.fn().mockRejectedValueOnce(
+      new Error("sensitive read failure")
+    );
+    const { client } = await createHarness(store, {
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
+
+    const result = await client.callTool({
+      name: "collection_rename",
+      arguments: { oldName: "docs", newName: "manual" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(getFirstText(result)).toMatch(/could not read.*status.*logs.*retry/i);
+    expect(getFirstText(result)).not.toMatch(/may have been renamed|sensitive/i);
+    expect(renameCollection).not.toHaveBeenCalled();
+  });
+
+  test("tools/list exposes collection_remove as an opt-in destructive local write", async () => {
+    const { store } = createStoreDouble();
+    const { client } = await createHarness(store, {
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
+
+    const tool = (await client.listTools()).tools.find(
+      candidate => candidate.name === "collection_remove"
+    );
+
+    expect(tool?.annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+    });
+    expect(Object.keys(tool?.inputSchema.properties ?? {})).toEqual(["name"]);
+    expect(tool?.inputSchema.required).toEqual(["name"]);
+    expect(tool?.description).toMatch(/source files.*unchanged/i);
+  });
+
+  test("collection_remove reports document deletion and global orphan cleanup", async () => {
+    const { store, removeCollection } = createStoreDouble();
+    const configured = await store.listCollections();
+    store.listCollections = async () => configured;
+    removeCollection.mockImplementation(async (name) => {
+      const index = configured.findIndex(collection => collection.name === name);
+      if (index < 0) {
+        return { removed: false, deletedDocs: 0, cleanedHashes: 0 };
+      }
+      configured.splice(index, 1);
+      return { removed: true, deletedDocs: 7, cleanedHashes: 5 };
+    });
+    const { client } = await createHarness(store, {
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
+
+    const result = await client.callTool({
+      name: "collection_remove",
+      arguments: { name: "docs" },
+    });
+
+    expect(removeCollection).toHaveBeenCalledWith("docs");
+    expect(result.structuredContent).toEqual({
+      removed: true,
+      deletedDocs: 7,
+      cleanedHashes: 5,
+    });
+    expect(getFirstText(result)).toMatch(
+      /removed.*docs.*7.*documents.*5.*globally orphaned.*source files.*unchanged/i
+    );
+  });
+
+  test("collection_remove rejects an unknown collection before the Store write", async () => {
+    const { store, removeCollection } = createStoreDouble();
+    const { client } = await createHarness(store, {
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
+
+    const result = await client.callTool({
+      name: "collection_remove",
+      arguments: { name: "missing" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(getFirstText(result)).toMatch(/missing.*does not exist.*collection_list/i);
+    expect(removeCollection).not.toHaveBeenCalled();
+  });
+
+  test("collection_remove distinguishes safe prevalidation failures from ambiguous mutations", async () => {
+    const { store, removeCollection } = createStoreDouble();
+    store.listCollections = vi.fn()
+      .mockRejectedValueOnce(new Error("sensitive read failure"))
+      .mockResolvedValue([
+        {
+          name: "docs",
+          pwd: "/docs",
+          glob_pattern: "**/*.md",
+          doc_count: 0,
+          active_count: 0,
+          last_modified: null,
+          includeByDefault: true,
+        },
+      ]);
+    const { client } = await createHarness(store, {
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
+
+    const unreadable = await client.callTool({
+      name: "collection_remove",
+      arguments: { name: "docs" },
+    });
+
+    removeCollection.mockRejectedValueOnce(new Error("sensitive write failure"));
+    const ambiguous = await client.callTool({
+      name: "collection_remove",
+      arguments: { name: "docs" },
+    });
+
+    expect(getFirstText(unreadable)).toMatch(/could not read.*status.*logs.*retry/i);
+    expect(getFirstText(unreadable)).not.toMatch(/may have been removed|sensitive/i);
+    expect(getFirstText(ambiguous)).toMatch(/may have been removed.*collection_list.*before retrying/i);
+    expect(getFirstText(ambiguous)).not.toContain("sensitive write failure");
+    expect([unreadable, ambiguous])
+      .toSatisfy(results => results.every(result => result.isError === true));
+  });
+
+  test("collection_remove reports a failed Store result as unchanged", async () => {
+    const { store, removeCollection } = createStoreDouble();
+    removeCollection.mockResolvedValueOnce({
+      removed: false,
+      deletedDocs: 0,
+      cleanedHashes: 0,
+    });
+    const { client } = await createHarness(store, {
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
+
+    const result = await client.callTool({
+      name: "collection_remove",
+      arguments: { name: "docs" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(getFirstText(result)).toMatch(/no collection was removed.*collection_list/i);
+  });
+
+  test("tools/list exposes read-only collection tools", async () => {
+    const { store } = createStoreDouble();
+    const { client } = await createHarness(store);
+
+    const { tools } = await client.listTools();
+    const collectionList = tools.find((tool) => tool.name === "collection_list");
+    const collectionShow = tools.find((tool) => tool.name === "collection_show");
+
+    expect(collectionList?.annotations).toEqual({
+      readOnlyHint: true,
+      openWorldHint: false,
+    });
+    expect(collectionShow?.annotations).toEqual({
+      readOnlyHint: true,
+      openWorldHint: false,
+    });
+    expect(collectionList?.inputSchema.properties).toEqual({});
+    expect(collectionShow?.inputSchema.required).toEqual(["name"]);
+  });
+
+  test("collection_list normalizes count semantics and sorts configured collections", async () => {
+    const { store } = createStoreDouble();
+    store.listCollections = async () => [
+      {
+        name: "notes",
+        pwd: "/notes",
+        glob_pattern: "notes/**/*.md",
+        doc_count: 5,
+        active_count: 3,
+        last_modified: "2026-07-29T12:00:00.000Z",
+        includeByDefault: false,
+      },
+      {
+        name: "docs",
+        pwd: "/docs",
+        glob_pattern: "**/*.md",
+        doc_count: 0,
+        active_count: 0,
+        last_modified: null,
+        includeByDefault: true,
+      },
+      {
+        name: "Ärger",
+        pwd: "/aerger",
+        glob_pattern: "**/*.md",
+        doc_count: 1,
+        active_count: 1,
+        last_modified: null,
+        includeByDefault: false,
+      },
+    ];
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "collection_list",
+      arguments: {},
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(result.structuredContent).toEqual({
+      collections: [
+        {
+          name: "docs",
+          path: "/docs",
+          pattern: "**/*.md",
+          documents: 0,
+          indexedDocuments: 0,
+          lastUpdated: null,
+          includeByDefault: true,
+        },
+        {
+          name: "notes",
+          path: "/notes",
+          pattern: "notes/**/*.md",
+          documents: 3,
+          indexedDocuments: 5,
+          lastUpdated: "2026-07-29T12:00:00.000Z",
+          includeByDefault: false,
+        },
+        {
+          name: "Ärger",
+          path: "/aerger",
+          pattern: "**/*.md",
+          documents: 1,
+          indexedDocuments: 1,
+          lastUpdated: null,
+          includeByDefault: false,
+        },
+      ],
+    });
+    expect(getFirstText(result)).toMatch(/3 configured collections/i);
+  });
+
+  test("collection_show returns the same wrapped collection contract", async () => {
+    const { store } = createStoreDouble();
+    store.listCollections = async () => [{
+      name: "notes",
+      pwd: "/notes",
+      glob_pattern: "notes/**/*.md",
+      doc_count: 5,
+      active_count: 3,
+      last_modified: "2026-07-29T12:00:00.000Z",
+      includeByDefault: false,
+    }];
+    const { client } = await createHarness(store);
+
+    const listResult = await client.callTool({
+      name: "collection_list",
+      arguments: {},
+    });
+    const showResult = await client.callTool({
+      name: "collection_show",
+      arguments: { name: "notes" },
+    });
+    const listCollection = (listResult.structuredContent as {
+      collections: unknown[];
+    }).collections[0];
+
+    expect(showResult.isError).not.toBe(true);
+    expect(showResult.structuredContent).toEqual({
+      collection: listCollection,
+    });
+    expect(showResult.structuredContent).toEqual({
+      collection: {
+        name: "notes",
+        path: "/notes",
+        pattern: "notes/**/*.md",
+        documents: 3,
+        indexedDocuments: 5,
+        lastUpdated: "2026-07-29T12:00:00.000Z",
+        includeByDefault: false,
+      },
+    });
+    expect(getFirstText(showResult)).toMatch(/notes.*\/notes.*3 active of 5 indexed documents/i);
+  });
+
+  test("collection_show rejects unknown names with a useful tool error", async () => {
+    const { store } = createStoreDouble();
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "collection_show",
+      arguments: { name: "missing" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toBeUndefined();
+    expect(getFirstText(result)).toMatch(/missing.*collection_list/i);
+  });
+
+  test("collection tools mask Store exceptions", async () => {
+    const testDir = await mkdtemp(join(tmpdir(), "qmd-collection-mask-"));
+    const { store } = createStoreDouble();
+    store.listCollections = async () => {
+      throw new Error("secret database path and stacktrace");
+    };
+    const { client } = await createHarness(store);
+    const { client: enabledClient } = await createHarness(store, {
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
+
+    try {
+      const listResult = await client.callTool({
+        name: "collection_list",
+        arguments: {},
+      });
+      const showResult = await client.callTool({
+        name: "collection_show",
+        arguments: { name: "docs" },
+      });
+      const addResult = await enabledClient.callTool({
+        name: "collection_add",
+        arguments: { path: testDir },
+      });
+
+      expect(listResult.isError).toBe(true);
+      expect(showResult.isError).toBe(true);
+      expect(addResult.isError).toBe(true);
+      expect(getFirstText(listResult)).not.toMatch(/secret|database path|stacktrace/i);
+      expect(getFirstText(showResult)).not.toMatch(/secret|database path|stacktrace/i);
+      expect(getFirstText(addResult)).not.toMatch(/secret|database path|stacktrace/i);
+    } finally {
+      await rm(testDir, { recursive: true, force: true });
+    }
+  });
+
   test("stdio tools/list exposes both maintenance tools", async () => {
     const testDir = await mkdtemp(join(tmpdir(), "qmd-mcp-stdio-"));
     const client = new Client({
@@ -173,6 +920,46 @@ describe("MCP maintenance tools", () => {
 
       expect(toolNames).toContain("update");
       expect(toolNames).toContain("embed");
+      expect(toolNames).toContain("collection_list");
+      expect(toolNames).toContain("collection_show");
+      expect(toolNames).not.toContain("collection_add");
+    } finally {
+      await client.close();
+      await rm(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test("stdio start option enables collection management", async () => {
+    const testDir = await mkdtemp(join(tmpdir(), "qmd-mcp-stdio-enabled-"));
+    const client = new Client({
+      name: "qmd-stdio-collection-test",
+      version: "1.0.0",
+    });
+    const transport = new StdioClientTransport({
+      command: "node",
+      args: [
+        "--import",
+        "tsx",
+        "src/cli/qmd.ts",
+        "mcp",
+        "--enable-collection-management",
+      ],
+      cwd: process.cwd(),
+      env: {
+        ...getDefaultEnvironment(),
+        INDEX_PATH: join(testDir, "index.sqlite"),
+        QMD_CONFIG_DIR: testDir,
+        LLAMA_LOG_LEVEL: "error",
+        GGML_LOG_LEVEL: "error",
+        GGML_BACKEND_SILENT: "1",
+      },
+      stderr: "pipe",
+    });
+
+    try {
+      await client.connect(transport);
+      const toolNames = (await client.listTools()).tools.map(tool => tool.name);
+      expect(toolNames).toContain("collection_add");
     } finally {
       await client.close();
       await rm(testDir, { recursive: true, force: true });
@@ -188,8 +975,13 @@ describe("MCP maintenance tools", () => {
       collections: [],
     });
     const { client } = await createHarness(store);
+    const { client: managementClient } = await createHarness(store, {
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
 
     const instructions = client.getInstructions() ?? "";
+    const managementInstructions = managementClient.getInstructions() ?? "";
 
     expect(instructions).toContain("Call the `update` MCP tool");
     expect(instructions).toContain("inspect `needsEmbedding`");
@@ -197,6 +989,15 @@ describe("MCP maintenance tools", () => {
       "Call the `embed` MCP tool only when `needsEmbedding` is greater than 0"
     );
     expect(instructions).not.toContain("qmd embed");
+    expect(instructions).not.toMatch(
+      /collection_add|collection_rename|collection_remove/
+    );
+    expect(managementInstructions).toMatch(
+      /collection_add.*update.*needsEmbedding.*embed/is
+    );
+    expect(managementInstructions).toMatch(
+      /collection_rename.*collection_remove/is
+    );
   });
 
   test("tools/list exposes update as a local idempotent write", async () => {
@@ -727,10 +1528,16 @@ describe("MCP maintenance tools", () => {
     expect(embed).not.toHaveBeenCalled();
   });
 
-  test("a running update blocks embed across sessions but not read tools", async () => {
+  test("a running update blocks embed and every collection write but not read tools", async () => {
     const started = deferred();
     const release = deferred();
-    const { store, embed } = createStoreDouble(async () => {
+    const {
+      store,
+      addCollection,
+      renameCollection,
+      removeCollection,
+      embed,
+    } = createStoreDouble(async () => {
       started.resolve();
       await release.promise;
       return {
@@ -743,7 +1550,10 @@ describe("MCP maintenance tools", () => {
       };
     });
     const first = await createHarness(store);
-    const second = await createHarness(store);
+    const second = await createHarness(store, {
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
 
     const updateCall = first.client.callTool({
       name: "update",
@@ -760,11 +1570,28 @@ describe("MCP maintenance tools", () => {
         name: "embed",
         arguments: {},
       });
+      const busyAdd = await second.client.callTool({
+        name: "collection_add",
+        arguments: { path: "/does/not/need/to/exist" },
+      });
+      const busyRename = await second.client.callTool({
+        name: "collection_rename",
+        arguments: { oldName: "docs", newName: "manual" },
+      });
+      const busyRemove = await second.client.callTool({
+        name: "collection_remove",
+        arguments: { name: "docs" },
+      });
 
       expect(statusResult.isError).not.toBe(true);
-      expect(busyResult.isError).toBe(true);
-      expect(getFirstText(busyResult)).toContain("busy");
+      expect([busyResult, busyAdd, busyRename, busyRemove])
+        .toSatisfy(results => results.every(result =>
+          result.isError === true && getFirstText(result).includes("busy")
+        ));
       expect(embed).not.toHaveBeenCalled();
+      expect(addCollection).not.toHaveBeenCalled();
+      expect(renameCollection).not.toHaveBeenCalled();
+      expect(removeCollection).not.toHaveBeenCalled();
     } finally {
       release.resolve();
       await updateCall;
@@ -820,6 +1647,124 @@ describe("MCP maintenance tools", () => {
       arguments: {},
     });
     expect(afterRelease.isError).not.toBe(true);
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  test("a running collection_add blocks writes across sessions while reads stay available", async () => {
+    const testDir = await mkdtemp(join(tmpdir(), "qmd-collection-lock-"));
+    const started = deferred();
+    const release = deferred();
+    const { store, addCollection, update, embed } = createStoreDouble();
+    const configured: Awaited<ReturnType<QMDStore["listCollections"]>> = [];
+    store.listCollections = vi.fn(async () => configured);
+    addCollection.mockImplementation(async (name, options) => {
+      started.resolve();
+      await release.promise;
+      configured.push({
+        name,
+        pwd: options.path,
+        glob_pattern: options.pattern ?? "**/*.md",
+        doc_count: 0,
+        active_count: 0,
+        last_modified: null,
+        includeByDefault: true,
+      });
+    });
+    const first = await createHarness(store, {
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
+    const second = await createHarness(store, {
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
+
+    const addCall = first.client.callTool({
+      name: "collection_add",
+      arguments: { path: testDir, name: "shared" },
+    });
+    await started.promise;
+
+    try {
+      const busyAdd = await second.client.callTool({
+        name: "collection_add",
+        arguments: { path: testDir, name: "shared" },
+      });
+      expect(store.listCollections).toHaveBeenCalledTimes(1);
+
+      const listResult = await second.client.callTool({
+        name: "collection_list",
+        arguments: {},
+      });
+      const showResult = await second.client.callTool({
+        name: "collection_show",
+        arguments: { name: "shared" },
+      });
+      const busyUpdate = await second.client.callTool({
+        name: "update",
+        arguments: {},
+      });
+      const busyEmbed = await second.client.callTool({
+        name: "embed",
+        arguments: {},
+      });
+
+      expect(listResult.isError).not.toBe(true);
+      expect(getFirstText(showResult)).not.toContain("busy");
+      expect([busyAdd, busyUpdate, busyEmbed])
+        .toSatisfy(results => results.every(result =>
+          result.isError === true && getFirstText(result).includes("busy")
+        ));
+      expect(addCollection).toHaveBeenCalledOnce();
+      expect(update).not.toHaveBeenCalled();
+      expect(embed).not.toHaveBeenCalled();
+    } finally {
+      release.resolve();
+      expect((await addCall).isError).not.toBe(true);
+    }
+
+    const collision = await second.client.callTool({
+      name: "collection_add",
+      arguments: { path: testDir, name: "shared" },
+    });
+    expect(collision.isError).toBe(true);
+    expect(getFirstText(collision)).toMatch(/shared.*already exists/i);
+    expect(addCollection).toHaveBeenCalledOnce();
+
+    const afterRelease = await second.client.callTool({
+      name: "update",
+      arguments: {},
+    });
+    expect(afterRelease.isError).not.toBe(true);
+    expect(update).toHaveBeenCalledOnce();
+
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  test("collection write validation and Store errors release the maintenance lock", async () => {
+    const { store, renameCollection, update } = createStoreDouble();
+    renameCollection.mockRejectedValueOnce(new Error("rename failed"));
+    const { client } = await createHarness(store, {
+      transport: "stdio",
+      enableCollectionManagement: true,
+    });
+
+    const invalid = await client.callTool({
+      name: "collection_remove",
+      arguments: { name: "missing" },
+    });
+    const storeError = await client.callTool({
+      name: "collection_rename",
+      arguments: { oldName: "docs", newName: "manual" },
+    });
+    const afterErrors = await client.callTool({
+      name: "update",
+      arguments: {},
+    });
+
+    expect(invalid.isError).toBe(true);
+    expect(storeError.isError).toBe(true);
+    expect(afterErrors.isError).not.toBe(true);
     expect(update).toHaveBeenCalledOnce();
   });
 

--- a/test/mcp-maintenance.test.ts
+++ b/test/mcp-maintenance.test.ts
@@ -1,0 +1,1292 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+  getDefaultEnvironment,
+  StdioClientTransport,
+} from "@modelcontextprotocol/sdk/client/stdio.js";
+import {
+  ProgressNotificationSchema,
+  type ProgressNotification,
+} from "@modelcontextprotocol/sdk/types.js";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { QMDStore } from "../src/index.js";
+import { createMcpServer } from "../src/mcp/server.js";
+
+const openHarnesses: Array<{
+  client: Client;
+  server: Awaited<ReturnType<typeof createMcpServer>>;
+}> = [];
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function createStoreDouble(
+  updateImplementation?: (
+    options?: Parameters<QMDStore["update"]>[0]
+  ) => ReturnType<QMDStore["update"]>,
+  embedImplementation?: (
+    options?: Parameters<QMDStore["embed"]>[0]
+  ) => ReturnType<QMDStore["embed"]>,
+) {
+  const update = vi.fn(updateImplementation ?? (async () => ({
+    collections: 2,
+    indexed: 3,
+    updated: 4,
+    unchanged: 5,
+    removed: 6,
+    needsEmbedding: 7,
+  })));
+  const embed = vi.fn(embedImplementation ?? (async () => ({
+    docsProcessed: 3,
+    chunksEmbedded: 4,
+    errors: 0,
+    durationMs: 5,
+    failures: [],
+  })));
+
+  const store = {
+    getStatus: async () => ({
+      totalDocuments: 0,
+      needsEmbedding: 0,
+      hasVectorIndex: false,
+      collections: [
+        {
+          name: "docs",
+          path: "/docs",
+          pattern: "**/*.md",
+          documents: 0,
+          lastUpdated: "",
+        },
+        {
+          name: "notes",
+          path: "/notes",
+          pattern: "**/*.md",
+          documents: 0,
+          lastUpdated: "",
+        },
+      ],
+    }),
+    getGlobalContext: async () => undefined,
+    getDefaultCollectionNames: async () => ["docs", "notes"],
+    listCollections: async () => [
+      {
+        name: "docs",
+        pwd: "/docs",
+        glob_pattern: "**/*.md",
+        doc_count: 0,
+        active_count: 0,
+        last_modified: null,
+        includeByDefault: true,
+      },
+      {
+        name: "notes",
+        pwd: "/notes",
+        glob_pattern: "**/*.md",
+        doc_count: 0,
+        active_count: 0,
+        last_modified: null,
+        includeByDefault: true,
+      },
+    ],
+    update,
+    embed,
+  } as unknown as QMDStore;
+
+  return { store, update, embed };
+}
+
+async function createHarness(store: QMDStore) {
+  const server = await createMcpServer(store);
+  const client = new Client({ name: "qmd-maintenance-test", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  openHarnesses.push({ client, server });
+  return { client, server, serverTransport };
+}
+
+function rejectProgressNotifications(serverTransport: InMemoryTransport): void {
+  const originalSend = serverTransport.send.bind(serverTransport);
+  serverTransport.send = async (message, options) => {
+    if (
+      "method" in message &&
+      message.method === "notifications/progress"
+    ) {
+      throw new Error("progress transport unavailable");
+    }
+
+    await originalSend(message, options);
+  };
+}
+
+function getFirstText(result: unknown): string {
+  const content = (result as {
+    content: Array<{ type: string; text?: string }>;
+  }).content;
+  expect(content[0]?.type).toBe("text");
+  return content[0]?.text ?? "";
+}
+
+afterEach(async () => {
+  await Promise.all(openHarnesses.splice(0).map(async ({ client, server }) => {
+    await client.close();
+    await server.close();
+  }));
+});
+
+describe("MCP maintenance tools", () => {
+  test("stdio tools/list exposes both maintenance tools", async () => {
+    const testDir = await mkdtemp(join(tmpdir(), "qmd-mcp-stdio-"));
+    const client = new Client({
+      name: "qmd-stdio-maintenance-test",
+      version: "1.0.0",
+    });
+    const transport = new StdioClientTransport({
+      command: "node",
+      args: ["--import", "tsx", "src/cli/qmd.ts", "mcp"],
+      cwd: process.cwd(),
+      env: {
+        ...getDefaultEnvironment(),
+        INDEX_PATH: join(testDir, "index.sqlite"),
+        QMD_CONFIG_DIR: testDir,
+        LLAMA_LOG_LEVEL: "error",
+        GGML_LOG_LEVEL: "error",
+        GGML_BACKEND_SILENT: "1",
+      },
+      stderr: "pipe",
+    });
+
+    try {
+      await client.connect(transport);
+      const { tools } = await client.listTools();
+      const toolNames = tools.map(tool => tool.name);
+
+      expect(toolNames).toContain("update");
+      expect(toolNames).toContain("embed");
+    } finally {
+      await client.close();
+      await rm(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test("server instructions recommend the safe MCP maintenance workflow", async () => {
+    const { store } = createStoreDouble();
+    store.getStatus = async () => ({
+      totalDocuments: 3,
+      needsEmbedding: 2,
+      hasVectorIndex: true,
+      collections: [],
+    });
+    const { client } = await createHarness(store);
+
+    const instructions = client.getInstructions() ?? "";
+
+    expect(instructions).toContain("Call the `update` MCP tool");
+    expect(instructions).toContain("inspect `needsEmbedding`");
+    expect(instructions).toContain(
+      "Call the `embed` MCP tool only when `needsEmbedding` is greater than 0"
+    );
+    expect(instructions).not.toContain("qmd embed");
+  });
+
+  test("tools/list exposes update as a local idempotent write", async () => {
+    const { store } = createStoreDouble();
+    const { client } = await createHarness(store);
+
+    const { tools } = await client.listTools();
+    const updateTool = tools.find((tool) => tool.name === "update");
+
+    expect(updateTool).toBeDefined();
+    expect(updateTool?.annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+    expect(updateTool?.inputSchema.properties).toHaveProperty("collections");
+    expect(
+      (updateTool?.inputSchema.properties?.collections as { minItems?: number })
+        .minItems
+    ).toBe(1);
+    expect(updateTool?.description).toMatch(/derived index/i);
+    expect(updateTool?.description).toMatch(/progress/i);
+    expect(updateTool?.description).toMatch(/best-effort/i);
+    expect(updateTool?.description).toMatch(/never change the tool result/i);
+    expect(updateTool?.description).toMatch(/busy|cancel/i);
+    expect(updateTool?.description).toMatch(/needsEmbedding/);
+  });
+
+  test("tools/list exposes embed without caller-controlled model or paths", async () => {
+    const { store } = createStoreDouble();
+    const { client } = await createHarness(store);
+
+    const { tools } = await client.listTools();
+    const embedTool = tools.find((tool) => tool.name === "embed");
+
+    expect(embedTool).toBeDefined();
+    expect(embedTool?.annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    });
+    expect(embedTool?.inputSchema.properties).not.toHaveProperty("model");
+    expect(embedTool?.inputSchema.properties).not.toHaveProperty("dbPath");
+    expect(embedTool?.inputSchema.properties).not.toHaveProperty("configPath");
+    expect(embedTool?.inputSchema.properties).not.toHaveProperty("path");
+    expect(embedTool?.description).toMatch(/derived index/i);
+    expect(embedTool?.description).toMatch(/30 minutes/i);
+    expect(embedTool?.description).toMatch(/progress/i);
+    expect(embedTool?.description).toMatch(/partial|busy|cancel/i);
+  });
+
+  test("embed validates and converts every supported option for the Store", async () => {
+    const { store, embed } = createStoreDouble();
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "embed",
+      arguments: {
+        collection: "docs",
+        force: true,
+        chunkStrategy: "regex",
+        maxDocsPerBatch: 12,
+        maxBatchMiB: 1.5,
+        timeoutMinutes: 0.25,
+      },
+    });
+
+    expect(embed).toHaveBeenCalledWith({
+      collection: "docs",
+      force: true,
+      chunkStrategy: "regex",
+      maxDocsPerBatch: 12,
+      maxBatchBytes: 1.5 * 1024 * 1024,
+      maxDurationMs: 0.25 * 60 * 1000,
+      onProgress: expect.any(Function),
+    });
+    expect(result.structuredContent).toMatchObject({
+      docsProcessed: 3,
+      chunksEmbedded: 4,
+      errors: 0,
+      durationMs: 5,
+      failureCount: 0,
+      failures: [],
+      failuresTruncated: false,
+    });
+  });
+
+  test("embed rejects an unknown collection before calling the Store", async () => {
+    const { store, embed } = createStoreDouble();
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "embed",
+      arguments: { collection: "missing" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(getFirstText(result)).toContain("missing");
+    expect(embed).not.toHaveBeenCalled();
+  });
+
+  test("embed forwards chunk progress with bytes, errors, and the MCP token", async () => {
+    const { store } = createStoreDouble(undefined, async (options) => {
+      options?.onProgress?.({
+        chunksEmbedded: 1,
+        totalChunks: 3,
+        bytesProcessed: 100,
+        totalBytes: 300,
+        errors: 0,
+        failures: [],
+      });
+      options?.onProgress?.({
+        chunksEmbedded: 2,
+        totalChunks: 3,
+        bytesProcessed: 200,
+        totalBytes: 300,
+        errors: 1,
+        failures: [],
+      });
+
+      return {
+        docsProcessed: 2,
+        chunksEmbedded: 2,
+        errors: 1,
+        durationMs: 10,
+        failures: [],
+      };
+    });
+    const { client } = await createHarness(store);
+    const progress: ProgressNotification["params"][] = [];
+
+    client.setNotificationHandler(ProgressNotificationSchema, (notification) => {
+      progress.push(notification.params);
+    });
+
+    await client.callTool({
+      name: "embed",
+      arguments: {},
+      _meta: { progressToken: 42 },
+    });
+
+    expect(progress.map(item => item.progressToken)).toEqual([42, 42]);
+    expect(progress.map(item => item.progress)).toEqual([1, 2]);
+    expect(progress.map(item => item.total)).toEqual([3, 3]);
+    expect(progress.map(item => item.message)).toEqual([
+      "1/3 chunks; 100/300 bytes; 0 errors",
+      "2/3 chunks; 200/300 bytes; 1 errors",
+    ]);
+  });
+
+  test("embed ignores rejected progress notifications after Store success", async () => {
+    const { store } = createStoreDouble(undefined, async (options) => {
+      options?.onProgress?.({
+        chunksEmbedded: 2,
+        totalChunks: 3,
+        bytesProcessed: 200,
+        totalBytes: 300,
+        errors: 0,
+        failures: [],
+      });
+
+      return {
+        docsProcessed: 2,
+        chunksEmbedded: 2,
+        errors: 0,
+        durationMs: 10,
+        failures: [],
+      };
+    });
+    const { client, serverTransport } = await createHarness(store);
+    rejectProgressNotifications(serverTransport);
+
+    const result = await client.callTool({
+      name: "embed",
+      arguments: {},
+      _meta: { progressToken: "rejected-embed-progress" },
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      docsProcessed: 2,
+      chunksEmbedded: 2,
+      errors: 0,
+      durationMs: 10,
+      failureCount: 0,
+      failures: [],
+      failuresTruncated: false,
+    });
+  });
+
+  test("embed handles rejected progress notifications when the Store throws", async () => {
+    const { store } = createStoreDouble(undefined, async (options) => {
+      options?.onProgress?.({
+        chunksEmbedded: 1,
+        totalChunks: 2,
+        bytesProcessed: 100,
+        totalBytes: 200,
+        errors: 0,
+        failures: [],
+      });
+      throw new Error("embedding failed");
+    });
+    const { client, serverTransport } = await createHarness(store);
+    rejectProgressNotifications(serverTransport);
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+
+    try {
+      const result = await client.callTool({
+        name: "embed",
+        arguments: {},
+        _meta: { progressToken: "rejected-embed-progress" },
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(result.isError).toBe(true);
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
+
+  test("embed converts Store exceptions into a safe tool error", async () => {
+    const { store, update } = createStoreDouble(undefined, async () => {
+      throw new Error("model failed with SECRET_MODEL_KEY\ninternal stack detail");
+    });
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "embed",
+      arguments: {},
+    });
+    const text = getFirstText(result);
+
+    expect(result.isError).toBe(true);
+    expect(text).toContain("Embedding failed");
+    expect(text).not.toContain("SECRET_MODEL_KEY");
+    expect(text).not.toContain("stack");
+
+    const afterError = await client.callTool({
+      name: "update",
+      arguments: {},
+    });
+    expect(afterError.isError).not.toBe(true);
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  test("embed applies the 30-minute default and preserves zero as unlimited", async () => {
+    const { store, embed } = createStoreDouble();
+    const { client } = await createHarness(store);
+
+    await client.callTool({ name: "embed", arguments: {} });
+    await client.callTool({
+      name: "embed",
+      arguments: { timeoutMinutes: 0 },
+    });
+
+    expect(embed.mock.calls[0]?.[0]).toEqual({
+      force: false,
+      maxDurationMs: 30 * 60 * 1000,
+      onProgress: expect.any(Function),
+    });
+    expect(embed.mock.calls[1]?.[0]).toEqual({
+      force: false,
+      maxDurationMs: 0,
+      onProgress: expect.any(Function),
+    });
+  });
+
+  test("embed treats a zero-work result as success", async () => {
+    const { store } = createStoreDouble(undefined, async () => ({
+      docsProcessed: 0,
+      chunksEmbedded: 0,
+      errors: 0,
+      durationMs: 0,
+      failures: [],
+    }));
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "embed",
+      arguments: {},
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toMatchObject({
+      docsProcessed: 0,
+      chunksEmbedded: 0,
+      errors: 0,
+      durationMs: 0,
+      failureCount: 0,
+      failures: [],
+      failuresTruncated: false,
+    });
+  });
+
+  test("embed masks raw failure reasons while preserving diagnostic fields", async () => {
+    const { store } = createStoreDouble(undefined, async () => ({
+      docsProcessed: 1,
+      chunksEmbedded: 0,
+      errors: 1,
+      durationMs: 5,
+      failures: [{
+        path: "docs/private.md",
+        hash: "hash-private",
+        seq: 7,
+        attempts: 3,
+        reason: "https://user:SECRET_TOKEN@example.test/model failed",
+      }],
+    }));
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "embed",
+      arguments: {},
+    });
+    const text = getFirstText(result);
+    const structuredText = JSON.stringify(result.structuredContent);
+
+    expect(text).not.toContain("SECRET_TOKEN");
+    expect(text).not.toContain("example.test");
+    expect(structuredText).not.toContain("SECRET_TOKEN");
+    expect(structuredText).not.toContain("example.test");
+    expect(result.structuredContent).toMatchObject({
+      failures: [{
+        path: "docs/private.md",
+        hash: "hash-private",
+        seq: 7,
+        attempts: 3,
+        reason: "embedding backend or index write failed",
+      }],
+    });
+  });
+
+  test("embed preserves safe Store reasons and sanitizes an expired batch detail", async () => {
+    const safeReasons = [
+      "embedding returned no vector",
+      "LLM session expired before embedding chunk",
+      "embedding aborted because error rate was too high",
+      "batch embedding returned no vector",
+    ];
+    const failures = [
+      ...safeReasons.map((reason, index) => ({
+        path: `docs/safe-${index}.md`,
+        hash: `hash-safe-${index}`,
+        seq: index,
+        attempts: 1,
+        reason,
+      })),
+      {
+        path: "docs/expired-batch.md",
+        hash: "hash-expired-batch",
+        seq: 4,
+        attempts: 3,
+        reason:
+          "batch failed and session expired: https://user:SECRET_TOKEN@example.test/model",
+      },
+    ];
+    const { store } = createStoreDouble(undefined, async () => ({
+      docsProcessed: 5,
+      chunksEmbedded: 0,
+      errors: 5,
+      durationMs: 5,
+      failures,
+    }));
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "embed",
+      arguments: {},
+    });
+    const structured = result.structuredContent as {
+      failures: Array<{ reason: string }>;
+    };
+
+    expect(structured.failures.map(failure => failure.reason)).toEqual([
+      ...safeReasons,
+      "batch failed and session expired",
+    ]);
+    expect(JSON.stringify(result.structuredContent)).not.toContain("SECRET_TOKEN");
+    expect(JSON.stringify(result.structuredContent)).not.toContain("example.test");
+  });
+
+  test("embed derives truncation only from available failure details", async () => {
+    const { store: shortStore } = createStoreDouble(undefined, async () => ({
+      docsProcessed: 25,
+      chunksEmbedded: 0,
+      errors: 25,
+      durationMs: 5,
+      failures: [{
+        path: "docs/only-detail.md",
+        hash: "hash-only",
+        seq: 1,
+        attempts: 3,
+        reason: "failed",
+      }],
+    }));
+    const { client: shortClient } = await createHarness(shortStore);
+    const shortResult = await shortClient.callTool({
+      name: "embed",
+      arguments: {},
+    });
+
+    expect(shortResult.structuredContent).toMatchObject({
+      failureCount: 25,
+      failuresTruncated: false,
+    });
+    expect(
+      (shortResult.structuredContent as { failures: unknown[] }).failures
+    ).toHaveLength(1);
+
+    const { store: missingStore } = createStoreDouble(undefined, async () => ({
+      docsProcessed: 25,
+      chunksEmbedded: 0,
+      errors: 25,
+      durationMs: 5,
+    }));
+    const { client: missingClient } = await createHarness(missingStore);
+    const missingResult = await missingClient.callTool({
+      name: "embed",
+      arguments: {},
+    });
+
+    expect(missingResult.structuredContent).toMatchObject({
+      failureCount: 25,
+      failures: [],
+      failuresTruncated: false,
+    });
+  });
+
+  test("embed keeps partial results while limiting failure details to 20", async () => {
+    const failures = Array.from({ length: 25 }, (_, index) => ({
+      path: `doc-${index}.md`,
+      hash: `hash-${index}`,
+      seq: index,
+      attempts: 3,
+      reason: "failed",
+    }));
+    const { store, update } = createStoreDouble(undefined, async () => ({
+      docsProcessed: 25,
+      chunksEmbedded: 10,
+      errors: 25,
+      durationMs: 50,
+      failures,
+    }));
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "embed",
+      arguments: {},
+    });
+    const structured = result.structuredContent as {
+      docsProcessed: number;
+      chunksEmbedded: number;
+      failureCount: number;
+      failures: unknown[];
+      failuresTruncated: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(structured.docsProcessed).toBe(25);
+    expect(structured.chunksEmbedded).toBe(10);
+    expect(structured.failureCount).toBe(25);
+    expect(structured.failures).toHaveLength(20);
+    expect(structured.failuresTruncated).toBe(true);
+
+    const afterPartialFailure = await client.callTool({
+      name: "update",
+      arguments: {},
+    });
+    expect(afterPartialFailure.isError).not.toBe(true);
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  test("embed rejects timer overflow and accepts the maximum safe duration", async () => {
+    const maxTimerMinutes = 35_791;
+    const { store, embed } = createStoreDouble();
+    const { client } = await createHarness(store);
+
+    const overflow = await client.callTool({
+      name: "embed",
+      arguments: { timeoutMinutes: maxTimerMinutes + 0.25 },
+    });
+
+    expect(overflow.isError).toBe(true);
+    expect(getFirstText(overflow)).toContain("Use 0 for no runtime limit");
+    expect(embed).not.toHaveBeenCalled();
+
+    const boundary = await client.callTool({
+      name: "embed",
+      arguments: { timeoutMinutes: maxTimerMinutes },
+    });
+
+    expect(boundary.isError).not.toBe(true);
+    expect(embed).toHaveBeenCalledOnce();
+    expect(embed.mock.calls[0]?.[0]).toEqual({
+      force: false,
+      maxDurationMs: 2_147_460_000,
+      onProgress: expect.any(Function),
+    });
+  });
+
+  test("embed rejects invalid numeric and chunk options before calling the Store", async () => {
+    const { store, embed } = createStoreDouble();
+    const { client } = await createHarness(store);
+    const invalidArguments = [
+      { maxDocsPerBatch: 0 },
+      { maxDocsPerBatch: 1.5 },
+      { maxBatchMiB: 0 },
+      { maxBatchMiB: Number.POSITIVE_INFINITY },
+      { timeoutMinutes: -1 },
+      { chunkStrategy: "semantic" },
+    ];
+
+    for (const arguments_ of invalidArguments) {
+      const result = await client.callTool({
+        name: "embed",
+        arguments: arguments_,
+      });
+      expect(result.isError).toBe(true);
+    }
+
+    expect(embed).not.toHaveBeenCalled();
+  });
+
+  test("a running update blocks embed across sessions but not read tools", async () => {
+    const started = deferred();
+    const release = deferred();
+    const { store, embed } = createStoreDouble(async () => {
+      started.resolve();
+      await release.promise;
+      return {
+        collections: 2,
+        indexed: 0,
+        updated: 0,
+        unchanged: 0,
+        removed: 0,
+        needsEmbedding: 0,
+      };
+    });
+    const first = await createHarness(store);
+    const second = await createHarness(store);
+
+    const updateCall = first.client.callTool({
+      name: "update",
+      arguments: {},
+    });
+    await started.promise;
+
+    try {
+      const statusResult = await second.client.callTool({
+        name: "status",
+        arguments: {},
+      });
+      const busyResult = await second.client.callTool({
+        name: "embed",
+        arguments: {},
+      });
+
+      expect(statusResult.isError).not.toBe(true);
+      expect(busyResult.isError).toBe(true);
+      expect(getFirstText(busyResult)).toContain("busy");
+      expect(embed).not.toHaveBeenCalled();
+    } finally {
+      release.resolve();
+      await updateCall;
+    }
+
+    const afterRelease = await second.client.callTool({
+      name: "embed",
+      arguments: {},
+    });
+    expect(afterRelease.isError).toBe(false);
+    expect(embed).toHaveBeenCalledOnce();
+  });
+
+  test("a running embed blocks update across sessions and releases afterward", async () => {
+    const started = deferred();
+    const release = deferred();
+    const { store, update } = createStoreDouble(undefined, async () => {
+      started.resolve();
+      await release.promise;
+      return {
+        docsProcessed: 0,
+        chunksEmbedded: 0,
+        errors: 0,
+        durationMs: 0,
+        failures: [],
+      };
+    });
+    const first = await createHarness(store);
+    const second = await createHarness(store);
+
+    const embedCall = first.client.callTool({
+      name: "embed",
+      arguments: {},
+    });
+    await started.promise;
+
+    try {
+      const busyResult = await second.client.callTool({
+        name: "update",
+        arguments: {},
+      });
+
+      expect(busyResult.isError).toBe(true);
+      expect(getFirstText(busyResult)).toContain("busy");
+      expect(update).not.toHaveBeenCalled();
+    } finally {
+      release.resolve();
+      await embedCall;
+    }
+
+    const afterRelease = await second.client.callTool({
+      name: "update",
+      arguments: {},
+    });
+    expect(afterRelease.isError).not.toBe(true);
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  test("an MCP abort without a progress token stops embed and sends no notification", async () => {
+    const started = deferred();
+    const continueWork = deferred();
+    const finished = deferred();
+    let continuedPastBoundary = false;
+    const { store, update } = createStoreDouble(undefined, async (options) => {
+      started.resolve();
+      try {
+        await continueWork.promise;
+        options?.onProgress?.({
+          chunksEmbedded: 1,
+          totalChunks: 2,
+          bytesProcessed: 100,
+          totalBytes: 200,
+          errors: 0,
+          failures: [],
+        });
+        continuedPastBoundary = true;
+        return {
+          docsProcessed: 1,
+          chunksEmbedded: 1,
+          errors: 0,
+          durationMs: 1,
+          failures: [],
+        };
+      } finally {
+        finished.resolve();
+      }
+    });
+    const first = await createHarness(store);
+    const second = await createHarness(store);
+    const progress: ProgressNotification["params"][] = [];
+    first.client.setNotificationHandler(ProgressNotificationSchema, (notification) => {
+      progress.push(notification.params);
+    });
+    const abortController = new AbortController();
+
+    const embedCall = first.client.callTool(
+      { name: "embed", arguments: {} },
+      undefined,
+      { signal: abortController.signal },
+    ).then(
+      () => ({ resolved: true }),
+      () => ({ resolved: false }),
+    );
+
+    await started.promise;
+    abortController.abort();
+    continueWork.resolve();
+    await finished.promise;
+
+    expect((await embedCall).resolved).toBe(false);
+    expect(continuedPastBoundary).toBe(false);
+    expect(progress).toEqual([]);
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const afterAbort = await second.client.callTool({
+      name: "update",
+      arguments: {},
+    });
+    expect(afterAbort.isError).not.toBe(true);
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  test("an MCP abort without a progress token stops update and sends no notification", async () => {
+    const started = deferred();
+    const continueWork = deferred();
+    const finished = deferred();
+    let continuedPastBoundary = false;
+    const { store, embed } = createStoreDouble(async (options) => {
+      started.resolve();
+      try {
+        await continueWork.promise;
+        options?.onProgress?.({
+          collection: "docs",
+          current: 1,
+          total: 2,
+          file: "first.md",
+        });
+        continuedPastBoundary = true;
+        return {
+          collections: 1,
+          indexed: 1,
+          updated: 0,
+          unchanged: 0,
+          removed: 0,
+          needsEmbedding: 1,
+        };
+      } finally {
+        finished.resolve();
+      }
+    });
+    const first = await createHarness(store);
+    const second = await createHarness(store);
+    const progress: ProgressNotification["params"][] = [];
+    first.client.setNotificationHandler(ProgressNotificationSchema, (notification) => {
+      progress.push(notification.params);
+    });
+    const abortController = new AbortController();
+
+    const updateCall = first.client.callTool(
+      { name: "update", arguments: {} },
+      undefined,
+      { signal: abortController.signal },
+    ).then(
+      () => ({ resolved: true }),
+      () => ({ resolved: false }),
+    );
+
+    await started.promise;
+    abortController.abort();
+    continueWork.resolve();
+    await finished.promise;
+
+    expect((await updateCall).resolved).toBe(false);
+    expect(continuedPastBoundary).toBe(false);
+    expect(progress).toEqual([]);
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const afterAbort = await second.client.callTool({
+      name: "embed",
+      arguments: {},
+    });
+    expect(afterAbort.isError).not.toBe(true);
+    expect(embed).toHaveBeenCalledOnce();
+  });
+
+  test("an MCP abort stops embed at the next progress boundary and releases the lock", async () => {
+    const started = deferred();
+    const continueWork = deferred();
+    const finished = deferred();
+    let continuedPastBoundary = false;
+    const { store, update } = createStoreDouble(undefined, async (options) => {
+      started.resolve();
+      try {
+        await continueWork.promise;
+        options?.onProgress?.({
+          chunksEmbedded: 1,
+          totalChunks: 2,
+          bytesProcessed: 100,
+          totalBytes: 200,
+          errors: 0,
+          failures: [],
+        });
+        continuedPastBoundary = true;
+        return {
+          docsProcessed: 1,
+          chunksEmbedded: 1,
+          errors: 0,
+          durationMs: 1,
+          failures: [],
+        };
+      } finally {
+        finished.resolve();
+      }
+    });
+    const first = await createHarness(store);
+    const second = await createHarness(store);
+    const abortController = new AbortController();
+
+    const embedCall = first.client.callTool(
+      {
+        name: "embed",
+        arguments: {},
+        _meta: { progressToken: "cancelled-embed" },
+      },
+      undefined,
+      { signal: abortController.signal },
+    ).then(
+      () => ({ resolved: true }),
+      () => ({ resolved: false }),
+    );
+
+    await started.promise;
+    abortController.abort();
+    continueWork.resolve();
+    await finished.promise;
+
+    const callResult = await embedCall;
+    expect(callResult.resolved).toBe(false);
+    expect(continuedPastBoundary).toBe(false);
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const afterAbort = await second.client.callTool({
+      name: "update",
+      arguments: {},
+    });
+    expect(afterAbort.isError).not.toBe(true);
+    expect(update).toHaveBeenCalledOnce();
+  });
+
+  test("an MCP abort during validation prevents the Store write and releases the lock", async () => {
+    const validationStarted = deferred();
+    const continueValidation = deferred();
+    const validationReturned = deferred();
+    const { store, update } = createStoreDouble();
+    store.listCollections = async () => {
+      validationStarted.resolve();
+      await continueValidation.promise;
+      validationReturned.resolve();
+      return [{
+        name: "docs",
+        pwd: "/docs",
+        glob_pattern: "**/*.md",
+        doc_count: 0,
+        active_count: 0,
+        last_modified: null,
+        includeByDefault: true,
+      }];
+    };
+    const first = await createHarness(store);
+    const second = await createHarness(store);
+    const abortController = new AbortController();
+
+    const updateCall = first.client.callTool(
+      {
+        name: "update",
+        arguments: { collections: ["docs"] },
+      },
+      undefined,
+      { signal: abortController.signal },
+    ).catch(() => undefined);
+
+    await validationStarted.promise;
+    abortController.abort();
+    continueValidation.resolve();
+    await validationReturned.promise;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(update).not.toHaveBeenCalled();
+    await updateCall;
+
+    const afterAbort = await second.client.callTool({
+      name: "embed",
+      arguments: {},
+    });
+    expect(afterAbort.isError).not.toBe(true);
+  });
+
+  test("update rejects every unknown collection before calling the store", async () => {
+    const { store, update } = createStoreDouble();
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "update",
+      arguments: { collections: ["missing", "also-missing"] },
+    });
+
+    expect(result.isError).toBe(true);
+    const text = getFirstText(result);
+    expect(text).toContain("also-missing");
+    expect(text).toContain("missing");
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  test("update forwards file progress with the original MCP token", async () => {
+    const { store } = createStoreDouble(async (options) => {
+      options?.onProgress?.({
+        collection: "docs",
+        current: 1,
+        total: 2,
+        file: "first.md",
+      });
+      options?.onProgress?.({
+        collection: "docs",
+        current: 2,
+        total: 2,
+        file: "second.md",
+      });
+
+      return {
+        collections: 1,
+        indexed: 2,
+        updated: 0,
+        unchanged: 0,
+        removed: 0,
+        needsEmbedding: 2,
+      };
+    });
+    const { client } = await createHarness(store);
+    const progress: ProgressNotification["params"][] = [];
+
+    client.setNotificationHandler(ProgressNotificationSchema, (notification) => {
+      progress.push(notification.params);
+    });
+
+    await client.callTool({
+      name: "update",
+      arguments: {},
+      _meta: { progressToken: "update-progress" },
+    });
+
+    expect(progress.map(item => item.progressToken)).toEqual([
+      "update-progress",
+      "update-progress",
+    ]);
+    expect(progress.map(item => item.progress)).toEqual([1, 2]);
+    expect(progress.map(item => item.total)).toEqual([2, 2]);
+    expect(progress.map(item => item.message)).toEqual([
+      "docs/first.md",
+      "docs/second.md",
+    ]);
+  });
+
+  test("update ignores rejected progress notifications after Store success", async () => {
+    const { store } = createStoreDouble(async (options) => {
+      options?.onProgress?.({
+        collection: "docs",
+        current: 1,
+        total: 1,
+        file: "first.md",
+      });
+
+      return {
+        collections: 1,
+        indexed: 1,
+        updated: 2,
+        unchanged: 3,
+        removed: 4,
+        needsEmbedding: 5,
+      };
+    });
+    const { client, serverTransport } = await createHarness(store);
+    rejectProgressNotifications(serverTransport);
+
+    const result = await client.callTool({
+      name: "update",
+      arguments: {},
+      _meta: { progressToken: "rejected-update-progress" },
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(result.structuredContent).toEqual({
+      collections: 1,
+      indexed: 1,
+      updated: 2,
+      unchanged: 3,
+      removed: 4,
+      needsEmbedding: 5,
+    });
+  });
+
+  test("update handles rejected progress notifications when the Store throws", async () => {
+    const { store } = createStoreDouble(async (options) => {
+      options?.onProgress?.({
+        collection: "docs",
+        current: 1,
+        total: 1,
+        file: "first.md",
+      });
+      throw new Error("update failed");
+    });
+    const { client, serverTransport } = await createHarness(store);
+    rejectProgressNotifications(serverTransport);
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+
+    try {
+      const result = await client.callTool({
+        name: "update",
+        arguments: {},
+        _meta: { progressToken: "rejected-update-progress" },
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(result.isError).toBe(true);
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
+
+  test("update converts Store exceptions into a safe tool error", async () => {
+    const { store, embed } = createStoreDouble(async () => {
+      throw new Error("database failed with SECRET_TOKEN\ninternal stack detail");
+    });
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "update",
+      arguments: {},
+    });
+    const text = getFirstText(result);
+
+    expect(result.isError).toBe(true);
+    expect(text).toContain("Update failed");
+    expect(text).not.toContain("SECRET_TOKEN");
+    expect(text).not.toContain("stack");
+
+    const afterError = await client.callTool({
+      name: "embed",
+      arguments: {},
+    });
+    expect(afterError.isError).toBe(false);
+    expect(embed).toHaveBeenCalledOnce();
+  });
+
+  test("update forwards an explicit collection selection unchanged", async () => {
+    const { store, update } = createStoreDouble();
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "update",
+      arguments: { collections: ["notes", "docs"] },
+    });
+
+    expect(update).toHaveBeenCalledWith({
+      collections: ["notes", "docs"],
+      onProgress: expect.any(Function),
+    });
+    expect(result.structuredContent).toEqual({
+      collections: 2,
+      indexed: 3,
+      updated: 4,
+      unchanged: 5,
+      removed: 6,
+      needsEmbedding: 7,
+    });
+    expect(getFirstText(result)).toContain("7 document(s) need embedding");
+  });
+
+  test("update without collections updates all and emits no unsolicited progress", async () => {
+    const { store, update } = createStoreDouble();
+    const { client } = await createHarness(store);
+    const progress: ProgressNotification["params"][] = [];
+
+    client.setNotificationHandler(ProgressNotificationSchema, (notification) => {
+      progress.push(notification.params);
+    });
+
+    const result = await client.callTool({
+      name: "update",
+      arguments: {},
+    });
+
+    expect(update).toHaveBeenCalledWith({
+      onProgress: expect.any(Function),
+    });
+    expect(result.structuredContent).toMatchObject({
+      collections: 2,
+      indexed: 3,
+      updated: 4,
+      unchanged: 5,
+      removed: 6,
+      needsEmbedding: 7,
+    });
+    expect(progress).toEqual([]);
+  });
+
+  test("update rejects an explicitly empty collection list before calling the store", async () => {
+    const { store, update } = createStoreDouble();
+    const { client } = await createHarness(store);
+
+    const result = await client.callTool({
+      name: "update",
+      arguments: { collections: [] },
+    });
+    const text = getFirstText(result);
+
+    expect(result.isError).toBe(true);
+    expect(text).toContain("collections");
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1099,6 +1099,8 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
     expect(toolNames).toContain("status");
     expect(toolNames).toContain("update");
     expect(toolNames).toContain("embed");
+    expect(toolNames).toContain("collection_list");
+    expect(toolNames).toContain("collection_show");
   });
 
   test("POST /mcp tools/call query returns results", async () => {

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -88,17 +88,15 @@ function initTestDatabase(db: Database): void {
 
   db.exec(`
     CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(
-      name, body,
-      content='documents',
-      content_rowid='id',
+      filepath, title, body,
       tokenize='porter unicode61'
     )
   `);
 
   db.exec(`
     CREATE TRIGGER IF NOT EXISTS documents_ai AFTER INSERT ON documents BEGIN
-      INSERT INTO documents_fts(rowid, name, body)
-      SELECT new.id, new.path, content.doc
+      INSERT INTO documents_fts(rowid, filepath, title, body)
+      SELECT new.id, new.collection || '/' || new.path, new.title, content.doc
       FROM content
       WHERE content.hash = new.hash;
     END
@@ -946,10 +944,15 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
   const origConfigDir = process.env.QMD_CONFIG_DIR;
 
   beforeAll(async () => {
-    // Create isolated test database with seeded data
+    // Initialize the HTTP fixture through the production schema and triggers.
     httpTestDbPath = `/tmp/qmd-mcp-http-test-${Date.now()}.sqlite`;
+    const schemaStore = createStore(httpTestDbPath);
+    schemaStore.ensureVecTable(768);
+    schemaStore.close();
+
+    // Reopen only after production initialization, then seed through its triggers.
     const db = openDatabase(httpTestDbPath);
-    initTestDatabase(db);
+    loadSqliteVec(db);
     seedTestData(db);
 
     // 300 pad lines (37 chars each = 11100 chars) puts the marker past the
@@ -1094,6 +1097,8 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
     expect(toolNames).toContain("query");
     expect(toolNames).toContain("get");
     expect(toolNames).toContain("status");
+    expect(toolNames).toContain("update");
+    expect(toolNames).toContain("embed");
   });
 
   test("POST /mcp tools/call query returns results", async () => {

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -191,28 +191,69 @@ describe("collection management", () => {
     expect(collections.find(c => c.name === "notes")).toBeDefined();
   });
 
-  test("removeCollection removes existing collection", async () => {
+  test("removeCollection reports and removes indexed documents and content", async () => {
     await store.addCollection("docs", { path: docsDir, pattern: "**/*.md" });
-    const removed = await store.removeCollection("docs");
+    await store.update();
 
-    expect(removed).toBe(true);
+    expect(await store.searchLex("Authentication", { collection: "docs" })).not.toHaveLength(0);
+    const expectedDeletedDocs = (
+      store.internal.db.prepare(
+        "SELECT COUNT(*) AS count FROM documents WHERE collection = ?"
+      ).get("docs") as { count: number }
+    ).count;
+    const expectedCleanedHashes = (
+      store.internal.db.prepare(`
+        SELECT COUNT(*) AS count
+        FROM content
+        WHERE hash NOT IN (
+          SELECT DISTINCT hash
+          FROM documents
+          WHERE collection <> ?
+        )
+      `).get("docs") as { count: number }
+    ).count;
+
+    const result = await store.removeCollection("docs");
+
+    expect(result).toEqual({
+      removed: true,
+      deletedDocs: expectedDeletedDocs,
+      cleanedHashes: expectedCleanedHashes,
+    });
+    expect(result.deletedDocs).toBeGreaterThan(0);
+    expect(result.cleanedHashes).toBeGreaterThan(0);
     const collections = await store.listCollections();
     expect(collections.map(c => c.name)).not.toContain("docs");
+    expect(await store.searchLex("Authentication", { collection: "docs" })).toHaveLength(0);
+    expect((await store.getStatus()).collections.map(c => c.name)).not.toContain("docs");
+    expect(existsSync(join(docsDir, "auth.md"))).toBe(true);
   });
 
-  test("removeCollection returns false for non-existent collection", async () => {
-    const removed = await store.removeCollection("nonexistent");
-    expect(removed).toBe(false);
+  test("removeCollection distinguishes a non-existent collection", async () => {
+    const result = await store.removeCollection("nonexistent");
+    expect(result).toEqual({
+      removed: false,
+      deletedDocs: 0,
+      cleanedHashes: 0,
+    });
   });
 
-  test("renameCollection renames a collection", async () => {
+  test("renameCollection renames the collection and its indexed documents", async () => {
     await store.addCollection("old-name", { path: docsDir, pattern: "**/*.md" });
+    await store.update();
+    expect(await store.searchLex("Authentication", { collection: "old-name" })).not.toHaveLength(0);
+
     const renamed = await store.renameCollection("old-name", "new-name");
 
     expect(renamed).toBe(true);
     const names = (await store.listCollections()).map(c => c.name);
     expect(names).toContain("new-name");
     expect(names).not.toContain("old-name");
+    expect(await store.searchLex("Authentication", { collection: "new-name" })).not.toHaveLength(0);
+    expect(await store.searchLex("Authentication", { collection: "old-name" })).toHaveLength(0);
+    const statusNames = (await store.getStatus()).collections.map(c => c.name);
+    expect(statusNames).toContain("new-name");
+    expect(statusNames).not.toContain("old-name");
   });
 
   test("renameCollection returns false for non-existent source", async () => {
@@ -223,8 +264,11 @@ describe("collection management", () => {
   test("renameCollection throws if target exists", async () => {
     await store.addCollection("a", { path: docsDir, pattern: "**/*.md" });
     await store.addCollection("b", { path: notesDir, pattern: "**/*.md" });
+    await store.update();
 
     await expect(store.renameCollection("a", "b")).rejects.toThrow("already exists");
+    expect(await store.searchLex("Authentication", { collection: "a" })).not.toHaveLength(0);
+    expect((await store.listCollections()).map(c => c.name).sort()).toEqual(["a", "b"]);
   });
 
   test("listCollections returns empty array for empty config", async () => {

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -5,7 +5,16 @@
  * Uses inline config (no YAML files) to verify the SDK works self-contained.
  */
 
-import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
 import { mkdtemp, writeFile, mkdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -23,6 +32,7 @@ import {
   type ExpandQueryOptions,
 } from "../src/index.js";
 import { setDefaultLlamaCpp } from "../src/llm.js";
+import * as llmModule from "../src/llm.js";
 
 // =============================================================================
 // Test Helpers
@@ -991,6 +1001,117 @@ describe("embed", () => {
       expect(result.docsProcessed).toBe(3);
       expect(result.chunksEmbedded).toBe(3);
     } finally {
+      setDefaultLlamaCpp(null);
+      await store.close();
+    }
+  });
+
+  test("store.embed forwards the max runtime budget", async () => {
+    const store = await createStore({
+      dbPath: freshDbPath(),
+      config: {
+        collections: {
+          docs: { path: docsDir, pattern: "**/*.md" },
+        },
+      },
+    });
+
+    const embedBatchCalls: string[][] = [];
+    const slowLlm = {
+      async embed() {
+        return { embedding: [0.1, 0.2, 0.3], model: "fake-embed" };
+      },
+      async embedBatch(texts: string[]) {
+        embedBatchCalls.push([...texts]);
+        await new Promise((resolve) => setTimeout(resolve, 80));
+        return texts.map((_text, index) => ({
+          embedding: [index + 1, index + 2, index + 3],
+          model: "fake-embed",
+        }));
+      },
+    };
+    const sessionSpy = vi.spyOn(llmModule, "withLLMSessionForLlm");
+
+    setDefaultLlamaCpp(createFakeTokenizer() as any);
+    store.internal.llm = slowLlm as any;
+
+    try {
+      await store.update();
+      const result = await store.embed({
+        maxDocsPerBatch: 1,
+        maxBatchBytes: 1024 * 1024,
+        maxDurationMs: 10,
+      });
+
+      expect(embedBatchCalls.length).toBeGreaterThanOrEqual(1);
+      expect(sessionSpy).toHaveBeenCalledWith(
+        slowLlm,
+        expect.any(Function),
+        { maxDuration: 10, name: "generateEmbeddings" },
+      );
+      expect(result.chunksEmbedded).toBeLessThan(3);
+    } finally {
+      sessionSpy.mockRestore();
+      setDefaultLlamaCpp(null);
+      await store.close();
+    }
+  });
+
+  test("store.embed preserves zero as an unlimited runtime budget", async () => {
+    const store = await createStore({
+      dbPath: freshDbPath(),
+      config: {
+        collections: {
+          docs: { path: docsDir, pattern: "**/*.md" },
+        },
+      },
+    });
+    const fakeLlm = createFakeEmbedLlm();
+    const sessionSpy = vi.spyOn(llmModule, "withLLMSessionForLlm");
+    setDefaultLlamaCpp(createFakeTokenizer() as any);
+    store.internal.llm = fakeLlm as any;
+
+    try {
+      await store.update();
+      await store.embed({ maxDurationMs: 0 });
+
+      expect(sessionSpy).toHaveBeenCalledWith(
+        fakeLlm,
+        expect.any(Function),
+        { maxDuration: 0, name: "generateEmbeddings" },
+      );
+    } finally {
+      sessionSpy.mockRestore();
+      setDefaultLlamaCpp(null);
+      await store.close();
+    }
+  });
+
+  test("store.embed applies the default runtime budget when omitted", async () => {
+    const store = await createStore({
+      dbPath: freshDbPath(),
+      config: {
+        collections: {
+          docs: { path: docsDir, pattern: "**/*.md" },
+        },
+      },
+    });
+    const fakeLlm = createFakeEmbedLlm();
+    const sessionSpy = vi.spyOn(llmModule, "withLLMSessionForLlm");
+    setDefaultLlamaCpp(createFakeTokenizer() as any);
+    store.internal.llm = fakeLlm as any;
+
+    try {
+      await store.update();
+      await store.embed();
+
+      expect(sessionSpy).toHaveBeenCalledWith(
+        fakeLlm,
+        expect.any(Function),
+        { maxDuration: 30 * 60 * 1000, name: "generateEmbeddings" },
+      );
+    } finally {
+      sessionSpy.mockRestore();
       setDefaultLlamaCpp(null);
       await store.close();
     }

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -48,6 +48,9 @@ import {
   isDocid,
   syncConfigToDb,
   reindexCollection,
+  removeCollection,
+  upsertStoreCollection,
+  deleteInactiveDocuments,
   STRONG_SIGNAL_MIN_SCORE,
   STRONG_SIGNAL_MIN_GAP,
   insertContent,
@@ -2429,6 +2432,66 @@ describe("Reindex Collection", () => {
 });
 
 // =============================================================================
+// Maintenance Operations
+// =============================================================================
+
+describe("Maintenance Operations", () => {
+  test("deleteInactiveDocuments reports the measured number of deleted document rows", async () => {
+    const store = await createTestStore();
+    const collectionName = await createTestCollection();
+
+    try {
+      await insertTestDocument(store.db, collectionName, { name: "active" });
+      await insertTestDocument(store.db, collectionName, { name: "inactive-a", active: 0 });
+      await insertTestDocument(store.db, collectionName, { name: "inactive-b", active: 0 });
+      await insertTestDocument(store.db, collectionName, { name: "inactive-c", active: 0 });
+
+      // Seed stale FTS rows so the documents_ad trigger performs observable
+      // work when the inactive document rows are hard-deleted. Databases from
+      // before the current trigger generation can retain these rows because
+      // schema upgrades recreate triggers without cleaning existing FTS data.
+      store.db.exec(`
+        INSERT INTO documents_fts(rowid, filepath, title, body)
+        SELECT
+          documents.id,
+          documents.collection || '/' || documents.path,
+          documents.title,
+          content.doc
+        FROM documents
+        JOIN content ON content.hash = documents.hash
+        WHERE documents.active = 0
+      `);
+
+      const { count: measuredInactive } = store.db.prepare(`
+        SELECT COUNT(*) AS count
+        FROM documents
+        WHERE active = 0
+      `).get() as { count: number };
+
+      const deleted = deleteInactiveDocuments(store.db);
+
+      expect(deleted).toBe(measuredInactive);
+      expect(
+        (store.db.prepare(`
+          SELECT COUNT(*) AS count
+          FROM documents
+          WHERE active = 0
+        `).get() as { count: number }).count
+      ).toBe(0);
+      expect(
+        (store.db.prepare(`
+          SELECT COUNT(*) AS count
+          FROM documents
+          WHERE active = 1
+        `).get() as { count: number }).count
+      ).toBe(1);
+    } finally {
+      await cleanupTestDb(store);
+    }
+  });
+});
+
+// =============================================================================
 // Index Status Tests
 // =============================================================================
 
@@ -2772,6 +2835,85 @@ describe("Integration", () => {
       expect(contentCount.count).toBe(5);
     } finally {
       await rm(collectionDir, { recursive: true, force: true });
+      await cleanupTestDb(store);
+    }
+  });
+
+  test("removing another collection preserves inactive tombstone identity and content", async () => {
+    const store = await createTestStore();
+    const removedDir = await mkdtemp(join(testDir, "remove-target-"));
+    const survivorDir = await mkdtemp(join(testDir, "inactive-survivor-"));
+    const removedFile = join(removedDir, "unique.md");
+    const survivorFile = join(survivorDir, "returning.md");
+    const removedBody = "# Removed\n\nUnique removed collection content.";
+    const survivorBody = "# Returning\n\nUnique reactivation marker.";
+
+    try {
+      await writeFile(removedFile, removedBody);
+      await writeFile(survivorFile, survivorBody);
+      upsertStoreCollection(store.db, "remove-target", {
+        path: removedDir,
+        pattern: "**/*.md",
+      });
+      upsertStoreCollection(store.db, "survivor", {
+        path: survivorDir,
+        pattern: "**/*.md",
+      });
+
+      await reindexCollection(store, removedDir, "**/*.md", "remove-target");
+      await reindexCollection(store, survivorDir, "**/*.md", "survivor");
+
+      const removedHash = await hashContent(removedBody);
+      const survivorHash = await hashContent(survivorBody);
+      const original = store.db.prepare(`
+        SELECT id
+        FROM documents
+        WHERE collection = 'survivor' AND path = 'returning.md'
+      `).get() as { id: number };
+
+      await rm(survivorFile);
+      await reindexCollection(store, survivorDir, "**/*.md", "survivor");
+
+      const inactive = store.db.prepare(`
+        SELECT id, active
+        FROM documents
+        WHERE collection = 'survivor' AND path = 'returning.md'
+      `).get() as { id: number; active: number };
+      expect(inactive).toEqual({ id: original.id, active: 0 });
+
+      removeCollection(store.db, "remove-target");
+
+      const preserved = store.db.prepare(`
+        SELECT id, active
+        FROM documents
+        WHERE collection = 'survivor' AND path = 'returning.md'
+      `).get() as { id: number; active: number } | undefined;
+      expect(preserved).toEqual({ id: original.id, active: 0 });
+      expect(store.db.prepare(`SELECT hash FROM content WHERE hash = ?`).get(survivorHash))
+        .toBeTruthy();
+      expect(
+        store.db.prepare(`SELECT hash FROM content WHERE hash = ?`).get(removedHash)
+          ?? undefined
+      ).toBeUndefined();
+
+      await writeFile(survivorFile, survivorBody);
+      await reindexCollection(store, survivorDir, "**/*.md", "survivor");
+
+      const reactivated = store.db.prepare(`
+        SELECT id, active
+        FROM documents
+        WHERE collection = 'survivor' AND path = 'returning.md'
+      `).get() as { id: number; active: number };
+      expect(reactivated).toEqual({ id: original.id, active: 1 });
+      expect(
+        (store.db.prepare(`SELECT doc FROM content WHERE hash = ?`).get(
+          survivorHash
+        ) as { doc: string }).doc
+      ).toBe(survivorBody);
+      expect(store.searchFTS("reactivation marker", 10, "survivor")).toHaveLength(1);
+    } finally {
+      await rm(removedDir, { recursive: true, force: true });
+      await rm(survivorDir, { recursive: true, force: true });
       await cleanupTestDb(store);
     }
   });


### PR DESCRIPTION
## Problem

MCP clients can search and maintain an index, but they cannot see or change which collections exist. `status` hints at them, yet there is no way to list one, inspect its configuration, or register a directory without dropping to a shell — impossible in environments that have no shell access.

## What this adds

**This PR contains two independent parts.** The first is #802, which I closed in favour of a single self-contained PR: the second part builds directly on the server factory it introduces and cannot be reviewed or merged without it. Both are separate commits, so the second can be dropped without losing the first.

**Part 1 — `update` and `embed`** (commit `a6bc12d`, unchanged from #802): maintenance tools registered in the shared factory, with progress notifications, a fail-fast lock, cancellation and sanitized failure details.

**Part 2 — five collection tools** (commit `e12ce1f`): `collection_list` and `collection_show` are always available; `collection_add`, `collection_rename` and `collection_remove` are off by default and exist only for a trusted local stdio client that opts in with `qmd mcp --enable-collection-management`.

- `collection_list` and `collection_show` report name, path, pattern, active and indexed document counts, last change and the unscoped-search default. They list every configured collection, including ones that have never been indexed.
- `collection_add` registers a directory without indexing it, resolves the path to its real location, and rejects a missing path, a non-directory, a taken name or a duplicate path/pattern pair before the store is called.
- `collection_rename` renames the collection and its indexed `qmd://` paths.
- `collection_remove` deletes the collection and its indexed data; source files are never touched.

## Safety boundaries

- The factory takes the transport and the operator opt-in. Writing tools register only for `stdio` **and** an explicit opt-in, so the rule lives in one place and applies to any future entry point rather than depending on each caller. Over Streamable HTTP they never appear in `tools/list` — that transport has no authentication and would otherwise turn a search service into a remote filesystem administration API.
- `--enable-collection-management` is rejected together with `--http` instead of being silently ignored. There is deliberately no environment variable or config file equivalent, so the opt-in cannot be inherited by a child process.
- All writes share the existing maintenance lock with `update` and `embed`. It is taken **before** validation, not just around the mutation, so a concurrent caller cannot pass a uniqueness check that a competing write is about to invalidate. Read tools stay available.
- Store exceptions are masked. Where an operation may have partially succeeded, the message asks the caller to verify rather than suggesting a retry.

## Two SDK defects fixed along the way

The tools would otherwise expose them:

- `removeCollection` removed only the configuration entry and left the indexed documents searchable. It now removes them transactionally and reports `{ removed, deletedDocs, cleanedHashes }`.
- `renameCollection` renamed only the configuration entry, so indexed documents stayed under the old collection name. It now renames both in one transaction.

Both counters are measured with `COUNT(*)` rather than read from `.changes`, which under Bun includes changes made by the documents FTS triggers.

Separately, the orphaned-content cleanup used two contradictory rules: `removeCollection` treated only active documents as references, while `cleanupOrphanedContent` documents why inactive tombstones must count. Because `documents.hash` is a foreign key on `content.hash` with `ON DELETE CASCADE`, the active-only variant silently hard-deleted tombstones belonging to *other* collections. Both call sites now share one predicate.

## Tests

Protocol-level tests drive real `tools/list` and `tools/call` messages over an in-memory transport against a controlled store double — no model, no GPU, no filesystem scan. The transport boundary is asserted as an invariant rather than a list of tool names: enabling the opt-in must not change what HTTP exposes, which stays true for any tool added later.

Node and Bun green; `npm run test:types`, `npm run build` and `npm run test:package` green.

> Note: `test/store-paths.test.ts` fails 4 tests on Linux and macOS on `main` as well — those tests expect Git-Bash-to-Windows path conversion unconditionally. Unrelated to this PR.
