### PR TITLE
feat(mcp): expire idle HTTP sessions with a configurable TTL

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -2772,6 +2772,7 @@ function parseCLI() {
       daemon: { type: "boolean" },
       port: { type: "string" },
       host: { type: "string" },
+      "session-ttl": { type: "string" },
     },
     allowPositionals: true,
     strict: false, // Allow unknown options to pass through
@@ -4424,6 +4425,10 @@ if (isMain) {
         // fallback (resolved in startMcpHttpServer). Use "0.0.0.0" to accept
         // off-host connections, e.g. a container liveness probe.
         const host = cli.values.host ? String(cli.values.host) : undefined;
+        // --session-ttl overrides the idle session TTL in seconds;
+        // QMD_MCP_SESSION_TTL env is the fallback and 0 disables expiry
+        // (resolved in startMcpHttpServer).
+        const sessionTtl = cli.values["session-ttl"] !== undefined ? Number(cli.values["session-ttl"]) : undefined;
 
         if (cli.values.daemon) {
           // Guard: check if already running
@@ -4444,9 +4449,10 @@ if (isMain) {
           const selfPath = fileURLToPath(import.meta.url);
           const indexArgs = cli.values.index ? ["--index", String(cli.values.index)] : [];
           const hostArgs = host ? ["--host", host] : [];
+          const sessionTtlArgs = sessionTtl !== undefined ? ["--session-ttl", String(sessionTtl)] : [];
           const spawnArgs = selfPath.endsWith(".ts")
-            ? ["--import", pathJoin(dirname(selfPath), "..", "..", "node_modules", "tsx", "dist", "esm", "index.mjs"), selfPath, ...indexArgs, "mcp", "--http", "--port", String(port), ...hostArgs]
-            : [selfPath, ...indexArgs, "mcp", "--http", "--port", String(port), ...hostArgs];
+            ? ["--import", pathJoin(dirname(selfPath), "..", "..", "node_modules", "tsx", "dist", "esm", "index.mjs"), selfPath, ...indexArgs, "mcp", "--http", "--port", String(port), ...hostArgs, ...sessionTtlArgs]
+            : [selfPath, ...indexArgs, "mcp", "--http", "--port", String(port), ...hostArgs, ...sessionTtlArgs];
           const child = nodeSpawn(process.execPath, spawnArgs, {
             stdio: ["ignore", logFd, logFd],
             detached: true,
@@ -4466,7 +4472,7 @@ if (isMain) {
         process.removeAllListeners("SIGINT");
         const { startMcpHttpServer } = await import("../mcp/server.js");
         try {
-          await startMcpHttpServer(port, { dbPath: getDbPath(), host });
+          await startMcpHttpServer(port, { dbPath: getDbPath(), host, ...(sessionTtl !== undefined ? { sessionTtlSeconds: sessionTtl } : {}) });
         } catch (e: unknown) {
           if (typeof e === "object" && e !== null && "code" in e && e.code === "EADDRINUSE") {
             console.error(`Port ${port} already in use. Try a different port with --port.`);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -609,14 +609,47 @@ export type HttpServerHandle = {
 };
 
 /**
+ * Default idle TTL for HTTP MCP sessions, in seconds. Overridable per call
+ * via `options.sessionTtlSeconds` or globally via the QMD_MCP_SESSION_TTL env
+ * var; 0 disables expiry entirely.
+ */
+const DEFAULT_SESSION_TTL_SECONDS = 3600;
+
+function resolveSessionTtlMs(sessionTtlSeconds?: number): number {
+  let seconds = sessionTtlSeconds;
+  if (seconds === undefined) {
+    const envValue = process.env.QMD_MCP_SESSION_TTL?.trim();
+    if (envValue) {
+      seconds = Number(envValue);
+      if (!Number.isFinite(seconds) || seconds < 0) {
+        throw new Error(`Invalid QMD_MCP_SESSION_TTL: ${envValue}. Must be a non-negative number of seconds (0 disables session expiry).`);
+      }
+    }
+  }
+  seconds ??= DEFAULT_SESSION_TTL_SECONDS;
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    throw new Error(`Invalid session TTL: ${seconds}. Must be a non-negative number of seconds (0 disables session expiry).`);
+  }
+  return Math.floor(seconds * 1000);
+}
+
+/**
  * Start MCP server over Streamable HTTP (JSON responses, no SSE).
  * Binds to `options.host` (default "localhost", overridable via the QMD_HOST
  * env var) — set "0.0.0.0" to accept connections from other hosts, e.g. a
  * container liveness probe. Returns a handle for shutdown and port discovery.
+ *
+ * Sessions idle for longer than the TTL (default 1 hour; see
+ * `resolveSessionTtlMs`) are closed by a background reaper. Ephemeral clients
+ * that connect once and never come back — agents, cron jobs, health probes —
+ * otherwise accumulate a server + transport pair each, forever. Expiry is
+ * spec-sanctioned: Streamable HTTP servers may terminate sessions at any
+ * time, and a client that gets 404 for its session ID MUST start a new one
+ * by re-initializing.
  */
 export async function startMcpHttpServer(
   port: number,
-  options: ({ quiet?: boolean; host?: string } & McpStartupOptions) = {},
+  options: ({ quiet?: boolean; host?: string; sessionTtlSeconds?: number } & McpStartupOptions) = {},
 ): Promise<HttpServerHandle> {
   // See startMcpServer() for the rationale — flip production mode here so the
   // HTTP transport resolves the real database path, without leaking state into
@@ -633,14 +666,18 @@ export async function startMcpHttpServer(
 
   // Session map: each client gets its own McpServer + Transport pair (MCP spec requirement).
   // The store is shared — it's stateless SQLite, safe for concurrent access.
-  const sessions = new Map<string, WebStandardStreamableHTTPServerTransport>();
+  type SessionEntry = {
+    transport: WebStandardStreamableHTTPServerTransport;
+    lastActivityAt: number;
+  };
+  const sessions = new Map<string, SessionEntry>();
 
   async function createSession(): Promise<WebStandardStreamableHTTPServerTransport> {
     const transport = new WebStandardStreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
       enableJsonResponse: true,
       onsessioninitialized: (sessionId: string) => {
-        sessions.set(sessionId, transport);
+        sessions.set(sessionId, { transport, lastActivityAt: Date.now() });
         log(`${ts()} New session ${sessionId} (${sessions.size} active)`);
       },
     });
@@ -654,6 +691,30 @@ export async function startMcpHttpServer(
     };
 
     return transport;
+  }
+
+  // Reap idle sessions so ephemeral clients can't grow the session table
+  // without bound. Any request routed to a session refreshes its activity
+  // timestamp, so long-lived clients that keep talking are never expired;
+  // clients whose session was reaped get 404 and re-initialize per spec.
+  const sessionTtlMs = resolveSessionTtlMs(options.sessionTtlSeconds);
+  let sessionReaper: ReturnType<typeof setInterval> | null = null;
+  if (sessionTtlMs > 0) {
+    sessionReaper = setInterval(() => {
+      const now = Date.now();
+      for (const [sessionId, entry] of sessions) {
+        if (now - entry.lastActivityAt < sessionTtlMs) continue;
+        const idleSeconds = Math.round((now - entry.lastActivityAt) / 1000);
+        log(`${ts()} Session ${sessionId} idle ${idleSeconds}s — expiring (${sessions.size - 1} active)`);
+        entry.transport.close().catch((err: unknown) => {
+          // transport.onclose normally removes the entry; make sure a close
+          // failure can't keep the session pinned in the map forever.
+          sessions.delete(sessionId);
+          log(`${ts()} Error closing idle session ${sessionId}: ${err}`);
+        });
+      }
+    }, Math.min(sessionTtlMs, 60_000));
+    sessionReaper.unref();
   }
 
   const startTime = Date.now();
@@ -800,7 +861,8 @@ export async function startMcpHttpServer(
             }));
             return;
           }
-          transport = existing;
+          existing.lastActivityAt = Date.now();
+          transport = existing.transport;
         } else if (isInitializeRequest(body)) {
           transport = await createSession();
         } else {
@@ -839,8 +901,8 @@ export async function startMcpHttpServer(
           }));
           return;
         }
-        const transport = sessions.get(sessionId);
-        if (!transport) {
+        const entry = sessions.get(sessionId);
+        if (!entry) {
           nodeRes.writeHead(404, { "Content-Type": "application/json" });
           nodeRes.end(JSON.stringify({
             jsonrpc: "2.0",
@@ -849,6 +911,8 @@ export async function startMcpHttpServer(
           }));
           return;
         }
+        entry.lastActivityAt = Date.now();
+        const transport = entry.transport;
 
         const url = `http://localhost:${port}${pathname}`;
         const rawBody = nodeReq.method !== "GET" && nodeReq.method !== "HEAD" ? await collectBody(nodeReq) : undefined;
@@ -880,8 +944,11 @@ export async function startMcpHttpServer(
   const stop = async () => {
     if (stopping) return;
     stopping = true;
-    for (const transport of sessions.values()) {
-      await transport.close();
+    if (sessionReaper) {
+      clearInterval(sessionReaper);
+    }
+    for (const entry of sessions.values()) {
+      await entry.transport.close();
     }
     sessions.clear();
     httpServer.close();

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1154,4 +1154,52 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
     expect(hit.line).toBe(301);
     expect(hit.snippet).toMatch(/^\d+: @@ -3\d\d,/);
   });
+
+  test("idle sessions expire after the TTL and clients can re-initialize", async () => {
+    // Separate server so the aggressive TTL can't interfere with the shared
+    // handle used by the other tests.
+    const ttlHandle = await startMcpHttpServer(0, { quiet: true, sessionTtlSeconds: 1 });
+    const url = `http://localhost:${ttlHandle.port}/mcp`;
+    const headers = {
+      "Content-Type": "application/json",
+      "Accept": "application/json, text/event-stream",
+    };
+    const initBody = (id: number) => JSON.stringify({
+      jsonrpc: "2.0", id, method: "initialize",
+      params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "test", version: "1.0" } },
+    });
+    try {
+      const init = await fetch(url, { method: "POST", headers, body: initBody(1) });
+      expect(init.status).toBe(200);
+      const sid = init.headers.get("mcp-session-id");
+      expect(sid).toBeTruthy();
+
+      // Requests inside the TTL keep the session alive.
+      const early = await fetch(url, {
+        method: "POST",
+        headers: { ...headers, "mcp-session-id": sid! },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }),
+      });
+      expect(early.status).toBe(200);
+
+      // Idle past the TTL: the reaper closes the session and the server
+      // answers 404, which per the Streamable HTTP spec tells the client to
+      // start a new session.
+      await new Promise(resolve => setTimeout(resolve, 2500));
+      const stale = await fetch(url, {
+        method: "POST",
+        headers: { ...headers, "mcp-session-id": sid! },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/list", params: {} }),
+      });
+      expect(stale.status).toBe(404);
+
+      const reinit = await fetch(url, { method: "POST", headers, body: initBody(4) });
+      expect(reinit.status).toBe(200);
+      const newSid = reinit.headers.get("mcp-session-id");
+      expect(newSid).toBeTruthy();
+      expect(newSid).not.toBe(sid);
+    } finally {
+      await ttlHandle.stop();
+    }
+  });
 });


