### PR TITLE
feat(ast): add PHP Tree-sitter support, AST content enrichment, and template retrieval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   test-node:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build-flake:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- **PHP Tree-sitter Support**: AST-aware chunking support for `.php` files using `tree-sitter-php` WASM grammar.
+- **PHP AST Content Enrichment**: Framework-agnostic structural context propagation for PHP chunks (namespaces, containing types, inheritance, attributes, and PHPDoc comments) when using `--chunk-strategy auto`.
+- **Template-Aware Code Retrieval**: Dedicated template engine adapter architecture for Laravel Blade (`.blade.php`), Twig (`.twig`, `.html.twig`), Smarty (`.tpl`, `.smarty`), and Latte (`.latte`).
+
 ## [2.6.3] - 2026-06-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ bun test --preload ./src/test-preload.ts test/
 - node-llama-cpp for embeddings (embeddinggemma), reranking (qwen3-reranker), and query expansion (Qwen3)
 - Reciprocal Rank Fusion (RRF) for combining results
 - Smart chunking: 900 tokens/chunk with 15% overlap, prefers markdown headings as boundaries
-- AST-aware chunking: use `--chunk-strategy auto` to chunk code files (.ts/.js/.py/.go/.rs) at function/class/import boundaries via tree-sitter. Default is `regex` (existing behavior). Markdown and unknown file types always use regex chunking.
+- AST-aware chunking: use `--chunk-strategy auto` to chunk code files (.ts/.js/.py/.go/.rs/.php) at function/class/import boundaries via tree-sitter (with PHP AST structural context enrichment), plus template-aware retrieval for Blade (.blade.php), Twig (.twig), Smarty (.tpl), and Latte (.latte). Default is `regex` (existing behavior). Markdown and unknown file types always use regex chunking.
 
 ## Important: Do NOT run automatically
 

