### PR TITLE
fix(store): exact-scan small collections in vsearch -c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@
 
 ### Fixed
 
+- `vsearch -c <collection>` no longer returns empty results for small
+  collections crowded out of the global ANN candidate pool. `searchVec` now
+  exact-scans the collection's vectors with `vec_distance_cosine` when the
+  set is within 20k rows (ANN + post-filter cannot see collections that never
+  enter global top-k, and sqlite-vec caps `k` at 4096 so a larger multiplier
+  alone is not enough). Larger collections still use capped ANN over-fetch
+  (#791, #803).
+
 - `multi-get --format files` now emits the docid as its own CSV field
   (`#docid,path,...`) instead of prepending it into the path field with a
   space (`#docid path,...`), matching `search --format files` and keeping

--- a/src/store.ts
+++ b/src/store.ts
@@ -3666,6 +3666,64 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
 // Vector Search
 // =============================================================================
 
+/** sqlite-vec rejects k above this in MATCH queries (v0.1.9). */
+const SQLITE_VEC_MAX_K = 4096;
+
+/**
+ * Max collection-scoped vectors for an exact cosine scan. Above this we fall
+ * back to global ANN with a capped over-fetch. Exact scan avoids the
+ * post-filter starvation of small collections (#791, #803); ANN remains for
+ * very large collections where a full scan would be expensive.
+ */
+const COLLECTION_VEC_EXACT_SCAN_MAX = 20_000;
+
+const VEC_HASH_SEQ_IN_CHUNK = 400;
+
+/**
+ * Exact cosine-distance scan over a known set of hash_seq keys.
+ * Uses vec_distance_cosine with chunked IN lists (no JOIN with vectors_vec).
+ */
+function exactVecScanByHashSeq(
+  db: Database,
+  embedding: number[],
+  hashSeqs: string[],
+  limit: number,
+): { hash_seq: string; distance: number }[] {
+  if (hashSeqs.length === 0 || limit <= 0) return [];
+
+  const queryVec = new Float32Array(embedding);
+  // Over-fetch a bit so multi-chunk docs can still yield `limit` unique files.
+  const fetchLimit = Math.max(limit * 3, limit);
+  const scored: { hash_seq: string; distance: number }[] = [];
+
+  for (let i = 0; i < hashSeqs.length; i += VEC_HASH_SEQ_IN_CHUNK) {
+    const chunk = hashSeqs.slice(i, i + VEC_HASH_SEQ_IN_CHUNK);
+    const placeholders = chunk.map(() => "?").join(",");
+    const rows = db.prepare(`
+      SELECT hash_seq, vec_distance_cosine(embedding, ?) AS distance
+      FROM vectors_vec
+      WHERE hash_seq IN (${placeholders})
+    `).all(queryVec, ...chunk) as { hash_seq: string; distance: number }[];
+    scored.push(...rows);
+  }
+
+  scored.sort((a, b) => a.distance - b.distance);
+  return scored.slice(0, fetchLimit);
+}
+
+function annVecScan(
+  db: Database,
+  embedding: number[],
+  k: number,
+): { hash_seq: string; distance: number }[] {
+  const vecK = Math.max(1, Math.min(SQLITE_VEC_MAX_K, k));
+  return db.prepare(`
+    SELECT hash_seq, distance
+    FROM vectors_vec
+    WHERE embedding MATCH ? AND k = ?
+  `).all(new Float32Array(embedding), vecK) as { hash_seq: string; distance: number }[];
+}
+
 export async function searchVec(db: Database, query: string, model: string, limit: number = 20, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]): Promise<SearchResult[]> {
   const tableExists = db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'`).get();
   if (!tableExists) return [];
@@ -3678,12 +3736,37 @@ export async function searchVec(db: Database, query: string, model: string, limi
   // "optimize" this by combining into a single query with JOINs - it will break.
   // See: https://github.com/tobi/qmd/pull/23
 
-  // Step 1: Get vector matches from sqlite-vec (no JOINs allowed)
-  const vecResults = db.prepare(`
-    SELECT hash_seq, distance
-    FROM vectors_vec
-    WHERE embedding MATCH ? AND k = ?
-  `).all(new Float32Array(embedding), limit * 3) as { hash_seq: string; distance: number }[];
+  // Step 1: Get vector matches from sqlite-vec (no JOINs allowed).
+  //
+  // Collection filter cannot be pushed into MATCH (sqlite-vec has no join-safe
+  // predicate here). Global ANN + post-filter starves small collections: they
+  // never enter the top-k (#791, #803). Multiplier over-fetch alone is not
+  // enough either — sqlite-vec caps k at 4096. For a collection filter we
+  // therefore exact-scan that collection's vectors when the set is small
+  // enough, and only then fall back to capped ANN + post-filter.
+  let vecResults: { hash_seq: string; distance: number }[];
+
+  if (collectionName) {
+    const collectionHashSeqs = withLazyContentVectorMigration(db, () =>
+      db.prepare(`
+        SELECT cv.hash || '_' || cv.seq AS hash_seq
+        FROM content_vectors cv
+        JOIN documents d ON d.hash = cv.hash AND d.active = 1
+        WHERE d.collection = ?
+      `).all(collectionName) as { hash_seq: string }[],
+    ).map((r) => r.hash_seq);
+
+    if (collectionHashSeqs.length === 0) return [];
+
+    if (collectionHashSeqs.length <= COLLECTION_VEC_EXACT_SCAN_MAX) {
+      vecResults = exactVecScanByHashSeq(db, embedding, collectionHashSeqs, limit);
+    } else {
+      // Large collection: ANN with over-fetch, hard-capped at sqlite-vec's max k.
+      vecResults = annVecScan(db, embedding, Math.max(limit * 30, limit * 3));
+    }
+  } else {
+    vecResults = annVecScan(db, embedding, limit * 3);
+  }
 
   if (vecResults.length === 0) return [];
 

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -2941,6 +2941,83 @@ describe("Integration", () => {
 });
 
 // =============================================================================
+// Vector Search collection filter (no LLM — uses precomputed embeddings)
+// =============================================================================
+
+describe("Vector Search collection filter", () => {
+  test("searchVec finds docs in a small collection crowded by a large one (#791, #803)", async () => {
+    const store = await createTestStore();
+    const large = await createTestCollection({ name: "large", pwd: "/test/large" });
+    const small = await createTestCollection({ name: "small", pwd: "/test/small" });
+
+    const dims = 8;
+    store.ensureVecTable(dims);
+    const now = new Date().toISOString();
+    const queryEmbedding = Array(dims).fill(0);
+    queryEmbedding[0] = 1;
+
+    // 250 nearer neighbours in the large collection. With limit=3:
+    //   - old global k=limit*3=9 never sees `small`
+    //   - a plain multiplier (limit*30=90) still misses it
+    //   - sqlite-vec also caps k at 4096, so multipliers cannot fix tiny
+    //     collections in huge indexes. Collection-scoped exact scan does.
+    for (let i = 0; i < 250; i++) {
+      const hash = `largehash${String(i).padStart(3, "0")}`;
+      await insertTestDocument(store.db, large, {
+        name: `noise-${i}`,
+        hash,
+        body: `Noise document ${i}`,
+        displayPath: `noise-${i}.md`,
+      });
+      const embedding = new Float32Array(dims);
+      embedding[0] = 1;
+      store.db.prepare(`INSERT INTO content_vectors (hash, seq, pos, model, embedded_at) VALUES (?, 0, 0, 'test', ?)`).run(hash, now);
+      store.db.prepare(`INSERT INTO vectors_vec (hash_seq, embedding) VALUES (?, ?)`).run(`${hash}_0`, embedding);
+    }
+
+    const targetHash = "smallhash001";
+    await insertTestDocument(store.db, small, {
+      name: "target",
+      hash: targetHash,
+      body: "Target document in the small collection",
+      displayPath: "target.md",
+    });
+    // Farther than the noise vectors — only found via collection-scoped scan.
+    const targetEmbedding = new Float32Array(dims);
+    targetEmbedding[0] = 0.6;
+    targetEmbedding[1] = 0.8;
+    store.db.prepare(`INSERT INTO content_vectors (hash, seq, pos, model, embedded_at) VALUES (?, 0, 0, 'test', ?)`).run(targetHash, now);
+    store.db.prepare(`INSERT INTO vectors_vec (hash_seq, embedding) VALUES (?, ?)`).run(`${targetHash}_0`, targetEmbedding);
+
+    const filtered = await store.searchVec(
+      "ignored — embedding precomputed",
+      "test-model",
+      3,
+      small,
+      undefined,
+      queryEmbedding,
+    );
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]!.collectionName).toBe(small);
+    expect(filtered[0]!.displayPath).toBe(`${small}/target.md`);
+
+    // Unfiltered search still ranks the closer large-collection docs first.
+    const unfiltered = await store.searchVec(
+      "ignored — embedding precomputed",
+      "test-model",
+      3,
+      undefined,
+      undefined,
+      queryEmbedding,
+    );
+    expect(unfiltered).toHaveLength(3);
+    expect(unfiltered.every((r) => r.collectionName === large)).toBe(true);
+
+    await cleanupTestDb(store);
+  });
+});
+
+// =============================================================================
 // LlamaCpp Integration Tests (using real local models)
 // =============================================================================
 


### PR DESCRIPTION
## Summary
- `vsearch -c <collection>` no longer returns empty results when the collection is a small share of the global vector index.
- Root cause: `searchVec` took a global ANN top-k then filtered by collection, so small collections never entered the candidate pool. A larger `k` multiplier alone is not enough — sqlite-vec caps `k` at 4096.
- Fix: when a collection filter is set and the collection has ≤20k vectors, exact-scan those vectors with `vec_distance_cosine` (chunked `IN`, no JOIN). Larger collections keep capped ANN over-fetch + post-filter.

Fixes #791
Fixes #803

## Test plan
- [x] `CI=true bun test … -t "small collection crowded"` (pass)
- [x] `CI=true vitest run … -t "small collection crowded"` (pass)
- [ ] Full Bun/Node unit suites before merge