### PR TITLE
fix(llm): gracefully fall back when reranker context creation fails

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -1212,7 +1212,11 @@ export class LlamaCpp implements LLM {
                 ...(threads > 0 ? { threads } : {}),
               }));
             } catch {
-              throw new Error("Failed to create any rerank context");
+              console.warn(
+                "Reranker unavailable — skipping reranking. " +
+                "Use --no-rerank to silence this warning.",
+              );
+              return [];
             }
           }
           break;
@@ -1561,6 +1565,12 @@ export class LlamaCpp implements LLM {
     this.touchActivity();
 
     const contexts = await this.ensureRerankContexts();
+    if (contexts.length === 0) {
+      return {
+        results: documents.map((d) => ({ ...d, score: 0.5, index: 0 })),
+        model: "fallback",
+      };
+    }
     const model = await this.ensureRerankModel();
 
     // Truncate documents that would exceed the rerank context size.


### PR DESCRIPTION
## Problem

When ensureRerankContexts() fails to create any rerank context (e.g. due to VRAM limits, model incompatibility, or GPU driver issues), the current code throws an uncaught error that crashes the entire qmd query pipeline. This happens even when search + embedding succeed.

Fixes #721.

## Root cause

Two issues compound:

1. In ensureRerankContexts(), the inner catch block throws an uncaught error.

2. In rerank(), there is no guard for empty contexts after ensureRerankContexts().

## Fix

1. ensureRerankContexts(): Replace throw with console.warn and return empty array.

2. rerank(): Add null-check. If no contexts, return documents with neutral score so RRF results are still returned.

## Verification

Tested on Linux (CachyOS, NVIDIA RTX 5060 Laptop 8GB) with Qwen3-Embedding/Reranker models. qmd query no longer crashes, warning printed, results returned via RRF.