### PR TITLE
fix(mcp): scope HTTP daemon pidfile per --index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
 
 ### Fixed
 
+- `qmd --index <name> mcp --http --daemon` now scopes PID/log files per index
+  (`mcp-<name>.pid`) and passes the resolved database path to the child, so a
+  named-index daemon no longer collides with the default `mcp.pid` or opens
+  the default store (#772).
+
 - Opening a store no longer throws `SQLiteError: no such column: T.name` when
   `documents_fts` is still the legacy `fts5(name, body, content='documents')`
   schema. `CREATE VIRTUAL TABLE IF NOT EXISTS` left that table in place, and

--- a/src/cli/mcp-pid.ts
+++ b/src/cli/mcp-pid.ts
@@ -9,6 +9,19 @@
 import { existsSync, readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 
+/**
+ * Pid/log filenames for the MCP HTTP daemon.
+ * The default index keeps `mcp.pid` / `mcp.log` for compatibility; named
+ * indexes are scoped so a named daemon can run alongside the default (#772).
+ */
+export function mcpDaemonStateFiles(indexName: string = "index"): { pidFile: string; logFile: string } {
+  const suffix = !indexName || indexName === "index" ? "" : `-${indexName}`;
+  return {
+    pidFile: `mcp${suffix}.pid`,
+    logFile: `mcp${suffix}.log`,
+  };
+}
+
 /** True if a process command line looks like a qmd CLI invocation. */
 export function looksLikeQmdMcpCommand(cmdline: string): boolean {
   const s = cmdline.trim();

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -2,7 +2,7 @@ import { isBun, openDatabase } from "../db.js";
 import type { Database, SQLiteValue } from "../db.js";
 import fastGlob from "fast-glob";
 import { spawn as nodeSpawn } from "child_process";
-import { isQmdMcpPid } from "./mcp-pid.js";
+import { isQmdMcpPid, mcpDaemonStateFiles } from "./mcp-pid.js";
 import { embedLockPathForDb, tryAcquireEmbedLock, EMBED_LOCK_BUSY_MESSAGE } from "./embed-lock.js";
 import { fileURLToPath } from "url";
 import { basename, dirname, join as pathJoin, relative as relativePath, resolve as pathResolve } from "path";
@@ -182,6 +182,18 @@ function getDbPath(): string {
 
 function getActiveIndexName(): string {
   return currentIndexName;
+}
+
+function mcpDaemonPaths(): { cacheDir: string; pidPath: string; logPath: string } {
+  const cacheDir = process.env.XDG_CACHE_HOME
+    ? resolve(process.env.XDG_CACHE_HOME, "qmd")
+    : resolve(homedir(), ".cache", "qmd");
+  const { pidFile, logFile } = mcpDaemonStateFiles(getActiveIndexName());
+  return {
+    cacheDir,
+    pidPath: resolve(cacheDir, pidFile),
+    logPath: resolve(cacheDir, logFile),
+  };
 }
 
 function setIndexName(name: string | null): void {
@@ -500,11 +512,8 @@ async function showStatus(): Promise<void> {
   console.log(`Index: ${dbPath}`);
   console.log(`Size:  ${formatBytes(indexSize)}`);
 
-  // MCP daemon status (check PID file liveness)
-  const mcpCacheDir = process.env.XDG_CACHE_HOME
-    ? resolve(process.env.XDG_CACHE_HOME, "qmd")
-    : resolve(homedir(), ".cache", "qmd");
-  const mcpPidPath = resolve(mcpCacheDir, "mcp.pid");
+  // MCP daemon status (check PID file liveness; scoped per --index)
+  const { pidPath: mcpPidPath } = mcpDaemonPaths();
   if (existsSync(mcpPidPath)) {
     const mcpPid = parseInt(readFileSync(mcpPidPath, "utf-8").trim());
     if (isQmdMcpPid(mcpPid)) {
@@ -4482,11 +4491,9 @@ if (isMain) {
     case "mcp": {
       const sub = cli.args[0]; // stop | status | undefined
 
-      // Cache dir for PID/log files — same dir as the index
-      const cacheDir = process.env.XDG_CACHE_HOME
-        ? resolve(process.env.XDG_CACHE_HOME, "qmd")
-        : resolve(homedir(), ".cache", "qmd");
-      const pidPath = resolve(cacheDir, "mcp.pid");
+      // Cache dir for PID/log files — scoped per --index so named daemons
+      // do not collide with the default index (#772).
+      const { cacheDir, pidPath, logPath } = mcpDaemonPaths();
 
       // Subcommands take priority over flags
       if (sub === "stop") {
@@ -4531,7 +4538,6 @@ if (isMain) {
           }
 
           mkdirSync(cacheDir, { recursive: true });
-          const logPath = resolve(cacheDir, "mcp.log");
           const logFd = openSync(logPath, "w"); // truncate — fresh log per daemon run
           const selfPath = fileURLToPath(import.meta.url);
           const indexArgs = cli.values.index ? ["--index", String(cli.values.index)] : [];
@@ -4542,6 +4548,12 @@ if (isMain) {
           const child = nodeSpawn(process.execPath, spawnArgs, {
             stdio: ["ignore", logFd, logFd],
             detached: true,
+            env: {
+              ...process.env,
+              // Explicit resolved DB path so the child does not depend on
+              // re-parsing --index (and cannot inherit a stale INDEX_PATH).
+              INDEX_PATH: getDbPath(),
+            },
           });
           child.unref();
           closeSync(logFd); // parent's copy; child inherited the fd

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2450,6 +2450,141 @@ describe("mcp http daemon", () => {
     }
   }, 10000);
 
+  test("daemon HTTP server honors --index, scopes pidfile, and queries the named store (#772)", async () => {
+    const customIndex = "mcp-daemon-alt-index";
+    const customCacheDir = join(daemonTestDir, `cache-daemon-index-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    const customConfigDir = join(daemonTestDir, `config-daemon-index-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    await mkdir(customCacheDir, { recursive: true });
+    await mkdir(customConfigDir, { recursive: true });
+
+    const addResult = await runQmd(
+      ["--index", customIndex, "collection", "add", fixturesDir, "--name", "mcp-fixtures"],
+      {
+        dbPath: daemonDbPath,
+        configDir: customConfigDir,
+        env: {
+          INDEX_PATH: "",
+          XDG_CACHE_HOME: customCacheDir,
+        },
+      },
+    );
+    expect(addResult.exitCode).toBe(0);
+
+    const updateResult = await runQmd(
+      ["--index", customIndex, "update"],
+      {
+        dbPath: daemonDbPath,
+        configDir: customConfigDir,
+        env: {
+          INDEX_PATH: "",
+          XDG_CACHE_HOME: customCacheDir,
+        },
+      },
+    );
+    expect(updateResult.exitCode).toBe(0);
+
+    const port = randomPort();
+    const { stdout, stderr, exitCode } = await runQmd(
+      ["--index", customIndex, "mcp", "--http", "--daemon", "--port", String(port)],
+      {
+        dbPath: daemonDbPath,
+        configDir: customConfigDir,
+        env: {
+          INDEX_PATH: "",
+          XDG_CACHE_HOME: customCacheDir,
+        },
+      },
+    );
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toContain("Already running");
+    expect(stdout).toContain(`http://localhost:${port}/mcp`);
+
+    const namedPidPath = join(customCacheDir, "qmd", `mcp-${customIndex}.pid`);
+    const defaultPidPath = join(customCacheDir, "qmd", "mcp.pid");
+    expect(existsSync(namedPidPath)).toBe(true);
+    expect(existsSync(defaultPidPath)).toBe(false);
+
+    const pid = parseInt(readFileSync(namedPidPath, "utf-8").trim());
+    spawnedPids.push(pid);
+
+    try {
+      const ready = await waitForServer(port);
+      expect(ready).toBe(true);
+
+      const res = await fetch(`http://localhost:${port}/query`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ searches: [{ type: "lex", query: "authentication" }], limit: 5, rerank: false }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      const files = body.results.map((r: { file: string }) => r.file);
+      expect(files.some((file: string) => file.includes("mcp-fixtures/notes/meeting.md"))).toBe(true);
+
+      const { stdout: stopOut, exitCode: stopCode } = await runQmd(
+        ["--index", customIndex, "mcp", "stop"],
+        {
+          dbPath: daemonDbPath,
+          configDir: customConfigDir,
+          env: {
+            INDEX_PATH: "",
+            XDG_CACHE_HOME: customCacheDir,
+          },
+        },
+      );
+      expect(stopCode).toBe(0);
+      expect(stopOut).toContain("Stopped");
+      expect(existsSync(namedPidPath)).toBe(false);
+    } finally {
+      try { process.kill(pid, "SIGTERM"); } catch { /* already stopped */ }
+      await sleep(300);
+      try { unlinkSync(namedPidPath); } catch {}
+    }
+  }, 15000);
+
+  test("named-index daemon does not collide with the default daemon pidfile (#772)", async () => {
+    const portDefault = randomPort();
+    const portNamed = randomPort();
+    const namedIndex = "other-index";
+
+    const { exitCode: defaultCode } = await runDaemonQmd([
+      "mcp", "--http", "--daemon", "--port", String(portDefault),
+    ]);
+    expect(defaultCode).toBe(0);
+    expect(existsSync(pidPath())).toBe(true);
+    const defaultPid = parseInt(readFileSync(pidPath(), "utf-8").trim());
+    spawnedPids.push(defaultPid);
+
+    const { stdout, stderr, exitCode: namedCode } = await runDaemonQmd([
+      "--index", namedIndex, "mcp", "--http", "--daemon", "--port", String(portNamed),
+    ]);
+    const namedPidPath = join(daemonCacheDir, "qmd", `mcp-${namedIndex}.pid`);
+    try {
+      expect(namedCode).toBe(0);
+      expect(stderr).not.toContain("Already running");
+      expect(stdout).toContain(`http://localhost:${portNamed}/mcp`);
+      expect(existsSync(namedPidPath)).toBe(true);
+
+      const namedPid = parseInt(readFileSync(namedPidPath, "utf-8").trim());
+      spawnedPids.push(namedPid);
+      expect(namedPid).not.toBe(defaultPid);
+
+      expect(await waitForServer(portDefault)).toBe(true);
+      expect(await waitForServer(portNamed)).toBe(true);
+    } finally {
+      try { process.kill(defaultPid, "SIGTERM"); } catch {}
+      try {
+        if (existsSync(namedPidPath)) {
+          const namedPid = parseInt(readFileSync(namedPidPath, "utf-8").trim());
+          try { process.kill(namedPid, "SIGTERM"); } catch {}
+        }
+      } catch {}
+      await sleep(500);
+      try { unlinkSync(pidPath()); } catch {}
+      try { unlinkSync(namedPidPath); } catch {}
+    }
+  });
+
   // -------------------------------------------------------------------------
   // Daemon lifecycle
   // -------------------------------------------------------------------------

--- a/test/mcp-pid.test.ts
+++ b/test/mcp-pid.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, test, expect } from "vitest";
-import { looksLikeQmdMcpCommand, isQmdMcpPid } from "../src/cli/mcp-pid.ts";
+import { looksLikeQmdMcpCommand, isQmdMcpPid, mcpDaemonStateFiles } from "../src/cli/mcp-pid.ts";
 
 describe("looksLikeQmdMcpCommand", () => {
   test("matches bare qmd and common CLI script paths", () => {
@@ -27,6 +27,21 @@ describe("looksLikeQmdMcpCommand", () => {
   test("does not match qmd as a substring of another token", () => {
     expect(looksLikeQmdMcpCommand("myqmdtool serve")).toBe(false);
     expect(looksLikeQmdMcpCommand("qmdfoo")).toBe(false);
+  });
+});
+
+describe("mcpDaemonStateFiles", () => {
+  test("default index keeps mcp.pid / mcp.log", () => {
+    expect(mcpDaemonStateFiles("index")).toEqual({ pidFile: "mcp.pid", logFile: "mcp.log" });
+    expect(mcpDaemonStateFiles("")).toEqual({ pidFile: "mcp.pid", logFile: "mcp.log" });
+    expect(mcpDaemonStateFiles()).toEqual({ pidFile: "mcp.pid", logFile: "mcp.log" });
+  });
+
+  test("named indexes get scoped pid/log files (#772)", () => {
+    expect(mcpDaemonStateFiles("hsm-public-repro")).toEqual({
+      pidFile: "mcp-hsm-public-repro.pid",
+      logFile: "mcp-hsm-public-repro.log",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- `qmd --index <name> mcp --http --daemon` shared `mcp.pid` / `mcp.log` with the default index, so a named daemon was rejected as already running and `mcp stop` / `status` targeted the wrong process.
- PID/log files are now scoped per index (`mcp-<name>.pid`); the default index keeps `mcp.pid` for compatibility.
- The spawned child also receives the resolved `INDEX_PATH`, so it opens the named store instead of depending on re-parsing `--index`.

Fixes #772

## Test plan
- [x] `bun test test/mcp-pid.test.ts` (7 pass)
- [x] `bun test test/cli.test.ts -t "mcp http daemon"` (11 pass, including two new #772 cases)
- [x] `node ./node_modules/vitest/vitest.mjs run test/mcp-pid.test.ts` (7 pass)
- [x] `node ./node_modules/vitest/vitest.mjs run test/cli.test.ts -t "mcp http daemon"` (11 pass)
- [ ] CI Bun/Node unit tests green (ignore pre-existing nix flake hash mismatches)