### PR TITLE
fix(embed): exclusive lock against concurrent embed races (#825)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@
 
 ### Fixed
 
+- `qmd embed` now takes an exclusive process lock (`.qmd-embed.lock` next to
+  the index DB) so concurrent invocations no longer race on `vectors_vec`
+  and fail with `UNIQUE constraint failed: vectors_vec.hash_seq`. A second
+  embed exits early with `Another embed process is already running. Skipping.`
+  Stale locks from crashed processes are recovered via PID identity checks
+  (#825).
+
 - windows prepare fix #778 keeps dist build #824
 
 - `qmd mcp` (stdio) now shuts down gracefully when stdin reaches EOF instead

--- a/src/cli/embed-lock.ts
+++ b/src/cli/embed-lock.ts
@@ -1,0 +1,100 @@
+/**
+ * Process-level exclusive lock for `qmd embed`.
+ *
+ * Concurrent embed runs against the same index can race on vectors_vec
+ * (UNIQUE constraint on hash_seq). This lockfile keeps a second process from
+ * starting while another embed holds the lock. Stale files left by crashed
+ * processes are recovered via PID identity checks (same spirit as mcp-pid.ts).
+ */
+
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { isQmdMcpPid } from "./mcp-pid.js";
+
+export type EmbedLockHandle = {
+  lockPath: string;
+  release: () => void;
+};
+
+/** Lockfile path sibling to the index database. */
+export function embedLockPathForDb(dbPath: string): string {
+  return join(dirname(dbPath), ".qmd-embed.lock");
+}
+
+function readLockPid(lockPath: string): number | null {
+  try {
+    const raw = readFileSync(lockPath, "utf-8").trim();
+    const pid = parseInt(raw, 10);
+    if (!Number.isInteger(pid) || pid <= 0) return null;
+    return pid;
+  } catch {
+    return null;
+  }
+}
+
+/** True if `pid` still owns a live embed/qmd process (or is this process). */
+export function isLiveEmbedLockHolder(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  // Same-process re-check: we obviously still hold our own lock.
+  if (pid === process.pid) return true;
+  return isQmdMcpPid(pid);
+}
+
+function createOwnedLock(lockPath: string): EmbedLockHandle {
+  writeFileSync(lockPath, `${process.pid}\n`, { flag: "wx" });
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    try {
+      if (!existsSync(lockPath)) return;
+      const written = readLockPid(lockPath);
+      if (written === process.pid) unlinkSync(lockPath);
+    } catch {
+      // best-effort cleanup
+    }
+  };
+  return { lockPath, release };
+}
+
+/**
+ * Try to acquire an exclusive embed lock at `lockPath`.
+ * Returns a handle with `release()` on success, or `null` if another live
+ * qmd process already holds the lock.
+ */
+export function tryAcquireEmbedLock(lockPath: string): EmbedLockHandle | null {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      return createOwnedLock(lockPath);
+    } catch (err: unknown) {
+      const code =
+        typeof err === "object" && err !== null && "code" in err
+          ? (err as NodeJS.ErrnoException).code
+          : undefined;
+      if (code !== "EEXIST") throw err;
+
+      const holderPid = readLockPid(lockPath);
+      if (holderPid !== null && isLiveEmbedLockHolder(holderPid)) {
+        return null;
+      }
+
+      // Stale / unreadable / recycled PID — remove and retry once.
+      try {
+        unlinkSync(lockPath);
+      } catch {
+        // Another process may have claimed it; loop and try wx again.
+      }
+    }
+  }
+
+  // Final attempt lost the race to a live holder (or repeated EEXIST).
+  const holderPid = readLockPid(lockPath);
+  if (holderPid !== null && isLiveEmbedLockHolder(holderPid)) {
+    return null;
+  }
+  return null;
+}
+
+/** User-facing message when a second embed is skipped. */
+export const EMBED_LOCK_BUSY_MESSAGE =
+  "Another embed process is already running. Skipping.";

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -3,6 +3,7 @@ import type { Database, SQLiteValue } from "../db.js";
 import fastGlob from "fast-glob";
 import { spawn as nodeSpawn } from "child_process";
 import { isQmdMcpPid } from "./mcp-pid.js";
+import { embedLockPathForDb, tryAcquireEmbedLock, EMBED_LOCK_BUSY_MESSAGE } from "./embed-lock.js";
 import { fileURLToPath } from "url";
 import { basename, dirname, join as pathJoin, relative as relativePath, resolve as pathResolve } from "path";
 import { parseArgs } from "util";
