### PR TITLE
fix(store): don't split UTF-16 surrogate pairs at chunk boundaries (#777)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@
 
 ### Fixed
 
+- `qmd embed` no longer splits a UTF-16 surrogate pair (emoji, etc.) across a
+  chunk boundary. A chunk ending or starting mid-pair produced an unpaired
+  surrogate in the chunk text, which some remote embedding APIs reject as
+  invalid JSON — permanently failing that chunk on every retry, since the
+  boundary calculation is deterministic. This covers both the character-based
+  chunker and `chunkDocumentByTokens`'s recursive re-splitting for
+  astral-plane-dense content, which could previously drive the char budget
+  low enough to reproduce the same split (#777).
+
 - `insertContext` looks up `store_collections` by name. #754 retargeted the
   query from the dropped `collections` table but left `WHERE id = ?`, and
   `store_collections` has `name TEXT PRIMARY KEY` with no `id` column — the

--- a/src/store.ts
+++ b/src/store.ts
@@ -270,6 +270,42 @@ export function mergeBreakPoints(a: BreakPoint[], b: BreakPoint[]): BreakPoint[]
 }
 
 /**
+ * True if `pos` sits between a UTF-16 high surrogate (at pos-1) and a low
+ * surrogate (at pos) — i.e. slicing at `pos` would split an astral-plane
+ * character (emoji, etc.) into two unpaired surrogates.
+ */
+function isSurrogatePairBoundary(content: string, pos: number): boolean {
+  if (pos <= 0 || pos >= content.length) return false;
+  const high = content.charCodeAt(pos - 1);
+  const low = content.charCodeAt(pos);
+  return high >= 0xd800 && high <= 0xdbff && low >= 0xdc00 && low <= 0xdfff;
+}
+
+/**
+ * Nudges `pos` off a surrogate-pair boundary so a slice ending or starting
+ * at `pos` never contains an unpaired surrogate. Prefers retreating by one
+ * code unit (excludes the pair from this slice, deferring it to the next
+ * chunk); when that would violate forward progress (`pos - 1 <= floor`,
+ * the caller-supplied lower bound, e.g. the previous chunk's start),
+ * advances by one code unit instead (includes the whole pair in this
+ * slice, slightly exceeding the caller's target width).
+ *
+ * Advancing is always safe: `isSurrogatePairBoundary` only returns true
+ * for `pos < content.length`, so `pos + 1 <= content.length`; and every
+ * call site already guarantees `pos > floor` before calling this function,
+ * so `pos + 1 > floor` too. This means a surrogate pair is never split —
+ * unlike a plain "give up and leave pos unchanged" fallback, which would
+ * let recursive re-chunking (e.g. chunkDocumentByTokens shrinking maxChars
+ * toward 1 for astral-dense content) reproduce the exact bug this exists
+ * to prevent.
+ */
+function adjustSurrogateBoundary(content: string, pos: number, floor: number): number {
+  if (!isSurrogatePairBoundary(content, pos)) return pos;
+  const retreat = pos - 1;
+  return retreat > floor ? retreat : pos + 1;
+}
+
+/**
  * Core chunk algorithm that operates on precomputed break points and code fences.
  * This is the shared implementation used by both regex-only and AST-aware chunking.
  */
@@ -310,6 +346,11 @@ export function chunkDocumentWithBreakPoints(
       endPos = Math.min(charPos + maxChars, content.length);
     }
 
