### PR TITLE
fix(store): keep caller intent out of query expansion and drop dud cached expansions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -192,6 +192,12 @@ export interface VectorSearchOptions {
  * Options for expandQuery() — manual query expansion.
  */
 export interface ExpandQueryOptions {
+  /**
+   * @deprecated Ignored. Intent no longer feeds the expansion model — caller
+   * intent is meta-language the model reproduced verbatim as sub-queries.
+   * Pass intent via SearchOptions instead, where it shapes reranking and
+   * snippet selection.
+   */
   intent?: string;
 }
 
@@ -427,7 +433,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
     },
     searchLex: async (q, opts) => internal.searchFTS(q, opts?.limit, opts?.collection),
     searchVector: async (q, opts) => internal.searchVec(q, llm.embedModelName, opts?.limit, opts?.collection),
-    expandQuery: async (q, opts) => internal.expandQuery(q, undefined, opts?.intent),
+    expandQuery: async (q) => internal.expandQuery(q),
     get: async (pathOrDocid, opts) => internal.findDocument(pathOrDocid, opts),
     getDocumentBody: async (pathOrDocid, opts) => {
       const result = internal.findDocument(pathOrDocid, { includeBody: false });

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -1451,7 +1451,7 @@ export class LlamaCpp implements LLM {
   // High-level abstractions
   // ==========================================================================
 
-  async expandQuery(query: string, options: { context?: string, includeLexical?: boolean, intent?: string } = {}): Promise<Queryable[]> {
+  async expandQuery(query: string, options: { context?: string, includeLexical?: boolean } = {}): Promise<Queryable[]> {
     if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();
@@ -1462,10 +1462,13 @@ export class LlamaCpp implements LLM {
     const includeLexical = options.includeLexical ?? true;
     const context = options.context;
 
-    const intent = options.intent;
-    const prompt = intent
-      ? `/no_think Expand this search query: ${query}\nQuery intent: ${intent}`
-      : `/no_think Expand this search query: ${query}`;
+    // The expansion prompt deliberately consumes ONLY the query text. Caller
+    // intent is free-form meta-language ("retest of the poisoned query", "so
+    // I can compare spend settings") that the expansion model reproduces
+    // verbatim as lex/vec sub-queries — degenerate terms that match nothing.
+    // Intent still shapes retrieval where it belongs: the reranker query
+    // prefix and keyword-based chunk/snippet selection.
+    const prompt = `/no_think Expand this search query: ${query}`;
 
     // Set up inside the try so any failure (grammar creation, context
     // allocation/VRAM, session prompt) falls back to the original query

--- a/src/store.ts
+++ b/src/store.ts
@@ -1312,7 +1312,9 @@ export type Store = {
   searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => Promise<SearchResult[]>;
 
   // Query expansion & reranking
-  expandQuery: (query: string, model?: string, intent?: string) => Promise<ExpandedQuery[]>;
+  expandQuery: (query: string, model?: string) => Promise<ExpandedQuery[]>;
+  /** Drop the cached expansion for a query so the next call regenerates. */
+  invalidateExpansionCache: (query: string) => void;
   rerank: (query: string, documents: { file: string; text: string }[], model?: string, intent?: string) => Promise<{ file: string; score: number }[]>;
 
   // Document retrieval
@@ -1994,7 +1996,8 @@ export function createStore(dbPath?: string): Store {
     searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => searchVec(db, query, model, limit, collectionName, session, precomputedEmbedding),
 
     // Query expansion & reranking
-    expandQuery: (query: string, model?: string, intent?: string) => expandQuery(query, model ?? store.llm?.generateModelName ?? DEFAULT_QUERY_MODEL, db, intent, store.llm),
+    expandQuery: (query: string, model?: string) => expandQuery(query, model ?? store.llm?.generateModelName ?? DEFAULT_QUERY_MODEL, db, store.llm),
+    invalidateExpansionCache: (query: string) => deleteExpansionCacheEntry(db, query, store.llm?.generateModelName ?? DEFAULT_QUERY_MODEL),
     rerank: (query: string, documents: { file: string; text: string }[], model?: string, intent?: string) => rerank(query, documents, model ?? store.llm?.rerankModelName ?? DEFAULT_RERANK_MODEL, db, intent, store.llm),
 
     // Document retrieval
@@ -3889,9 +3892,13 @@ function removeIncompleteEmbeddings(db: Database, expectedChunksByHash: Map<stri
 // Query expansion
 // =============================================================================
 
-export async function expandQuery(query: string, model: string = DEFAULT_QUERY_MODEL, db: Database, intent?: string, llmOverride?: LlamaCpp): Promise<ExpandedQuery[]> {
-  // Check cache first — stored as JSON preserving types
-  const cacheKey = getCacheKey("expandQuery", { query, model, ...(intent && { intent }) });
+export async function expandQuery(query: string, model: string = DEFAULT_QUERY_MODEL, db: Database, llmOverride?: LlamaCpp): Promise<ExpandedQuery[]> {
+  // Check cache first — stored as JSON preserving types. Intent is
+  // deliberately absent from both the cache key and the generation call:
+  // feeding caller intent to the expansion model contaminates sub-queries
+  // with intent meta-language (see LlamaCpp.expandQuery), and keying the
+  // cache by intent multiplied the poisoned entries per (query, intent) pair.
+  const cacheKey = getCacheKey("expandQuery", { query, model });
   const cached = getCachedResult(db, cacheKey);
   if (cached) {
     try {
@@ -3911,7 +3918,7 @@ export async function expandQuery(query: string, model: string = DEFAULT_QUERY_M
 
   const llm = llmOverride ?? getDefaultLlamaCpp();
   // Note: LlamaCpp uses hardcoded model, model parameter is ignored
-  const results = await llm.expandQuery(query, { intent });
+  const results = await llm.expandQuery(query);
 
   // Map Queryable[] → ExpandedQuery[] (same shape, decoupled from llm.ts internals).
   // Filter out entries that duplicate the original query text.
@@ -3924,6 +3931,16 @@ export async function expandQuery(query: string, model: string = DEFAULT_QUERY_M
   }
 
   return expanded;
+}
+
+/**
+ * Delete the cached expansion for a query. hybridQuery() calls this when an
+ * expansion's sub-queries all came back empty — left in place, the dud entry
+ * would replay the same misses on every warm repeat of the query.
+ */
+export function deleteExpansionCacheEntry(db: Database, query: string, model: string = DEFAULT_QUERY_MODEL): void {
+  const cacheKey = getCacheKey("expandQuery", { query, model });
+  db.prepare(`DELETE FROM llm_cache WHERE hash = ?`).run(cacheKey);
 }
 
 // =============================================================================
@@ -4768,7 +4785,7 @@ export async function hybridQuery(
   const expandStart = Date.now();
   const expanded = hasStrongSignal
     ? []
-    : await store.expandQuery(query, undefined, intent);
+    : await store.expandQuery(query);
 
   hooks?.onExpand?.(query, expanded, Date.now() - expandStart);
 
@@ -4844,6 +4861,19 @@ export async function hybridQuery(
           query: vecQueries[i]!.text,
         });
       }
+    }
+  }
+
+  // Step 3c: drop a cached expansion whose sub-queries all came back empty —
+  // the dud is cached per (query, model), so left in place it deterministically
+  // replays the same misses on every warm repeat. Only judge sub-queries the
+  // store could actually run: on FTS-only stores, vec/hyde expansions never
+  // execute and say nothing about the expansion's quality.
+  if (expanded.length > 0) {
+    const runnable = expanded.filter(q => q.type === "lex" || hasVectors);
+    const expansionContributed = rankedListMeta.some(m => m.queryType !== "original");
+    if (runnable.length > 0 && !expansionContributed) {
+      store.invalidateExpansionCache(query);
     }
   }
 
@@ -5055,7 +5085,7 @@ export async function vectorSearchQuery(
 
   // Expand query — filter to vec/hyde only (lex queries target FTS, not vector)
   const expandStart = Date.now();
-  const allExpanded = await store.expandQuery(query, undefined, intent);
+  const allExpanded = await store.expandQuery(query);
   const vecExpanded = allExpanded.filter(q => q.type !== 'lex');
   options?.hooks?.onExpand?.(query, vecExpanded, Date.now() - expandStart);
 

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -41,6 +41,7 @@ import {
   reciprocalRankFusion,
   extractSnippet,
   getCacheKey,
+  DEFAULT_QUERY_MODEL,
   normalizeVirtualPath,
   isVirtualPath,
   parseVirtualPath,
@@ -3528,6 +3529,67 @@ describe("Embedding batching", () => {
       expect(searchVecSpy.mock.calls[0]?.[0]).toBe("hybrid query");
       expect(searchVecSpy.mock.calls[0]?.[1]).toBe(model);
       expect(searchVecSpy.mock.calls[0]?.[5]).toEqual([1, 2, 3]);
+    } finally {
+      await cleanupTestDb(store);
+    }
+  });
+
+  test("expandQuery serves cached expansions without invoking the LLM", async () => {
+    const store = await createTestStore();
+    try {
+      const model = store.llm?.generateModelName ?? DEFAULT_QUERY_MODEL;
+      const seeded = [{ type: "lex", query: "seeded-term" }];
+      store.setCachedResult(getCacheKey("expandQuery", { query: "cached question", model }), JSON.stringify(seeded));
+
+      // CI mode makes any real generation throw, so a passing call proves the
+      // cache path; locally the seed always hits, so the LLM is never
+      // consulted either way.
+      const out = await store.expandQuery("cached question");
+      expect(out).toEqual([{ type: "lex", query: "seeded-term" }]);
+    } finally {
+      await cleanupTestDb(store);
+    }
+  });
+
+  test("hybridQuery drops a cached expansion whose sub-queries contributed nothing", async () => {
+    const store = await createTestStore();
+    try {
+      await insertTestDocument(store.db, "docs", {
+        name: "alpha",
+        title: "Alpha Bravo",
+        body: "# Alpha\n\nalpha bravo charlie content.",
+      });
+      const model = store.llm?.generateModelName ?? DEFAULT_QUERY_MODEL;
+      const cacheKey = getCacheKey("expandQuery", { query: "alpha bravo", model });
+      store.setCachedResult(cacheKey, JSON.stringify([{ type: "lex", query: "zzzqqq wwwuuu" }]));
+
+      // intent disables the strong-signal bypass so the cached expansion is
+      // actually consulted; it no longer reaches the expansion model itself.
+      await hybridQuery(store, "alpha bravo", { limit: 5, minScore: 0, skipRerank: true, intent: "unrelated meta commentary" });
+
+      // The dud expansion found nothing — it must not survive to poison the
+      // next warm repeat of this query.
+      expect(store.getCachedResult(cacheKey)).toBeNull();
+    } finally {
+      await cleanupTestDb(store);
+    }
+  });
+
+  test("hybridQuery keeps a cached expansion that contributed results", async () => {
+    const store = await createTestStore();
+    try {
+      await insertTestDocument(store.db, "docs", {
+        name: "alpha",
+        title: "Alpha Bravo",
+        body: "# Alpha\n\nalpha bravo charlie content.",
+      });
+      const model = store.llm?.generateModelName ?? DEFAULT_QUERY_MODEL;
+      const cacheKey = getCacheKey("expandQuery", { query: "alpha bravo", model });
+      store.setCachedResult(cacheKey, JSON.stringify([{ type: "lex", query: "charlie" }]));
+
+      await hybridQuery(store, "alpha bravo", { limit: 5, minScore: 0, skipRerank: true, intent: "unrelated meta commentary" });
+
+      expect(store.getCachedResult(cacheKey)).not.toBeNull();
     } finally {
       await cleanupTestDb(store);
     }


### PR DESCRIPTION
## What

Two coupled fixes to auto-expansion:

1. `expandQuery()` consumes **only the query text** — caller `intent` no longer enters the expansion prompt or the expansion cache key. Intent keeps doing its real jobs downstream: the reranker query prefix and keyword-based chunk/snippet selection (both unchanged).
2. `hybridQuery()` deletes a cached expansion whose runnable sub-queries all came back empty, so a dud expansion can't deterministically replay the same misses on every warm repeat of the query.

## Why

When `intent` is passed to the MCP `query` tool — which the server's own instructions tell every client to always do — the expansion model builds sub-queries from the *intent's* meta-language instead of the query. Production cache rows (agent MCP clients, 83.5k-doc index) captured it directly; the worst case was an expansion whose **every** lex/vec/hyde line was the caller's intent string verbatim:

```
[{"type":"lex","query":"post-purge retest of the exact poisoned auto-expand query"},
 {"type":"vec","query":"post-purge retest of the exact poisoned auto-expand query"}, ...]
```

Degenerate terms match nothing → empty results; the dud is cached per `(query, intent)` → deterministic empties on every warm repeat. Control on the same index: the identical query returned **20 relevant hits without intent, zero with it**. The `hasQueryTerm` output filter doesn't catch this because real-world intents share vocabulary with their queries.

The finetune data does condition on intent, but only in a small slice of examples with short task-style intents ("optimizing a C++ application"); free-form agent intents are far outside that distribution and get reproduced verbatim.

After this fix, the exact production repro (same query, same intent, same index) returns **5 relevant hits in 8.9s** where it previously returned zero — and dropping intent from the cache key orphans all previously poisoned entries without needing a purge.

## Details

- The empty-contribution invalidation only judges sub-queries the store could actually run: on FTS-only stores, vec/hyde expansions never execute and say nothing about the expansion's quality (guards against invalidate/regenerate thrash).
- `ExpandQueryOptions.intent` is deprecated (accepted, ignored) for API compatibility; `SearchOptions.intent` is unchanged. The instructions' "always provide `intent`" guidance becomes safe again with this in place.
- If you'd rather keep intent-conditioned expansion and instead harden the output filter or the finetune distribution, happy to rework — this shape is the smallest change that stops the poisoning.

## Testing

- New tests in `test/store.test.ts`: cached expansions serve without invoking the LLM; a cached expansion contributing nothing is dropped by `hybridQuery`; a contributing one survives. 226/226 pass; `test/structured-search.test.ts` 75/75; `tsc -p tsconfig.build.json --noEmit` clean.
- Live verification against the production index that surfaced the bug: the previously poisoned `(query, intent)` pair now returns 5 hits in 8.9s via `store.search`.