@@ -1905,86 +1906,98 @@ async function vectorIndex(
   const storeInstance = getStore();
   const db = storeInstance.db;
 
-  if (force) {
-    console.log(`${c.yellow}Force re-indexing: clearing all vectors...${c.reset}`);
-  }
-
-  // Check if there's work to do before starting
-  const hashesToEmbed = getHashesNeedingEmbedding(db, batchOptions?.collection, model);
-  if (hashesToEmbed === 0 && !force) {
-    console.log(`${c.green}✓ All content hashes already have embeddings.${c.reset}`);
+  // Exclusive process lock — concurrent embeds race on vectors_vec (#825)
+  const embedLock = tryAcquireEmbedLock(embedLockPathForDb(getDbPath()));
+  if (!embedLock) {
+    console.log(EMBED_LOCK_BUSY_MESSAGE);
     closeDb();
     return;
   }
 
-  console.log(`${c.dim}Model: ${shortModelName(model)}${c.reset}\n`);
-  if (batchOptions?.maxDocsPerBatch !== undefined || batchOptions?.maxBatchBytes !== undefined) {
-    const maxDocsPerBatch = batchOptions.maxDocsPerBatch ?? DEFAULT_EMBED_MAX_DOCS_PER_BATCH;
-    const maxBatchBytes = batchOptions.maxBatchBytes ?? DEFAULT_EMBED_MAX_BATCH_BYTES;
-    console.log(`${c.dim}Batch: ${maxDocsPerBatch} docs / ${formatBytes(maxBatchBytes)}${c.reset}\n`);
-  }
-  cursor.hide();
-  progress.indeterminate();
+  try {
+    if (force) {
+      console.log(`${c.yellow}Force re-indexing: clearing all vectors...${c.reset}`);
+    }
 
-  const startTime = Date.now();
+    // Check if there's work to do before starting
+    const hashesToEmbed = getHashesNeedingEmbedding(db, batchOptions?.collection, model);
+    if (hashesToEmbed === 0 && !force) {
+      console.log(`${c.green}✓ All content hashes already have embeddings.${c.reset}`);
+      closeDb();
+      return;
+    }
 
-  const result = await generateEmbeddings(storeInstance, {
-    force,
-    model,
-    collection: batchOptions?.collection,
-    maxDocsPerBatch: batchOptions?.maxDocsPerBatch,
-    maxBatchBytes: batchOptions?.maxBatchBytes,
-    chunkStrategy: batchOptions?.chunkStrategy,
-    maxDurationMs: batchOptions?.maxDurationMs,
-    onProgress: (info) => {
-      if (info.totalBytes === 0) return;
-      // Progress is measured by input bytes, not by chunks. The final chunk
-      // count is discovered lazily batch-by-batch, so displaying
-      // chunksEmbedded/totalChunks makes the percent look wrong when a few
-      // large documents remain. Show chunks as a count and label the byte
-      // percentage explicitly as input progress.
-      const percent = Math.min(100, (info.bytesProcessed / info.totalBytes) * 100);
-      progress.set(percent);
+    console.log(`${c.dim}Model: ${shortModelName(model)}${c.reset}\n`);
+    if (batchOptions?.maxDocsPerBatch !== undefined || batchOptions?.maxBatchBytes !== undefined) {
+      const maxDocsPerBatch = batchOptions.maxDocsPerBatch ?? DEFAULT_EMBED_MAX_DOCS_PER_BATCH;
+      const maxBatchBytes = batchOptions.maxBatchBytes ?? DEFAULT_EMBED_MAX_BATCH_BYTES;
+      console.log(`${c.dim}Batch: ${maxDocsPerBatch} docs / ${formatBytes(maxBatchBytes)}${c.reset}\n`);
+    }
+    cursor.hide();
+    progress.indeterminate();
 
-      const elapsed = (Date.now() - startTime) / 1000;
-      const bytesPerSec = elapsed > 0 ? info.bytesProcessed / elapsed : 0;
-      const remainingBytes = Math.max(0, info.totalBytes - info.bytesProcessed);
-      const etaSec = bytesPerSec > 0 ? remainingBytes / bytesPerSec : Number.POSITIVE_INFINITY;
+    const startTime = Date.now();
 
-      const bar = renderProgressBar(percent);
-      const percentStr = percent.toFixed(0).padStart(3);
-      const throughput = bytesPerSec > 0 ? `${formatBytes(bytesPerSec)}/s` : ".../s";
-      const eta = elapsed > 2 && Number.isFinite(etaSec) ? formatETA(etaSec) : "...";
-      const inputStr = `${formatBytes(info.bytesProcessed)}/${formatBytes(info.totalBytes)} input`;
-      const chunkStr = `${formatCount(info.chunksEmbedded)} chunks`;
-      const errStr = info.errors > 0 ? ` ${c.yellow}${formatCount(info.errors)} err${c.reset}` : "";
+    const result = await generateEmbeddings(storeInstance, {
+      force,
+      model,
+      collection: batchOptions?.collection,
+      maxDocsPerBatch: batchOptions?.maxDocsPerBatch,
+      maxBatchBytes: batchOptions?.maxBatchBytes,
+      chunkStrategy: batchOptions?.chunkStrategy,
+      maxDurationMs: batchOptions?.maxDurationMs,
+      onProgress: (info) => {
+        if (info.totalBytes === 0) return;
+        // Progress is measured by input bytes, not by chunks. The final chunk
+        // count is discovered lazily batch-by-batch, so displaying
+        // chunksEmbedded/totalChunks makes the percent look wrong when a few
+        // large documents remain. Show chunks as a count and label the byte
+        // percentage explicitly as input progress.
+        const percent = Math.min(100, (info.bytesProcessed / info.totalBytes) * 100);
+        progress.set(percent);
 
-      if (isTTY) process.stderr.write(`\r${c.cyan}${bar}${c.reset} ${c.bold}${percentStr}% input${c.reset} ${c.dim}${chunkStr}${errStr} · ${inputStr} · ${throughput} · ETA ${eta}${c.reset}   `);
-    },
-  });
+        const elapsed = (Date.now() - startTime) / 1000;
+        const bytesPerSec = elapsed > 0 ? info.bytesProcessed / elapsed : 0;
+        const remainingBytes = Math.max(0, info.totalBytes - info.bytesProcessed);
+        const etaSec = bytesPerSec > 0 ? remainingBytes / bytesPerSec : Number.POSITIVE_INFINITY;
 
-  progress.clear();
-  cursor.show();
+        const bar = renderProgressBar(percent);
+        const percentStr = percent.toFixed(0).padStart(3);
+        const throughput = bytesPerSec > 0 ? `${formatBytes(bytesPerSec)}/s` : ".../s";
+        const eta = elapsed > 2 && Number.isFinite(etaSec) ? formatETA(etaSec) : "...";
+        const inputStr = `${formatBytes(info.bytesProcessed)}/${formatBytes(info.totalBytes)} input`;
+        const chunkStr = `${formatCount(info.chunksEmbedded)} chunks`;
+        const errStr = info.errors > 0 ? ` ${c.yellow}${formatCount(info.errors)} err${c.reset}` : "";
 
-  const totalTimeSec = result.durationMs / 1000;
+        if (isTTY) process.stderr.write(`\r${c.cyan}${bar}${c.reset} ${c.bold}${percentStr}% input${c.reset} ${c.dim}${chunkStr}${errStr} · ${inputStr} · ${throughput} · ETA ${eta}${c.reset}   `);
+      },
+    });
 
-  if (result.chunksEmbedded === 0 && result.docsProcessed === 0) {
-    console.log(`${c.green}✓ No non-empty documents to embed.${c.reset}`);
-  } else {
-    console.log(`\r${c.green}${renderProgressBar(100)}${c.reset} ${c.bold}100%${c.reset}                                    `);
-    console.log(`\n${c.green}✓ Done!${c.reset} Embedded ${c.bold}${result.chunksEmbedded}${c.reset} chunks from ${c.bold}${result.docsProcessed}${c.reset} documents in ${c.bold}${formatETA(totalTimeSec)}${c.reset}`);
-    if (result.errors > 0) {
-      console.log(`${c.yellow}⚠ ${formatCount(result.errors)} chunks still failed after retries${c.reset}`);
-      for (const failure of (result.failures ?? []).slice(0, 8)) {
-        console.log(`  ${c.dim}${failure.path}#${failure.seq} (${failure.attempts} attempts): ${failure.reason}${c.reset}`);
-      }
-      if ((result.failures?.length ?? 0) > 8) {
-        console.log(`  ${c.dim}...and ${formatCount((result.failures?.length ?? 0) - 8)} more${c.reset}`);
+    progress.clear();
+    cursor.show();
+
+    const totalTimeSec = result.durationMs / 1000;
+
+    if (result.chunksEmbedded === 0 && result.docsProcessed === 0) {
+      console.log(`${c.green}✓ No non-empty documents to embed.${c.reset}`);
+    } else {
+      console.log(`\r${c.green}${renderProgressBar(100)}${c.reset} ${c.bold}100%${c.reset}                                    `);
+      console.log(`\n${c.green}✓ Done!${c.reset} Embedded ${c.bold}${result.chunksEmbedded}${c.reset} chunks from ${c.bold}${result.docsProcessed}${c.reset} documents in ${c.bold}${formatETA(totalTimeSec)}${c.reset}`);
+      if (result.errors > 0) {
+        console.log(`${c.yellow}⚠ ${formatCount(result.errors)} chunks still failed after retries${c.reset}`);
+        for (const failure of (result.failures ?? []).slice(0, 8)) {
+          console.log(`  ${c.dim}${failure.path}#${failure.seq} (${failure.attempts} attempts): ${failure.reason}${c.reset}`);
+        }
+        if ((result.failures?.length ?? 0) > 8) {
+          console.log(`  ${c.dim}...and ${formatCount((result.failures?.length ?? 0) - 8)} more${c.reset}`);
+        }
       }
     }
-  }
 
-  closeDb();
+    closeDb();
+  } finally {
+    embedLock.release();
+  }
 }
 
 // Sanitize a term for FTS5: remove punctuation except apostrophes

--- a/test/_helpers/embed-lock-holder.ts
+++ b/test/_helpers/embed-lock-holder.ts
@@ -1,0 +1,30 @@
+/**
+ * Child helper for embed-lock cross-process tests (#825).
+ * Args: <lockPath> <holdMs> [ignored qmd tokens...]
+ */
+import { tryAcquireEmbedLock } from "../../src/cli/embed-lock.ts";
+
+async function main(): Promise<void> {
+  const lockPath = process.argv[2];
+  const holdMs = Number(process.argv[3] ?? "1000");
+  if (!lockPath || !Number.isFinite(holdMs)) {
+    console.error("usage: embed-lock-holder.ts <lockPath> <holdMs>");
+    process.exit(2);
+  }
+
+  const handle = tryAcquireEmbedLock(lockPath);
+  if (!handle) {
+    console.error("child failed to acquire");
+    process.exit(2);
+  }
+
+  process.stdout.write("HOLD\n");
+  await new Promise((r) => setTimeout(r, holdMs));
+  handle.release();
+  process.stdout.write("RELEASED\n");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/test/embed-lock.test.ts
+++ b/test/embed-lock.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for embed exclusive lock (#825).
+ */
+import { describe, test, expect } from "vitest";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { existsSync, writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+import {
+  embedLockPathForDb,
+  tryAcquireEmbedLock,
+  isLiveEmbedLockHolder,
+  EMBED_LOCK_BUSY_MESSAGE,
+} from "../src/cli/embed-lock.ts";
+
+const thisDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(thisDir, "..");
+const tsxCli = join(projectRoot, "node_modules", "tsx", "dist", "cli.mjs");
+const isBunRuntime = typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
+
+describe("embedLockPathForDb", () => {
+  test("places .qmd-embed.lock next to the index database", () => {
+    expect(embedLockPathForDb("/tmp/qmd-cache/index.sqlite")).toBe("/tmp/qmd-cache/.qmd-embed.lock");
+    expect(embedLockPathForDb("/var/lib/qmd/custom.sqlite")).toBe("/var/lib/qmd/.qmd-embed.lock");
+  });
+});
+
+describe("isLiveEmbedLockHolder", () => {
+  test("treats the current process as a live holder", () => {
+    expect(isLiveEmbedLockHolder(process.pid)).toBe(true);
+  });
+
+  test("rejects invalid and dead PIDs", () => {
+    expect(isLiveEmbedLockHolder(0)).toBe(false);
+    expect(isLiveEmbedLockHolder(-1)).toBe(false);
+    expect(isLiveEmbedLockHolder(999999999)).toBe(false);
+  });
+});
+
+describe("tryAcquireEmbedLock", () => {
+  test("lock held → second acquire skips; release → acquire proceeds", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "qmd-embed-lock-"));
+    const lockPath = join(dir, ".qmd-embed.lock");
+    try {
+      const first = tryAcquireEmbedLock(lockPath);
+      expect(first).not.toBeNull();
+      expect(existsSync(lockPath)).toBe(true);
+      expect((await readFile(lockPath, "utf-8")).trim()).toBe(String(process.pid));
+
+      // Same process still holds the lock — second caller must skip.
+      expect(tryAcquireEmbedLock(lockPath)).toBeNull();
+
+      first!.release();
+      expect(existsSync(lockPath)).toBe(false);
+
+      const again = tryAcquireEmbedLock(lockPath);
+      expect(again).not.toBeNull();
+      again!.release();
+      expect(existsSync(lockPath)).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("cross-process: live qmd-like holder blocks; release allows proceed", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "qmd-embed-lock-xp-"));
+    const lockPath = join(dir, ".qmd-embed.lock");
+    const holderTs = join(thisDir, "_helpers", "embed-lock-holder.ts");
+    const holdMs = 1000;
+
+    // Include a bare `qmd` argv token so isQmdMcpPid(child) is true.
+    const args = isBunRuntime
+      ? [holderTs, lockPath, String(holdMs), "qmd", "embed"]
+      : [tsxCli, holderTs, lockPath, String(holdMs), "qmd", "embed"];
+
+    try {
+      const child = spawn(process.execPath, args, { stdio: ["ignore", "pipe", "pipe"] });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (d: Buffer) => { stdout += d.toString(); });
+      child.stderr.on("data", (d: Buffer) => { stderr += d.toString(); });
+
+      await new Promise<void>((resolve, reject) => {
+        const start = Date.now();
+        const timer = setInterval(() => {
+          if (stdout.includes("HOLD")) {
+            clearInterval(timer);
+            resolve();
+          } else if (Date.now() - start > 8000) {
+            clearInterval(timer);
+            reject(new Error(`child never acquired lock: stdout=${stdout} stderr=${stderr}`));
+          }
+        }, 20);
+      });
+
+      expect(tryAcquireEmbedLock(lockPath)).toBeNull();
+
+      const exitCode = await new Promise<number | null>((resolve) => {
+        child.on("close", (code) => resolve(code));
+      });
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("RELEASED");
+
+      const after = tryAcquireEmbedLock(lockPath);
+      expect(after).not.toBeNull();
+      after!.release();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }, 20_000);
+
+  test("replaces a stale lock from a dead PID and proceeds", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "qmd-embed-lock-stale-"));
+    const lockPath = join(dir, ".qmd-embed.lock");
+    try {
+      writeFileSync(lockPath, "999999999\n");
+      const handle = tryAcquireEmbedLock(lockPath);
+      expect(handle).not.toBeNull();
+      expect((await readFile(lockPath, "utf-8")).trim()).toBe(String(process.pid));
+      handle!.release();
+      expect(existsSync(lockPath)).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("release is idempotent and only unlinks owned lock", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "qmd-embed-lock-own-"));
+    const lockPath = join(dir, ".qmd-embed.lock");
+    try {
+      const handle = tryAcquireEmbedLock(lockPath);
+      expect(handle).not.toBeNull();
+      handle!.release();
+      handle!.release();
+      expect(existsSync(lockPath)).toBe(false);
+
+      const again = tryAcquireEmbedLock(lockPath);
+      expect(again).not.toBeNull();
+      writeFileSync(lockPath, "1\n");
+      again!.release();
+      expect(existsSync(lockPath)).toBe(true);
+      unlinkSync(lockPath);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("EMBED_LOCK_BUSY_MESSAGE", () => {
+  test("matches the issue-requested skip message", () => {
+    expect(EMBED_LOCK_BUSY_MESSAGE).toBe("Another embed process is already running. Skipping.");
+  });
+});


### PR DESCRIPTION
## Summary
- Add a dependency-free exclusive lockfile (`.qmd-embed.lock` next to the index DB) at the start of `qmd embed`, so a second concurrent invocation exits early with `Another embed process is already running. Skipping.`
- Stale locks from crashed processes are recovered via PID identity checks (same spirit as `mcp-pid.ts`).
- Unit/integration coverage for lock held → skip, release → proceed, stale PID recovery, and cross-process holding.

Fixes #825

## Test plan
- [x] `CI=true node ./node_modules/vitest/vitest.mjs run test/embed-lock.test.ts` (green)
- [x] `CI=true bun test --preload ./src/test-preload.ts test/embed-lock.test.ts` (green)
- [ ] CI unit tests green on the PR
- [ ] Optional manual: start `qmd embed` in one terminal, run `qmd embed` in another → second prints skip message