### PR TITLE
feat(mcp): prefetch model files in the background at HTTP server start

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -1294,6 +1294,22 @@ export class LlamaCpp implements LLM {
     return { text: truncatedText, truncated: true, limit: maxTokens };
   }
 
+  /**
+   * Ensure every configured model file is present in the local cache,
+   * downloading any that are missing. Models are NOT loaded into memory —
+   * lazy loading applies as before — so this is nearly free when the cache
+   * is already populated. Long-lived servers call this in the background at
+   * startup: without it, the first request that needs a missing GGUF pays
+   * for a multi-GB download synchronously inside the caller's request, which
+   * over MCP is an unexplained multi-minute hang.
+   */
+  async prefetchModels(): Promise<void> {
+    if (this._ciMode) return;
+    await this.resolveModel(this.embedModelUri);
+    await this.resolveModel(this.generateModelUri);
+    await this.resolveModel(this.rerankModelUri);
+  }
+
   async embed(text: string, options: EmbedOptions = {}): Promise<EmbeddingResult | null> {
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -876,6 +876,22 @@ export async function startMcpHttpServer(
 
   const actualPort = (httpServer.address() as import("net").AddressInfo).port;
 
+  // Prefetch model files in the background once the server is accepting
+  // connections. A cold model cache otherwise turns the first vec/hyde or
+  // rerank request into a synchronous multi-GB download inside that client's
+  // call — over MCP that reads as the server silently hanging. Gated on an
+  // existing vector index so lex-only installs never fetch models they
+  // don't use; models still load into memory lazily on first use.
+  void (async () => {
+    try {
+      const status = await store.getStatus();
+      if (!status.hasVectorIndex) return;
+      await store.internal.llm?.prefetchModels();
+    } catch (err) {
+      log(`${ts()} Model prefetch failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  })();
+
   let stopping = false;
   const stop = async () => {
     if (stopping) return;


### PR DESCRIPTION
## What

When the HTTP server starts, resolve all configured model files in the background once the listener is up (`LlamaCpp.prefetchModels()`): downloads happen off the request path, models still load into memory lazily, and a warm cache makes the pass a near-free no-op (~450ms observed).

## Why

The first request that needs a missing GGUF pays for its download synchronously inside the caller's request. The CLI at least renders a progress bar; over MCP the call just hangs with no feedback until the download completes — measured at **28s for the 1.28 GB expansion model** on a fast connection, minutes on slower links. That blows through common MCP client timeouts, so a daemon with a cold or partially-evicted model cache reads as "the server is down" exactly once per cache loss and then never reproduces — a miserable failure mode to diagnose from the client side.

## Details

- Gated on `status.hasVectorIndex`, so lex-only installs never fetch models they don't use (trade-off: such installs still lazy-download the reranker on their first reranked query — happy to change the gate if you'd rather prefetch unconditionally, make it an opt-in flag, or extend it to stdio).
- `prefetchModels()` is a public method on `LlamaCpp`; it only ensures the files exist locally (`resolveModel` per configured model), never loads them into memory. No-op in CI mode.
- Prefetch failures are logged and non-fatal; the lazy path still works as before.

## Testing

- Verified standalone: warm cache → `prefetchModels()` resolves in ~450ms with no network; HTTP server over a no-vector index → no fetch attempted (empty cache stays empty).
- Existing suites pass; `tsc -p tsconfig.build.json --noEmit` clean.
