### PR TITLE
fix(ci): align workflow Node.js version with package engines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node-version: ["22", "23"]
+        node-version: ["22"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Why
Package metadata declares `engines.node` / `volta.node` / `.nvmrc` as `22,24,26`, but CI workflows still pin `node-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `node-version` pins so they satisfy `22,24,26` (using `26` where a concrete pin is needed).

- `.github/workflows/ci.yml`
  - `node-version: ["22", "23"]` → `node-version: ["22"]`

## Test plan
- [ ] Package `engines.node` / `volta.node` / `.nvmrc` is still `22,24,26`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.
