### PR TITLE
fix(multi-get): emit docid as its own field in --format files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
 
 ### Fixed
 
+- `multi-get --format files` now emits the docid as its own CSV field
+  (`#docid,path,...`) instead of prepending it into the path field with a
+  space (`#docid path,...`), matching `search --format files` and keeping
+  naive comma-splitting usable (#760).
+
 - `qmd embed` now takes an exclusive process lock (`.qmd-embed.lock` next to
   the index DB) so concurrent invocations no longer race on `vectors_vec`
   and fail with `UNIQUE constraint failed: vectors_vec.hash_seq`. A second

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -1317,9 +1317,12 @@ function multiGet(pattern: string, maxLines?: number, maxBytes: number = DEFAULT
       console.log([docidVal ? `#${docidVal}` : "", identOf(r), r.title, r.context, r.skipped ? "true" : "false", r.skipped ? r.skipReason : r.body].map(escapeField).join(","));
     }
   } else if (format === "files") {
+    // Headerless CSV: docid,filepath[,context][,status] — docid is its own
+    // field (comma-separated), matching search --format files shape so naive
+    // comma-splitting stays usable (#760).
     for (const r of results) {
       const docidVal = docidOf(r);
-      const id = docidVal ? `#${docidVal} ` : "";
+      const id = docidVal ? `#${docidVal},` : "";
       const ctx = r.context ? `,"${r.context.replace(/"/g, '""')}"` : "";
       const status = r.skipped ? "[SKIPPED]" : "";
       console.log(`${id}${identOf(r)}${ctx}${status ? `,${status}` : ""}`);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -996,6 +996,20 @@ describe("CLI Multi-Get Command", () => {
     }
   });
 
+  test("--format files emits docid as its own CSV field (#760)", async () => {
+    const { stdout, exitCode } = await runQmd(
+      ["multi-get", "README.md", "--format", "files"],
+      { dbPath: localDbPath },
+    );
+    expect(exitCode).toBe(0);
+    const line = stdout.trim().split("\n")[0] ?? "";
+    // Shape: #docid,path[,"context"] — not "#docid path,..."
+    expect(line).toMatch(/^#[a-f0-9]{6},[^,\s]+/);
+    expect(line).not.toMatch(/^#[a-f0-9]{6} /);
+    const firstField = line.split(",")[0] ?? "";
+    expect(firstField).toMatch(/^#[a-f0-9]{6}$/);
+  });
+
   test("retrieves a document by docid", async () => {
     const lookup = await runQmd(["multi-get", "README.md", "--json"], { dbPath: localDbPath });
     expect(lookup.exitCode).toBe(0);

--- a/test/full-path-fallback.test.ts
+++ b/test/full-path-fallback.test.ts
@@ -176,7 +176,7 @@ describe("--full-path fallback for unresolvable results", () => {
       { cwd: collectionDir, dbPath, configDir }
     );
     expect(exitCode).toBe(0);
-    expect(stdout).toMatch(/#[a-f0-9]{6} qmd:\/\/stale\/beta\.md/);
+    expect(stdout).toMatch(/#[a-f0-9]{6},qmd:\/\/stale\/beta\.md/);
     expect(hasFullPathWarning(stderr)).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- `multi-get --format files` now emits `#docid,path,...` with docid as its own CSV field, matching `search --format files`.
- Previously docid was space-prepended into the path field (`#docid path,...`), breaking naive comma-splitting.
- Adds a regression test and updates the `--full-path` fallback expectation.

Fixes #760

## Test plan
- [x] `CI=true bun test --timeout 60000 --preload ./src/test-preload.ts test/cli.test.ts test/full-path-fallback.test.ts` (162 pass)
- [x] `CI=true node ./node_modules/vitest/vitest.mjs run --reporter=verbose --testTimeout 60000 test/cli.test.ts test/full-path-fallback.test.ts` (162 pass)
- [ ] CI unit tests green before merge