### PR DESCRIPTION
## What

Adds idle-session expiry to `qmd mcp --http`: every request routed to a session refreshes its activity timestamp, and a background reaper closes sessions idle longer than a configurable TTL (default 1 hour).

## Why

The HTTP transport registers a session per client connect and never removes any — a transport only leaves the map when its client explicitly closes it. Ephemeral MCP clients (agents, cron jobs, health probes) rarely do, so the session table grows without bound: on one fleet host the daemon accumulated **324 sessions in six days**, roughly one per agent reconnect, none ever reaped. Each leaked session pins a `McpServer` + transport pair for the life of the process.

Expiry is spec-sanctioned: the Streamable HTTP spec lets the server terminate sessions at any time, and a client that receives 404 for its session ID MUST start a new session by re-initializing — the 404 path already exists in this server.

## Details

- Config surface: `--session-ttl <seconds>` on `qmd mcp --http` (passed through in `--daemon` mode), `QMD_MCP_SESSION_TTL` env var, or `sessionTtlSeconds` in the programmatic API. `0` disables expiry.
- Long-lived clients that keep talking are never expired (touch-on-request).
- The reaper interval is `unref()`ed so it never holds the process open; `stop()` clears it. Reap events are logged with the remaining session count.

## Testing

- New test in the HTTP describe of `test/mcp.test.ts`: with `sessionTtlSeconds: 1`, an active session survives past the TTL via touch-on-request, an idle one gets 404, and a re-initialize issues a fresh session.
- Heads-up: on a clean checkout of current `main` (e428df7) the HTTP describe fails in `beforeAll` before any test runs — `rebuildFTSForCjkNormalization` throws `SqliteError: no such column: T.name` against the raw-SQL fixture DB (pre-existing; CI skips the block). I verified the same four assertions standalone against a real `createStore` schema: all pass.
- `tsc -p tsconfig.build.json --noEmit` clean.
