### PR TITLE
fix(cli): require path for collection add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 
 ### Fixed
 
+- `qmd collection add` with no path argument now errors with usage instead of
+  silently indexing the current working directory (#684). Pass `.` to index
+  CWD, matching the documented examples.
+
 - `qmd status` reports orphaned embedding chunks, `qmd update` hints when they
   exceed 10% of vectors, and `qmd cleanup --dry-run` previews what would be
   removed. Incremental update still does not auto-prune vectors (a transient

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -4245,7 +4245,12 @@ if (isMain) {
         }
 
         case "add": {
-          const pwd = cli.args[1] || getPwd();
+          const pwd = cli.args[1];
+          if (!pwd) {
+            console.error("Usage: qmd collection add <path> [--name NAME]");
+            console.error("  Pass '.' to index the current directory.");
+            process.exit(1);
+          }
           const resolvedPwd = pwd === '.' ? getPwd() : getRealPath(resolve(pwd));
           const globPattern = cli.values.mask as string || DEFAULT_GLOB;
           const name = cli.values.name as string | undefined;

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -477,6 +477,26 @@ describe("CLI Add Command", () => {
     expect(stdout).toContain("Collection 'fixtures' created successfully");
   });
 
+  test("requires a path argument instead of silently indexing CWD (#684)", async () => {
+    const env = await createIsolatedTestEnv("collection-add-no-path");
+    const { stdout, stderr, exitCode } = await runQmd(["collection", "add"], {
+      dbPath: env.dbPath,
+      configDir: env.configDir,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Usage: qmd collection add <path>");
+    expect(stderr).toContain("Pass '.' to index the current directory");
+    expect(stdout).not.toContain("created successfully");
+    expect(readFileSync(join(env.configDir, "index.yml"), "utf8")).toBe("collections: {}\n");
+
+    const listResult = await runQmd(["collection", "list"], {
+      dbPath: env.dbPath,
+      configDir: env.configDir,
+    });
+    expect(listResult.stdout).toContain("No collections found");
+  });
+
   test("rejects a nonexistent collection path without persisting it", async () => {
     const env = await createIsolatedTestEnv("missing-collection-path");
     const missingPath = join(fixturesDir, "does-not-exist");


### PR DESCRIPTION
## Summary
- Bare `qmd collection add` defaulted to CWD and started indexing with no prompt, which is a footgun on large trees.
- The path argument is now required; missing it exits non-zero with usage and a hint to pass `.` for the old CWD behavior.
- Documented examples already use `qmd collection add .`, so this matches existing help text.

Fixes #684

## Test plan
- [x] `bun test test/cli.test.ts -t "CLI Add Command"` (7 pass, including new #684 case)
- [x] `node ./node_modules/vitest/vitest.mjs run test/cli.test.ts -t "CLI Add Command"` (7 pass)
- [x] `CI=true bun test --timeout 60000 --preload ./src/test-preload.ts test/` (956 pass, 80 skip, 0 fail)
- [x] `CI=true node ./node_modules/vitest/vitest.mjs run --testTimeout 60000 test/` (956 pass, 73 skip, 0 fail)
- [ ] CI Bun/Node unit tests green (ignore pre-existing nix flake hash mismatches)