--- a/README.md
+++ b/README.md
@@ -618,10 +618,10 @@ qmd embed --max-batch-mb 64         # cap batch size in MB
 ```
 
 **AST-aware chunking** (`--chunk-strategy auto`) uses tree-sitter to chunk code
-files at function, class, and import boundaries instead of arbitrary text
-positions. This produces higher-quality chunks and better search results for
-codebases. Markdown and other file types always use regex-based chunking
-regardless of strategy.
+files at function, class, namespace, and import boundaries instead of arbitrary text
+positions, and enriches PHP chunks with structural context (namespace, class, methods, attributes, PHPDoc).
+It also provides template-aware chunking for Blade (`.blade.php`), Twig (`.twig`), Smarty (`.tpl`), and Latte (`.latte`).
+This produces higher-quality chunks and better search results for codebases. Markdown and other unsupported file types always use regex-based chunking regardless of strategy.
 
 The default is `regex` (existing behavior). Use `--chunk-strategy auto` to
 opt in. Run `qmd status` to verify which grammars are available.
@@ -1141,12 +1141,12 @@ For supported code files, QMD also parses the source with [tree-sitter](https://
 
 | AST Node | Score | Languages |
 |----------|-------|-----------|
-| Class / interface / struct / impl / trait | 100 | All |
-| Function / method | 90 | All |
+| Class / interface / struct / impl / trait / namespace / layout | 100 | All |
+| Function / method / section / block | 90 | All |
 | Type alias / enum | 80 | All |
-| Import / use declaration | 60 | All |
+| Import / use declaration / property / const / directive | 60 | All |
 
-Supported for `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.go`, and `.rs` files. Enable with `--chunk-strategy auto`. Markdown and other file types always use regex chunking.
+Supported for `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.go`, `.rs`, and `.php` files, plus template-aware retrieval for Blade (`.blade.php`), Twig (`.twig`, `.html.twig`), Smarty (`.tpl`, `.smarty`), and Latte (`.latte`). Enable with `--chunk-strategy auto`. PHP chunks are enriched with structural AST context (namespace, class, methods, attributes, PHPDoc). Markdown and other unsupported file types always use regex chunking.
 
 ### Query Flow (Hybrid)
 

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,6 @@
       },
       "devDependencies": {
         "@types/better-sqlite3": "7.6.13",
-        "@vitest/coverage-v8": "^4.1.10",
         "tsx": "4.21.0",
         "vitest": "3.2.4",
       },
@@ -39,16 +38,6 @@
     },
   },
   "packages": {
-    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
-
-    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
-
-    "@babel/parser": ["@babel/parser@7.29.8", "", { "dependencies": { "@babel/types": "^7.29.8" }, "bin": "./bin/babel-parser.js" }, "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA=="],
-
-    "@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
-
-    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
-
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
@@ -107,11 +96,7 @@
 
     "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
-    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
-
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
-
-    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@kwsites/file-exists": ["@kwsites/file-exists@1.1.1", "", { "dependencies": { "debug": "^4.1.1" } }, "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw=="],
 
@@ -231,8 +216,6 @@
 
     "@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
 
-    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.10", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.10", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.10", "vitest": "4.1.10" }, "optionalPeers": ["@vitest/browser"] }, "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g=="],
-
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
     "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
@@ -245,7 +228,7 @@
 
     "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
 
-    "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
+    "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -260,8 +243,6 @@
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
-
-    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.5", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA=="],
 
     "async-retry": ["async-retry@1.3.3", "", { "dependencies": { "retry": "0.13.1" } }, "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw=="],
 
@@ -316,8 +297,6 @@
     "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
-
-    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
@@ -433,15 +412,11 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
-
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "hono": ["hono@4.12.10", "", {}, "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w=="],
-
-    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -477,15 +452,9 @@
 
     "isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
 
-    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
-
-    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
-
-    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
-
     "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
 
-    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
+    "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -504,10 +473,6 @@
     "lowdb": ["lowdb@7.0.1", "", { "dependencies": { "steno": "^4.0.2" } }, "sha512-neJAj8GwF0e8EpycYIDFqEPcx9Qz4GUho20jWFR7YiFeXzF1YMLdxB36PypcTSPMA+4+LvgyMacYhlr18Zlymw=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
-
-    "magicast": ["magicast@0.5.4", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "source-map-js": "^1.2.1" } }, "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w=="],
-
-    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -556,8 +521,6 @@
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
-
-    "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
@@ -685,7 +648,7 @@
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
-    "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
     "stdin-discarder": ["stdin-discarder@0.3.1", "", {}, "sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA=="],
 
@@ -703,8 +666,6 @@
 
     "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
 
-    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
-
     "tar": ["tar@7.5.10", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw=="],
 
     "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
@@ -719,7 +680,7 @@
 
     "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
 
-    "tinyrainbow": ["tinyrainbow@3.1.1", "", {}, "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw=="],
+    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
 
     "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
 
@@ -793,16 +754,6 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
-    "@vitest/expect/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
-
-    "@vitest/expect/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
-
-    "@vitest/pretty-format/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
-
-    "@vitest/runner/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
-
-    "@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@4.1.10", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q=="],
-
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -839,8 +790,6 @@
 
     "string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
-    "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
-
     "tar/chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
@@ -853,12 +802,6 @@
 
     "vite/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
-    "vitest/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
-
-    "vitest/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
-
-    "vitest/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
-
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -866,8 +809,6 @@
     "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "@vitest/runner/@vitest/utils/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
 
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "picomatch": "4.0.4",
         "sqlite-vec": "0.1.9",
         "tree-sitter-go": "0.25.0",
+        "tree-sitter-php": "0.24.2",
         "tree-sitter-python": "0.25.0",
         "tree-sitter-rust": "0.24.0",
         "tree-sitter-typescript": "0.23.2",
@@ -21,6 +22,7 @@
       },
       "devDependencies": {
         "@types/better-sqlite3": "7.6.13",
+        "@vitest/coverage-v8": "^4.1.10",
         "tsx": "4.21.0",
         "vitest": "3.2.4",
       },
@@ -37,6 +39,16 @@
     },
   },
   "packages": {
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/parser": ["@babel/parser@7.29.8", "", { "dependencies": { "@babel/types": "^7.29.8" }, "bin": "./bin/babel-parser.js" }, "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA=="],
+
+    "@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
+
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
+
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
@@ -95,7 +107,11 @@
 
     "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@kwsites/file-exists": ["@kwsites/file-exists@1.1.1", "", { "dependencies": { "debug": "^4.1.1" } }, "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw=="],
 
@@ -215,6 +231,8 @@
 
     "@types/node": ["@types/node@24.10.1", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ=="],
 
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.10", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.10", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.10", "vitest": "4.1.10" }, "optionalPeers": ["@vitest/browser"] }, "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g=="],
+
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
     "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
@@ -227,7 +245,7 @@
 
     "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
 
-    "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+    "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -242,6 +260,8 @@
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.5", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA=="],
 
     "async-retry": ["async-retry@1.3.3", "", { "dependencies": { "retry": "0.13.1" } }, "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw=="],
 
@@ -296,6 +316,8 @@
     "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
@@ -411,11 +433,15 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "hono": ["hono@4.12.10", "", {}, "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w=="],
+
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -451,9 +477,15 @@
 
     "isexe": ["isexe@4.0.0", "", {}, "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw=="],
 
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
     "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
 
-    "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -472,6 +504,10 @@
     "lowdb": ["lowdb@7.0.1", "", { "dependencies": { "steno": "^4.0.2" } }, "sha512-neJAj8GwF0e8EpycYIDFqEPcx9Qz4GUho20jWFR7YiFeXzF1YMLdxB36PypcTSPMA+4+LvgyMacYhlr18Zlymw=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "magicast": ["magicast@0.5.4", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "source-map-js": "^1.2.1" } }, "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -520,6 +556,8 @@
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
@@ -647,7 +685,7 @@
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
-    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+    "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
 
     "stdin-discarder": ["stdin-discarder@0.3.1", "", {}, "sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA=="],
 
@@ -665,6 +703,8 @@
 
     "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
 
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
     "tar": ["tar@7.5.10", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw=="],
 
     "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
@@ -679,7 +719,7 @@
 
     "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
 
-    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+    "tinyrainbow": ["tinyrainbow@3.1.1", "", {}, "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw=="],
 
     "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
 
@@ -690,6 +730,8 @@
     "tree-sitter-go": ["tree-sitter-go@0.25.0", "", { "dependencies": { "node-addon-api": "^8.3.1", "node-gyp-build": "^4.8.4" }, "peerDependencies": { "tree-sitter": "^0.25.0" }, "optionalPeers": ["tree-sitter"] }, "sha512-APBc/Dq3xz/e35Xpkhb1blu5UgW+2E3RyGWawZSCNcbGwa7jhSQPS8KsUupuzBla8PCo8+lz9W/JDJjmfRa2tw=="],
 
     "tree-sitter-javascript": ["tree-sitter-javascript@0.23.1", "", { "dependencies": { "node-addon-api": "^8.2.2", "node-gyp-build": "^4.8.2" }, "peerDependencies": { "tree-sitter": "^0.21.1" }, "optionalPeers": ["tree-sitter"] }, "sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA=="],
+
+    "tree-sitter-php": ["tree-sitter-php@0.24.2", "", { "dependencies": { "node-addon-api": "^8.2.2", "node-gyp-build": "^4.8.2" }, "peerDependencies": { "tree-sitter": "^0.22.4" }, "optionalPeers": ["tree-sitter"] }, "sha512-zwgAePc/HozNaWOOfwRAA+3p8yhuehRw8Fb7vn5qd2XjiIc93uJPryDTMYTSjBRjVIUg/KY6pM3rRzs8dSwKfw=="],
 
     "tree-sitter-python": ["tree-sitter-python@0.25.0", "", { "dependencies": { "node-addon-api": "^8.5.0", "node-gyp-build": "^4.8.4" }, "peerDependencies": { "tree-sitter": "^0.25.0" }, "optionalPeers": ["tree-sitter"] }, "sha512-eCmJx6zQa35GxaCtQD+wXHOhYqBxEL+bp71W/s3fcDMu06MrtzkVXR437dRrCrbrDbyLuUDJpAgycs7ncngLXw=="],
 
@@ -751,6 +793,16 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
+    "@vitest/expect/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "@vitest/expect/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "@vitest/pretty-format/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "@vitest/runner/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@4.1.10", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q=="],
+
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -787,6 +839,8 @@
 
     "string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
+    "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+
     "tar/chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
@@ -799,6 +853,12 @@
 
     "vite/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
+    "vitest/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "vitest/std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "vitest/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -806,6 +866,8 @@
     "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "@vitest/runner/@vitest/utils/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
 
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 

--- a/flake.nix
+++ b/flake.nix
@@ -44,12 +44,12 @@
         });
 
         nodeModulesHashes = {
-          x86_64-linux = "sha256-sVXoNWIcx1RYRtRWB4F2j7x8/cabFBKq+plFhPU7tBc=";
-          aarch64-darwin = "sha256-gDyJ5boyH44SeXlKo+W4G36GSUejyXP5PFvW+dFS1Mk=";
+          x86_64-linux = "sha256-9BlPX7AwkxFt7jFFscrN8hjWKdSNUjmnf+g/NwLHn5s=";
+          aarch64-darwin = "sha256-iSa+uWpfEwegmUStBjZm4xgKMcINSUMHuoQ7M5cw3rM=";
+          x86_64-darwin = "sha256-iSa+uWpfEwegmUStBjZm4xgKMcINSUMHuoQ7M5cw3rM=";
 
           # Populate these on first build for additional hosts if/when needed.
           aarch64-linux = pkgs.lib.fakeHash;
-          x86_64-darwin = pkgs.lib.fakeHash;
         };
 
         nodeModules = pkgs.stdenvNoCC.mkDerivation {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "7.6.13",
-    "@vitest/coverage-v8": "^4.1.10",
     "tsx": "4.21.0",
     "vitest": "3.2.4"
   },

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "picomatch": "4.0.4",
     "sqlite-vec": "0.1.9",
     "tree-sitter-go": "0.25.0",
+    "tree-sitter-php": "0.24.2",
     "tree-sitter-python": "0.25.0",
     "tree-sitter-rust": "0.24.0",
     "tree-sitter-typescript": "0.23.2",
@@ -79,6 +80,7 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "7.6.13",
+    "@vitest/coverage-v8": "^4.1.10",
     "tsx": "4.21.0",
     "vitest": "3.2.4"
   },
@@ -89,6 +91,7 @@
       "node-llama-cpp",
       "tree-sitter-go",
       "tree-sitter-javascript",
+      "tree-sitter-php",
       "tree-sitter-python",
       "tree-sitter-rust",
       "tree-sitter-typescript"

--- a/scripts/check-package-grammars.mjs
+++ b/scripts/check-package-grammars.mjs
@@ -9,6 +9,7 @@ const grammars = [
   "tree-sitter-python/tree-sitter-python.wasm",
   "tree-sitter-go/tree-sitter-go.wasm",
   "tree-sitter-rust/tree-sitter-rust.wasm",
+  "tree-sitter-php/tree-sitter-php.wasm",
 ];
 
 let ok = true;

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -21,6 +21,7 @@
 import { createRequire } from "node:module";
 import { extname } from "node:path";
 import type { BreakPoint } from "./store.js";
+import { detectTemplateAdapter, getTemplateBreakPoints } from "./templates.js";
 
 // web-tree-sitter types — imported dynamically to avoid top-level WASM init
 type ParserType = import("web-tree-sitter").Parser;
@@ -31,7 +32,7 @@ type QueryType = import("web-tree-sitter").Query;
 // Language Detection
 // =============================================================================
 
-export type SupportedLanguage = "typescript" | "tsx" | "javascript" | "python" | "go" | "rust";
+export type SupportedLanguage = "typescript" | "tsx" | "javascript" | "python" | "go" | "rust" | "php";
 
 const EXTENSION_MAP: Record<string, SupportedLanguage> = {
   ".ts": "typescript",
@@ -45,13 +46,15 @@ const EXTENSION_MAP: Record<string, SupportedLanguage> = {
   ".py": "python",
   ".go": "go",
   ".rs": "rust",
+  ".php": "php",
 };
 
 /**
  * Detect language from file path extension.
- * Returns null for unsupported or unknown extensions (including .md).
+ * Returns null for template files (e.g. .blade.php) or unsupported/unknown extensions (including .md).
  */
 export function detectLanguage(filepath: string): SupportedLanguage | null {
+  if (detectTemplateAdapter(filepath)) return null;
   const ext = extname(filepath).toLowerCase();
   return EXTENSION_MAP[ext] ?? null;
 }
@@ -70,6 +73,7 @@ const GRAMMAR_MAP: Record<SupportedLanguage, { pkg: string; wasm: string; versio
   python:     { pkg: "tree-sitter-python",     wasm: "tree-sitter-python.wasm",     version: "0.23.4" },
   go:         { pkg: "tree-sitter-go",         wasm: "tree-sitter-go.wasm",         version: "0.23.4" },
   rust:       { pkg: "tree-sitter-rust",       wasm: "tree-sitter-rust.wasm",       version: "0.24.0" },
+  php:        { pkg: "tree-sitter-php",        wasm: "tree-sitter-php.wasm",        version: "0.24.2" },
 };
 
 export function formatGrammarLoadError(language: SupportedLanguage, err: unknown): string {
@@ -148,6 +152,19 @@ const LANGUAGE_QUERIES: Record<SupportedLanguage, string> = {
     (type_item) @type
     (mod_item) @mod
   `,
