### PR TITLE
fix(store): include resolved rerank model in cache key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 
 ### Fixed
 
+- Rerank cache keys now include the resolved `models.rerank` URI, so swapping
+  the configured reranker no longer serves the previous model's cached scores
+  (#764).
+
 - `vsearch -c <collection>` no longer returns empty results for small
   collections crowded out of the global ANN candidate pool. `searchVec` now
   exact-scans the collection's vectors with `vec_distance_cosine` when the

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -138,11 +138,13 @@ function getStore(): ReturnType<typeof createStore> {
       const activeModels = ensureModelsConfiguredForCli();
       const config = loadConfig();
       syncConfigToDb(store.db, config);
-      setDefaultLlamaCpp(new LlamaCpp({
+      const llm = new LlamaCpp({
         embedModel: activeModels.embed,
         generateModel: activeModels.generate,
         rerankModel: activeModels.rerank,
-      }));
+      });
+      setDefaultLlamaCpp(llm);
+      store.llm = llm;
     } catch {
       // Config may not exist yet — that's fine, DB works without it
     }

--- a/src/store.ts
+++ b/src/store.ts
@@ -2022,7 +2022,13 @@ export function createStore(dbPath?: string): Store {
 
     // Query expansion & reranking
     expandQuery: (query: string, model?: string, intent?: string) => expandQuery(query, model ?? store.llm?.generateModelName ?? DEFAULT_QUERY_MODEL, db, intent, store.llm),
-    rerank: (query: string, documents: { file: string; text: string }[], model?: string, intent?: string) => rerank(query, documents, model ?? store.llm?.rerankModelName ?? DEFAULT_RERANK_MODEL, db, intent, store.llm),
+    rerank: (query: string, documents: { file: string; text: string }[], model?: string, intent?: string) => {
+      // Cache keys must use the resolved rerank model (store.llm or the global
+      // singleton from models.rerank). Falling back to DEFAULT_RERANK_MODEL when
+      // store.llm is unset made keys stable across config swaps (#764).
+      const llm = getLlm(store);
+      return rerank(query, documents, model ?? llm.rerankModelName ?? DEFAULT_RERANK_MODEL, db, intent, llm);
+    },
 
     // Document retrieval
     findDocument: (filename: string, options?: { includeBody?: boolean }) => findDocument(db, filename, options),
@@ -4043,6 +4049,10 @@ export async function expandQuery(query: string, model: string = DEFAULT_QUERY_M
 export async function rerank(query: string, documents: { file: string; text: string }[], model: string = DEFAULT_RERANK_MODEL, db: Database, intent?: string, llmOverride?: LlamaCpp): Promise<{ file: string; score: number }[]> {
   // Prepend intent to rerank query so the reranker scores with domain context
   const rerankQuery = intent ? `${intent}\n\n${query}` : query;
+  const llm = llmOverride ?? getDefaultLlamaCpp();
+  // Prefer the LLM instance's resolved URI so a models.rerank swap cannot
+  // reuse another model's cache entries (#764).
+  const cacheModel = llm.rerankModelName ?? model;
 
   const cachedResults: Map<string, number> = new Map();
   const uncachedDocsByChunk: Map<string, RerankDocument> = new Map();
@@ -4053,8 +4063,8 @@ export async function rerank(query: string, documents: { file: string; text: str
   // File path is excluded from the new cache key because the reranker score
   // depends on the chunk content, not where it came from.
   for (const doc of documents) {
-    const cacheKey = getCacheKey("rerank", { query: rerankQuery, model, chunk: doc.text });
-    const legacyCacheKey = getCacheKey("rerank", { query, file: doc.file, model, chunk: doc.text });
+    const cacheKey = getCacheKey("rerank", { query: rerankQuery, model: cacheModel, chunk: doc.text });
+    const legacyCacheKey = getCacheKey("rerank", { query, file: doc.file, model: cacheModel, chunk: doc.text });
     const cached = getCachedResult(db, cacheKey) ?? getCachedResult(db, legacyCacheKey);
     if (cached !== null) {
       cachedResults.set(doc.text, parseFloat(cached));
@@ -4065,15 +4075,14 @@ export async function rerank(query: string, documents: { file: string; text: str
 
   // Rerank uncached documents using LlamaCpp
   if (uncachedDocsByChunk.size > 0) {
-    const llm = llmOverride ?? getDefaultLlamaCpp();
     const uncachedDocs = [...uncachedDocsByChunk.values()];
-    const rerankResult = await llm.rerank(rerankQuery, uncachedDocs, { model });
+    const rerankResult = await llm.rerank(rerankQuery, uncachedDocs, { model: cacheModel });
 
     // Cache results by chunk text so identical chunks across files are scored once.
     const textByFile = new Map(uncachedDocs.map(d => [d.file, d.text]));
     for (const result of rerankResult.results) {
       const chunk = textByFile.get(result.file) || "";
-      const cacheKey = getCacheKey("rerank", { query: rerankQuery, model, chunk });
+      const cacheKey = getCacheKey("rerank", { query: rerankQuery, model: cacheModel, chunk });
       setCachedResult(db, cacheKey, result.score.toString());
       cachedResults.set(chunk, result.score);
     }

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -17,6 +17,7 @@ import * as llmModule from "../src/llm.js";
 import { disposeDefaultLlamaCpp, setDefaultLlamaCpp } from "../src/llm.js";
 import {
   createStore,
+  DEFAULT_RERANK_MODEL,
   verifySqliteVecLoaded,
   getDefaultDbPath,
   homedir,
@@ -1149,6 +1150,17 @@ describe("Caching", () => {
     expect(key1).not.toBe(key2);
   });
 
+  test("rerank cache keys differ when the rerank model differs (#764)", () => {
+    const query = "same query";
+    const chunk = "same chunk";
+    const keyA = getCacheKey("rerank", { query, model: "hf:example/rerank-a/a.gguf", chunk });
+    const keyB = getCacheKey("rerank", { query, model: "hf:example/rerank-b/b.gguf", chunk });
+    const keyNoModel = getCacheKey("rerank", { query, chunk });
+    expect(keyA).not.toBe(keyB);
+    expect(keyA).not.toBe(keyNoModel);
+    expect(keyB).not.toBe(keyNoModel);
+  });
+
   test("store cache operations work correctly", async () => {
     const store = await createTestStore();
 
@@ -1169,6 +1181,91 @@ describe("Caching", () => {
     expect(store.getCachedResult(key)).toBeNull();
 
     await cleanupTestDb(store);
+  });
+
+  test("rerank cache key includes the resolved rerank model (#764)", async () => {
+    const store = await createTestStore();
+    const query = "rerank cache model swap";
+    const chunk = "identical chunk text";
+    const docs = [{ file: "doc.md", text: chunk }];
+
+    const makeMock = (modelName: string, score: number) => {
+      const rerankSpy = vi.fn(async (_query: string, scoredDocs: { file: string; text: string }[]) => ({
+        results: scoredDocs.map((doc, index) => ({ file: doc.file, score, index })),
+        model: modelName,
+      }));
+      return {
+        spy: rerankSpy,
+        llm: { rerank: rerankSpy, rerankModelName: modelName },
+      };
+    };
+
+    const modelA = "hf:example/rerank-a/a.gguf";
+    const modelB = "hf:example/rerank-b/b.gguf";
+    const mockA = makeMock(modelA, 0.11);
+    const llmSpy = vi.spyOn(llmModule, "getDefaultLlamaCpp").mockReturnValue(mockA.llm as any);
+
+    try {
+      const first = await store.rerank(query, docs);
+      expect(first[0]!.score).toBe(0.11);
+      expect(mockA.spy).toHaveBeenCalledTimes(1);
+
+      const keyA = getCacheKey("rerank", { query, model: modelA, chunk });
+      const keyB = getCacheKey("rerank", { query, model: modelB, chunk });
+      const keyDefault = getCacheKey("rerank", { query, model: DEFAULT_RERANK_MODEL, chunk });
+      const keyNoModel = getCacheKey("rerank", { query, chunk });
+
+      expect(store.getCachedResult(keyA)).toBe("0.11");
+      expect(store.getCachedResult(keyNoModel)).toBeNull();
+      expect(store.getCachedResult(keyDefault)).toBeNull();
+
+      const mockB = makeMock(modelB, 0.99);
+      llmSpy.mockReturnValue(mockB.llm as any);
+
+      const second = await store.rerank(query, docs);
+      expect(mockB.spy).toHaveBeenCalledTimes(1);
+      expect(second[0]!.score).toBe(0.99);
+      expect(store.getCachedResult(keyB)).toBe("0.99");
+
+      const third = await store.rerank(query, docs);
+      expect(mockB.spy).toHaveBeenCalledTimes(1);
+      expect(third[0]!.score).toBe(0.99);
+    } finally {
+      llmSpy.mockRestore();
+      await cleanupTestDb(store);
+    }
+  });
+
+  test("rerank cache key follows store.llm.rerankModelName (#764)", async () => {
+    const store = await createTestStore();
+    const query = "store.llm model swap";
+    const docs = [{ file: "doc.md", text: "chunk" }];
+
+    const makeMock = (modelName: string, score: number) => {
+      const rerankSpy = vi.fn(async (_query: string, scoredDocs: { file: string; text: string }[]) => ({
+        results: scoredDocs.map((doc, index) => ({ file: doc.file, score, index })),
+        model: modelName,
+      }));
+      return { spy: rerankSpy, llm: { rerank: rerankSpy, rerankModelName: modelName } };
+    };
+
+    const mockA = makeMock("hf:example/store-llm-a/a.gguf", 0.21);
+    const mockB = makeMock("hf:example/store-llm-b/b.gguf", 0.87);
+    store.llm = mockA.llm as any;
+
+    try {
+      const first = await store.rerank(query, docs);
+      expect(first[0]!.score).toBe(0.21);
+      expect(mockA.spy).toHaveBeenCalledTimes(1);
+
+      store.llm = mockB.llm as any;
+      const second = await store.rerank(query, docs);
+      expect(second[0]!.score).toBe(0.87);
+      expect(mockB.spy).toHaveBeenCalledTimes(1);
+      expect(mockA.spy).toHaveBeenCalledTimes(1);
+    } finally {
+      await cleanupTestDb(store);
+    }
   });
 });
 
@@ -3236,6 +3333,7 @@ describe.skipIf(!!process.env.CI)("LlamaCpp Integration", () => {
       await cleanupTestDb(store);
     }
   });
+
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Swapping `models.rerank` in `index.yml` reused the previous model's cached scores for any (query, chunk) pair that had already been scored.
- Root cause: `store.rerank` keyed `llm_cache` with `store.llm?.rerankModelName ?? DEFAULT_RERANK_MODEL`, but the CLI never assigned `store.llm` (only the global singleton). Cache keys stayed on the default URI while inference used the configured model.
- Fix: resolve the LLM via `getLlm(store)` (store instance or global singleton), key the cache with that instance's `rerankModelName`, and attach the configured `LlamaCpp` to `store.llm` in the CLI.

Fixes #764

## Test plan
- [x] `CI=true bun test --timeout 60000 --preload ./src/test-preload.ts test/store.test.ts -t "764"` (2 pass)
- [x] `CI=true vitest run test/store.test.ts -t "764"` (2 pass)
- [x] `CI=true bun test --timeout 60000 --preload ./src/test-preload.ts test/store.test.ts` (215 pass, 13 skip)
- [x] `CI=true vitest run test/store.test.ts` (216 pass, 13 skip)
- [ ] Full Bun/Node unit suites before merge