### PR TITLE
fix: reject invalid collection paths before creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `qmd collection add` now rejects missing paths and regular files before
+  creating collection configuration or index state. The error reports both the
+  received and resolved path so malformed shell arguments can be corrected.
+
 ## [2.6.3] - 2026-06-24
 
 ### Added

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -4147,6 +4147,22 @@ if (isMain) {
           const globPattern = cli.values.mask as string || DEFAULT_GLOB;
           const name = cli.values.name as string | undefined;
 
+          if (!existsSync(resolvedPwd)) {
+            console.error(`${c.yellow}Collection path does not exist.${c.reset}`);
+            console.error(`  Received: ${pwd}`);
+            console.error(`  Resolved: ${resolvedPwd}`);
+            console.error("Provide an existing directory and run 'qmd collection add <path>' again.");
+            process.exit(1);
+          }
+
+          if (!statSync(resolvedPwd).isDirectory()) {
+            console.error(`${c.yellow}Collection path is not a directory.${c.reset}`);
+            console.error(`  Received: ${pwd}`);
+            console.error(`  Resolved: ${resolvedPwd}`);
+            console.error("Choose a directory and run 'qmd collection add <path>' again.");
+            process.exit(1);
+          }
+
           await collectionAdd(resolvedPwd, globPattern, name);
           break;
         }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -474,6 +474,79 @@ describe("CLI Add Command", () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain("Collection:");
     expect(stdout).toContain("Indexed:");
+    expect(stdout).toContain("Collection 'fixtures' created successfully");
+  });
+
+  test("rejects a nonexistent collection path without persisting it", async () => {
+    const env = await createIsolatedTestEnv("missing-collection-path");
+    const missingPath = join(fixturesDir, "does-not-exist");
+
+    const { stdout, stderr, exitCode } = await runQmd(["collection", "add", missingPath], {
+      dbPath: env.dbPath,
+      configDir: env.configDir,
+    });
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("Collection path does not exist");
+    expect(stderr).toContain(`Received: ${missingPath}`);
+    expect(stderr).toContain("Resolved:");
+    expect(stderr).toContain("Provide an existing directory");
+    expect(stdout).not.toContain("created successfully");
+    expect(readFileSync(join(env.configDir, "index.yml"), "utf8")).toBe("collections: {}\n");
+
+    const listResult = await runQmd(["collection", "list"], {
+      dbPath: env.dbPath,
+      configDir: env.configDir,
+    });
+    expect(listResult.stdout).not.toContain("does-not-exist");
+  });
+
+  test("rejects a path containing swallowed collection flags without persisting it", async () => {
+    const env = await createIsolatedTestEnv("swallowed-collection-flags");
+    const malformedPath = `${join(fixturesDir, "missing")} --name swallowed --mask *.md`;
+    const derivedName = "missing --name swallowed --mask *.md";
+
+    const { stdout, stderr, exitCode } = await runQmd(["collection", "add", malformedPath], {
+      dbPath: env.dbPath,
+      configDir: env.configDir,
+    });
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("Collection path does not exist");
+    expect(stderr).toContain(`Received: ${malformedPath}`);
+    expect(stderr).toContain("Resolved:");
+    expect(stdout).not.toContain("created successfully");
+    expect(readFileSync(join(env.configDir, "index.yml"), "utf8")).toBe("collections: {}\n");
+
+    const listResult = await runQmd(["collection", "list"], {
+      dbPath: env.dbPath,
+      configDir: env.configDir,
+    });
+    expect(listResult.stdout).not.toContain(derivedName);
+  });
+
+  test("rejects a regular file as a collection path without persisting it", async () => {
+    const env = await createIsolatedTestEnv("file-collection-path");
+    const filePath = join(fixturesDir, "README.md");
+
+    const { stdout, stderr, exitCode } = await runQmd(["collection", "add", filePath], {
+      dbPath: env.dbPath,
+      configDir: env.configDir,
+    });
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("Collection path is not a directory");
+    expect(stderr).toContain(`Received: ${filePath}`);
+    expect(stderr).toContain("Resolved:");
+    expect(stderr).toContain("Choose a directory");
+    expect(stdout).not.toContain("created successfully");
+    expect(readFileSync(join(env.configDir, "index.yml"), "utf8")).toBe("collections: {}\n");
+
+    const listResult = await runQmd(["collection", "list"], {
+      dbPath: env.dbPath,
+      configDir: env.configDir,
+    });
+    expect(listResult.stdout).not.toContain("README.md");
   });
 
   test("adds files with custom glob pattern", async () => {


### PR DESCRIPTION
## Summary

In the `collection add` dispatch path in `src/cli/qmd.ts`, validate the fully resolved path before calling `collectionAdd`, so invalid input cannot reach the existing YAML/SQLite persistence sequence. Treat a missing target and a target that exists but is not a directory as distinct non-zero CLI errors, and include the received/resolved path plus corrective guidance in the diagnostic; do not special-case or sanitize quote/flag substrings. Preserve the existing behavior for an existing directory whose mask matches zero files, because an empty directory can be intentional and the two reported failures are unambiguously identified by filesystem validation.

## Verification

- Adding an existing fixture directory still indexes files, prints the normal success output, and exits zero.
- Adding a nonexistent path exits non-zero with a path-not-found diagnostic, does not print `created successfully`, and does not add the derived collection name to `index.yml` or `collection list` output.
- Passing a single path argument containing the swallowed ` --name ... --mask ...` text fails through the same nonexistent-path validation, demonstrating that the Windows failure shape cannot create a default-named collection even when the test runner supplies the already-misparsed argument directly.
- Passing an existing regular file instead of a directory exits non-zero with a not-a-directory diagnostic and leaves configuration and index state unchanged.

## Why

`qmd collection add` currently resolves its positional path and persists a collection before confirming that the directory exists. On Windows, a trailing backslash before a closing quote can cause the runtime to fold later flags into that path; a second reproduction on macOS shows the same false-success outcome when arguments are ordered incorrectly. Both cases resolve to a nonexistent directory, index zero files, leave a broken collection behind, print a green success message, and exit zero. The issue is therefore addressable without trying to repair platform-specific shell parsing: QMD can validate the filesystem target it actually received.

Closes #738
