### PR TITLE
fix: build dist/ in prepare so git installs work

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "prepare": "[ -d .git ] && ./scripts/install-hooks.sh || true",
+    "prepare": "([ -d .git ] && ./scripts/install-hooks.sh || true) && node scripts/build.mjs",
     "build": "node scripts/build.mjs",
     "test": "node scripts/test-all.mjs",
     "test:types": "node ./node_modules/typescript/bin/tsc -p tsconfig.build.json --noEmit",


### PR DESCRIPTION
## Problem

`npm install -g tobi/qmd` (the README's bleeding-edge install) and `npx github:tobi/qmd` currently install a broken package. When npm installs a git dependency it clones, runs `prepare`, then packs per the `files` list (`bin/`, `dist/`, `skills/` — no `src/`). But `dist/` is not committed and nothing builds it at install time (`prepare` only installs git hooks), so the installed package has no executable code and the launcher exits with:

```
qmd is not built: missing .../node_modules/@tobilu/qmd/dist/cli/qmd.js
```

## Fix

Run the build in `prepare`, which npm executes (with devDependencies installed) before packing a git dependency — the designated hook for exactly this case.

## Verification

Installed from a `git+file://` URL (exercises the same git-dependency pack path as a GitHub install):

- before: no `dist/`, launcher errors as above
- after: `dist/cli/qmd.js` present, `qmd --version` reports the correct commit build stamp

Registry installs are unaffected. Local `npm install` in a checkout now also builds `dist/`, which keeps `./bin/qmd`'s dist-mode fallback fresh — a minor side benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)