### PR TITLE
fix(store): index content_vectors for the embedding-status scan

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -1026,6 +1026,8 @@ function initializeDatabase(db: Database): void {
     )
   `);
 
+  ensureContentVectorsStatusIndex(db);
+
   // Store collections — makes the DB self-contained (no external config needed)
   db.exec(`
     CREATE TABLE IF NOT EXISTS store_collections (
@@ -1570,6 +1572,30 @@ function isContentVectorColumnError(error: unknown): boolean {
   return CONTENT_VECTOR_DESIRED_COLUMNS.some(col => message.includes(col.name));
 }
 
+/**
+ * Covering index for the embedding-status aggregations over content_vectors
+ * (getHashesNeedingEmbedding and the legacy-fingerprint scans). Without it,
+ * SQLite materializes a transient "automatic covering index" over the whole
+ * table on every execution — measured at ~3.3s per call on an 81k-row index,
+ * and the MCP server runs that query synchronously inside every `initialize`.
+ * Legacy databases can predate the (model, embed_fingerprint, total_chunks)
+ * columns: skip creation there so startup stays probe-free, and let
+ * runContentVectorColumnRepairs() add the index right after it adds the
+ * missing columns.
+ */
+function ensureContentVectorsStatusIndex(db: Database): void {
+  try {
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_content_vectors_model_fingerprint
+      ON content_vectors(model, embed_fingerprint, hash, total_chunks)
+    `);
+  } catch (error) {
+    if (!isContentVectorColumnError(error)) {
+      throw error;
+    }
+  }
+}
+
 function runContentVectorColumnRepairs(db: Database): void {
   for (const column of CONTENT_VECTOR_DESIRED_COLUMNS) {
     try {
@@ -1584,6 +1610,7 @@ function runContentVectorColumnRepairs(db: Database): void {
       }
     }
   }
+  ensureContentVectorsStatusIndex(db);
 }
 
 function withLazyContentVectorMigration<T>(db: Database, operation: () => T): T {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -326,6 +326,15 @@ describe("Store Creation", () => {
     expect(tableNames).toContain("llm_cache");
     // Note: path_contexts table removed in favor of YAML-based context storage
 
+    // The status-scan covering index ships with the schema — without it every
+    // getHashesNeedingEmbedding() pays a full content_vectors scan through a
+    // transient automatic index.
+    const indexes = store.db.prepare(`
+      SELECT name FROM sqlite_master
+      WHERE type='index' AND tbl_name='content_vectors'
+    `).all() as { name: string }[];
+    expect(indexes.map(i => i.name)).toContain("idx_content_vectors_model_fingerprint");
+
     await cleanupTestDb(store);
   });
 
@@ -368,8 +377,15 @@ describe("Store Creation", () => {
     legacyDb.close();
 
     const store = createStore(dbPath);
+    const indexNames = () => (store.db.prepare(`
+      SELECT name FROM sqlite_master
+      WHERE type='index' AND tbl_name='content_vectors'
+    `).all() as { name: string }[]).map(i => i.name);
     let columns = store.db.prepare(`PRAGMA table_info(content_vectors)`).all() as { name: string }[];
     expect(columns.map(col => col.name)).not.toContain("embed_fingerprint");
+    // The status-scan index needs the modern columns, so it must stay deferred
+    // alongside the column migration itself.
+    expect(indexNames()).not.toContain("idx_content_vectors_model_fingerprint");
 
     expect(store.getHashesNeedingEmbedding(model)).toBe(1);
 
@@ -377,6 +393,8 @@ describe("Store Creation", () => {
     const migratedRow = store.db.prepare(`SELECT embed_fingerprint FROM content_vectors WHERE hash = ?`).get("hash1") as { embed_fingerprint: string };
     expect(columns.map(col => col.name)).toContain("embed_fingerprint");
     expect(migratedRow.embed_fingerprint).toBe("");
+    // The lazy column repair recreates the deferred status-scan index.
+    expect(indexNames()).toContain("idx_content_vectors_model_fingerprint");
 
     await cleanupTestDb(store);
   });


### PR DESCRIPTION
## What

Adds a covering index over `content_vectors(model, embed_fingerprint, hash, total_chunks)`, created with the rest of the schema and re-created by the lazy column-repair path for legacy databases that can't take it at startup.

## Why

`getStatus()` → `getHashesNeedingEmbedding()` aggregates all of `content_vectors` filtered by `(model, embed_fingerprint)`. No existing index covers that shape (the PK is `(hash, seq)`), so SQLite materializes a transient *automatic covering index* over the whole table on **every execution** — and the MCP server pays that synchronously inside every `initialize` (`buildInstructions()` → `getStatus()`), once per session on the HTTP transport.

Measured on a production index with 83.5k `content_vectors` rows (M3 Ultra):

- status scan: **~3.3s per call** before → **~0.4s cold / low-ms warm** after
- MCP `initialize` on a long-running HTTP daemon: collapsed to **60–81s** under agent reconnect bursts (stacked scans) before → **~53–86ms** warm after
- query plan: `SCAN content_vectors ... USING AUTOMATIC COVERING INDEX` → `SEARCH content_vectors USING COVERING INDEX (model=? AND embed_fingerprint=?)`

The same prefix also serves the legacy-fingerprint scans in `maybeAdoptLegacyEmbeddingFingerprint()`.

## Details

- Startup stays probe-free: on legacy DBs missing the newer columns, the `CREATE INDEX` throws a recognized column error and is skipped; `runContentVectorColumnRepairs()` re-creates the index right after adding the missing columns.
- First startup on an existing large DB pays a one-time index build (~1–2s at 83.5k rows).
- Embedding writes maintain one extra index; negligible next to embedding compute.

## Testing

- `test/store.test.ts`: the schema test now asserts the index exists, and the deferred-migration test asserts it is absent pre-repair and present post-repair — 223/223 pass locally.
- `tsc -p tsconfig.build.json --noEmit` clean.