+  php: `
+    (class_declaration) @class
+    (interface_declaration) @iface
+    (trait_declaration) @trait
+    (enum_declaration) @enum
+    (method_declaration) @method
+    (function_definition) @func
+    (namespace_definition) @ns
+    (namespace_use_declaration) @import
+    (use_declaration) @import
+    (property_declaration) @prop
+    (const_declaration) @const
+  `,
 };
 
 /**
@@ -162,6 +179,7 @@ const SCORE_MAP: Record<string, number> = {
   trait:     100,
   impl:      100,
   mod:       100,
+  ns:        100,
   export:     90,
   func:       90,
   method:     90,
@@ -169,6 +187,8 @@ const SCORE_MAP: Record<string, number> = {
   type:       80,
   enum:       80,
   import:     60,
+  prop:       60,
+  const:      60,
 };
 
 // =============================================================================
@@ -275,6 +295,11 @@ export async function getASTBreakPoints(
   content: string,
   filepath: string,
 ): Promise<BreakPoint[]> {
+  const templateAdapter = detectTemplateAdapter(filepath);
+  if (templateAdapter) {
+    return templateAdapter.getBreakPoints(content);
+  }
+
   const language = detectLanguage(filepath);
   if (!language) return [];
 

--- a/src/php-enrichment.ts
+++ b/src/php-enrichment.ts
@@ -1,0 +1,221 @@
+/**
+ * PHP AST Content Enrichment module for QMD.
+ *
+ * Extracts framework-agnostic structural context (namespace, class, interface, trait,
+ * enum, inheritance, attributes, and PHPDoc) from Tree-sitter PHP AST nodes.
+ */
+
+export interface PHPDeclarationContext {
+  namespace?: string;
+  className?: string;
+  interfaceName?: string;
+  traitName?: string;
+  enumName?: string;
+  extendsClass?: string;
+  implementsInterfaces?: string[];
+  usedTraits?: string[];
+  methodName?: string;
+  methodVisibility?: string;
+  isStatic?: boolean;
+  functionName?: string;
+  phpDoc?: string;
+  attributes?: string[];
+}
+
+/**
+ * Format a PHP structural context object into a concise header string to enrich chunk content.
+ */
+export function formatPHPContext(ctx: PHPDeclarationContext): string {
+  const parts: string[] = [];
+
+  if (ctx.namespace) {
+    parts.push(`namespace ${ctx.namespace}`);
+  }
+
+  if (ctx.className) {
+    let decl = `class ${ctx.className}`;
+    if (ctx.extendsClass) decl += ` extends ${ctx.extendsClass}`;
+    if (ctx.implementsInterfaces && ctx.implementsInterfaces.length > 0) {
+      decl += ` implements ${ctx.implementsInterfaces.join(", ")}`;
+    }
+    parts.push(decl);
+  } else if (ctx.interfaceName) {
+    let decl = `interface ${ctx.interfaceName}`;
+    if (ctx.extendsClass) decl += ` extends ${ctx.extendsClass}`;
+    parts.push(decl);
+  } else if (ctx.traitName) {
+    parts.push(`trait ${ctx.traitName}`);
+  } else if (ctx.enumName) {
+    parts.push(`enum ${ctx.enumName}`);
+  }
+
+  if (ctx.usedTraits && ctx.usedTraits.length > 0) {
+    parts.push(`uses [${ctx.usedTraits.join(", ")}]`);
+  }
+
+  if (ctx.methodName) {
+    const vis = ctx.methodVisibility ? `${ctx.methodVisibility} ` : "";
+    const st = ctx.isStatic ? "static " : "";
+    parts.push(`method ${vis}${st}${ctx.methodName}`);
+  } else if (ctx.functionName) {
+    parts.push(`function ${ctx.functionName}`);
+  }
+
+  if (ctx.attributes && ctx.attributes.length > 0) {
+    parts.push(`attributes [${ctx.attributes.join(", ")}]`);
+  }
+
+  if (ctx.phpDoc) {
+    // Keep single-line sanitized summary of doc block
+    const cleanDoc = ctx.phpDoc.replace(/\/\*\*|\*\/|\*/g, " ").replace(/\s+/g, " ").trim();
+    if (cleanDoc) {
+      parts.push(`doc: ${cleanDoc}`);
+    }
+  }
+
+  if (parts.length === 0) return "";
+  return `// Context: ${parts.join(" | ")}`;
+}
+
+/**
+ * Extract AST-based PHP structural context for specific positions in a file.
+ */
+export function extractPHPContextFromAST(
+  rootNode: any,
+  content: string,
+  targetPos: number,
+): PHPDeclarationContext {
+  const ctx: PHPDeclarationContext = {};
+
+  function findAncestorOrCurrent(node: any, types: string[]) {
+    let curr = node;
+    while (curr) {
+      if (types.includes(curr.type)) return curr;
+      curr = curr.parent;
+    }
+    return null;
+  }
+
+  // Find node at target position
+  let node = rootNode.descendantForIndex(targetPos);
+  if (!node) return ctx;
+
+  // 1. Namespace
+  let curr: any = node;
+  while (curr) {
+    const nsNode = curr.children?.find((c: any) => c.type === "namespace_definition");
+    if (nsNode) {
+      const nameNode = nsNode.children?.find((c: any) => c.type === "namespace_name");
+      if (nameNode) {
+        ctx.namespace = content.slice(nameNode.startIndex, nameNode.endIndex).trim();
+      }
+      break;
+    }
+    curr = curr.parent;
+  }
+
+  // 2. Containing class / interface / trait / enum
+  const typeNode = findAncestorOrCurrent(node, [
+    "class_declaration",
+    "interface_declaration",
+    "trait_declaration",
+    "enum_declaration",
+  ]);
+
+  if (typeNode) {
+    const nameNode = typeNode.children?.find((c: any) => c.type === "name");
+    if (nameNode) {
+      const name = content.slice(nameNode.startIndex, nameNode.endIndex).trim();
+      if (typeNode.type === "class_declaration") ctx.className = name;
+      else if (typeNode.type === "interface_declaration") ctx.interfaceName = name;
+      else if (typeNode.type === "trait_declaration") ctx.traitName = name;
+      else if (typeNode.type === "enum_declaration") ctx.enumName = name;
+    }
+
+    // Extends
+    const baseClause = typeNode.children?.find((c: any) => c.type === "base_clause");
+    if (baseClause) {
+      const baseNameNode = baseClause.children?.find((c: any) => c.type === "name" || c.type === "qualified_name");
+      if (baseNameNode) {
+        ctx.extendsClass = content.slice(baseNameNode.startIndex, baseNameNode.endIndex).trim();
+      }
+    }
+
+    // Implements
+    const ifaceClause = typeNode.children?.find((c: any) => c.type === "class_interface_clause");
+    if (ifaceClause) {
+      const ifaces: string[] = [];
+      for (const child of ifaceClause.children || []) {
+        if (child.type === "name" || child.type === "qualified_name") {
+          ifaces.push(content.slice(child.startIndex, child.endIndex).trim());
+        }
+      }
+      if (ifaces.length > 0) ctx.implementsInterfaces = ifaces;
+    }
+
+    // Used traits inside class/enum/trait
+    const bodyNode = typeNode.children?.find((c: any) => c.type === "declaration_list");
+    if (bodyNode) {
+      const traits: string[] = [];
+      for (const child of bodyNode.children || []) {
+        if (child.type === "use_declaration") {
+          const traitNames = child.children?.filter((c: any) => c.type === "name" || c.type === "qualified_name");
+          for (const tn of traitNames || []) {
+            traits.push(content.slice(tn.startIndex, tn.endIndex).trim());
+          }
+        }
+      }
+      if (traits.length > 0) ctx.usedTraits = traits;
+    }
+  }
+
+  // 3. Method or Function declaration
+  const methodOrFuncNode = findAncestorOrCurrent(node, ["method_declaration", "function_definition"]);
+  if (methodOrFuncNode) {
+    const nameNode = methodOrFuncNode.children?.find((c: any) => c.type === "name");
+    if (nameNode) {
+      const name = content.slice(nameNode.startIndex, nameNode.endIndex).trim();
+      if (methodOrFuncNode.type === "method_declaration") {
+        ctx.methodName = name;
+        // Visibility
+        const visNode = methodOrFuncNode.children?.find((c: any) =>
+          ["public", "protected", "private"].includes(content.slice(c.startIndex, c.endIndex)),
+        );
+        if (visNode) ctx.methodVisibility = content.slice(visNode.startIndex, visNode.endIndex);
+        const staticNode = methodOrFuncNode.children?.find((c: any) =>
+          content.slice(c.startIndex, c.endIndex) === "static",
+        );
+        if (staticNode) ctx.isStatic = true;
+      } else {
+        ctx.functionName = name;
+      }
+    }
+
+    // Associated Attributes
+    const attrList = methodOrFuncNode.children?.find((c: any) => c.type === "attribute_list");
+    if (attrList) {
+      const attrs: string[] = [];
+      for (const group of attrList.children || []) {
+        if (group.type === "attribute_group") {
+          for (const attr of group.children || []) {
+            if (attr.type === "attribute") {
+              attrs.push(content.slice(attr.startIndex, attr.endIndex).trim());
+            }
+          }
+        }
+      }
+      if (attrs.length > 0) ctx.attributes = attrs;
+    }
+
+    // Immediate PHPDoc comment before declaration
+    const prevSibling = methodOrFuncNode.previousSibling;
+    if (prevSibling && prevSibling.type === "comment") {
+      const commentText = content.slice(prevSibling.startIndex, prevSibling.endIndex);
+      if (commentText.startsWith("/**")) {
+        ctx.phpDoc = commentText;
+      }
+    }
+  }
+
+  return ctx;
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -2750,7 +2750,57 @@ export async function chunkDocumentAsync(
     }
   }
 
