### PR TITLE
fix(store): preserve case-sensitive document identities (#801)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
 
 ### Fixed
 
+- Case-sensitive collections no longer collapse distinct document identities that
+  differ only by path casing. The implicit `COLLATE NOCASE` legacy migration was
+  unsafe for filesystems that contain both `README.md` and `readme.md`; case-only
+  legacy migrations must now be explicit and operator-reviewed (#801).
+
 - `cleanupOrphanedVectors` now runs its orphan count and both DELETEs in a
   single immediate transaction. An interruption between the two DELETEs
   (crash, `SQLITE_BUSY`) could desync `vectors_vec` from `content_vectors`,

--- a/src/store.ts
+++ b/src/store.ts
@@ -2764,13 +2764,10 @@ export function findOrMigrateLegacyDocument(
   const existing = findActiveDocument(db, collectionName, path);
   if (existing) return existing;
 
-  // Case-insensitive match (legacy normalization: e.g. "README.md" → "readme.md").
-  const legacyCase = db.prepare(`
-    SELECT id, hash, title FROM documents
-    WHERE collection = ? AND path COLLATE NOCASE = ? AND active = 1
-    ORDER BY id
-    LIMIT 1
-  `).get(collectionName, path) as { id: number; hash: string; title: string } | undefined;
+  // Do not use a case-insensitive fallback here. Case-sensitive filesystems can
+  // contain distinct paths such as `README.md` and `readme.md`; collapsing them
+  // makes one document disappear on every update. Legacy case-only migrations
+  // require an explicit, operator-reviewed migration instead of implicit lookup.
 
   // Handalized-path match: existing DBs indexed with handelize() stored slugged paths
   // like "Budget-Revenue-Q4-2024.md" for a raw path like "Budget & Revenue (Q4) [2024].md".
@@ -2791,7 +2788,7 @@ export function findOrMigrateLegacyDocument(
     // handelize throws on invalid paths; just skip
   }
 
-  const legacy = legacyCase ?? legacyHandalized;
+  const legacy = legacyHandalized;
   if (!legacy) return null;
 
   // Wrap rename + FTS rebuild in a transaction for atomicity.

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -2579,7 +2579,7 @@ describe("Reciprocal Rank Fusion", () => {
 // =============================================================================
 
 describe("Reindex Collection", () => {
-  test("preserves document id and embeddings when file path changes only by case", async () => {
+  test("treats a case-only rename as a new identity on a case-sensitive collection", async () => {
     const store = await createTestStore();
     const collectionName = "docs";
     const collectionPath = join(testDir, `case-rename-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -2607,27 +2607,34 @@ describe("Reindex Collection", () => {
     await rename(originalPath, renamedPath);
 
     const secondResult = await reindexCollection(store, collectionPath, "**/*.md", collectionName);
-    expect(secondResult.indexed).toBe(0);
-    expect(secondResult.unchanged).toBe(1);
-    expect(secondResult.removed).toBe(0);
+    expect(secondResult.indexed).toBe(1);
+    expect(secondResult.unchanged).toBe(0);
+    expect(secondResult.removed).toBe(1);
 
     const afterRows = store.db.prepare(`
       SELECT id, path, hash, active FROM documents
       WHERE collection = ?
       ORDER BY id
     `).all(collectionName) as { id: number; path: string; hash: string; active: number }[];
-    expect(afterRows).toHaveLength(1);
-    expect(afterRows[0]).toMatchObject({ id: before.id, path: "readme.md", hash: before.hash, active: 1 });
+    expect(afterRows).toHaveLength(2);
+    expect(afterRows).toEqual([
+      { id: before.id, path: "README.md", hash: before.hash, active: 0 },
+      { id: expect.any(Number), path: "readme.md", hash: before.hash, active: 1 }
+    ]);
 
+    // Embeddings remain content-addressed, so the case-distinct document can
+    // safely share existing vectors without collapsing document identity.
     const vectorCount = store.db.prepare(`
       SELECT COUNT(*) AS count FROM content_vectors WHERE hash = ?
     `).get(before.hash) as { count: number };
     expect(vectorCount.count).toBe(1);
 
     const ftsRows = store.db.prepare(`
-      SELECT rowid, filepath FROM documents_fts WHERE rowid = ?
-    `).all(before.id) as { rowid: number; filepath: string }[];
-    expect(ftsRows).toEqual([{ rowid: before.id, filepath: "docs/readme.md" }]);
+      SELECT rowid, filepath FROM documents_fts WHERE filepath = ?
+    `).all("docs/readme.md") as { rowid: number; filepath: string }[];
+    expect(ftsRows).toEqual([
+      { rowid: expect.any(Number), filepath: "docs/readme.md" }
+    ]);
 
     await cleanupTestDb(store);
   });
@@ -4375,35 +4382,24 @@ describe("Content-Addressable Storage", () => {
     await cleanupTestDb(store);
   });
 
-  test("findOrMigrateLegacyDocument renames lowercase path to case-preserved", async () => {
+  test("does not collapse distinct case-sensitive paths through legacy migration", async () => {
     const store = await createTestStore();
     const collectionName = await createTestCollection();
     const now = new Date().toISOString();
 
-    const content = "# My Skill";
-    const hash = await hashContent(content);
-    store.insertContent(hash, content, now);
-    // Simulate legacy index: path stored as lowercase
-    store.insertDocument(collectionName, "skills/skill.md", "My Skill", hash, now, now);
+    const lowerHash = await hashContent("# lowercase");
+    const upperHash = await hashContent("# uppercase");
+    store.insertContent(lowerHash, "# lowercase", now);
+    store.insertContent(upperHash, "# uppercase", now);
+    store.insertDocument(collectionName, "skills/skill.md", "lowercase", lowerHash, now, now);
 
-    // Migration: look up case-preserved path, expect rename
-    const result = store.findOrMigrateLegacyDocument(collectionName, "skills/SKILL.md");
-    expect(result).not.toBeNull();
-    expect(result!.hash).toBe(hash);
+    // On case-sensitive collections this is a separate source identity, not a
+    // legacy spelling of the existing path.
+    expect(store.findOrMigrateLegacyDocument(collectionName, "skills/SKILL.md")).toBeNull();
+    store.insertDocument(collectionName, "skills/SKILL.md", "uppercase", upperHash, now, now);
 
-    // Old lowercase path should no longer be findable
-    expect(store.findActiveDocument(collectionName, "skills/skill.md")).toBeNull();
-    // New case-preserved path should be active
-    const migrated = store.findActiveDocument(collectionName, "skills/SKILL.md");
-    expect(migrated).not.toBeNull();
-    expect(migrated!.hash).toBe(hash);
-
-    // FTS should reflect the new path (documents_au trigger)
-    const ftsRow = store.db.prepare(
-      `SELECT filepath FROM documents_fts WHERE rowid = ?`
-    ).get(result!.id) as { filepath: string } | undefined;
-    expect(ftsRow).toBeDefined();
-    expect(ftsRow!.filepath).toContain("SKILL.md");
+    expect(store.findActiveDocument(collectionName, "skills/skill.md")?.hash).toBe(lowerHash);
+    expect(store.findActiveDocument(collectionName, "skills/SKILL.md")?.hash).toBe(upperHash);
 
     await cleanupTestDb(store);
   });


### PR DESCRIPTION
## Summary
- Rebases / lands the #801 fix on current `main`. `findOrMigrateLegacyDocument` no longer uses a `COLLATE NOCASE` fallback that collapsed distinct paths such as `README.md` and `readme.md` on case-sensitive filesystems.
- Exact-path lookup and the separate handalized-path migration are unchanged. Case-only legacy migrations must now be explicit and operator-reviewed.
- Regression coverage: a case-only rename is a new identity (old row deactivated, new row inserted; embeddings stay content-addressed), and two case-distinct paths are not collapsed through legacy migration.

Supersedes #801 (same fix, rebased onto post-#856 `main`; CHANGELOG-only conflict).

## Test plan
- [x] Local Bun store tests: 227 pass, 13 skip
- [x] Local Bun `test/`: 976 pass, 80 skip
- [x] Local Node `test/`: 976 pass, 73 skip
- [ ] CI Bun + Node 22/23 green