### PR TITLE
fix(doctor): ignore .etag sidecars in model cache check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Fixed
 
+- `qmd doctor` no longer false-positives `.etag` HTTP sidecars (written by
+  `qmd pull` next to each download) as invalid GGUF models. The model-cache
+  check now only inspects real `.gguf` files, so a sidecar that happens to
+  sort before the blob no longer poisons the report. #812
+
 - `qmd collection add` now rejects missing paths and regular files before
   creating collection configuration or index state. The error reports both the
   received and resolved path so malformed shell arguments can be corrected.

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -3446,11 +3446,12 @@ function findCachedModelInspection(model: string): CachedModelInspection {
     if (!filename || !existsSync(DEFAULT_MODEL_CACHE_DIR)) return { path: null, invalid };
     const entries = readdirSync(DEFAULT_MODEL_CACHE_DIR, { withFileTypes: true });
     for (const entry of entries) {
-      // Skip the `<filename>.etag` HTTP sidecar that `qmd pull` writes next to
-      // each blob. It satisfies `includes(filename)` but is not a GGUF, so
-      // inspecting it as one surfaces a spurious "invalid" model in `qmd
-      // doctor` whenever readdir happens to yield the sidecar before the blob.
-      if (!entry.isFile() || entry.name.endsWith(".etag") || !entry.name.includes(filename)) continue;
+      // Only consider real `.gguf` blobs. `qmd pull` writes a `<filename>.etag`
+      // HTTP sidecar next to each download; that name also satisfies
+      // `includes(filename)`, so inspecting it as GGUF false-positives
+      // "invalid model" in `qmd doctor` whenever readdir yields the sidecar
+      // before the blob (#812).
+      if (!entry.isFile() || !entry.name.endsWith(".gguf") || !entry.name.includes(filename)) continue;
       const candidate = pathJoin(DEFAULT_MODEL_CACHE_DIR, entry.name);
       const inspection = inspectGgufFile(candidate);
       if (inspection.valid) return { path: candidate, invalid };

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -669,19 +669,22 @@ describe("CLI Status Command", () => {
     // blob. That sidecar matches the model-cache lookup's `includes(filename)`
     // test, so a naive scan inspects it as a GGUF and reports the model
     // "invalid" — order-dependently, whenever readdir yields the sidecar
-    // before the blob. The sidecar must be skipped.
+    // before the blob (#812). Only real `.gguf` files must be considered.
     const env = await createIsolatedTestEnv("doctor-etag-sidecar");
-    const model = "hf:example/custom-model/custom.gguf";
+    // Mirror the embeddinggemma layout from #812: bare `<name>.gguf.etag`
+    // sorts before the node-llama-cpp `hf_<org>_<name>.gguf` blob.
+    const model = "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";
     await writeFile(join(env.configDir, "index.yml"), `collections: {}\nmodels:\n  embed: ${model}\n  generate: ${model}\n  rerank: ${model}\n`);
     const cacheRoot = join(env.configDir, "cache");
     const modelCacheDir = join(cacheRoot, "qmd", "models");
     await mkdir(modelCacheDir, { recursive: true });
     // Create the sidecar first so readdir is more likely to surface it before
     // the blob on order-preserving filesystems (the bug's trigger condition).
-    await writeFile(join(modelCacheDir, "custom.gguf.etag"), '"a1b2c3d4e5"\n');
-    // A real blob: node-llama-cpp stores it `hf_<org>_<filename>`. Any name
-    // containing the filename works; it just needs the GGUF magic to be valid.
-    await writeFile(join(modelCacheDir, "hf_example_custom.gguf"), Buffer.concat([Buffer.from("GGUF"), Buffer.alloc(60)]));
+    await writeFile(join(modelCacheDir, "embeddinggemma-300M-Q8_0.gguf.etag"), '"9d3a1b2c3d4e5"\n');
+    await writeFile(
+      join(modelCacheDir, "hf_ggml-org_embeddinggemma-300M-Q8_0.gguf"),
+      Buffer.concat([Buffer.from("GGUF"), Buffer.alloc(60)]),
+    );
 
     const { stdout, exitCode } = await runQmd(["doctor"], {
       dbPath: env.dbPath,


### PR DESCRIPTION
## Summary
- `qmd doctor`'s model-cache scan matched cache filenames with `includes(filename)`, so a `<name>.gguf.etag` HTTP sidecar written by `qmd pull` could be inspected as GGUF and reported invalid whenever `readdir` yielded it before the real blob.
- Restrict the scan to real `*.gguf` files so sidecars are ignored.
- Strengthen the regression test to use the embeddinggemma cache layout from #812, and note the fix under CHANGELOG Unreleased.

Fixes #812

## Test plan
- [x] `CI=true bun test --timeout 60000 --preload ./src/test-preload.ts test/cli.test.ts -t "etag|identifies cached non-GGUF"`
- [ ] Run `qmd doctor` against a cache that has both `embeddinggemma-300M-Q8_0.gguf.etag` and `hf_ggml-org_embeddinggemma-300M-Q8_0.gguf` and confirm no invalid-model warning for the sidecar