### PR TITLE
fix(embed): session reliability — 120min cap, configured-model pending count, node-llama-cpp 3.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Default embed session cap (`DEFAULT_EMBED_MAX_DURATION_MS`) raised from 30 to
+  120 minutes. A full re-embed of a mid-size index (e.g. ~1,500 documents with a
+  4B embedding model) takes ~40 minutes and was silently truncated at the
+  30-minute mark, leaving remaining chunks marked "LLM session expired". The
+  `--timeout <minutes>` flag still overrides the cap and `--timeout 0` removes
+  it; re-running `qmd embed` resumes where a capped run left off.
+- `node-llama-cpp` upgraded 3.18.1 → 3.19.1 (llama.cpp b8390 → b10068). On
+  Apple Silicon running macOS 26.4, the Metal 4 tensor-API self-test probe
+  fails to JIT-compile (upstream llama.cpp#21048 fixed the probe dimensions,
+  but the probe still fails on M5 + macOS 26.4 — see tobi/qmd#735). On b8390
+  this failure was ungraceful: embed could deadlock at 0% CPU mid-run
+  (node-llama-cpp#595). On b10068 the same probe failure degrades gracefully —
+  Metal stays enabled, tensor API disables cleanly, no deadlock. Stored vectors
+  verified compatible post-upgrade (`qmd doctor` vector-sample check passes).
+- README/CLAUDE.md: documented `qmd embed --timeout` alongside the memory flags
+  and updated CLI help text for the new default.
+
+### Fixed
+
+- `qmd update` and the single-collection reindex computed the "N unique hashes
+  need vectors" notice with the built-in default embedding model instead of the
+  configured one (`models.embed` in `index.yml` / `QMD_EMBED_MODEL`). With a
+  non-default embedding model, every active hash was falsely reported as
+  needing vectors after each update. Both call sites now resolve the configured
+  model, matching `qmd status` and `qmd embed`.
+
 ## [2.6.3] - 2026-06-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ qmd status                        # Show index status and collections
 qmd doctor                        # Diagnose config, index, model, and device issues
 qmd update                        # Re-index collections; configured update hooks run first
 qmd embed                         # Generate vector embeddings (uses node-llama-cpp)
+qmd embed --timeout <minutes>     # Override the embed session cap (default 120; 0 = no limit)
 qmd query <query>                 # Search with query expansion + reranking (recommended)
 qmd search <query>                # Full-text keyword search (BM25, no LLM)
 qmd vsearch <query>               # Vector similarity search (no reranking)

--- a/README.md
+++ b/README.md
@@ -615,6 +615,10 @@ qmd query "auth flow" --chunk-strategy auto
 # Memory control for large corpora / constrained systems
 qmd embed --max-docs-per-batch 50   # cap docs per embedding batch
 qmd embed --max-batch-mb 64         # cap batch size in MB
+
+# Time control for very large indexes
+qmd embed --timeout 180             # extend the embed session cap (default 120 min)
+qmd embed --timeout 0               # remove the cap entirely
 ```
 
 **AST-aware chunking** (`--chunk-strategy auto`) uses tree-sitter to chunk code

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@modelcontextprotocol/sdk": "1.29.0",
         "better-sqlite3": "12.10.0",
         "fast-glob": "3.3.3",
-        "node-llama-cpp": "3.18.1",
+        "node-llama-cpp": "3.19.1",
         "picomatch": "4.0.4",
         "sqlite-vec": "0.1.9",
         "tree-sitter-go": "0.25.0",
@@ -36,6 +36,9 @@
       },
     },
   },
+  "trustedDependencies": [
+    "node-llama-cpp",
+  ],
   "packages": {
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
@@ -103,31 +106,33 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@node-llama-cpp/linux-arm64": ["@node-llama-cpp/linux-arm64@3.18.1", "", { "os": "linux", "cpu": [ "x64", "arm64", ] }, "sha512-rXMgZxUay78FOJV/fJ67apYP9eElH5jd4df5YRKPlLhLHHchuOSyDn+qtyW/L/EnPzpogoLkmULqCkdXU39XsQ=="],
+    "@node-llama-cpp/linux-arm64": ["@node-llama-cpp/linux-arm64@3.19.1", "", { "os": "linux", "cpu": [ "x64", "arm64", ] }, "sha512-lDfmsN2ChkfM9vcglYoJ8jiaQACTF/bMgdO/owkzhNLdFkIFI6eAqSFaBsCsYq53BspN/JTssle7QOOI+nDx3A=="],
 
-    "@node-llama-cpp/linux-armv7l": ["@node-llama-cpp/linux-armv7l@3.18.1", "", { "os": "linux", "cpu": [ "arm", "x64", ] }, "sha512-BrJL2cGo0pN5xd5nw+CzTn2rFMpz9MJyZZPUY81ptGkF2uIuXT2hdCVh56i9ImQrTwBfq1YcZL/l/Qe/1+HR/Q=="],
+    "@node-llama-cpp/linux-armv7l": ["@node-llama-cpp/linux-armv7l@3.19.1", "", { "os": "linux", "cpu": [ "arm", "x64", ] }, "sha512-7z15VVqb9vjnidUxVDlkOlSmBCsVsH+5cAYzOCXJm97XiQE9julGeAtWh/H/3D2Mkt/ABy2V8rMsGA5FwP3y0A=="],
 
-    "@node-llama-cpp/linux-x64": ["@node-llama-cpp/linux-x64@3.18.1", "", { "os": "linux", "cpu": "x64" }, "sha512-tRmWcsyvAcqJHQHXHsaOkx6muGbcirA9nRdNgH6n7bjGUw4VuoBD3dChyNF3/Ktt7ohB9kz+XhhyZjbDHpXyMA=="],
+    "@node-llama-cpp/linux-riscv64": ["@node-llama-cpp/linux-riscv64@3.19.1", "", { "os": "linux", "cpu": "none" }, "sha512-FUQe5ur6k9d2/2TLoz42+66wHVZed4kUNBUZVqqv6jq2pmFClMHOtgkTZOKGMaUvr+XAQwQkS8y2oTjpbJJ6fg=="],
 
-    "@node-llama-cpp/linux-x64-cuda": ["@node-llama-cpp/linux-x64-cuda@3.18.1", "", { "os": "linux", "cpu": "x64" }, "sha512-qOaYP4uwsUoBHQ/7xSOvyJIuXapS57Al+Sudgi00f96ldNZLKe1vuSGptAi5LTM2lIj66PKm6h8PlRWctwsZ2g=="],
+    "@node-llama-cpp/linux-x64": ["@node-llama-cpp/linux-x64@3.19.1", "", { "os": "linux", "cpu": "x64" }, "sha512-ntnV8GLeuuGwp5eS5aCxmF0oo4OjjDo6LTWJGJhuieLF6SwMlfbqxCYh3yo1lcepeNf2uCHnXMydyCVnqLWJcQ=="],
 
-    "@node-llama-cpp/linux-x64-cuda-ext": ["@node-llama-cpp/linux-x64-cuda-ext@3.18.1", "", { "os": "linux", "cpu": "x64" }, "sha512-VqyKhAVHPCpFzh0f1koCBgpThL+04QOXwv0oDQ8s8YcpfMMOXQlBhTB0plgTh0HrPExoObfTS4ohkrbyGgmztQ=="],
+    "@node-llama-cpp/linux-x64-cuda": ["@node-llama-cpp/linux-x64-cuda@3.19.1", "", { "os": "linux", "cpu": "x64" }, "sha512-jm6+tBVvIbNLaajVAAzoUWvoMOoKa/P0rUpwX9UAJJJthM3gigy+UshG7fVMtt+ExFapy5MPSWDNKvjwWIt67Q=="],
 
-    "@node-llama-cpp/linux-x64-vulkan": ["@node-llama-cpp/linux-x64-vulkan@3.18.1", "", { "os": "linux", "cpu": "x64" }, "sha512-SIaNTK5pUPhwJD0gmiQfHa8OrRctVMmnqu+slJrz2Mzgg/XrwFndJlS9hvc+jSjTXCouwf7sYeQaaJWvQgBh/A=="],
+    "@node-llama-cpp/linux-x64-cuda-ext": ["@node-llama-cpp/linux-x64-cuda-ext@3.19.1", "", { "os": "linux", "cpu": "x64" }, "sha512-7xi2XMB0HBvFRYjfMMLjv6Su2roA3EZl9siJpxim716Oume017Lk1hF/72Mn0XnKfQWd2Z9vfstFTvEYTfZ0WQ=="],
 
-    "@node-llama-cpp/mac-arm64-metal": ["@node-llama-cpp/mac-arm64-metal@3.18.1", "", { "os": "darwin", "cpu": [ "x64", "arm64", ] }, "sha512-cyZTdsUMlvuRlGmkkoBbN3v/DT6NuruEqoQYd9CqIrPyLa1xLNBTSKIZ9SgRnw23iCOj4URfITvRP+2pu63LuQ=="],
+    "@node-llama-cpp/linux-x64-vulkan": ["@node-llama-cpp/linux-x64-vulkan@3.19.1", "", { "os": "linux", "cpu": "x64" }, "sha512-VcNq3bKEbOkUernV6HFSmD4WrxL37rTdumPlMcVnQFvzC9q+P3gLKxRCLeqpJ26wU/iMHqzlz1/fOMwn9FWjDw=="],
 
-    "@node-llama-cpp/mac-x64": ["@node-llama-cpp/mac-x64@3.18.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-GfCPgdltaIpBhEnQ7WfsrRXrZO9r9pBtDUAQMXRuJwOPP5q7xKrQZUXI6J6mpc8tAG0//CTIuGn4hTKoD/8V8w=="],
+    "@node-llama-cpp/mac-arm64-metal": ["@node-llama-cpp/mac-arm64-metal@3.19.1", "", { "os": "darwin", "cpu": [ "x64", "arm64", ] }, "sha512-M4ignq2Hhru35/zPrTAxUsuHOK96Hk7xeY1Oj9+Gty6XQ4dEmVUPwEYpB9ra3D0vTxQaMgFt4pj8L+gTR5u9fg=="],
 
-    "@node-llama-cpp/win-arm64": ["@node-llama-cpp/win-arm64@3.18.1", "", { "os": "win32", "cpu": [ "x64", "arm64", ] }, "sha512-S05YUzBMVSRS5KNbOS26cDYugeQHqogI3uewtTUBVC0tPbTHRSKjsdicmgWru1eNAry399LWWhzOf/3St/qsAw=="],
+    "@node-llama-cpp/mac-x64": ["@node-llama-cpp/mac-x64@3.19.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-wDv1cuxDopj3ZF3fCCJtcn++ypb8h6QIH8yFevijxeMCaFqSzWm1o/uLkiXiEE2pbb9tq5uCD1x4Ss+iJvCs9w=="],
 
-    "@node-llama-cpp/win-x64": ["@node-llama-cpp/win-x64@3.18.1", "", { "os": "win32", "cpu": "x64" }, "sha512-QLDVphPl+YDI+x/VYYgIV1N9g0GMXk3PqcoopOUG3cBRUtce7FO+YX903YdRJezs4oKbIp8YaO+xYBgeUSqhpA=="],
+    "@node-llama-cpp/win-arm64": ["@node-llama-cpp/win-arm64@3.19.1", "", { "os": "win32", "cpu": [ "x64", "arm64", ] }, "sha512-mmzC7bydEn/D0IJXMJ1GT/WSu48u/oIkwMPvo1G51JI/QoG1mRsdx0dBFvPVfraIveSvLCvV09ZbGpm2SdgMMg=="],
 
-    "@node-llama-cpp/win-x64-cuda": ["@node-llama-cpp/win-x64-cuda@3.18.1", "", { "os": "win32", "cpu": "x64" }, "sha512-drgJmBhnxGQtB/SLo4sf4PPSuxRv3MdNP0FF6rKPY9TtzEOV293bRQyYEu/JYwvXfVApAIsRaJUTGvCkA9Qobw=="],
+    "@node-llama-cpp/win-x64": ["@node-llama-cpp/win-x64@3.19.1", "", { "os": "win32", "cpu": "x64" }, "sha512-BpWFyyj0om2fFLoA3JpANepw0vdQiaalvc4pooH5NN2N7i9yutTEgXpn2s+qVpryM+NCT6WrfV/kN/oRfCowNw=="],
 
-    "@node-llama-cpp/win-x64-cuda-ext": ["@node-llama-cpp/win-x64-cuda-ext@3.18.1", "", { "os": "win32", "cpu": "x64" }, "sha512-u0FzJBQsJA355ksKERxwPJhlcWl3ZJSNkU2ZUwDEiKNOCbv3ybvSCIEyDvB63wdtkfVUuCRJWijZnpDZxrCGqg=="],
+    "@node-llama-cpp/win-x64-cuda": ["@node-llama-cpp/win-x64-cuda@3.19.1", "", { "os": "win32", "cpu": "x64" }, "sha512-uDeiuXvj871az+QfxjRNb2/frUiH3KnW6J2f73AL5mQoZuunyt4i/Bq25RjfE6kS8aZopBwCjRfzN/P+KxPC/g=="],
 
-    "@node-llama-cpp/win-x64-vulkan": ["@node-llama-cpp/win-x64-vulkan@3.18.1", "", { "os": "win32", "cpu": "x64" }, "sha512-PjmxrnPToi7y0zlP7l+hRIhvOmuEv94P6xZ11vjqICEJu8XdAJpvTfPKgDW4W0p0v4+So8ZiZYLUuwIHcsseyQ=="],
+    "@node-llama-cpp/win-x64-cuda-ext": ["@node-llama-cpp/win-x64-cuda-ext@3.19.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6WDpsUkkLbYbfipAgb3UiFqze21DYLefkU/hpnXcMXK6SwkfmMl5VTbbi4giXBWWD+Rxw/7lu8bUQoCRO2XuvQ=="],
+
+    "@node-llama-cpp/win-x64-vulkan": ["@node-llama-cpp/win-x64-vulkan@3.19.1", "", { "os": "win32", "cpu": "x64" }, "sha512-yFk9sk6Eph8Kmxsp/r7lzerpAX0j3xPKHOfetjIWxSQr81fvs8RHpOqAfc+YjbTI9iQe989LDV0A1kNuq8MnDw=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -515,7 +520,7 @@
 
     "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
-    "node-llama-cpp": ["node-llama-cpp@3.18.1", "", { "dependencies": { "@huggingface/jinja": "^0.5.6", "async-retry": "^1.3.3", "bytes": "^3.1.2", "chalk": "^5.6.2", "chmodrp": "^1.0.2", "cmake-js": "^8.0.0", "cross-spawn": "^7.0.6", "env-var": "^7.5.0", "filenamify": "^6.0.0", "fs-extra": "^11.3.4", "ignore": "^7.0.4", "ipull": "^3.9.5", "is-unicode-supported": "^2.1.0", "lifecycle-utils": "^3.1.1", "log-symbols": "^7.0.1", "nanoid": "^5.1.6", "node-addon-api": "^8.6.0", "ora": "^9.3.0", "pretty-ms": "^9.3.0", "proper-lockfile": "^4.1.2", "semver": "^7.7.1", "simple-git": "^3.33.0", "slice-ansi": "^8.0.0", "stdout-update": "^4.0.1", "strip-ansi": "^7.2.0", "validate-npm-package-name": "^7.0.2", "which": "^6.0.1", "yargs": "^17.7.2" }, "optionalDependencies": { "@node-llama-cpp/linux-arm64": "3.18.1", "@node-llama-cpp/linux-armv7l": "3.18.1", "@node-llama-cpp/linux-x64": "3.18.1", "@node-llama-cpp/linux-x64-cuda": "3.18.1", "@node-llama-cpp/linux-x64-cuda-ext": "3.18.1", "@node-llama-cpp/linux-x64-vulkan": "3.18.1", "@node-llama-cpp/mac-arm64-metal": "3.18.1", "@node-llama-cpp/mac-x64": "3.18.1", "@node-llama-cpp/win-arm64": "3.18.1", "@node-llama-cpp/win-x64": "3.18.1", "@node-llama-cpp/win-x64-cuda": "3.18.1", "@node-llama-cpp/win-x64-cuda-ext": "3.18.1", "@node-llama-cpp/win-x64-vulkan": "3.18.1" }, "peerDependencies": { "typescript": ">=5.0.0" }, "optionalPeers": ["typescript"], "bin": { "node-llama-cpp": "dist/cli/cli.js", "nlc": "dist/cli/cli.js" } }, "sha512-w0zfuy/IKS2fhrbed5SylZDXJHTVz4HnkwZ4UrFPgSNwJab3QIPwIl4lyCKHHy9flLrtxsAuV5kXfH3HZ6bb8w=="],
+    "node-llama-cpp": ["node-llama-cpp@3.19.1", "", { "dependencies": { "@huggingface/jinja": "^0.5.6", "async-retry": "^1.3.3", "bytes": "^3.1.2", "chalk": "^5.6.2", "chmodrp": "^1.0.2", "cmake-js": "^8.0.0", "cross-spawn": "^7.0.6", "env-var": "^7.5.0", "filenamify": "^6.0.0", "fs-extra": "^11.3.4", "ignore": "^7.0.4", "ipull": "^3.9.5", "is-unicode-supported": "^2.1.0", "lifecycle-utils": "^3.1.1", "log-symbols": "^7.0.1", "nanoid": "^5.1.6", "node-addon-api": "^8.6.0", "ora": "^9.3.0", "pretty-ms": "^9.3.0", "proper-lockfile": "^4.1.2", "semver": "^7.7.1", "simple-git": "^3.33.0", "slice-ansi": "^8.0.0", "stdout-update": "^4.0.1", "strip-ansi": "^7.2.0", "validate-npm-package-name": "^7.0.2", "which": "^6.0.1", "yargs": "^17.7.2" }, "optionalDependencies": { "@node-llama-cpp/linux-arm64": "3.19.1", "@node-llama-cpp/linux-armv7l": "3.19.1", "@node-llama-cpp/linux-riscv64": "3.19.1", "@node-llama-cpp/linux-x64": "3.19.1", "@node-llama-cpp/linux-x64-cuda": "3.19.1", "@node-llama-cpp/linux-x64-cuda-ext": "3.19.1", "@node-llama-cpp/linux-x64-vulkan": "3.19.1", "@node-llama-cpp/mac-arm64-metal": "3.19.1", "@node-llama-cpp/mac-x64": "3.19.1", "@node-llama-cpp/win-arm64": "3.19.1", "@node-llama-cpp/win-x64": "3.19.1", "@node-llama-cpp/win-x64-cuda": "3.19.1", "@node-llama-cpp/win-x64-cuda-ext": "3.19.1", "@node-llama-cpp/win-x64-vulkan": "3.19.1" }, "peerDependencies": { "typescript": ">=5.0.0" }, "optionalPeers": ["typescript"], "bin": { "node-llama-cpp": "dist/cli/cli.js", "nlc": "dist/cli/cli.js" } }, "sha512-i3yq1IHSg+ugdl78/noPeYvtMFIMBaW10nWl0KIXoES9P7HCnrKT3yhpO4p08bib7YJ1boFdnibg8znOILzpCA=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 

--- a/finetune/AGENTS.md
+++ b/finetune/AGENTS.md
@@ -1,0 +1,103 @@
+# finetune/ — Python ML Pipeline
+
+Fine-tunes Qwen3-1.7B to expand QMD search queries into `hyde:` / `lex:` / `vec:` structured output. **Isolated from `src/`** — no Python imports the TS runtime; the bridge is a HuggingFace-hosted GGUF file consumed by `src/llm.ts`.
+
+## STRUCTURE
+
+```
+finetune/
+├── train.py                # 670 lines — SFT entrypoint (LoRA on Qwen3-1.7B)
+├── reward.py               # 698 lines — SCORING SOURCE OF TRUTH (5 dimensions, max 140 pts)
+├── eval.py                 # 194 lines — generate expansions + score them
+├── eval_retrieval.py       # 488 lines — retrieval-quality eval (separate from reward.py)
+├── benchmark.py            # 182 lines — model comparison harness
+├── convert_gguf.py         # 221 lines — base + adapter merge → quantized GGUF
+├── convert_onnx.py         # 461 lines — ONNX export path (alternative to GGUF)
+├── train_unsloth.py        # 198 lines — Unsloth-optimized SFT variant
+├── SCORING.md              # full rubric (read this before touching reward.py)
+├── CLAUDE.md               # canonical contributor doc (read first)
+├── README.md               # HuggingFace model card
+├── Justfile                # common commands (validate, eval, etc.)
+├── Modelfile               # Ollama import template
+├── pyproject.toml          # uv-managed deps (torch, trl, peft, transformers, accelerate)
+├── dataset/
+│   ├── schema.py           # 244 lines — Pydantic `TrainingExample` + `load_examples()`
+│   ├── prepare_data.py     # 184 lines — chat-template format + dedup + train/val split
+│   ├── validate_schema.py  # 88 lines — JSONL validator (CI gate)
+│   ├── score_data.py       # 96 lines — score all examples via reward.py
+│   ├── analyze_data.py     # 243 lines — distribution + quality analysis
+│   └── prepare_data_lfm2.py # 85 lines — LFM2-specific prep (experimental)
+├── data/                   # 13 JSONL files (~2,290 examples) + train/ (ephemeral build artifacts)
+├── configs/                # 4 YAML: sft.yaml, sft_local.yaml, sft-lfm2.yaml, accelerate_multi_gpu.yaml
+├── evals/queries.txt       # 80 test queries (8 categories)
+├── jobs/                   # HuggingFace Jobs scripts (sft.py, eval.py, eval_common.py)
+└── experiments/            # NOT PRODUCTION — gepa/, grpo/, lfm2/
+```
+
+## WHERE TO LOOK
+
+| Task | Start here |
+|------|-----------|
+| Change scoring rubric | `reward.py` (then update `SCORING.md`) |
+| Change training recipe | `train.py` + `configs/sft.yaml` |
+| Add new training data | Drop `.jsonl` into `data/` (must pass `dataset/schema.py`) |
+| Validate data | `uv run dataset/validate_schema.py` |
+| Prepare train/val split | `uv run dataset/prepare_data.py` (writes to `data/train/`, ephemeral) |
+| Run SFT locally | `uv run train.py sft --config configs/sft_local.yaml` (needs CUDA) |
+| Run SFT on HF Jobs | `hf jobs uv run --flavor a10g-large --secrets HF_TOKEN --timeout 2h jobs/sft.py` |
+| Evaluate model | `uv run eval.py tobil/qmd-query-expansion-1.7B` |
+| Convert to GGUF | `uv run convert_gguf.py --size 1.7B` |
+| Inspect dataset stats | `uv run dataset/analyze_data.py` |
+
+## CONVENTIONS
+
+- **`uv` only — never `pip`.** `uv run <script>` resolves deps from `pyproject.toml` + `uv.lock`.
+- **Python ≥3.10.** Use modern syntax (`match`, PEP 604 unions, `from __future__ import annotations` not needed).
+- **Strict Pydantic schema** — every JSONL row must validate against `dataset/schema.py:TrainingExample`. No legacy fallbacks. Run `validate_schema.py` before committing data.
+- **All `.jsonl` in `data/` are concatenated + deduplicated** for training. The `data/train/*.jsonl` files are ephemeral outputs of `prepare_data.py` — do not edit them directly.
+- **Base model is always `Qwen/Qwen3-1.7B`.** Don't substitute without a separate experiment branch.
+- **Prompt format: Qwen3 chat template + `/no_think`.** Suppresses CoT mode; produces direct `lex:/vec:/hyde:` output without `<think>` blocks.
+- **Output order: `hyde:` FIRST.** Then `lex:` lines, then `vec:` lines. `reward.py` enforces this.
+- **HuggingFace repos are unversioned.** Update in place — never push `*-v1`, `*-v2` suffixes. See `CLAUDE.md:48`.
+- **Justfile** is the canonical command surface — `just validate`, `just eval`, etc. Mirror new commands there.
+
+## ANTI-PATTERNS
+
+Inherits all root rules. Plus:
+
+| Rule | Why |
+|------|-----|
+| **NEVER** use `pip install` | Use `uv` — `uv.lock` is the source of truth |
+| **NEVER** create versioned HF repos (`-v2`, `-v3`) | Update `tobil/qmd-query-expansion-1.7B` in place. Past `-v2`, `-v3` repos exist as historical mistakes. |
+| **NEVER** add a new JSONL field without updating `dataset/schema.py` | Pydantic fails loudly. Extra metadata fields are allowed but ignored — don't depend on them downstream. |
+| **NEVER** reorder the output format (`lex:` before `hyde:`) | Reward function deducts heavily; downstream QMD parser expects `hyde:` first |
+| **NEVER** push a model without eval results in the model card | Blocker for deployment |
+| **NEVER** run `train.py grpo` expecting production output | GRPO lives in `experiments/grpo/` — see "Production path is SFT-only" note in `README.md` |
+| **NEVER** use `<think>` mode in Qwen3 prompts | The `/no_think` directive is mandatory. `<think>` triggers CoT which breaks the output format. |
+
+## UNIQUE STYLES
+
+- **`reward.py` is the single source of truth** for what "good expansion" means. Five dimensions:
+  - Format (0-30): has `lex/vec` lines, no invalid lines
+  - Diversity (0-30): multiple types, no query echoes
+  - HyDE (0-20): 50-200 chars, single line, not repetitive
+  - Quality (0-20): `lex` shorter than `vec`, natural language
+  - Entity (-45 to +20): named entities preserved (negative scoring for loss)
+  - Think bonus (0-20): reward for NOT using `<think>` mode
+  - Max: 140 with hyde, 120 without
+- **Hard failures (instant 0.0):** chat template leakage (`<|im_start|>`, `<|im_end|>`), any line without valid `lex:`/`vec:`/`hyde:` prefix.
+- **`experiments/` is a sandbox** — three independent tracks:
+  - `gepa/` — DSPy-based prompt optimization
+  - `grpo/` — experimental RL recipe (NOT in production path as of v2.6.3)
+  - `lfm2/` — LiquidAI LFM2-1.2B alternative (hybrid arch, faster inference)
+- **`jobs/` scripts are self-contained** — they re-import shared code from `jobs/eval_common.py` but don't depend on the parent `finetune/` package being installed. Each can run standalone on HuggingFace Jobs hardware.
+- **`convert_onnx.py` is an alternative export path** (not GGUF). Used for browser-deployable runtimes (Transformers.js, ONNX Runtime Web). Not currently in production.
+
+## NOTES
+
+- **Cross-stack contract:** Output of this pipeline → `tobil/qmd-query-expansion-1.7B-gguf`. `src/llm.ts:DEFAULT_GENERATE_MODEL` references that repo. Changing the output format (e.g. adding a new prefix beyond `lex/vec/hyde`) requires coordinated updates in both repos.
+- **Eval scores are the deploy gate.** Only push to `tobil/qmd-query-expansion-1.7B-gguf` if eval improves over current deployed model. Always attach eval JSON to the HF model card.
+- **`SCORING.md` is the rubric reference.** Read it before editing `reward.py` — the deductions are subtle and interlocking.
+- **`eval_retrieval.py`** is a separate retrieval-quality eval (end-to-end search quality), distinct from `eval.py` (which scores format compliance via `reward.py`). Both matter; they measure different things.
+- **`train_unsloth.py`** uses Unsloth for faster LoRA training on consumer GPUs. Falls back to standard TRL `SFTTrainer` if Unsloth is unavailable.
+- **See also:** `CLAUDE.md` (canonical contributor guide), `SCORING.md` (rubric), `../AGENTS.md` (root).

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@modelcontextprotocol/sdk": "1.29.0",
     "better-sqlite3": "12.10.0",
     "fast-glob": "3.3.3",
-    "node-llama-cpp": "3.18.1",
+    "node-llama-cpp": "3.19.1",
     "picomatch": "4.0.4",
     "sqlite-vec": "0.1.9",
     "tree-sitter-go": "0.25.0",
@@ -118,5 +118,8 @@
     "llm"
   ],
   "author": "Tobi Lutke <tobi@lutke.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "trustedDependencies": [
+    "node-llama-cpp"
+  ]
 }

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -740,7 +740,7 @@ async function updateCollections(): Promise<void> {
   }
 
   // Check if any documents need embedding (show once at end)
-  const needsEmbedding = getHashesNeedingEmbedding(db);
+  const needsEmbedding = getHashesNeedingEmbedding(db, undefined, resolveEmbedModelForCli());
   closeDb();
 
   console.log(`${c.green}✓ All collections updated.${c.reset}`);
@@ -1773,7 +1773,7 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
   const orphanedContent = cleanupOrphanedContent(db);
 
   // Check if vector index needs updating
-  const needsEmbedding = getHashesNeedingEmbedding(db);
+  const needsEmbedding = getHashesNeedingEmbedding(db, undefined, resolveEmbedModelForCli());
 
   progress.clear();
   console.log(`\nIndexed: ${indexed} new, ${updated} updated, ${unchanged} unchanged, ${removed} removed`);

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -2749,7 +2749,7 @@ function parseCLI() {
       force: { type: "boolean", short: "f" },
       "max-docs-per-batch": { type: "string" },
       "max-batch-mb": { type: "string" },
-      timeout: { type: "string" },  // embed session cap in minutes (0 = no limit; default 30)
+      timeout: { type: "string" },  // embed session cap in minutes (0 = no limit; default 120)
       // Update options
       pull: { type: "boolean" },  // git pull before update
       refresh: { type: "boolean" },
@@ -3288,7 +3288,7 @@ function showHelp(): void {
   console.log("  qmd embed [-f] [-c <name>]    - Generate/refresh vector embeddings");
   console.log("    --max-docs-per-batch <n>    - Cap docs loaded into memory per embedding batch");
   console.log("    --max-batch-mb <n>          - Cap UTF-8 MB loaded into memory per embedding batch");
-  console.log("    --timeout <minutes>         - Embed session cap in minutes (0 = no limit; default 30)");
+    console.log("    --timeout <minutes>         - Embed session cap in minutes (0 = no limit; default 120)");
   console.log("  qmd cleanup                   - Clear caches, vacuum DB");
   console.log("");
   console.log("Query syntax (qmd query):");
@@ -3355,7 +3355,7 @@ function showHelp(): void {
   console.log("");
   console.log("Embed/query options:");
   console.log("  --chunk-strategy <auto|regex> - Chunking mode (default: regex; auto uses AST for code files)");
-  console.log("  --timeout <minutes>          - Embed session cap in minutes (0 = no limit; default 30)");
+  console.log("  --timeout <minutes>          - Embed session cap in minutes (0 = no limit; default 120)");
   console.log("");
   console.log("Multi-get options:");
   console.log("  -l <num>                   - Maximum lines per file");

--- a/src/store.ts
+++ b/src/store.ts
@@ -49,7 +49,7 @@ export const DEFAULT_GLOB = "**/*.md";
 export const DEFAULT_MULTI_GET_MAX_BYTES = 64 * 1024; // 64KB
 export const DEFAULT_EMBED_MAX_DOCS_PER_BATCH = 64;
 export const DEFAULT_EMBED_MAX_BATCH_BYTES = 64 * 1024 * 1024; // 64MB
-export const DEFAULT_EMBED_MAX_DURATION_MS = 30 * 60 * 1000; // 30 minutes; see EmbedOptions.maxDurationMs
+export const DEFAULT_EMBED_MAX_DURATION_MS = 120 * 60 * 1000; // 120 minutes; see EmbedOptions.maxDurationMs
 
 const EMBED_FINGERPRINT_PROBE_QUERY = "__qmd_embedding_query_probe__";
 const EMBED_FINGERPRINT_PROBE_TITLE = "__qmd_embedding_title_probe__";
@@ -1510,7 +1510,7 @@ export type EmbedOptions = {
    * Max wall-clock duration for the whole embed session, in milliseconds. When the
    * cap is reached, remaining document batches are skipped (re-run `qmd embed` to
    * continue). A value <= 0 disables the cap. Defaults to
-   * {@link DEFAULT_EMBED_MAX_DURATION_MS} (30 minutes).
+   * {@link DEFAULT_EMBED_MAX_DURATION_MS} (120 minutes).
    */
   maxDurationMs?: number;
   onProgress?: (info: EmbedProgress) => void;

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -3471,7 +3471,7 @@ describe("Embedding batching", () => {
       expect(sessionSpy).toHaveBeenCalledWith(
         fakeLlm,
         expect.any(Function),
-        expect.objectContaining({ maxDuration: 30 * 60 * 1000, name: "generateEmbeddings" }),
+        expect.objectContaining({ maxDuration: 120 * 60 * 1000, name: "generateEmbeddings" }),
       );
     } finally {
       sessionSpy.mockRestore();


### PR DESCRIPTION
## Summary

Three embed-pipeline reliability fixes, all surfaced by one real-world failure on macOS 26.4 (Apple M5 Max) where `qmd embed` died at exactly 30m08s with `⚠ Session expired — skipping 834 remaining chunks`:

1. **`fix(update)`** — post-update "N unique hashes need vectors" notice counted pending hashes against the *built-in default* embed model instead of the configured one, so anyone overriding `models.embed` / `QMD_EMBED_MODEL` got a false full-corpus warning after every `qmd update`.
2. **`fix(embed)`** — the default 30-minute embed session cap silently truncated full re-embeds of mid-size indexes (~1.5k docs with a 4B model needs ~40 min); remaining chunks were recorded as "LLM session expired before embedding chunk".
3. **`chore(deps)`** — node-llama-cpp 3.18.1 → 3.19.1 (llama.cpp b8390 → b10068), fixing a sporadic embed deadlock on Apple Silicon + macOS 26.4.

## Root causes & evidence

**Session expiry (cap).** `DEFAULT_EMBED_MAX_DURATION_MS` was 30 min; the observed run aborted at 30m08s exactly. The session wrapper (`withLLMSessionForLlm`) has no auto-renewal, so the remaining 834 chunks were dropped. `--timeout <minutes>` already existed to override it, but the default was too small for the corpora people actually have.

**False pending count.** After the backlog was cleared (`qmd doctor`: all 1,441 docs on the current fingerprint, 0 pending), `qmd update` still printed *"1263 unique hashes need vectors"* — and `COUNT(DISTINCT hash)` of active documents was exactly 1263. `updateCollections()`/`indexFiles()` called `getHashesNeedingEmbedding(db)` with no model argument; `showStatus()` and `embed` already resolve the configured model correctly. Both call sites fixed.

**Metal deadlock.** On macOS 26.4, llama.cpp's Metal 4 tensor-API self-test probe fails to JIT-compile (`ggml_metal_library_init_from_source: error compiling source`; matmul2d_descriptor static_assert in the 26.4 SDK's MetalPerformancePrimitives headers — see llama.cpp#21048 and #735). On b8390 (node-llama-cpp 3.18.1) this failure is ungraceful: we reproduced the reported hang (node-llama-cpp#595) — 15 wall minutes at 0% CPU after model load. On b10068 (3.19.1) the same probe failure degrades gracefully: Metal stays enabled, tensor API disables cleanly, no deadlock. Probe still fails upstream, so M5 tensor acceleration is not yet enabled — a future llama.cpp bump should recover a 2-3× prefill speedup.

## Verification

- `npm test` fully green: vitest 881 passed / 0 failed, bun 881 passed / 0 failed, package smoke (build + grammars + compiled CLI under Node and Bun) OK.
- `qmd doctor` post-upgrade: Metal backend enabled, **3 sampled chunks reproduce stored vectors** (fingerprint-compatible, no re-embed needed).
- Real `qmd update`: false pending notice gone.
- Real embed backlog completed (81 docs; fingerprint count 1,360 → 1,441), plus end-to-end `qmd query` smoke against newly embedded docs.

## Notes

- The bun `trustedDependencies` entry records the postinstall trust so `bun install` fetches the prebuilt binary without manual `bun pm trust`.
- The Metal probe error line still prints on stderr on macOS 26.4; it is cosmetic (graceful degradation), tracked upstream.
