### PR TITLE
fix: scope plugin source to ./skills so installs ship 50 KB, not 230 MB

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
 	"plugins": [
 		{
 			"name": "qmd",
-			"source": "./",
+			"source": "./skills",
 			"description": "Search and retrieve documents from local markdown files.",
 			"version": "0.1.0",
 			"author": {
@@ -17,7 +17,7 @@
 			"repository": "https://github.com/tobi/qmd",
 			"license": "MIT",
 			"keywords": ["markdown", "search", "qmd"],
-			"skills": ["./skills/"],
+			"skills": ["./qmd", "./release"],
 			"mcpServers": {
 				"qmd": {
 					"command": "qmd",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - `qmd collection add` now rejects missing paths and regular files before
   creating collection configuration or index state. The error reports both the
   received and resolved path so malformed shell arguments can be corrected.
+- Claude Code plugin: scope the plugin `source` to `./skills` so installs
+  copy just the skills (~50 KB) instead of the entire repository. Previously a
+  canonical install materialized ~230 MB / 9,000+ items into
+  `~/.claude/plugins/cache/` — including a full npm dependency install
+  triggered by the repo-root `package.json`. Both skills (`qmd` and `release`)
+  still ship, unchanged. (#790)
 
 ## [2.6.3] - 2026-06-24
 


### PR DESCRIPTION
Relands #795 onto current `main` (original was conflicted).

Fixes #790.

Original author: @rymalia

## Summary
Scope the Claude Code plugin `source` to `./skills` so installs copy just the skills (~50 KB) instead of the entire repository (~230 MB with npm install).

Changelog conflict resolved by keeping both Unreleased Fixed bullets.