+    // Never slice through the middle of a surrogate pair (e.g. an emoji) —
+    // an unpaired surrogate in the chunk text breaks JSON serialization for
+    // remote embedding APIs.
+    endPos = adjustSurrogateBoundary(content, endPos, charPos);
+
     chunks.push({ text: content.slice(charPos, endPos), pos: charPos });
 
     if (endPos >= content.length) {
@@ -320,6 +361,7 @@ export function chunkDocumentWithBreakPoints(
     if (charPos <= lastChunkPos) {
       charPos = endPos;
     }
+    charPos = adjustSurrogateBoundary(content, charPos, lastChunkPos);
   }
 
   return chunks;
@@ -2850,6 +2892,58 @@ export async function chunkDocumentAsync(
 }
 
 /**
+ * Strips any unpaired surrogate at the start or end of `text`, so the
+ * result is always well-formed UTF-16. Handles all four ways a lone
+ * surrogate can sit at a boundary:
+ *   - leading lone low surrogate (never valid as the first unit of a pair)
+ *   - leading lone high surrogate NOT followed by a matching low surrogate
+ *     (a leading high surrogate that IS followed by its low surrogate is a
+ *     complete, valid pair and must be left alone)
+ *   - trailing lone high surrogate (never valid as the last unit of a pair)
+ *   - trailing lone low surrogate NOT preceded by a matching high surrogate
+ *     (mirrors the leading-high case)
+ *
+ * Defense-in-depth for chunkDocumentByTokens: chunkDocumentWithBreakPoints
+ * (via chunkDocument) never itself produces a split surrogate pair (see
+ * adjustSurrogateBoundary), but a lone surrogate can already be present in
+ * the source document (unrelated upstream encoding bug) and land at an
+ * ordinary chunk boundary by coincidence, and the tokenizer's detokenize()
+ * truncation fallback below reconstructs text from raw token IDs — a
+ * different code path chunk-boundary adjustment doesn't cover, since a
+ * tokenizer is free to encode a single astral-plane character as multiple
+ * tokens and truncate between them.
+ */
+function stripUnpairedSurrogates(text: string): string {
+  let start = 0;
+  let end = text.length;
+  if (end > 0) {
+    const first = text.charCodeAt(0);
+    const firstIsLow = first >= 0xdc00 && first <= 0xdfff;
+    const firstIsHigh = first >= 0xd800 && first <= 0xdbff;
+    if (firstIsLow) {
+      start = 1;
+    } else if (firstIsHigh) {
+      const second = end > 1 ? text.charCodeAt(1) : NaN;
+      const secondIsLow = second >= 0xdc00 && second <= 0xdfff;
+      if (!secondIsLow) start = 1;
+    }
+  }
+  if (end > start) {
+    const last = text.charCodeAt(end - 1);
+    const lastIsHigh = last >= 0xd800 && last <= 0xdbff;
+    const lastIsLow = last >= 0xdc00 && last <= 0xdfff;
+    if (lastIsHigh) {
+      end -= 1;
+    } else if (lastIsLow) {
+      const prev = end - 1 > start ? text.charCodeAt(end - 2) : NaN;
+      const prevIsHigh = prev >= 0xd800 && prev <= 0xdbff;
+      if (!prevIsHigh) end -= 1;
+    }
+  }
+  return start === 0 && end === text.length ? text : text.slice(start, end);
+}
+
+/**
  * Chunk a document by actual token count using the LLM tokenizer.
  * More accurate than character-based chunking but requires async.
  *
@@ -2890,7 +2984,12 @@ export async function chunkDocumentByTokens(
 
     const tokens = await llm.tokenize(text);
     if (tokens.length <= maxTokens || text.length <= 1) {
-      results.push({ text, pos, tokens: tokens.length });
+      // Safety net: text.length <= 1 can only legitimately be a single
+      // BMP character (a well-formed astral character needs 2 code units),
+      // so this only ever strips something for already-malformed input.
+      const safeText = stripUnpairedSurrogates(text);
+      if (safeText.length === 0) return;
+      results.push({ text: safeText, pos, tokens: tokens.length });
       return;
     }
 
@@ -2925,7 +3024,11 @@ export async function chunkDocumentByTokens(
       || subChunks[0]?.text.length === text.length
     ) {
       const fallbackTokens = tokens.slice(0, Math.max(1, maxTokens));
-      const truncatedText = await llm.detokenize(fallbackTokens);
+      // Safety net: detokenize() reconstructs text from raw token IDs, and
+      // a tokenizer can encode a single astral-plane character across
+      // multiple tokens — truncating the token list can land mid-character.
+      const truncatedText = stripUnpairedSurrogates(await llm.detokenize(fallbackTokens));
+      if (truncatedText.length === 0) return;
       results.push({
         text: truncatedText,
         pos,

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1065,6 +1065,42 @@ describe("chunkDocumentWithBreakPoints", () => {
       expect(chunksNew[i]!.pos).toBe(chunksOriginal[i]!.pos);
     }
   });
+
+  test("does not split a surrogate pair at the raw chunk boundary", () => {
+    // "🚀" is a two-code-unit surrogate pair (high 0xD83D, low 0xDE80).
+    // Place it so the raw fallback boundary (charPos + maxChars) falls
+    // exactly between the two code units: 99 "x" chars, then the emoji at
+    // indices 99-100, so targetEndPos=100 lands right after the high
+    // surrogate.
+    const maxChars = 100;
+    const overlapChars = 20;
+    const windowChars = 10;
+    const content = "x".repeat(99) + "\u{1F680}" + "y".repeat(50);
+
+    const chunks = chunkDocumentWithBreakPoints(content, [], [], maxChars, overlapChars, windowChars);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.text.isWellFormed()).toBe(true);
+    }
+  });
+
+  test("does not split a surrogate pair at the overlap-derived chunk start", () => {
+    // Place the emoji so the boundary itself (charPos + maxChars = 100) is
+    // clean, but the next chunk's start (endPos - overlapChars = 100 - 20 = 80)
+    // falls between the high surrogate (index 79) and low surrogate (index 80).
+    const maxChars = 100;
+    const overlapChars = 20;
+    const windowChars = 10;
+    const content = "x".repeat(79) + "\u{1F680}" + "y".repeat(69);
+
+    const chunks = chunkDocumentWithBreakPoints(content, [], [], maxChars, overlapChars, windowChars);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.text.isWellFormed()).toBe(true);
+    }
+  });
 });
 
 describe("AST-aware chunkDocumentAsync", () => {
@@ -3847,6 +3883,148 @@ describe("Token chunking guardrails", () => {
       expect(chunks.every((chunk) => chunk.tokens <= 100)).toBe(true);
       for (let i = 1; i < chunks.length; i++) {
         expect(chunks[i]!.pos).toBeGreaterThan(chunks[i - 1]!.pos);
+      }
+    } finally {
+      setDefaultLlamaCpp(null);
+    }
+  });
+
+  test("chunkDocumentByTokens keeps surrogate pairs intact when the token budget shrinks the char budget below 2", async () => {
+    // A tokenizer that reports one token per UTF-16 code unit makes
+    // astral-plane content (emoji) look 2x as "expensive" as it actually
+    // is, driving pushChunkWithinTokenLimit's recursive safeMaxChars
+    // calculation down to 1 char — exactly the case that used to make
+    // chunkDocument() slice a surrogate pair in half.
+    setDefaultLlamaCpp({
+      async tokenize(text: string) {
+        return Array.from({ length: text.length }, () => 1);
+      },
+      async detokenize(tokens: readonly number[]) {
+        return "x".repeat(tokens.length);
+      },
+    } as any);
+
+    try {
+      const content = "\u{1F680}".repeat(30); // 30 emoji, 60 UTF-16 code units
+      const chunks = await chunkDocumentByTokens(content, 2, 0, 0);
+
+      expect(chunks.length).toBeGreaterThan(1);
+      for (const chunk of chunks) {
+        expect(chunk.text.isWellFormed()).toBe(true);
+      }
+    } finally {
+      setDefaultLlamaCpp(null);
+    }
+  });
+
+  test("chunkDocumentByTokens drops rather than emits an unpaired surrogate from the detokenize() truncation fallback", async () => {
+    // Simulates a tokenizer that encodes a single astral-plane character
+    // across multiple tokens and, when the truncation fallback slices the
+    // token list down to a single token, detokenizes it back into a lone
+    // high surrogate — the shape a real BPE-style tokenizer can produce.
+    // This exercises the results.push() site fed by llm.detokenize()
+    // rather than by chunkDocument()'s char-slicing.
+    setDefaultLlamaCpp({
+      async tokenize(text: string) {
+        return Array.from({ length: text.length }, () => 1);
+      },
+      async detokenize(tokens: readonly number[]) {
+        return tokens.length === 1 ? "\uD83D" : "\u{1F680}".repeat(Math.ceil(tokens.length / 2));
+      },
+    } as any);
+
+    try {
+      const chunks = await chunkDocumentByTokens("\u{1F680}", 1, 0, 0);
+
+      // A single emoji at maxTokens=1 has no valid within-budget
+      // representation once the malformed detokenize() output is
+      // stripped, so the safety net drops it entirely rather than
+      // emitting a broken fragment. Asserting the exact count (rather
+      // than leaving it unchecked) makes that intentional outcome
+      // explicit and avoids a vacuous pass on an empty array.
+      expect(chunks.length).toBe(0);
+      for (const chunk of chunks) {
+        expect(chunk.text.isWellFormed()).toBe(true);
+      }
+    } finally {
+      setDefaultLlamaCpp(null);
+    }
+  });
+
+  test("chunkDocumentByTokens drops rather than emits an already-malformed lone surrogate from source content", async () => {
+    // Defense-in-depth for the text.length <= 1 base case: a bare lone
+    // surrogate that was already malformed in the source document (e.g.
+    // from an unrelated upstream encoding bug) should never reach the
+    // embedding pipeline as a 1-character chunk.
+    setDefaultLlamaCpp({
+      async tokenize(text: string) {
+        return Array.from({ length: text.length }, () => 1);
+      },
+      async detokenize(tokens: readonly number[]) {
+        return "x".repeat(tokens.length);
+      },
+    } as any);
+
+    try {
+      const chunks = await chunkDocumentByTokens("\uD800", 900, 135);
+
+      expect(chunks.length).toBe(0);
+    } finally {
+      setDefaultLlamaCpp(null);
+    }
+  });
+
+  test("chunkDocumentByTokens strips a lone high surrogate that lands at an ordinary chunk's leading edge", async () => {
+    // The lone high surrogate is already malformed in the source content
+    // (not produced by chunking) and happens to fall exactly on a normal,
+    // non-degenerate chunk boundary — reached via the plain base case
+    // (tokens.length <= maxTokens on the first try), not the recursive
+    // re-split or single-character-chunk paths already covered above.
+    setDefaultLlamaCpp({
+      async tokenize(text: string) {
+        return Array.from({ length: Math.ceil(text.length / 3) }, () => 1);
+      },
+      async detokenize(tokens: readonly number[]) {
+        return "x".repeat(tokens.length);
+      },
+    } as any);
+
+    try {
+      // maxChars = maxTokens(10) * avgCharsPerToken(3) = 30, so the first
+      // chunk boundary lands at index 30 — exactly where the lone high
+      // surrogate sits, making it the leading character of chunk 2.
+      const content = "x".repeat(30) + "\uD800" + "y".repeat(29);
+      const chunks = await chunkDocumentByTokens(content, 10, 0, 0);
+
+      expect(chunks.length).toBeGreaterThan(1);
+      for (const chunk of chunks) {
+        expect(chunk.text.isWellFormed()).toBe(true);
+      }
+    } finally {
+      setDefaultLlamaCpp(null);
+    }
+  });
+
+  test("chunkDocumentByTokens strips a lone low surrogate that lands at an ordinary chunk's trailing edge", async () => {
+    // Mirror of the leading-high case: a lone low surrogate already
+    // malformed in the source content falls exactly at the end of the
+    // first chunk, reached via the same plain base case.
+    setDefaultLlamaCpp({
+      async tokenize(text: string) {
+        return Array.from({ length: Math.ceil(text.length / 3) }, () => 1);
+      },
+      async detokenize(tokens: readonly number[]) {
+        return "x".repeat(tokens.length);
+      },
+    } as any);
+
+    try {
+      const content = "x".repeat(29) + "\uDC00" + "y".repeat(30);
+      const chunks = await chunkDocumentByTokens(content, 10, 0, 0);
+
+      expect(chunks.length).toBeGreaterThan(1);
+      for (const chunk of chunks) {
+        expect(chunk.text.isWellFormed()).toBe(true);
       }
     } finally {
       setDefaultLlamaCpp(null);


### PR DESCRIPTION
## Summary

Rebase of #777 onto current main (CHANGELOG-only conflict).

`qmd embed` could slice a chunk through the middle of a UTF-16 surrogate pair (emoji, etc.). The resulting unpaired surrogate is invalid JSON for some remote embedding APIs, and because the boundary math is deterministic the same chunk failed on every retry.

This nudges chunk boundaries off surrogate-pair splits (retreat when possible, otherwise advance so the whole pair stays together), and strips leftover unpaired surrogates in `chunkDocumentByTokens` as defense-in-depth for the detokenize() truncation path and already-malformed source text.

## Test plan

- [x] `CI=true bun test --preload ./src/test-preload.ts test/store.test.ts -t surrogate` — 7 pass
- [x] `CI=true bun test --preload ./src/test-preload.ts test/` — 972 pass / 80 skip / 0 fail
- [x] `CI=true node ./node_modules/vitest/vitest.mjs run test/` — 972 pass / 73 skipped
- [ ] CI Bun + Node green