### PR TITLE
perf(mcp): cache server instructions instead of rebuilding per request

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -164,6 +164,34 @@ async function buildInstructions(store: QMDStore): Promise<string> {
 }
 
 /**
+ * Cache built instructions per store. The HTTP transport builds a fresh
+ * McpServer per request (sessionless MCP 2026-07-28), and buildInstructions()
+ * runs a full index-status aggregation, so rebuilding it per request puts that
+ * scan in front of every call. Concurrent builds share one in-flight promise,
+ * and entries expire after a short TTL so index updates from other processes
+ * still surface without a server restart.
+ */
+const INSTRUCTIONS_CACHE_TTL_MS = 60_000;
+const instructionsCache = new WeakMap<QMDStore, { promise: Promise<string>; builtAt: number }>();
+
+function getInstructions(store: QMDStore): Promise<string> {
+  const cached = instructionsCache.get(store);
+  if (cached && Date.now() - cached.builtAt < INSTRUCTIONS_CACHE_TTL_MS) {
+    return cached.promise;
+  }
+  const promise = buildInstructions(store);
+  instructionsCache.set(store, { promise, builtAt: Date.now() });
+  // Drop failed builds so the next initialize retries instead of replaying
+  // the cached rejection for the rest of the TTL window.
+  promise.catch(() => {
+    if (instructionsCache.get(store)?.promise === promise) {
+      instructionsCache.delete(store);
+    }
+  });
+  return promise;
+}
+
+/**
  * Create an MCP server with all QMD tools, resources, and prompts registered.
  * Shared by both stdio and HTTP transports.
  */
@@ -174,7 +202,7 @@ async function createMcpServer(store: QMDStore, inflight?: InflightGate): Promis
   const server = new McpServer(
     { name: "qmd", version: getPackageVersion() },
     {
-      instructions: await buildInstructions(store),
+      instructions: await getInstructions(store),
       // tools/list is static for the process lifetime; resources/read stays
       // uncacheable because the index can change under us.
       cacheHints: {

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1092,6 +1092,55 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
     expect(json.result.serverInfo.name).toBe("qmd");
   });
 
+  test("POST /mcp initialize serves cached instructions across requests", async () => {
+    // The legacy initialize path answers either JSON or a single SSE frame
+    // depending on how the transport negotiates; read both the same way.
+    const legacyInitialize = async (id: number) => {
+      const res = await fetch(`${baseUrl}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept": "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-03-26",
+            capabilities: {},
+            clientInfo: { name: "test-client", version: "1.0.0" },
+          },
+        }),
+      });
+      const text = await res.text();
+      const data = text.includes("data:")
+        ? text.split("\n").find(line => line.startsWith("data:"))!.slice(5).trim()
+        : text;
+      return JSON.parse(data) as any;
+    };
+
+    const first = await legacyInitialize(10);
+    const firstInstructions = first.result.instructions;
+    expect(typeof firstInstructions).toBe("string");
+    expect(firstInstructions.length).toBeGreaterThan(0);
+
+    // Change the index under the server. HTTP builds a fresh McpServer per
+    // request, so without the cache the next initialize rebuilds the
+    // instructions and reports the new document count; with it, the same
+    // string is served until the TTL lapses.
+    const db = openDatabase(httpTestDbPath);
+    const now = new Date().toISOString();
+    db.prepare(`INSERT OR IGNORE INTO content (hash, doc, created_at) VALUES (?, ?, ?)`)
+      .run("hash-instr-cache", "# Cache probe\nbody", now);
+    db.prepare(`INSERT INTO documents (collection, path, title, hash, created_at, modified_at, active) VALUES ('docs', ?, ?, ?, ?, ?, 1)`)
+      .run("instructions-cache-probe.md", "Cache Probe", "hash-instr-cache", now, now);
+    db.close();
+
+    const second = await legacyInitialize(11);
+    expect(second.result.instructions).toBe(firstInstructions);
+  });
+
   test("POST /mcp tools/list returns registered tools without a session", async () => {
     const { status, json, contentType, headers } = await mcpRequest("tools/list");
     expect(status).toBe(200);


### PR DESCRIPTION
## What

Caches the built MCP server instructions per store — shared in-flight promise, 60s TTL — instead of rebuilding them inside every `createMcpServer()` call.

## Why

The Streamable HTTP transport creates one `McpServer` per MCP session, so every `initialize` re-runs the full index-status aggregation behind `buildInstructions()`. On a large index that recomputation dominates the handshake, and agent reconnect bursts stack N status scans (observed on a production 83.5k-row index as multi-second to tens-of-seconds initializes; companion fix #814 removes most of the per-scan cost, this PR removes the per-session recomputation).

With the cache, a reconnect burst costs one status scan: concurrent initializes share a single in-flight build.

## Details

- Failed builds are dropped from the cache, so the next `initialize` retries instead of replaying a cached rejection for the rest of the TTL window.
- Index updates from other processes surface within 60s without restarting the server; the `status` tool is untouched and always live.
- Stdio transport behavior is unchanged (one server per process).

## Testing

- New test in the HTTP describe of `test/mcp.test.ts`: two fresh sessions receive identical instructions while the index is mutated between them.
- Heads-up: on a clean checkout of current `main` (e428df7) the HTTP describe fails in `beforeAll` before any test runs — `rebuildFTSForCjkNormalization` throws `SqliteError: no such column: T.name` against the raw-SQL fixture DB (pre-existing; CI skips the block via `describe.skipIf(CI)`). I verified the behavior standalone against a real `createStore` schema: a second session receives the identical cached string, still carrying the pre-mutation document count.
- `tsc -p tsconfig.build.json --noEmit` clean.
