### PR TITLE
test: cover Windows-safe prepare hooks installer (#778)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 ### Fixed
 
+- windows prepare fix #778 keeps dist build #824
+
 - `qmd mcp` (stdio) now shuts down gracefully when stdin reaches EOF instead
   of orphaning to PID 1 when the parent MCP client dies (#751): the server
   closes its transport, gives in-flight request handlers a bounded window to

--- a/test/install-hooks.test.ts
+++ b/test/install-hooks.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "vitest";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const scriptSrc = join(repoRoot, "scripts", "install-hooks.mjs");
+const prePushSrc = join(repoRoot, "scripts", "pre-push");
+
+function runInstallHooks(cwd: string) {
+  return spawnSync(process.execPath, [join(cwd, "scripts", "install-hooks.mjs")], {
+    cwd,
+    encoding: "utf8",
+  });
+}
+
+function makeFixture(withGitHooks: boolean) {
+  const root = mkdtempSync(join(tmpdir(), "qmd-install-hooks-"));
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  writeFileSync(join(root, "scripts", "install-hooks.mjs"), readFileSync(scriptSrc));
+  writeFileSync(join(root, "scripts", "pre-push"), readFileSync(prePushSrc));
+  chmodSync(join(root, "scripts", "pre-push"), 0o755);
+  if (withGitHooks) {
+    mkdirSync(join(root, ".git", "hooks"), { recursive: true });
+  }
+  return root;
+}
+
+describe("scripts/install-hooks.mjs", () => {
+  test("skips when .git/hooks is missing (non-git / packaged install)", () => {
+    const root = makeFixture(false);
+    try {
+      const result = runInstallHooks(root);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toMatch(/Not a git repository, skipping hook install/);
+      expect(existsSync(join(root, ".git", "hooks", "pre-push"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("copies pre-push into .git/hooks when present", () => {
+    const root = makeFixture(true);
+    try {
+      const result = runInstallHooks(root);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toMatch(/Installed git hooks: pre-push/);
+      const installed = join(root, ".git", "hooks", "pre-push");
+      expect(existsSync(installed)).toBe(true);
+      expect(readFileSync(installed, "utf8")).toBe(readFileSync(prePushSrc, "utf8"));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("package.json prepare keeps Windows-safe hooks AND dist build", () => {
+    const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
+    expect(pkg.scripts.prepare).toBe(
+      "node scripts/install-hooks.mjs && node scripts/build.mjs",
+    );
+    // Must not use a POSIX shell test / .sh fragment (breaks cmd.exe).
+    expect(pkg.scripts.prepare).not.toMatch(/\[ -d|\.sh/);
+  });
+});


### PR DESCRIPTION
## Summary
- Follow-up to #839 / #779: the prepare fix is already on main (`node scripts/install-hooks.mjs && node scripts/build.mjs`).
- Adds `test/install-hooks.test.ts` (skip when not a git checkout, copy pre-push, assert prepare keeps dist build).
- Changelog Unreleased note for #778 / #824.

## Test plan
- [x] `test/install-hooks.test.ts` green under Node 22 vitest and bun