### PR TITLE
fix(cli): stamp the build's commit instead of guessing at runtime (#787)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,21 @@
   today, despite the qmd skill nearly tripling in size since). Also bumps
   the plugin to `2.6.3` as a one-time catch-up so existing installs pick
   up the current skill on their next `claude plugin update`. (#789)
+- `qmd --version` no longer reports an unrelated repository's commit (#787).
+  The commit was discovered at runtime with `git -C <installDir> rev-parse`,
+  and `git -C` walks *up*, so any install nested inside another checkout
+  reported that checkout's HEAD — a global npm install under a git-managed
+  prefix such as Homebrew's `/opt/homebrew` claimed Homebrew's commit as
+  qmd's. Identical tarballs reported different "commits" depending only on
+  where they were installed, which is why one issue can collect three distinct
+  hashes for the same published build. `scripts/build.mjs` now stamps the
+  commit it built from into `dist/cli/build-info.json` (suffixed `-dirty` when
+  built from a modified tree), and the runtime prefers that. Source checkouts
+  still resolve their own HEAD, but only after confirming the enclosing
+  repository is qmd's; anything else reports no commit rather than a
+  misleading one. The lookup also no longer interpolates the install path into
+  a shell string, so a path containing a space stops silently dropping the
+  commit, and `--version` from a build runs no subprocess at all.
 
 ## [2.6.3] - 2026-06-24
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
-import { chmodSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { chmodSync, readFileSync, realpathSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -27,3 +27,40 @@ const withoutExistingShebang = built.startsWith("#!") ? built.slice(built.indexO
 writeFileSync(tmpPath, `#!/usr/bin/env node\n${withoutExistingShebang}`);
 renameSync(tmpPath, cliPath);
 chmodSync(cliPath, 0o755);
+
+// Stamp the commit this build came from, for `qmd --version`.
+//
+// It has to happen here: a published tarball has no git history of its own, so
+// discovering the commit at runtime finds whatever repository the install
+// happens to sit inside (a global install under /opt/homebrew reported
+// Homebrew's HEAD as qmd's). See src/cli/version.ts.
+//
+// Uses spawnSync directly rather than run() above, because run() exits the
+// build on a non-zero status: no git, no repo, or a source tarball must all
+// degrade to an unstamped build, not a failed one.
+function git(args) {
+  const result = spawnSync("git", args, { cwd: root, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] });
+  if (result.status !== 0 || typeof result.stdout !== "string") return null;
+  return result.stdout.trim();
+}
+
+function buildCommit() {
+  const top = git(["rev-parse", "--show-toplevel"]);
+  // Only trust a repository that *is* this package — same rule the runtime
+  // fallback applies, so building from inside an unrelated checkout can't
+  // stamp that checkout's commit.
+  if (top === null || realpathSync(top) !== realpathSync(root)) return "";
+
+  const commit = git(["rev-parse", "--short", "HEAD"]);
+  if (!commit) return "";
+
+  // A build from a dirty tree is not the commit it claims to be; say so, so
+  // "did my install actually take?" has an answer.
+  const status = git(["status", "--porcelain"]);
+  return status ? `${commit}-dirty` : commit;
+}
+
+writeFileSync(
+  join(root, "dist", "cli", "build-info.json"),
+  `${JSON.stringify({ commit: buildCommit(), builtAt: new Date().toISOString() }, null, 2)}\n`,
+);

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -1,7 +1,7 @@
 import { isBun, openDatabase } from "../db.js";
 import type { Database, SQLiteValue } from "../db.js";
 import fastGlob from "fast-glob";
-import { execSync, spawn as nodeSpawn } from "child_process";
+import { spawn as nodeSpawn } from "child_process";
 import { isQmdMcpPid } from "./mcp-pid.js";
 import { fileURLToPath } from "url";
 import { basename, dirname, join as pathJoin, relative as relativePath, resolve as pathResolve } from "path";
@@ -91,6 +91,7 @@ import {
   escapeCSV,
   type OutputFormat,
 } from "./formatter.js";
+import { resolveCommit } from "./version.js";
 import {
   getCollection as getCollectionFromYaml,
   listCollections as yamlListCollections,
@@ -3976,16 +3977,13 @@ function readPackageJson(): PackageJson {
   return JSON.parse(readFileSync(pkgPath, "utf-8"));
 }
 
-async function showVersion(): Promise<void> {
+function showVersion(): void {
   const scriptDir = dirname(fileURLToPath(import.meta.url));
   const pkg = readPackageJson();
 
-  let commit = "";
-  try {
-    commit = execSync(`git -C ${scriptDir} rev-parse --short HEAD`, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
-  } catch {
-    // Not a git repo or git not available
-  }
+  // Prefer the commit stamped in at build time; fall back to the checkout's
+  // HEAD only when this really is qmd's own checkout. See src/cli/version.ts.
+  const commit = resolveCommit(scriptDir, pathResolve(scriptDir, "..", ".."));
 
   const versionStr = commit ? `${pkg.version} (${commit})` : pkg.version;
   console.log(`qmd ${versionStr}`);
@@ -4007,7 +4005,7 @@ if (isMain) {
   const cli = parseCLI();
 
   if (cli.values.version) {
-    await showVersion();
+    showVersion();
     process.exit(0);
   }
 

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -1,0 +1,89 @@
+/**
+ * Build/commit identification for `qmd --version`.
+ *
+ * The commit is *stamped at build time* (scripts/build.mjs writes
+ * build-info.json next to the compiled CLI) rather than discovered at runtime.
+ * A published tarball carries no git history of its own, so a runtime lookup
+ * can only ever find some *other* repository's HEAD: `git -C <dir> rev-parse`
+ * walks up the tree, and a global install under a git-managed prefix (e.g.
+ * Homebrew's /opt/homebrew) reported that prefix's commit as qmd's.
+ *
+ * Running from a source checkout has no stamp, so the git lookup remains as a
+ * fallback — but only after confirming the enclosing repository is the package
+ * we are actually running from.
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, realpathSync } from "node:fs";
+import { join } from "node:path";
+
+/** Written next to the compiled CLI (dist/cli/) by scripts/build.mjs. */
+export const BUILD_INFO_FILENAME = "build-info.json";
+
+export type BuildInfo = {
+  commit: string;
+  builtAt?: string;
+};
+
+/**
+ * Read the commit stamped into this build, or "" when there is none.
+ *
+ * Deliberately looks beside the running script rather than in the package's
+ * dist/ directory: a source run (src/cli/) must not pick up the stamp left by
+ * an earlier, possibly unrelated, build in dist/.
+ */
+export function readStampedCommit(scriptDir: string): string {
+  try {
+    const raw = readFileSync(join(scriptDir, BUILD_INFO_FILENAME), "utf-8");
+    const info = JSON.parse(raw) as Partial<BuildInfo>;
+    return typeof info.commit === "string" ? info.commit : "";
+  } catch {
+    // No stamp (source run), unreadable, or malformed — fall through.
+    return "";
+  }
+}
+
+function git(args: string[], cwd: string): string {
+  // execFileSync, not execSync: no shell, so a path containing spaces or shell
+  // metacharacters is passed through intact instead of silently failing.
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["pipe", "pipe", "pipe"],
+  }).trim();
+}
+
+/**
+ * Short HEAD of the checkout we are running from, or "" when we are not
+ * running from one.
+ *
+ * The guard is the whole point: an enclosing repository is only qmd's if its
+ * top level *is* this package's root. Without that check, any install nested
+ * inside an unrelated repository reports that repository's HEAD.
+ */
+export function gitCommitForCheckout(scriptDir: string, packageRoot: string): string {
+  try {
+    const top = git(["rev-parse", "--show-toplevel"], scriptDir);
+    if (realpathSync(top) !== realpathSync(packageRoot)) return "";
+
+    const commit = git(["rev-parse", "--short", "HEAD"], top);
+    if (!commit) return "";
+
+    // Same "-dirty" marker scripts/build.mjs stamps: running edited sources is
+    // not the commit it names, and that distinction is the whole point of
+    // printing a commit at all.
+    const dirty = git(["status", "--porcelain"], top);
+    return dirty ? `${commit}-dirty` : commit;
+  } catch {
+    // Not a git repo, git not installed, or an unborn branch.
+    return "";
+  }
+}
+
+/**
+ * The commit to report for this invocation: the build stamp when there is one,
+ * otherwise the verified checkout HEAD, otherwise nothing.
+ */
+export function resolveCommit(scriptDir: string, packageRoot: string): string {
+  return readStampedCommit(scriptDir) || gitCommitForCheckout(scriptDir, packageRoot);
+}

--- a/test/esm-ambiguous-module.test.ts
+++ b/test/esm-ambiguous-module.test.ts
@@ -1,20 +1,23 @@
-import { describe, expect, test } from "vitest";
+import { beforeAll, describe, expect, test } from "vitest";
 import { execFileSync } from "child_process";
-import { mkdtempSync } from "fs";
+import { existsSync, mkdtempSync, readFileSync } from "fs";
 import { tmpdir } from "os";
 import { dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
+// One build for the whole file: both tests exercise the compiled CLI.
+beforeAll(() => {
+  execFileSync(process.execPath, ["scripts/build.mjs"], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    stdio: "pipe",
+  });
+}, 120_000);
+
 describe("Node ESM entrypoints", () => {
   test("CLI --index path normalizes via setIndexName/setConfigIndexName under Node 22+", () => {
-    execFileSync(process.execPath, ["scripts/build.mjs"], {
-      cwd: repoRoot,
-      encoding: "utf-8",
-      stdio: "pipe",
-    });
-
     const indexPath = join(mkdtempSync(join(tmpdir(), "qmd-index-")), "nested", "idx");
     const output = execFileSync(process.execPath, ["dist/cli/qmd.js", "--index", indexPath, "--version"], {
       cwd: repoRoot,
@@ -23,5 +26,31 @@ describe("Node ESM entrypoints", () => {
     });
 
     expect(output).toContain("qmd ");
+  }, 120_000);
+
+  // Regression for #787: the commit must come from the build, not from
+  // whatever repository the install happens to sit inside.
+  test("the build stamps the commit it was built from", () => {
+    const stampPath = join(repoRoot, "dist", "cli", "build-info.json");
+    expect(existsSync(stampPath), "scripts/build.mjs should write dist/cli/build-info.json").toBe(true);
+    const stamp = JSON.parse(readFileSync(stampPath, "utf-8")) as { commit?: string };
+
+    const output = execFileSync(process.execPath, ["dist/cli/qmd.js", "--version"], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: "pipe",
+    }).trim();
+
+    // `qmd 2.6.3` or `qmd 2.6.3 (abc1234)` / `(abc1234-dirty)` — never anything else.
+    expect(output).toMatch(/^qmd \d+\.\d+\.\d+(?: \([0-9a-f]{7,}(?:-dirty)?\))?$/);
+
+    // In a checkout, git is available and the stamp must be this repo's HEAD.
+    const head = execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+      cwd: repoRoot,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    expect(stamp.commit).toMatch(new RegExp(`^${head}(?:-dirty)?$`));
+    expect(output).toContain(`(${stamp.commit})`);
   }, 120_000);
 });

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Version/commit identification tests (issue #717's sibling, #787).
+ *
+ * `qmd --version` used to run `git -C <scriptDir> rev-parse --short HEAD`.
+ * `git -C` walks *up*, so any install nested inside an unrelated repository
+ * reported that repository's HEAD as qmd's — the reason bug reports for the
+ * same published tarball carried three different "commits".
+ *
+ * These tests pin the two rules that replace it: a build stamp wins, and a
+ * git lookup is only trusted when the enclosing repository is the package we
+ * are actually running from.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { execFileSync } from "child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  BUILD_INFO_FILENAME,
+  gitCommitForCheckout,
+  readStampedCommit,
+  resolveCommit,
+} from "../src/cli/version.js";
+
+let testDir: string;
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["pipe", "pipe", "pipe"],
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "qmd test",
+      GIT_AUTHOR_EMAIL: "test@example.com",
+      GIT_COMMITTER_NAME: "qmd test",
+      GIT_COMMITTER_EMAIL: "test@example.com",
+    },
+  }).trim();
+}
+
+/**
+ * A git repo whose working tree is clean: everything already present in `dir`
+ * is committed, so later assertions can distinguish clean from dirty.
+ * Returns the short HEAD.
+ */
+function initRepo(dir: string): string {
+  git(["init", "-q", "--initial-branch=main", "."], dir);
+  git(["add", "-A"], dir);
+  git(["commit", "-q", "--allow-empty", "-m", "root"], dir);
+  return git(["rev-parse", "--short", "HEAD"], dir);
+}
+
+/** package root + the directory the CLI runs from (dist/cli or src/cli). */
+async function makePackage(root: string): Promise<{ packageRoot: string; scriptDir: string }> {
+  const scriptDir = join(root, "dist", "cli");
+  await mkdir(scriptDir, { recursive: true });
+  await writeFile(join(root, "package.json"), JSON.stringify({ name: "@tobilu/qmd", version: "9.9.9" }));
+  return { packageRoot: root, scriptDir };
+}
+
+beforeAll(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "qmd-version-"));
+});
+
+afterAll(async () => {
+  await rm(testDir, { recursive: true, force: true });
+});
+
+describe("gitCommitForCheckout", () => {
+  test("returns nothing when the enclosing repo is not this package (#787)", async () => {
+    // The reported scenario: a global install living inside an unrelated
+    // checkout (e.g. npm prefix under a git-managed /opt/homebrew).
+    const outer = join(testDir, "unrelated-repo");
+    await mkdir(outer, { recursive: true });
+    const outerHead = initRepo(outer);
+
+    const { packageRoot, scriptDir } = await makePackage(join(outer, "lib", "node_modules", "@tobilu", "qmd"));
+
+    const commit = gitCommitForCheckout(scriptDir, packageRoot);
+    expect(commit).toBe("");
+    // The bug was reporting exactly this.
+    expect(commit).not.toBe(outerHead);
+  });
+
+  test("returns the real HEAD when the package root is the repo", async () => {
+    const repo = join(testDir, "qmd-checkout");
+    const { packageRoot, scriptDir } = await makePackage(repo);
+    const head = initRepo(repo);
+
+    expect(gitCommitForCheckout(scriptDir, packageRoot)).toBe(head);
+  });
+
+  test("marks a dirty working tree", async () => {
+    const repo = join(testDir, "dirty-checkout");
+    const { packageRoot, scriptDir } = await makePackage(repo);
+    const head = initRepo(repo);
+    await writeFile(join(repo, "uncommitted.txt"), "edit\n");
+
+    expect(gitCommitForCheckout(scriptDir, packageRoot)).toBe(`${head}-dirty`);
+  });
+
+  test("works when the install path contains a space", async () => {
+    // The old code interpolated the directory into a shell string unquoted, so
+    // a space made git fail and the commit silently vanished.
+    const repo = join(testDir, "a dir", "qmd checkout");
+    const { packageRoot, scriptDir } = await makePackage(repo);
+    const head = initRepo(repo);
+
+    expect(gitCommitForCheckout(scriptDir, packageRoot)).toBe(head);
+  });
+
+  test("returns nothing outside any repository", async () => {
+    const plain = join(testDir, "no-repo");
+    await mkdir(plain, { recursive: true });
+    const { packageRoot, scriptDir } = await makePackage(plain);
+
+    expect(gitCommitForCheckout(scriptDir, packageRoot)).toBe("");
+  });
+});
+
+describe("readStampedCommit", () => {
+  test("reads the commit stamped beside the running script", async () => {
+    const { scriptDir } = await makePackage(join(testDir, "stamped"));
+    await writeFile(
+      join(scriptDir, BUILD_INFO_FILENAME),
+      JSON.stringify({ commit: "abc1234", builtAt: "2026-01-01T00:00:00.000Z" })
+    );
+
+    expect(readStampedCommit(scriptDir)).toBe("abc1234");
+  });
+
+  test("returns nothing when there is no stamp", async () => {
+    const { scriptDir } = await makePackage(join(testDir, "unstamped"));
+    expect(readStampedCommit(scriptDir)).toBe("");
+  });
+
+  test("tolerates a malformed or commit-less stamp", async () => {
+    const { scriptDir } = await makePackage(join(testDir, "malformed"));
+    await writeFile(join(scriptDir, BUILD_INFO_FILENAME), "{not json");
+    expect(readStampedCommit(scriptDir)).toBe("");
+
+    await writeFile(join(scriptDir, BUILD_INFO_FILENAME), JSON.stringify({ builtAt: "whenever" }));
+    expect(readStampedCommit(scriptDir)).toBe("");
+  });
+});
+
+describe("resolveCommit", () => {
+  test("prefers the build stamp over the enclosing checkout", async () => {
+    const repo = join(testDir, "stamp-wins");
+    const { packageRoot, scriptDir } = await makePackage(repo);
+    const head = initRepo(repo);
+    await writeFile(join(scriptDir, BUILD_INFO_FILENAME), JSON.stringify({ commit: "stamped1" }));
+
+    expect(resolveCommit(scriptDir, packageRoot)).toBe("stamped1");
+    expect(resolveCommit(scriptDir, packageRoot)).not.toBe(head);
+  });
+
+  test("falls back to the verified checkout when unstamped", async () => {
+    const repo = join(testDir, "fallback");
+    const { packageRoot, scriptDir } = await makePackage(repo);
+    const head = initRepo(repo);
+
+    expect(resolveCommit(scriptDir, packageRoot)).toBe(head);
+  });
+
+  test("reports nothing rather than a foreign commit", async () => {
+    const outer = join(testDir, "foreign");
+    await mkdir(outer, { recursive: true });
+    initRepo(outer);
+    const { packageRoot, scriptDir } = await makePackage(join(outer, "node_modules", "@tobilu", "qmd"));
+
+    expect(resolveCommit(scriptDir, packageRoot)).toBe("");
+  });
+});


### PR DESCRIPTION
Relands #788 onto current main (original was conflicted).

Fixes #787.

Original author: @danmackinlay

## Summary
Stamp the build commit into dist/cli/build-info.json and prefer that at runtime so qmd --version does not report an unrelated repository commit.

Conflict resolution: kept isQmdMcpPid import from main; dropped unused execSync; merged all Unreleased Fixed changelog bullets.
