### PR TITLE
fix(store): look up insertContext collections by name (#853)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@
 
 ### Fixed
 
+- `insertContext` looks up `store_collections` by name. #754 retargeted the
+  query from the dropped `collections` table but left `WHERE id = ?`, and
+  `store_collections` has `name TEXT PRIMARY KEY` with no `id` column — the
+  call threw `no such column: id`. Matches `deleteContext` /
+  `updateStoreContext` (#853).
+
 - `qmd collection add` with no path argument now errors with usage instead of
   silently indexing the current working directory (#684). Pass `.` to index
   CWD, matching the documented examples.

--- a/src/store.ts
+++ b/src/store.ts
@@ -3292,15 +3292,17 @@ export function renameCollection(db: Database, oldName: string, newName: string)
 
 /**
  * Insert or update a context for a specific collection and path prefix.
+ *
+ * `store_collections` is keyed by name (`TEXT PRIMARY KEY`), not an integer id.
+ * #754 retargeted this query from the dropped `collections` table but left
+ * `WHERE id = ?`, which throws `no such column: id`.
  */
-export function insertContext(db: Database, collectionId: number, pathPrefix: string, context: string): void {
-  // Get collection name from ID
-  const coll = db.prepare(`SELECT name FROM store_collections WHERE id = ?`).get(collectionId) as { name: string } | null;
+export function insertContext(db: Database, collectionName: string, pathPrefix: string, context: string): void {
+  const coll = db.prepare(`SELECT name FROM store_collections WHERE name = ?`).get(collectionName) as { name: string } | null;
   if (!coll) {
-    throw new Error(`Collection with id ${collectionId} not found`);
+    throw new Error(`Collection '${collectionName}' not found`);
   }
 
-  // Add context to store_collections
   updateStoreContext(db, coll.name, pathPrefix, context);
 }
 

--- a/test/store-insert-context.test.ts
+++ b/test/store-insert-context.test.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createStore,
+  insertContext,
+  upsertStoreCollection,
+  getStoreContexts,
+} from "../src/store.js";
+
+let testDir: string;
+
+beforeAll(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "qmd-insert-context-"));
+});
+
+afterAll(async () => {
+  try {
+    await rm(testDir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+function freshDbPath(): string {
+  return join(testDir, `ctx-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+}
+
+describe("insertContext", () => {
+  test("looks up store_collections by name and writes path context", () => {
+    const store = createStore(freshDbPath());
+    try {
+      upsertStoreCollection(store.db, "docs", { path: "/tmp/docs" });
+      insertContext(store.db, "docs", "/api", "API documentation");
+      expect(getStoreContexts(store.db)).toEqual([
+        { collection: "docs", path: "/api", context: "API documentation" },
+      ]);
+    } finally {
+      store.close();
+    }
+  });
+
+  test("overwrites existing context for the same path prefix", () => {
+    const store = createStore(freshDbPath());
+    try {
+      upsertStoreCollection(store.db, "docs", { path: "/tmp/docs" });
+      insertContext(store.db, "docs", "/api", "old");
+      insertContext(store.db, "docs", "/api", "new");
+      expect(getStoreContexts(store.db)).toEqual([
+        { collection: "docs", path: "/api", context: "new" },
+      ]);
+    } finally {
+      store.close();
+    }
+  });
+
+  test("throws a collection-not-found error, not no such column: id", () => {
+    const store = createStore(freshDbPath());
+    try {
+      expect(() => insertContext(store.db, "missing", "/api", "nope")).toThrow(
+        "Collection 'missing' not found",
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  test("store_collections has no id column", () => {
+    const store = createStore(freshDbPath());
+    try {
+      const cols = store.db.prepare("PRAGMA table_info(store_collections)").all() as { name: string }[];
+      expect(cols.map((c) => c.name)).not.toContain("id");
+      expect(cols.map((c) => c.name)).toContain("name");
+    } finally {
+      store.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

#754 retargeted `insertContext` from the dropped `collections` table to `store_collections`, but left `WHERE id = ?`. `store_collections` has `name TEXT PRIMARY KEY` and no `id` column, so the lookup threw `SQLiteError: no such column: id`.

`deleteContext` / `updateStoreContext` already key by collection name. `insertContext` now matches.

The public SDK `addContext` path was already going through `updateStoreContext(name)` and is unaffected.

## Test plan

- [x] `CI=true bun test test/store-insert-context.test.ts` — 4 pass
- [x] `CI=true node ./node_modules/vitest/vitest.mjs run test/store-insert-context.test.ts` — 4 pass
- [x] full Node unit suite — 965 pass / 73 skipped
- [x] full Bun unit suite — 965 pass / 0 fail
- [ ] CI Bun + Node green