### PR TITLE
test: post-commit hyphen BM25 regression coverage

### DIFF
--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1638,6 +1638,35 @@ describe("FTS Search", () => {
 
     await cleanupTestDb(store);
   });
+
+  test("searchFTS matches hyphenated git-hook terms like post-commit", async () => {
+    // Regression: v1.0.0 stripped hyphens (post-commit → postcommit) while the
+    // unicode61 tokenizer indexes the body as adjacent tokens post + commit.
+    const store = await createTestStore();
+    const collectionName = await createTestCollection();
+
+    await insertTestDocument(store.db, collectionName, {
+      name: "hook-doc",
+      title: "QMD post-commit hook regression",
+      body: "The repo-local post-commit hook chains to ~/.githooks dispatcher.",
+      displayPath: "test/hook-doc.md",
+    });
+
+    await insertTestDocument(store.db, collectionName, {
+      name: "other-doc",
+      title: "Unrelated",
+      body: "Gardening and cooking with no hooks.",
+      displayPath: "test/other.md",
+    });
+
+    const single = store.searchFTS("post-commit", 10);
+    expect(single.map(r => r.displayPath)).toContain(`${collectionName}/test/hook-doc.md`);
+
+    const multi = store.searchFTS("post-commit hook dispatcher", 10);
+    expect(multi.map(r => r.displayPath)).toContain(`${collectionName}/test/hook-doc.md`);
+
+    await cleanupTestDb(store);
+  });
 });
 
 // =============================================================================

--- a/test/structured-search.test.ts
+++ b/test/structured-search.test.ts
@@ -572,6 +572,16 @@ describe("buildFTS5Query (lex parser)", () => {
     expect(buildFTS5Query("gpt-4")).toBe('"gpt 4"');
   });
 
+  test("git-hook style hyphenated term post-commit → phrase match (#regression v1.0.0)", () => {
+    expect(buildFTS5Query("post-commit")).toBe('"post commit"');
+  });
+
+  test("post-commit in multi-term query does not concatenate into postcommit", () => {
+    expect(buildFTS5Query("qmd embed index post-commit hook")).toBe(
+      '"qmd"* AND "embed"* AND "index"* AND "post commit" AND "hook"*'
+    );
+  });
+
   test("multi-hyphen term → phrase match", () => {
     expect(buildFTS5Query("foo-bar-baz")).toBe('"foo bar baz"');
   });


### PR DESCRIPTION
## Summary

Adds regression tests for hyphenated git-hook terms like `post-commit` in BM25 search.

v1.0.0 stripped hyphens in `sanitizeFTS5Term` (`post-commit` → `postcommit`) while FTS5 `unicode61` indexes body text as adjacent `post` + `commit` tokens. Strict-AND multi-term queries then returned zero hits even when vsearch found the doc.

The lexer fix landed in 2.5+ (`isHyphenatedToken` / `sanitizeHyphenatedTerm`); these tests lock the behaviour so it does not regress.

## Test plan

- [x] `bun test test/structured-search.test.ts -t post-commit`
- [x] `bun test test/store.test.ts -t post-commit`


Made with [Cursor](https://cursor.com)