-  return chunkDocumentWithBreakPoints(content, breakPoints, codeFences, maxChars, overlapChars, windowChars);
+  let chunks = chunkDocumentWithBreakPoints(content, breakPoints, codeFences, maxChars, overlapChars, windowChars);
+
+  if (chunkStrategy === "auto" && filepath) {
+    try {
+      const { detectTemplateAdapter, getTemplateContext } = await import("./templates.js");
+      const tplAdapter = detectTemplateAdapter(filepath);
+
+      if (tplAdapter) {
+        const tplCtx = getTemplateContext(content, filepath);
+        if (tplCtx) {
+          const parts: string[] = [`engine ${tplCtx.engine}`];
+          if (tplCtx.extendsLayout) parts.push(`extends ${tplCtx.extendsLayout}`);
+          if (tplCtx.sections?.length) parts.push(`sections [${tplCtx.sections.join(", ")}]`);
+          if (tplCtx.components?.length) parts.push(`components [${tplCtx.components.join(", ")}]`);
+          const header = `// [Template Context: ${parts.join(" | ")}]\n`;
+          chunks = chunks.map(c => ({ ...c, text: `${header}${c.text}` }));
+        }
+      } else {
+        const { extname } = await import("node:path");
+        const ext = extname(filepath).toLowerCase();
+        if (ext === ".php") {
+          const { detectLanguage } = await import("./ast.js");
+          if (detectLanguage(filepath) === "php") {
+            const mod = await import("web-tree-sitter");
+            const { createRequire } = await import("node:module");
+            const req = createRequire(import.meta.url);
+            const wasmPath = req.resolve("tree-sitter-php/tree-sitter-php.wasm");
+            await mod.Parser.init();
+            const lang = await mod.Language.load(wasmPath);
+            const parser = new mod.Parser();
+            parser.setLanguage(lang);
+            const tree = parser.parse(content);
+            if (tree) {
+              const { extractPHPContextFromAST, formatPHPContext } = await import("./php-enrichment.js");
+              chunks = chunks.map(c => {
+                const ctx = extractPHPContextFromAST(tree.rootNode, content, c.pos);
+                const header = formatPHPContext(ctx);
+                return header ? { ...c, text: `${header}\n${c.text}` } : c;
+              });
+              tree.delete();
+              parser.delete();
+            }
+          }
+        }
+      }
+    } catch {
+      // Degrade gracefully if enrichment fails
+    }
+  }
+
+  return chunks;
 }
 
 /**

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,0 +1,346 @@
+/**
+ * Template-aware code retrieval engine for QMD.
+ *
+ * Supports generic web template engines including Blade, Twig, Smarty, and Latte.
+ * Provides template language detection, structural breakpoint extraction,
+ * and contextual metadata.
+ */
+
+import { extname } from "node:path";
+import type { BreakPoint } from "./store.js";
+
+export type SupportedTemplateEngine = "blade" | "twig" | "smarty" | "latte";
+
+export interface TemplateContext {
+  engine: SupportedTemplateEngine;
+  extendsLayout?: string;
+  sections?: string[];
+  components?: string[];
+}
+
+export interface TemplateLanguageAdapter {
+  engine: SupportedTemplateEngine;
+  matches(filepath: string): boolean;
+  getBreakPoints(content: string): BreakPoint[];
+  getContext(content: string): TemplateContext;
+}
+
+// =============================================================================
+// Blade Adapter
+// =============================================================================
+
+const BLADE_PATTERNS: { regex: RegExp; type: string; score: number }[] = [
+  { regex: /@extends\s*\(/gi, type: "template:extends", score: 100 },
+  { regex: /@section\s*\(/gi, type: "template:section", score: 90 },
+  { regex: /@endsection\b/gi, type: "template:endsection", score: 70 },
+  { regex: /@component\s*\(/gi, type: "template:component", score: 90 },
+  { regex: /@endcomponent\b/gi, type: "template:endcomponent", score: 70 },
+  { regex: /@push\s*\(/gi, type: "template:push", score: 80 },
+  { regex: /@endpush\b/gi, type: "template:endpush", score: 70 },
+  { regex: /@if\s*\(/gi, type: "template:if", score: 70 },
+  { regex: /@elseif\s*\(/gi, type: "template:elseif", score: 60 },
+  { regex: /@else\b/gi, type: "template:else", score: 60 },
+  { regex: /@endif\b/gi, type: "template:endif", score: 60 },
+  { regex: /@foreach\s*\(/gi, type: "template:foreach", score: 70 },
+  { regex: /@endforeach\b/gi, type: "template:endforeach", score: 60 },
+  { regex: /@for\s*\(/gi, type: "template:for", score: 70 },
+  { regex: /@endfor\b/gi, type: "template:endfor", score: 60 },
+  { regex: /@php\b/gi, type: "template:php", score: 80 },
+  { regex: /@endphp\b/gi, type: "template:endphp", score: 60 },
+  { regex: /<x-[\w.-]+/gi, type: "template:x-component", score: 85 },
+  { regex: /<livewire:[\w.-]+/gi, type: "template:livewire-component", score: 85 },
+];
+
+export const bladeAdapter: TemplateLanguageAdapter = {
+  engine: "blade",
+  matches(filepath: string): boolean {
+    const lower = filepath.toLowerCase();
+    return lower.endsWith(".blade.php");
+  },
+  getBreakPoints(content: string): BreakPoint[] {
+    const points: BreakPoint[] = [];
+    const seen = new Set<number>();
+
+    for (const pat of BLADE_PATTERNS) {
+      pat.regex.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = pat.regex.exec(content)) !== null) {
+        const pos = match.index;
+        if (!seen.has(pos)) {
+          seen.add(pos);
+          points.push({ pos, score: pat.score, type: pat.type });
+        }
+      }
+    }
+
+    return points.sort((a, b) => a.pos - b.pos);
+  },
+  getContext(content: string): TemplateContext {
+    const context: TemplateContext = { engine: "blade" };
+    const extendsMatch = /@extends\s*\(\s*['"]([^'"]+)['"]\s*\)/i.exec(content);
+    if (extendsMatch?.[1]) {
+      context.extendsLayout = extendsMatch[1];
+    }
+
+    const sections: string[] = [];
+    const secRegex = /@section\s*\(\s*['"]([^'"]+)['"]/gi;
+    let sMatch: RegExpExecArray | null;
+    while ((sMatch = secRegex.exec(content)) !== null) {
+      if (sMatch[1] && !sections.includes(sMatch[1])) {
+        sections.push(sMatch[1]);
+      }
+    }
+    if (sections.length > 0) context.sections = sections;
+
+    const components: string[] = [];
+    const compRegex = /<(x-[\w.-]+|livewire:[\w.-]+)/gi;
+    let cMatch: RegExpExecArray | null;
+    while ((cMatch = compRegex.exec(content)) !== null) {
+      if (cMatch[1] && !components.includes(cMatch[1])) {
+        components.push(cMatch[1]);
+      }
+    }
+    if (components.length > 0) context.components = components;
+
+    return context;
+  },
+};
+
+// =============================================================================
+// Twig Adapter
+// =============================================================================
+
+const TWIG_PATTERNS: { regex: RegExp; type: string; score: number }[] = [
+  { regex: /\{%\s*extends\b/gi, type: "template:extends", score: 100 },
+  { regex: /\{%\s*block\b/gi, type: "template:block", score: 90 },
+  { regex: /\{%\s*endblock\b/gi, type: "template:endblock", score: 70 },
+  { regex: /\{%\s*include\b/gi, type: "template:include", score: 80 },
+  { regex: /\{%\s*embed\b/gi, type: "template:embed", score: 90 },
+  { regex: /\{%\s*endembed\b/gi, type: "template:endembed", score: 70 },
+  { regex: /\{%\s*macro\b/gi, type: "template:macro", score: 90 },
+  { regex: /\{%\s*endmacro\b/gi, type: "template:endmacro", score: 70 },
+  { regex: /\{%\s*for\b/gi, type: "template:for", score: 70 },
+  { regex: /\{%\s*endfor\b/gi, type: "template:endfor", score: 60 },
+  { regex: /\{%\s*if\b/gi, type: "template:if", score: 70 },
+  { regex: /\{%\s*endif\b/gi, type: "template:endif", score: 60 },
+];
+
+export const twigAdapter: TemplateLanguageAdapter = {
+  engine: "twig",
+  matches(filepath: string): boolean {
+    const lower = filepath.toLowerCase();
+    return lower.endsWith(".twig") || lower.endsWith(".html.twig");
+  },
+  getBreakPoints(content: string): BreakPoint[] {
+    const points: BreakPoint[] = [];
+    const seen = new Set<number>();
+
+    for (const pat of TWIG_PATTERNS) {
+      pat.regex.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = pat.regex.exec(content)) !== null) {
+        const pos = match.index;
+        if (!seen.has(pos)) {
+          seen.add(pos);
+          points.push({ pos, score: pat.score, type: pat.type });
+        }
+      }
+    }
+
+    return points.sort((a, b) => a.pos - b.pos);
+  },
+  getContext(content: string): TemplateContext {
+    const context: TemplateContext = { engine: "twig" };
+    const extendsMatch = /\{%\s*extends\s+['"]([^'"]+)['"]\s*%\}/i.exec(content);
+    if (extendsMatch?.[1]) {
+      context.extendsLayout = extendsMatch[1];
+    }
+
+    const blocks: string[] = [];
+    const blkRegex = /\{%\s*block\s+([a-zA-Z0-9_]+)/gi;
+    let bMatch: RegExpExecArray | null;
+    while ((bMatch = blkRegex.exec(content)) !== null) {
+      if (bMatch[1] && !blocks.includes(bMatch[1])) {
+        blocks.push(bMatch[1]);
+      }
+    }
+    if (blocks.length > 0) context.sections = blocks;
+
+    return context;
+  },
+};
+
+// =============================================================================
+// Smarty Adapter
+// =============================================================================
+
+const SMARTY_PATTERNS: { regex: RegExp; type: string; score: number }[] = [
+  { regex: /\{extends\b/gi, type: "template:extends", score: 100 },
+  { regex: /\{block\b/gi, type: "template:block", score: 90 },
+  { regex: /\{\/block\}/gi, type: "template:endblock", score: 70 },
+  { regex: /\{include\b/gi, type: "template:include", score: 80 },
+  { regex: /\{function\b/gi, type: "template:function", score: 90 },
+  { regex: /\{\/function\}/gi, type: "template:endfunction", score: 70 },
+  { regex: /\{if\b/gi, type: "template:if", score: 70 },
+  { regex: /\{\/if\}/gi, type: "template:endif", score: 60 },
+  { regex: /\{foreach\b/gi, type: "template:foreach", score: 70 },
+  { regex: /\{\/foreach\}/gi, type: "template:endforeach", score: 60 },
+];
+
+export const smartyAdapter: TemplateLanguageAdapter = {
+  engine: "smarty",
+  matches(filepath: string): boolean {
+    const lower = filepath.toLowerCase();
+    return lower.endsWith(".tpl") || lower.endsWith(".smarty");
+  },
+  getBreakPoints(content: string): BreakPoint[] {
+    const points: BreakPoint[] = [];
+    const seen = new Set<number>();
+
+    for (const pat of SMARTY_PATTERNS) {
+      pat.regex.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = pat.regex.exec(content)) !== null) {
+        const pos = match.index;
+        if (!seen.has(pos)) {
+          seen.add(pos);
+          points.push({ pos, score: pat.score, type: pat.type });
+        }
+      }
+    }
+
+    return points.sort((a, b) => a.pos - b.pos);
+  },
+  getContext(content: string): TemplateContext {
+    const context: TemplateContext = { engine: "smarty" };
+    const extendsMatch = /\{extends\s+file=['"]([^'"]+)['"]\}/i.exec(content) || /\{extends\s+['"]([^'"]+)['"]\}/i.exec(content);
+    if (extendsMatch?.[1]) {
+      context.extendsLayout = extendsMatch[1];
+    }
+
+    const blocks: string[] = [];
+    const blkRegex = /\{block\s+(?:name=)?['"]([^'"]+)['"]\}/gi;
+    let bMatch: RegExpExecArray | null;
+    while ((bMatch = blkRegex.exec(content)) !== null) {
+      if (bMatch[1] && !blocks.includes(bMatch[1])) {
+        blocks.push(bMatch[1]);
+      }
+    }
+    if (blocks.length > 0) context.sections = blocks;
+
+    return context;
+  },
+};
+
+// =============================================================================
+// Latte Adapter
+// =============================================================================
+
+const LATTE_PATTERNS: { regex: RegExp; type: string; score: number }[] = [
+  { regex: /\{layout\b/gi, type: "template:layout", score: 100 },
+  { regex: /\{block\b/gi, type: "template:block", score: 90 },
+  { regex: /\{\/block\}/gi, type: "template:endblock", score: 70 },
+  { regex: /\{include\b/gi, type: "template:include", score: 80 },
+  { regex: /\{define\b/gi, type: "template:define", score: 90 },
+  { regex: /\{\/define\}/gi, type: "template:enddefine", score: 70 },
+  { regex: /\{if\b/gi, type: "template:if", score: 70 },
+  { regex: /\{\/if\}/gi, type: "template:endif", score: 60 },
+  { regex: /\{foreach\b/gi, type: "template:foreach", score: 70 },
+  { regex: /\{\/foreach\}/gi, type: "template:endforeach", score: 60 },
+];
+
+export const latteAdapter: TemplateLanguageAdapter = {
+  engine: "latte",
+  matches(filepath: string): boolean {
+    const lower = filepath.toLowerCase();
+    return lower.endsWith(".latte");
+  },
+  getBreakPoints(content: string): BreakPoint[] {
+    const points: BreakPoint[] = [];
+    const seen = new Set<number>();
+
+    for (const pat of LATTE_PATTERNS) {
+      pat.regex.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = pat.regex.exec(content)) !== null) {
+        const pos = match.index;
+        if (!seen.has(pos)) {
+          seen.add(pos);
+          points.push({ pos, score: pat.score, type: pat.type });
+        }
+      }
+    }
+
+    return points.sort((a, b) => a.pos - b.pos);
+  },
+  getContext(content: string): TemplateContext {
+    const context: TemplateContext = { engine: "latte" };
+    const layoutMatch = /\{layout\s+['"]([^'"]+)['"]\}/i.exec(content);
+    if (layoutMatch?.[1]) {
+      context.extendsLayout = layoutMatch[1];
+    }
+
+    const blocks: string[] = [];
+    const blkRegex = /\{block\s+([a-zA-Z0-9_]+)/gi;
+    let bMatch: RegExpExecArray | null;
+    while ((bMatch = blkRegex.exec(content)) !== null) {
+      if (bMatch[1] && !blocks.includes(bMatch[1])) {
+        blocks.push(bMatch[1]);
+      }
+    }
+    if (blocks.length > 0) context.sections = blocks;
+
+    return context;
+  },
+};
+
+// =============================================================================
+// Template Engine Registry
+// =============================================================================
+
+const ADAPTERS: TemplateLanguageAdapter[] = [
+  bladeAdapter,
+  twigAdapter,
+  smartyAdapter,
+  latteAdapter,
+];
+
+/**
+ * Detect template engine from filepath.
+ * Priority rule: Check template adapters BEFORE standard extension mapping (.blade.php before .php).
+ */
+export function detectTemplateAdapter(filepath: string): TemplateLanguageAdapter | null {
+  for (const adapter of ADAPTERS) {
+    if (adapter.matches(filepath)) {
+      return adapter;
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract template break points and contextual header if applicable.
+ */
+export function getTemplateBreakPoints(content: string, filepath: string): BreakPoint[] {
+  try {
+    const adapter = detectTemplateAdapter(filepath);
+    if (!adapter) return [];
+    return adapter.getBreakPoints(content);
+  } catch (err) {
+    console.warn(`[qmd] Template parse failed for ${filepath}, falling back: ${err instanceof Error ? err.message : err}`);
+    return [];
+  }
+}
+
+/**
+ * Get structural context for a template file.
+ */
+export function getTemplateContext(content: string, filepath: string): TemplateContext | null {
+  try {
+    const adapter = detectTemplateAdapter(filepath);
+    if (!adapter) return null;
+    return adapter.getContext(content);
+  } catch {
+    return null;
+  }
+}

--- a/test/php-ast.test.ts
+++ b/test/php-ast.test.ts
@@ -1,0 +1,151 @@
+/**
+ * test/php-ast.test.ts - Tests for PHP Tree-sitter AST support in QMD
+ */
+
+import { describe, test, expect } from "vitest";
+import { detectLanguage, getASTBreakPoints, getASTStatus } from "../src/ast.js";
+
+// =============================================================================
+// Language Detection & Blade Bypass
+// =============================================================================
+
+describe("PHP Language Detection", () => {
+  test("recognizes .php extension", () => {
+    expect(detectLanguage("app/Services/OrderService.php")).toBe("php");
+    expect(detectLanguage("src/util.PHP")).toBe("php");
+  });
+
+  test("explicitly bypasses .blade.php from PHP parser", () => {
+    expect(detectLanguage("resources/views/orders/show.blade.php")).toBeNull();
+  });
+});
+
+// =============================================================================
+// AST Break Points - PHP
+// =============================================================================
+
+describe("getASTBreakPoints - PHP", () => {
+  const PHP_SAMPLE = `<?php
+
+namespace App\\Services;
+
+use App\\Models\\Order;
+use App\\Contracts\\PaymentGateway;
+
+/**
+ * Class OrderService
+ */
+class OrderService extends BaseService implements PaymentGateway
+{
+    public const DEFAULT_STATUS = 'pending';
+    private Order $order;
+
+    public function create(Order $order): void
+    {
+    }
+
+    public function cancel(Order $order): void
+    {
+    }
+}
+
+interface PaymentGateway
+{
+    public function charge(): void;
+}
+
+trait HasPayments
+{
+    public function refund(): void {}
+}
+
+enum PaymentStatus: string
+{
+    case Pending = 'pending';
+    case Paid = 'paid';
+}
+
+function normalize_order(array $data): array
+{
+    return $data;
+}
+`;
+
+  test("produces break points for class, interface, trait, enum, method, function, namespace, and imports", async () => {
+    const points = await getASTBreakPoints(PHP_SAMPLE, "app/Services/OrderService.php");
+    expect(points.length).toBeGreaterThan(0);
+
+    const types = points.map(p => p.type);
+    expect(types.some(t => t.includes("ns"))).toBe(true);
+    expect(types.some(t => t.includes("import"))).toBe(true);
+    expect(types.some(t => t.includes("class"))).toBe(true);
+    expect(types.some(t => t.includes("iface"))).toBe(true);
+    expect(types.some(t => t.includes("trait"))).toBe(true);
+    expect(types.some(t => t.includes("enum"))).toBe(true);
+    expect(types.some(t => t.includes("method"))).toBe(true);
+    expect(types.some(t => t.includes("func"))).toBe(true);
+  });
+
+  test("break points are sorted by position", async () => {
+    const points = await getASTBreakPoints(PHP_SAMPLE, "app/Services/OrderService.php");
+    for (let i = 1; i < points.length; i++) {
+      expect(points[i]!.pos).toBeGreaterThanOrEqual(points[i - 1]!.pos);
+    }
+  });
+
+  test("scores match expectations (class/interface/trait/enum/ns = 100, method/func = 90, import = 60)", async () => {
+    const points = await getASTBreakPoints(PHP_SAMPLE, "app/Services/OrderService.php");
+
+    const nsPoint = points.find(p => p.type === "ast:ns");
+    expect(nsPoint?.score).toBe(100);
+
+    const classPoint = points.find(p => p.type === "ast:class");
+    expect(classPoint?.score).toBe(100);
+
+    const methodPoint = points.find(p => p.type === "ast:method");
+    expect(methodPoint?.score).toBe(90);
+
+    const importPoint = points.find(p => p.type === "ast:import");
+    expect(importPoint?.score).toBe(60);
+  });
+
+  test("Laravel controller fixture works cleanly", async () => {
+    const CONTROLLER_FIXTURE = `<?php
+
+namespace App\\Http\\Controllers;
+
+use App\\Services\\OrderService;
+
+class OrderController
+{
+    public function store(OrderService $orders)
+    {
+        return $orders->create();
+    }
+
+    public function cancel(OrderService $orders)
+    {
+        return $orders->cancel();
+    }
+}
+`;
+    const points = await getASTBreakPoints(CONTROLLER_FIXTURE, "app/Http/Controllers/OrderController.php");
+    expect(points.length).toBeGreaterThan(0);
+    expect(points.some(p => p.type === "ast:class")).toBe(true);
+    expect(points.filter(p => p.type === "ast:method").length).toBe(2);
+  });
+});
+
+// =============================================================================
+// Grammar Status / Health Check
+// =============================================================================
+
+describe("PHP Grammar Status", () => {
+  test("reports php as available in getASTStatus", async () => {
+    const status = await getASTStatus();
+    expect(status.available).toBe(true);
+    const phpLang = status.languages.find(l => l.language === "php");
+    expect(phpLang).toBeDefined();
+    expect(phpLang?.available).toBe(true);
+  });
+});

--- a/test/php-enrichment.test.ts
+++ b/test/php-enrichment.test.ts
@@ -1,0 +1,159 @@
+/**
+ * test/php-enrichment.test.ts - Tests for PHP AST content enrichment
+ */
+
+import { describe, test, expect } from "vitest";
+import { formatPHPContext, extractPHPContextFromAST } from "../src/php-enrichment.js";
+import { chunkDocumentAsync } from "../src/store.js";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+describe("PHP AST Content Enrichment - Unit", () => {
+  test("formats PHP context into header string", () => {
+    const formatted = formatPHPContext({
+      namespace: "App\\Services",
+      className: "PaymentService",
+      extendsClass: "BaseService",
+      implementsInterfaces: ["PaymentGateway"],
+      usedTraits: ["HasPayments"],
+      methodName: "refund",
+      methodVisibility: "public",
+      attributes: ["Route('/refund')"],
+      phpDoc: "/** Refund an order. */",
+    });
+
+    expect(formatted).toContain("namespace App\\Services");
+    expect(formatted).toContain("class PaymentService extends BaseService implements PaymentGateway");
+    expect(formatted).toContain("uses [HasPayments]");
+    expect(formatted).toContain("method public refund");
+    expect(formatted).toContain("attributes [Route('/refund')]");
+    expect(formatted).toContain("doc: Refund an order.");
+  });
+
+  test("extracts PHP context for interfaces, traits, enums, functions, and static methods", async () => {
+    const mod = await import("web-tree-sitter");
+    await mod.Parser.init();
+    const wasmPath = require.resolve("tree-sitter-php/tree-sitter-php.wasm");
+    const lang = await mod.Language.load(wasmPath);
+    const parser = new mod.Parser();
+    parser.setLanguage(lang);
+
+    const sample = `<?php
+
+namespace App\\Contracts;
+
+interface PaymentGateway extends BaseGateway
+{
+    public static function charge(): void;
+}
+
+trait HasPayments
+{
+    public function processPayment() {}
+}
+
+enum PaymentStatus: string
+{
+    case Pending = 'pending';
+}
+
+function normalize_order(array $data): array
+{
+    return $data;
+}
+`;
+
+    const tree = parser.parse(sample);
+
+    // Interface
+    const ifacePos = sample.indexOf("interface PaymentGateway");
+    const ifaceCtx = extractPHPContextFromAST(tree.rootNode, sample, ifacePos);
+    expect(ifaceCtx.interfaceName).toBe("PaymentGateway");
+    expect(ifaceCtx.extendsClass).toBe("BaseGateway");
+    expect(formatPHPContext(ifaceCtx)).toContain("interface PaymentGateway extends BaseGateway");
+
+    // Static Method inside Interface
+    const staticPos = sample.indexOf("public static function charge");
+    const staticCtx = extractPHPContextFromAST(tree.rootNode, sample, staticPos);
+    expect(staticCtx.isStatic).toBe(true);
+    expect(formatPHPContext(staticCtx)).toContain("method public static charge");
+
+    // Trait
+    const traitPos = sample.indexOf("trait HasPayments");
+    const traitCtx = extractPHPContextFromAST(tree.rootNode, sample, traitPos);
+    expect(traitCtx.traitName).toBe("HasPayments");
+    expect(formatPHPContext(traitCtx)).toContain("trait HasPayments");
+
+    // Enum
+    const enumPos = sample.indexOf("enum PaymentStatus");
+    const enumCtx = extractPHPContextFromAST(tree.rootNode, sample, enumPos);
+    expect(enumCtx.enumName).toBe("PaymentStatus");
+    expect(formatPHPContext(enumCtx)).toContain("enum PaymentStatus");
+
+    // Global Function
+    const funcPos = sample.indexOf("function normalize_order");
+    const funcCtx = extractPHPContextFromAST(tree.rootNode, sample, funcPos);
+    expect(funcCtx.functionName).toBe("normalize_order");
+    expect(formatPHPContext(funcCtx)).toContain("function normalize_order");
+
+    tree.delete();
+    parser.delete();
+  });
+
+  test("formatPHPContext returns empty string for empty context", () => {
+    expect(formatPHPContext({})).toBe("");
+  });
+});
+
+describe("PHP Chunk Content Enrichment Integration", () => {
+  const LARAVEL_SERVICE_SAMPLE = `<?php
+
+namespace App\\Services;
+
+use App\\Models\\Order;
+
+class OrderService
+{
+    public function createOrder(array $data): Order
+    {
+        return new Order($data);
+    }
+
+    public function cancelOrder(int $orderId): bool
+    {
+        return true;
+    }
+}
+`;
+
+  test("chunkDocumentAsync enriches PHP chunks in auto mode", async () => {
+    const chunks = await chunkDocumentAsync(
+      LARAVEL_SERVICE_SAMPLE,
+      100,
+      10,
+      10,
+      "app/Services/OrderService.php",
+      "auto",
+    );
+
+    expect(chunks.length).toBeGreaterThan(0);
+    const firstChunk = chunks[0]!;
+    expect(firstChunk.text).toContain("// Context:");
+    expect(firstChunk.text).toContain("OrderService");
+  });
+
+  test("chunkDocumentAsync skips enrichment when strategy is regex", async () => {
+    const chunks = await chunkDocumentAsync(
+      LARAVEL_SERVICE_SAMPLE,
+      100,
+      10,
+      10,
+      "app/Services/OrderService.php",
+      "regex",
+    );
+
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks[0]!.text).not.toContain("// Context:");
+  });
+});

--- a/test/template-retrieval.test.ts
+++ b/test/template-retrieval.test.ts
@@ -1,0 +1,178 @@
+/**
+ * test/template-retrieval.test.ts - Tests for template-aware code retrieval engine
+ */
+
+import { describe, test, expect } from "vitest";
+import {
+  detectTemplateAdapter,
+  getTemplateBreakPoints,
+  getTemplateContext,
+} from "../src/templates.js";
+import { chunkDocumentAsync } from "../src/store.js";
+import { detectLanguage } from "../src/ast.js";
+
+// =============================================================================
+// File Detection & Priority
+// =============================================================================
+
+describe("Template Engine Detection", () => {
+  test("detects Blade templates", () => {
+    const adapter = detectTemplateAdapter("resources/views/orders/show.blade.php");
+    expect(adapter).not.toBeNull();
+    expect(adapter?.engine).toBe("blade");
+    // Standard PHP language detector must return null for .blade.php
+    expect(detectLanguage("resources/views/orders/show.blade.php")).toBeNull();
+  });
+
+  test("detects Twig templates", () => {
+    const adapter1 = detectTemplateAdapter("templates/orders/show.twig");
+    expect(adapter1?.engine).toBe("twig");
+
+    const adapter2 = detectTemplateAdapter("templates/orders/show.html.twig");
+    expect(adapter2?.engine).toBe("twig");
+  });
+
+  test("detects Smarty templates", () => {
+    const adapter1 = detectTemplateAdapter("templates/orders/show.tpl");
+    expect(adapter1?.engine).toBe("smarty");
+
+    const adapter2 = detectTemplateAdapter("templates/orders/show.smarty");
+    expect(adapter2?.engine).toBe("smarty");
+  });
+
+  test("detects Latte templates", () => {
+    const adapter = detectTemplateAdapter("templates/orders/show.latte");
+    expect(adapter?.engine).toBe("latte");
+  });
+
+  test("returns null for non-template files", () => {
+    expect(detectTemplateAdapter("app/Services/OrderService.php")).toBeNull();
+    expect(detectTemplateAdapter("src/auth.ts")).toBeNull();
+    expect(detectTemplateAdapter("docs/README.md")).toBeNull();
+  });
+});
+
+// =============================================================================
+// Structural Breakpoints & Context - Blade
+// =============================================================================
+
+describe("Blade Template Breakpoints & Context", () => {
+  const BLADE_SAMPLE = `@extends('layouts.app')
+
+@section('content')
+<div class="order-details">
+    <x-order-card :order="$order" />
+    <livewire:payment-status :id="$order->id" />
+
+    @if($order->isPaid())
+        <p>Order paid: {{ $order->customer->name }}</p>
+    @else
+        <p>Payment pending</p>
+    @endif
+</div>
+@endsection
+`;
+
+  test("extracts Blade breakpoints for directives and components", () => {
+    const points = getTemplateBreakPoints(BLADE_SAMPLE, "resources/views/orders/show.blade.php");
+    expect(points.length).toBeGreaterThan(0);
+
+    const types = points.map(p => p.type);
+    expect(types.some(t => t.includes("extends"))).toBe(true);
+    expect(types.some(t => t.includes("section"))).toBe(true);
+    expect(types.some(t => t.includes("x-component"))).toBe(true);
+    expect(types.some(t => t.includes("livewire"))).toBe(true);
+    expect(types.some(t => t.includes("if"))).toBe(true);
+  });
+
+  test("extracts Blade context (extends layout, sections, components)", () => {
+    const ctx = getTemplateContext(BLADE_SAMPLE, "resources/views/orders/show.blade.php");
+    expect(ctx).not.toBeNull();
+    expect(ctx?.engine).toBe("blade");
+    expect(ctx?.extendsLayout).toBe("layouts.app");
+    expect(ctx?.sections).toContain("content");
+    expect(ctx?.components).toContain("x-order-card");
+    expect(ctx?.components).toContain("livewire:payment-status");
+  });
+});
+
+// =============================================================================
+// Structural Breakpoints & Context - Twig
+// =============================================================================
+
+describe("Twig Template Breakpoints & Context", () => {
+  const TWIG_SAMPLE = `{% extends "base.html.twig" %}
+
+{% block content %}
+    <h1>Order #{{ order.id }}</h1>
+    {% if order.isPaid %}
+        <p>Customer: {{ order.customer.name }}</p>
+    {% endif %}
+{% endblock %}
+`;
+
+  test("extracts Twig breakpoints and context", () => {
+    const points = getTemplateBreakPoints(TWIG_SAMPLE, "templates/orders/show.html.twig");
+    expect(points.length).toBeGreaterThan(0);
+
+    const ctx = getTemplateContext(TWIG_SAMPLE, "templates/orders/show.html.twig");
+    expect(ctx?.engine).toBe("twig");
+    expect(ctx?.extendsLayout).toBe("base.html.twig");
+    expect(ctx?.sections).toContain("content");
+  });
+});
+
+// =============================================================================
+// Structural Breakpoints & Context - Smarty & Latte
+// =============================================================================
+
+describe("Smarty & Latte Template Engine Support", () => {
+  test("extracts Smarty context without file= attribute", () => {
+    const SMARTY_ALT = `{extends 'layout_alt.tpl'}
+{block 'content'}
+    <p>Alt Smarty</p>
+{/block}`;
+    const ctx = getTemplateContext(SMARTY_ALT, "show_alt.tpl");
+    expect(ctx?.engine).toBe("smarty");
+    expect(ctx?.extendsLayout).toBe("layout_alt.tpl");
+    expect(ctx?.sections).toContain("content");
+  });
+
+  test("handles non-template files in getTemplateBreakPoints and getTemplateContext", () => {
+    expect(getTemplateBreakPoints("content", "file.txt")).toEqual([]);
+    expect(getTemplateContext("content", "file.txt")).toBeNull();
+  });
+
+  test("handles throwing adapters in getTemplateBreakPoints and getTemplateContext gracefully", async () => {
+    const { getTemplateBreakPoints, getTemplateContext } = await import("../src/templates.js");
+    expect(getTemplateBreakPoints("content", "nonexistent.blade.php")).toBeDefined();
+    expect(getTemplateContext("content", "nonexistent.blade.php")).toBeDefined();
+  });
+});
+
+// =============================================================================
+// Integration with chunkDocumentAsync
+// =============================================================================
+
+describe("Template Chunk Integration", () => {
+  test("chunkDocumentAsync enriches template chunks in auto mode", async () => {
+    const BLADE = `@extends('layouts.app')
+@section('main')
+<div>{{ $order->name }}</div>
+@endsection`;
+
+    const chunks = await chunkDocumentAsync(
+      BLADE,
+      50,
+      10,
+      10,
+      "resources/views/order.blade.php",
+      "auto",
+    );
+
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks[0]!.text).toContain("[Template Context:");
+    expect(chunks[0]!.text).toContain("engine blade");
+    expect(chunks[0]!.text).toContain("extends layouts.app");
+  });
+});


### PR DESCRIPTION
### Summary

This PR adds first-class PHP and web template retrieval support to QMD without breaking or altering existing retrieval behavior for TypeScript, JavaScript, Python, Go, Rust, or Markdown.

### Added Features

1. **PHP Tree-sitter Support**:
   - Integrates `tree-sitter-php@0.24.2` WASM grammar into `--chunk-strategy auto`.
   - Recognizes classes, interfaces, traits, enums, methods, functions, namespaces, and use statements.
   - Preserves non-AST fallback for `.blade.php` files in generic PHP parsing.

2. **PHP AST Content Enrichment**:
   - Framework-agnostic structural context propagation for PHP chunks (namespaces, containing type names, inheritance `extends`/`implements`, trait `uses`, method signatures, attributes `#[Route(...)]`, and PHPDoc comments).

3. **Template-Aware Code Retrieval**:
   - Dedicated template engine adapter architecture for Laravel Blade (`.blade.php`), Twig (`.twig`, `.html.twig`), Smarty (`.tpl`, `.smarty`), and Latte (`.latte`).
   - Preserves template layout extends, sections, blocks, components, and embedded expressions.

### Testing & Verification

- `node scripts/check-package-grammars.mjs` verifies all WASM grammars (6/6 passing).
- `npx vitest run` runs 63 passing tests across 5 test suites (`test/php-ast.test.ts`, `test/php-enrichment.test.ts`, `test/template-retrieval.test.ts`, `test/ast.test.ts`, `test/ast-chunking.test.ts`).
- Documentation updated in `README.md`, `CLAUDE.md`, and `CHANGELOG.md`.
