### PR TITLE
fix(cli): report orphaned embedding vectors and add cleanup --dry-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
 
 ### Fixed
 
+- `qmd status` reports orphaned embedding chunks, `qmd update` hints when they
+  exceed 10% of vectors, and `qmd cleanup --dry-run` previews what would be
+  removed. Incremental update still does not auto-prune vectors (a transient
+  empty mount would otherwise force a full re-embed) (#768).
+
 - `qmd --index <name> mcp --http --daemon` now scopes PID/log files per index
   (`mcp-<name>.pid`) and passes the resolved database path to the child, so a
   named-index daemon no longer collides with the default `mcp.pid` or opens

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -58,6 +58,7 @@ import {
   deleteLLMCache,
   deleteInactiveDocuments,
   cleanupOrphanedVectors,
+  countOrphanedVectors,
   vacuumDatabase,
   getCollectionsWithoutContext,
   getTopLevelPathsWithoutContext,
@@ -482,6 +483,14 @@ function sanitizeDiagnosticMessage(message: string): string {
     .join("; ");
 }
 
+/** Hint after `qmd update` when orphaned embedding chunks exceed this share of vectors (#768). */
+const ORPHAN_VECTOR_HINT_RATIO = 0.1;
+
+function formatOrphanedVectorHint(orphaned: number, total: number): string {
+  const pct = total > 0 ? Math.round((orphaned / total) * 100) : 0;
+  return `${orphaned} orphaned embedding chunks (${pct}% of vectors) — run 'qmd cleanup' to reclaim space`;
+}
+
 async function showStatus(): Promise<void> {
   const dbPath = getDbPath();
   const db = getDb();
@@ -525,9 +534,15 @@ async function showStatus(): Promise<void> {
   }
   console.log("");
 
+  const orphanedVectors = countOrphanedVectors(db);
+
   console.log(`${c.bold}Documents${c.reset}`);
   console.log(`  Total:    ${totalDocs.count} files indexed`);
   console.log(`  Vectors:  ${vectorCount.count} embedded`);
+  if (orphanedVectors > 0) {
+    const pct = vectorCount.count > 0 ? Math.round((orphanedVectors / vectorCount.count) * 100) : 0;
+    console.log(`  ${c.yellow}Orphaned: ${orphanedVectors} embedding chunks (${pct}%)${c.reset} — run 'qmd cleanup'`);
+  }
   if (needsEmbedding > 0) {
     console.log(`  ${c.yellow}Pending:  ${needsEmbedding} need embedding${c.reset} (run 'qmd embed')`);
   }
@@ -756,11 +771,16 @@ async function updateCollections(): Promise<void> {
 
   // Check if any documents need embedding (show once at end)
   const needsEmbedding = getHashesNeedingEmbedding(db);
+  const vectorTotal = (db.prepare(`SELECT COUNT(*) as count FROM content_vectors`).get() as { count: number }).count;
+  const orphanedVectors = countOrphanedVectors(db);
   closeDb();
 
   console.log(`${c.green}✓ All collections updated.${c.reset}`);
   if (needsEmbedding > 0) {
     console.log(`\nRun 'qmd embed' to update embeddings (${needsEmbedding} unique hashes need vectors)`);
+  }
+  if (vectorTotal > 0 && orphanedVectors / vectorTotal >= ORPHAN_VECTOR_HINT_RATIO) {
+    console.log(`\n${formatOrphanedVectorHint(orphanedVectors, vectorTotal)}`);
   }
 }
 
@@ -2836,6 +2856,7 @@ function parseCLI() {
       // Update options
       pull: { type: "boolean" },  // git pull before update
       refresh: { type: "boolean" },
+      "dry-run": { type: "boolean" },  // cleanup: report what would be removed
       // Get options
       l: { type: "string" },  // max lines
       from: { type: "string" },  // start line
@@ -3372,7 +3393,7 @@ function showHelp(): void {
   console.log("    --max-docs-per-batch <n>    - Cap docs loaded into memory per embedding batch");
   console.log("    --max-batch-mb <n>          - Cap UTF-8 MB loaded into memory per embedding batch");
   console.log("    --timeout <minutes>         - Embed session cap in minutes (0 = no limit; default 30)");
-  console.log("  qmd cleanup                   - Clear caches, vacuum DB");
+  console.log("  qmd cleanup [--dry-run]       - Clear caches, vacuum DB");
   console.log("");
   console.log("Query syntax (qmd query):");
   console.log("  QMD queries are either a single expand query (no prefix) or a multi-line");
@@ -4657,6 +4678,26 @@ if (isMain) {
 
     case "cleanup": {
       const db = getDb();
+      const dryRun = Boolean(cli.values["dry-run"]);
+
+      if (dryRun) {
+        const cacheCount = (db.prepare(`SELECT COUNT(*) as c FROM llm_cache`).get() as { c: number }).c;
+        const orphanedVecs = countOrphanedVectors(db);
+        const inactiveDocs = (db.prepare(`SELECT COUNT(*) as c FROM documents WHERE active = 0`).get() as { c: number }).c;
+        console.log("Dry run — no changes made.\n");
+        console.log(`Would clear ${cacheCount} cached API responses`);
+        if (orphanedVecs > 0) {
+          console.log(`Would remove ${orphanedVecs} orphaned embedding chunks`);
+        } else {
+          console.log(`${c.dim}No orphaned embeddings to remove${c.reset}`);
+        }
+        if (inactiveDocs > 0) {
+          console.log(`Would remove ${inactiveDocs} inactive document records`);
+        }
+        console.log("Would vacuum the database");
+        closeDb();
+        break;
+      }
 
       // 1. Clear llm_cache
       const cacheCount = deleteLLMCache(db);

--- a/src/store.ts
+++ b/src/store.ts
@@ -2486,6 +2486,30 @@ export function cleanupOrphanedContent(db: Database): number {
   return result.changes;
 }
 
+const ORPHANED_VECTOR_COUNT_SQL = `
+  SELECT COUNT(*) as c FROM content_vectors cv
+  WHERE NOT EXISTS (
+    SELECT 1 FROM documents d WHERE d.hash = cv.hash AND d.active = 1
+  )
+`;
+
+/**
+ * Count embedding chunks whose hash is not referenced by any active document.
+ * Reads `content_vectors` only, so this works even when sqlite-vec is unavailable (#768).
+ */
+export function countOrphanedVectors(db: Database): number {
+  try {
+    return withLazyContentVectorMigration(db, () => {
+      const row = db.prepare(ORPHANED_VECTOR_COUNT_SQL).get() as { c: number };
+      return row.c;
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/no such table/i.test(message)) return 0;
+    throw error;
+  }
+}
+
 /**
  * Remove orphaned vector embeddings that are not referenced by any active document.
  * Returns the number of orphaned embedding chunks deleted.
@@ -2508,18 +2532,12 @@ export function cleanupOrphanedVectors(db: Database): number {
     return 0;
   }
 
-  return withLazyContentVectorMigration(db, () => {
-    // Count orphaned vectors first
-    const countResult = db.prepare(`
-      SELECT COUNT(*) as c FROM content_vectors cv
-      WHERE NOT EXISTS (
-        SELECT 1 FROM documents d WHERE d.hash = cv.hash AND d.active = 1
-      )
-    `).get() as { c: number };
+  const orphaned = countOrphanedVectors(db);
+  if (orphaned === 0) {
+    return 0;
+  }
 
-    if (countResult.c === 0) {
-      return 0;
-    }
+  return withLazyContentVectorMigration(db, () => {
 
     // Delete from vectors_vec first
     db.exec(`
@@ -2538,7 +2556,7 @@ export function cleanupOrphanedVectors(db: Database): number {
       )
     `);
 
-    return countResult.c;
+    return orphaned;
   });
 }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1202,6 +1202,96 @@ describe("CLI Cleanup Command", () => {
   });
 });
 
+describe("orphaned embedding vectors (#768)", () => {
+  let localDbPath: string;
+  let localConfigDir: string;
+
+  function seedOrphans(opts: { live?: number; orphaned?: number; cache?: number; inactive?: number } = {}) {
+    const live = opts.live ?? 1;
+    const orphaned = opts.orphaned ?? 3;
+    const cache = opts.cache ?? 2;
+    const inactive = opts.inactive ?? 1;
+    const db = openDatabase(localDbPath);
+    const now = new Date().toISOString();
+    const doc = db.prepare(`SELECT hash FROM documents WHERE active = 1 LIMIT 1`).get() as { hash: string } | undefined;
+    if (doc) {
+      for (let i = 0; i < live; i++) {
+        db.prepare(`
+          INSERT OR REPLACE INTO content_vectors (hash, seq, pos, model, embed_fingerprint, total_chunks, embedded_at)
+          VALUES (?, ?, 0, 'test', '', 1, ?)
+        `).run(doc.hash, i, now);
+      }
+    }
+    for (let i = 0; i < orphaned; i++) {
+      db.prepare(`
+        INSERT OR REPLACE INTO content_vectors (hash, seq, pos, model, embed_fingerprint, total_chunks, embedded_at)
+        VALUES (?, 0, 0, 'test', '', 1, ?)
+      `).run(`orphan-hash-${i}`, now);
+    }
+    for (let i = 0; i < cache; i++) {
+      db.prepare(`INSERT OR REPLACE INTO llm_cache (hash, result, created_at) VALUES (?, '{}', ?)`).run(`cache-${i}`, now);
+    }
+    for (let i = 0; i < inactive; i++) {
+      const hash = `inactive-hash-${i}`;
+      db.prepare(`INSERT OR IGNORE INTO content (hash, doc, created_at) VALUES (?, 'gone', ?)`).run(hash, now);
+      db.prepare(`
+        INSERT OR REPLACE INTO documents (collection, path, title, hash, created_at, modified_at, active)
+        VALUES ('fixtures', ?, 'Gone', ?, ?, ?, 0)
+      `).run(`gone-${i}.md`, hash, now, now);
+    }
+    db.close();
+  }
+
+  beforeAll(async () => {
+    const env = await createIsolatedTestEnv("orphan-vectors");
+    localDbPath = env.dbPath;
+    localConfigDir = env.configDir;
+    const { exitCode, stderr } = await runQmd(
+      ["collection", "add", fixturesDir, "--name", "fixtures"],
+      { dbPath: localDbPath, configDir: localConfigDir },
+    );
+    if (exitCode !== 0) console.error("collection add failed:", stderr);
+    expect(exitCode).toBe(0);
+    seedOrphans();
+  });
+
+  test("status reports orphaned embedding chunks", async () => {
+    const { stdout, exitCode } = await runQmd(["status"], { dbPath: localDbPath, configDir: localConfigDir });
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/Orphaned:\s+3 embedding chunks \(75%\)/);
+    expect(stdout).toContain("qmd cleanup");
+  });
+
+  test("update hints when orphan ratio exceeds 10%", async () => {
+    const { stdout, exitCode } = await runQmd(["update"], { dbPath: localDbPath, configDir: localConfigDir });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("3 orphaned embedding chunks (75% of vectors)");
+    expect(stdout).toContain("run 'qmd cleanup' to reclaim space");
+  });
+
+  test("cleanup --dry-run reports what would be removed without deleting", async () => {
+    // `qmd update` clears llm_cache; re-seed so dry-run has something to report.
+    seedOrphans({ live: 0, orphaned: 0, cache: 2, inactive: 0 });
+    const { stdout, exitCode } = await runQmd(["cleanup", "--dry-run"], { dbPath: localDbPath, configDir: localConfigDir });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Dry run — no changes made");
+    expect(stdout).toContain("Would clear 2 cached API responses");
+    expect(stdout).toContain("Would remove 3 orphaned embedding chunks");
+    expect(stdout).toContain("Would remove 1 inactive document records");
+    expect(stdout).toContain("Would vacuum the database");
+    expect(stdout).not.toContain("Database vacuumed");
+
+    const db = openDatabase(localDbPath);
+    const vectors = (db.prepare(`SELECT COUNT(*) as c FROM content_vectors`).get() as { c: number }).c;
+    const cache = (db.prepare(`SELECT COUNT(*) as c FROM llm_cache`).get() as { c: number }).c;
+    const inactive = (db.prepare(`SELECT COUNT(*) as c FROM documents WHERE active = 0`).get() as { c: number }).c;
+    db.close();
+    expect(vectors).toBe(4);
+    expect(cache).toBe(2);
+    expect(inactive).toBe(1);
+  });
+});
+
 describe("CLI Error Handling", () => {
   test("handles unknown command", async () => {
     const { stderr, exitCode } = await runQmd(["unknowncommand"]);

--- a/test/store.helpers.unit.test.ts
+++ b/test/store.helpers.unit.test.ts
@@ -17,6 +17,7 @@ import {
   isDocid,
   handelize,
   cleanupOrphanedVectors,
+  countOrphanedVectors,
   sanitizeFTS5Term,
 } from "../src/store";
 
@@ -90,6 +91,26 @@ describe("Path Utilities", () => {
 // =============================================================================
 // Handelize Tests
 // =============================================================================
+
+describe("countOrphanedVectors", () => {
+  test("returns 0 when content_vectors is missing", () => {
+    const db = {
+      prepare: () => { throw new Error("no such table: content_vectors"); },
+    } as any;
+    expect(countOrphanedVectors(db)).toBe(0);
+  });
+
+  test("returns the COUNT of hashes not referenced by an active document (#768)", () => {
+    const db = {
+      prepare: (sql: string) => {
+        expect(sql).toContain("content_vectors");
+        expect(sql).toContain("d.active = 1");
+        return { get: () => ({ c: 42 }) };
+      },
+    } as any;
+    expect(countOrphanedVectors(db)).toBe(42);
+  });
+});
 
 describe("cleanupOrphanedVectors", () => {
   test("returns 0 when vec table exists in schema but sqlite-vec is unavailable", () => {


### PR DESCRIPTION
## Summary
- Incremental `qmd update` still does **not** auto-prune embedding vectors (a transient empty/partial mount would otherwise force a full re-embed).
- `qmd status` now reports orphaned embedding chunks (count + percent) when any exist.
- `qmd update` prints a hint when orphans exceed 10% of vectors: `N orphaned embedding chunks (M% of vectors) — run 'qmd cleanup' to reclaim space`.
- `qmd cleanup --dry-run` previews cache/orphan/inactive/vacuum work without changing the database.

Fixes #768

## Test plan
- [x] `bun test test/store.helpers.unit.test.ts` (countOrphanedVectors + existing cleanupOrphanedVectors)
- [x] `bun test test/cli.test.ts -t "orphaned embedding vectors|CLI Cleanup Command|CLI Status Command|CLI Update Command"`
- [x] `node ./node_modules/vitest/vitest.mjs run test/store.helpers.unit.test.ts test/cli.test.ts -t "orphaned embedding vectors|CLI Cleanup Command|countOrphanedVectors"`
- [ ] CI Bun/Node unit tests green (ignore pre-existing nix flake hash mismatches)