### PR TITLE
fix(store): repair legacy FTS schema before CJK rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@
 
 ### Fixed
 
+- Opening a store no longer throws `SQLiteError: no such column: T.name` when
+  `documents_fts` is still the legacy `fts5(name, body, content='documents')`
+  schema. `CREATE VIRTUAL TABLE IF NOT EXISTS` left that table in place, and
+  the CJK FTS rebuild's `DELETE FROM documents_fts` compiled against
+  `documents.name`, which does not exist (#792).
+
 - Rerank cache keys now include the resolved `models.rerank` URI, so swapping
   the configured reranker no longer serves the previous model's cached scores
   (#764).

--- a/src/store.ts
+++ b/src/store.ts
@@ -797,57 +797,101 @@ function getUserVersion(db: Database): number {
 // Gate the work behind PRAGMA user_version and apply it inside one IMMEDIATE
 // transaction: the DROP+CREATE pair is atomic across connections, and a
 // double-checked read skips it once any process has stamped the version.
+function installFtsSyncTriggers(db: Database): void {
+  db.exec(`DROP TRIGGER IF EXISTS documents_ai`);
+  db.exec(`
+    CREATE TRIGGER documents_ai AFTER INSERT ON documents
+    WHEN new.active = 1
+    BEGIN
+      INSERT INTO documents_fts(rowid, filepath, title, body)
+      SELECT
+        new.id,
+        new.collection || '/' || new.path,
+        new.title,
+        (SELECT doc FROM content WHERE hash = new.hash)
+      WHERE new.active = 1;
+    END
+  `);
+
+  db.exec(`DROP TRIGGER IF EXISTS documents_ad`);
+  db.exec(`
+    CREATE TRIGGER documents_ad AFTER DELETE ON documents BEGIN
+      DELETE FROM documents_fts WHERE rowid = old.id;
+    END
+  `);
+
+  db.exec(`DROP TRIGGER IF EXISTS documents_au`);
+  db.exec(`
+    CREATE TRIGGER documents_au AFTER UPDATE ON documents
+    BEGIN
+      -- Delete from FTS if no longer active
+      DELETE FROM documents_fts WHERE rowid = old.id AND new.active = 0;
+
+      -- Update FTS if still/newly active
+      INSERT OR REPLACE INTO documents_fts(rowid, filepath, title, body)
+      SELECT
+        new.id,
+        new.collection || '/' || new.path,
+        new.title,
+        (SELECT doc FROM content WHERE hash = new.hash)
+      WHERE new.active = 1;
+    END
+  `);
+}
+
 function applyFtsSyncTriggers(db: Database): void {
   if (getUserVersion(db) >= STORE_SCHEMA_VERSION) return;
   db.exec(`BEGIN IMMEDIATE`);
   try {
     if (getUserVersion(db) < STORE_SCHEMA_VERSION) {
-      db.exec(`DROP TRIGGER IF EXISTS documents_ai`);
-      db.exec(`
-        CREATE TRIGGER documents_ai AFTER INSERT ON documents
-        WHEN new.active = 1
-        BEGIN
-          INSERT INTO documents_fts(rowid, filepath, title, body)
-          SELECT
-            new.id,
-            new.collection || '/' || new.path,
-            new.title,
-            (SELECT doc FROM content WHERE hash = new.hash)
-          WHERE new.active = 1;
-        END
-      `);
-
-      db.exec(`DROP TRIGGER IF EXISTS documents_ad`);
-      db.exec(`
-        CREATE TRIGGER documents_ad AFTER DELETE ON documents BEGIN
-          DELETE FROM documents_fts WHERE rowid = old.id;
-        END
-      `);
-
-      db.exec(`DROP TRIGGER IF EXISTS documents_au`);
-      db.exec(`
-        CREATE TRIGGER documents_au AFTER UPDATE ON documents
-        BEGIN
-          -- Delete from FTS if no longer active
-          DELETE FROM documents_fts WHERE rowid = old.id AND new.active = 0;
-
-          -- Update FTS if still/newly active
-          INSERT OR REPLACE INTO documents_fts(rowid, filepath, title, body)
-          SELECT
-            new.id,
-            new.collection || '/' || new.path,
-            new.title,
-            (SELECT doc FROM content WHERE hash = new.hash)
-          WHERE new.active = 1;
-        END
-      `);
-
+      installFtsSyncTriggers(db);
       db.exec(`PRAGMA user_version = ${STORE_SCHEMA_VERSION}`);
     }
     db.exec(`COMMIT`);
   } catch (err) {
     db.exec(`ROLLBACK`);
     throw err;
+  }
+}
+
+/**
+ * True when documents_fts is the current standalone (filepath, title, body)
+ * table. Older schemas used fts5(name, body, content='documents'), and
+ * CREATE VIRTUAL TABLE IF NOT EXISTS will not replace them. A CJK rebuild
+ * then runs `DELETE FROM documents_fts`, which FTS5 compiles against the
+ * external content table as `SELECT T.name FROM documents AS T` — documents
+ * has no `name` column, so open throws `no such column: T.name` (#792).
+ */
+function documentsFtsSchemaIsCurrent(db: Database): boolean {
+  const row = db.prepare(
+    `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'documents_fts'`
+  ).get() as { sql?: string } | undefined | null;
+  const sql = (row?.sql ?? "").toLowerCase().replace(/\s+/g, "");
+  return sql.includes("filepath") && sql.includes("title") && !sql.includes("content=");
+}
+
+function recreateDocumentsFts(db: Database): void {
+  db.exec(`DROP TRIGGER IF EXISTS documents_ai`);
+  db.exec(`DROP TRIGGER IF EXISTS documents_ad`);
+  db.exec(`DROP TRIGGER IF EXISTS documents_au`);
+  db.exec(`DROP TABLE IF EXISTS documents_fts`);
+  db.exec(`
+    CREATE VIRTUAL TABLE documents_fts USING fts5(
+      filepath, title, body,
+      tokenize='porter unicode61'
+    )
+  `);
+  db.exec(`DELETE FROM store_config WHERE key = 'fts_cjk_normalized_version'`);
+}
+
+function ensureDocumentsFtsSchema(db: Database): void {
+  if (documentsFtsSchemaIsCurrent(db)) return;
+  recreateDocumentsFts(db);
+  // recreateDocumentsFts dropped the sync triggers. applyFtsSyncTriggers
+  // only reinstalls them when user_version is stale, so a DB that already
+  // has the current user_version would otherwise be left untriggered.
+  if (getUserVersion(db) >= STORE_SCHEMA_VERSION) {
+    installFtsSyncTriggers(db);
   }
 }
 
@@ -1057,6 +1101,7 @@ function initializeDatabase(db: Database): void {
     )
   `);
 
+  ensureDocumentsFtsSchema(db);
   applyFtsSyncTriggers(db);
 
   rebuildFTSForCjkNormalization(db);

--- a/test/store-cjk-fts.test.ts
+++ b/test/store-cjk-fts.test.ts
@@ -14,7 +14,9 @@
  * These tests exercise the migration through createStore()/openDatabase() on a
  * pre-seeded DB that omits the fts_cjk_normalized_version marker (forcing a
  * rebuild on open), plus a structural assertion that .iterate() — not .all() —
- * drives the body scan.
+ * drives the body scan. They also cover a brand-new empty store and a legacy
+ * fts5(name, body, content='documents') schema, which used to throw
+ * `no such column: T.name` during rebuildFTSForCjkNormalization (#792).
  *
  * Run with: bun test test/store-cjk-fts.test.ts
  *        or: pnpm test:node test/store-cjk-fts.test.ts
@@ -501,6 +503,130 @@ describe("rebuildFTSForCjkNormalization — Latin search regression guard", () =
       const both = store.searchFTS("keyword inverted", 10, "en");
       expect(both.length).toBe(1);
       expect(both[0]!.displayPath).toBe("en/keyword.md");
+    } finally {
+      store.close();
+    }
+  });
+});
+
+
+// =============================================================================
+// Test 6 — legacy fts5(name, body, content='documents') must not crash open (#792)
+// =============================================================================
+
+describe("rebuildFTSForCjkNormalization — legacy external-content FTS schema (#792)", () => {
+  let dbPath: string;
+
+  beforeEach(async () => {
+    await setEmptyConfig();
+    dbPath = freshDbPath();
+  });
+
+  afterEach(async () => {
+    try {
+      await unlink(dbPath);
+    } catch {
+      // ignore
+    }
+  });
+
+  test("createStore on a brand-new empty file stamps the CJK version", async () => {
+    const store = createStore(dbPath);
+    try {
+      const ver = store.db.prepare(
+        `SELECT value FROM store_config WHERE key = 'fts_cjk_normalized_version'`
+      ).get() as { value?: string } | undefined;
+      expect(ver?.value).toBe(FTS_CJK_NORMALIZED_VERSION);
+      expect(ftsRowCount(store.db)).toBe(0);
+
+      const sqlRow = store.db.prepare(
+        `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'documents_fts'`
+      ).get() as { sql?: string } | undefined;
+      const sql = (sqlRow?.sql ?? "").toLowerCase();
+      expect(sql).toContain("filepath");
+      expect(sql).toContain("title");
+      expect(sql).not.toMatch(/content\s*=/);
+    } finally {
+      store.close();
+    }
+  });
+
+  test("opens a DB whose documents_fts still uses name/body + content='documents'", async () => {
+    {
+      const seed = openDatabase(dbPath);
+      seed.exec(`
+        CREATE TABLE IF NOT EXISTS content (
+          hash TEXT PRIMARY KEY,
+          doc TEXT NOT NULL,
+          created_at TEXT NOT NULL
+        )
+      `);
+      seed.exec(`
+        CREATE TABLE IF NOT EXISTS documents (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          collection TEXT NOT NULL,
+          path TEXT NOT NULL,
+          title TEXT NOT NULL,
+          hash TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          modified_at TEXT NOT NULL,
+          active INTEGER NOT NULL DEFAULT 1,
+          FOREIGN KEY (hash) REFERENCES content(hash) ON DELETE CASCADE,
+          UNIQUE(collection, path)
+        )
+      `);
+      seed.exec(`
+        CREATE TABLE IF NOT EXISTS store_config (
+          key TEXT PRIMARY KEY,
+          value TEXT
+        )
+      `);
+      // The schema that produced `no such column: T.name` on CJK rebuild:
+      // FTS5 external-content maps column `name` onto documents.name.
+      seed.exec(`
+        CREATE VIRTUAL TABLE documents_fts USING fts5(
+          name, body,
+          content='documents',
+          content_rowid='id',
+          tokenize='porter unicode61'
+        )
+      `);
+      seed.exec(`
+        CREATE TRIGGER documents_ai AFTER INSERT ON documents BEGIN
+          INSERT INTO documents_fts(rowid, name, body)
+          SELECT new.id, new.path, content.doc
+          FROM content
+          WHERE content.hash = new.hash;
+        END
+      `);
+      seedDocument(seed, {
+        id: 1,
+        collection: "docs",
+        path: "readme.md",
+        title: "Project README",
+        body: "legacy fts canary token UNIQUE_KEYWORD_XYZ",
+      });
+      seed.close();
+    }
+
+    const store = createStore(dbPath);
+    try {
+      const sqlRow = store.db.prepare(
+        `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'documents_fts'`
+      ).get() as { sql?: string } | undefined;
+      const sql = (sqlRow?.sql ?? "").toLowerCase();
+      expect(sql).toContain("filepath");
+      expect(sql).toContain("title");
+      expect(sql).not.toMatch(/content\s*=/);
+
+      const ver = store.db.prepare(
+        `SELECT value FROM store_config WHERE key = 'fts_cjk_normalized_version'`
+      ).get() as { value?: string } | undefined;
+      expect(ver?.value).toBe(FTS_CJK_NORMALIZED_VERSION);
+
+      const hits = store.searchFTS("UNIQUE_KEYWORD_XYZ", 10, "docs");
+      expect(hits.length).toBe(1);
+      expect(hits[0]!.displayPath).toBe("docs/readme.md");
     } finally {
       store.close();
     }


### PR DESCRIPTION
## Summary
- Opening a store no longer throws `SQLiteError: no such column: T.name` when `documents_fts` is still the legacy `fts5(name, body, content='documents')` schema (the MCP test helper, and any similarly old DB).
- `CREATE VIRTUAL TABLE IF NOT EXISTS` left that table in place; the CJK rebuild then ran `DELETE FROM documents_fts`, which FTS5 compiles against `documents.name`.
- On open, replace a mismatched FTS table with the current standalone `(filepath, title, body)` schema, reinstall sync triggers, and let the CJK rebuild populate it.

Fixes #792

## Test plan
- [x] `bun test test/store-cjk-fts.test.ts` (8 pass, including fresh empty store + legacy `content='documents'` schema)
- [x] `node ./node_modules/vitest/vitest.mjs run test/store-cjk-fts.test.ts` (8 pass)
- [x] `bun test test/mcp.test.ts -t "MCP HTTP Transport"` (7 pass; this was the original reproduction)
- [ ] CI Bun/Node unit tests green (ignore pre-existing nix flake hash mismatches)