### PR TITLE
fix: bump plugin version on every release so installed plugins receive updates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
 			"name": "qmd",
 			"source": "./skills",
 			"description": "Search and retrieve documents from local markdown files.",
-			"version": "0.1.0",
+			"version": "2.6.3",
 			"author": {
 				"name": "tobi",
 				"email": "tobi@lutke.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@
   `~/.claude/plugins/cache/` — including a full npm dependency install
   triggered by the repo-root `package.json`. Both skills (`qmd` and `release`)
   still ship, unchanged. (#790)
+- Claude Code plugin: releases now bump the plugin version in
+  `.claude-plugin/marketplace.json` in lockstep with `package.json`. The
+  plugin cache is keyed on this version, and it had been stuck at `0.1.0`
+  since February — so installed plugins never received skill updates
+  (users who installed in February are still being served that snapshot
+  today, despite the qmd skill nearly tripling in size since). Also bumps
+  the plugin to `2.6.3` as a one-time catch-up so existing installs pick
+  up the current skill on their next `claude plugin update`. (#789)
 
 ## [2.6.3] - 2026-06-24
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -108,7 +108,18 @@ awk '
 
 jq --arg v "$NEW" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
 
-git add package.json CHANGELOG.md
+# Keep the Claude Code plugin version in lockstep with the package version.
+# The plugin cache is keyed on this version: if it never changes, installed
+# plugins never pick up skill updates shipped in this release. (sed, not jq,
+# to preserve the file's formatting; the file has a single "version" key.)
+# The grep guard fails the release if the stamp didn't land (a non-matching
+# sed exits 0, which set -e would never catch).
+sed 's/"version": "[^"]*"/"version": "'"$NEW"'"/' \
+  .claude-plugin/marketplace.json > .claude-plugin/marketplace.json.tmp
+grep -qF "\"version\": \"$NEW\"" .claude-plugin/marketplace.json.tmp
+mv .claude-plugin/marketplace.json.tmp .claude-plugin/marketplace.json
+
+git add package.json CHANGELOG.md .claude-plugin/marketplace.json
 git commit -m "release: v$NEW"
 git tag -a "v$NEW" -m "v$NEW"
 

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -31,7 +31,9 @@ When the user triggers `/release <version>`:
 
 4. **Cut the release** — run `scripts/release.sh <version>`. This renames
    `[Unreleased]` → `[X.Y.Z] - date`, inserts a fresh `[Unreleased]`,
-   bumps `package.json`, commits, and tags.
+   bumps `package.json` and the plugin version in
+   `.claude-plugin/marketplace.json` (so installed plugins see the update),
+   commits, and tags.
 
 5. **Show the final changelog** — print the full `[Unreleased]` +
    minor series rollup via `scripts/extract-changelog.sh <version>`.


### PR DESCRIPTION
Relands #794 onto current main (original was conflicted).

Fixes #789.

Original author: @rymalia

## Summary
Bump the Claude Code plugin version in marketplace.json on every release so installed plugins receive skill updates. Catch-up bump to 2.6.3.

Combined carefully with #831 marketplace.json source scoping. Changelog keeps all Unreleased Fixed bullets.
