### PR TITLE
fix(build): spawn tsc without a Windows cmd.exe shell (#681)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@
 
 ### Fixed
 
+- `scripts/build.mjs` no longer passes `shell: true` to `spawnSync` on Windows.
+  With the default Node install path (`C:\Program Files\nodejs\node.exe`),
+  `cmd.exe` split the unquoted `process.execPath` at the space, the `tsc`
+  spawn failed, and `prepare` could still report success with no `dist/` —
+  leaving `bin/qmd` at "not built". The helper always receives a real binary
+  path plus an args array, so no shell is needed. A spawn error now prints
+  the missing binary path instead of failing silently. (#681)
+
 - Case-sensitive collections no longer collapse distinct document identities that
   differ only by path casing. The implicit `COLLATE NOCASE` legacy migration was
   unsafe for filesystems that contain both `README.md` and `readme.md`; case-only

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -10,10 +10,16 @@ function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
     cwd: root,
     stdio: "inherit",
-    shell: process.platform === "win32",
+    // Never shell:true — on Windows, cmd.exe splits unquoted process.execPath
+    // at spaces (C:\Program Files\nodejs\node.exe) and the build can exit 0
+    // with no dist/. spawnSync can spawn the binary + args array directly. (#681)
+    shell: false,
     ...options,
   });
-  if (result.status !== 0) {
+  if (result.error || result.status !== 0) {
+    if (result.error) {
+      console.error(`build: failed to spawn ${command}: ${result.error.message}`);
+    }
     process.exit(result.status ?? 1);
   }
 }

--- a/test/build-script.test.ts
+++ b/test/build-script.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const buildSrc = readFileSync(join(repoRoot, "scripts", "build.mjs"), "utf8");
+
+const fixtures: string[] = [];
+
+afterEach(() => {
+  for (const dir of fixtures.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("scripts/build.mjs Windows execPath spaces (#681)", () => {
+  test("does not enable a Windows cmd.exe shell for spawnSync", () => {
+    // cmd.exe splits unquoted C:\\Program Files\\nodejs\\node.exe at the space.
+    expect(buildSrc).not.toMatch(/shell:\s*process\.platform\s*===\s*["']win32["']/);
+    expect(buildSrc).toMatch(/shell:\s*false/);
+    expect(buildSrc).toMatch(/result\.error/);
+  });
+
+  test("spawnSync without a shell can run a binary whose path contains a space", () => {
+    const root = mkdtempSync(join(tmpdir(), "qmd-build-execpath-"));
+    fixtures.push(root);
+    const spacedDir = join(root, "Program Files", "nodejs");
+    mkdirSync(spacedDir, { recursive: true });
+    const spacedBin = join(spacedDir, "node");
+    // Stand-in for C:\\Program Files\\nodejs\\node.exe: a real executable
+    // whose path contains a space. We own this file so chmod is allowed.
+    writeFileSync(
+      spacedBin,
+      `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} "$@"\n`,
+    );
+    chmodSync(spacedBin, 0o755);
+
+    const result = spawnSync(spacedBin, ["-e", "process.stdout.write('ok')"], {
+      encoding: "utf8",
+      shell: false,
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("ok");
+  });
+
+  test("run() treats a spawn error as a failed build, not status 0", () => {
+    // Mirrors scripts/build.mjs run(): a missing binary must not look successful.
+    const result = spawnSync(join(tmpdir(), "no-such-qmd-node-binary"), ["-e", "0"], {
+      encoding: "utf8",
+      shell: false,
+    });
+    expect(result.error).toBeDefined();
+    expect(result.status).not.toBe(0);
+    const exitCode = result.error || result.status !== 0 ? (result.status ?? 1) : 0;
+    expect(exitCode).not.toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Rebases / lands the #681 fix on current `main`. `scripts/build.mjs` no longer passes `shell: true` to `spawnSync` on Windows.
- With the default Node path (`C:\Program Files\nodejs\node.exe`), `cmd.exe` split the unquoted `process.execPath` at the space, so `prepare` could report success with no `dist/` and `bin/qmd` stayed at "not built". The helper always receives a real binary + args array, so no shell is needed.
- A spawn error now prints the missing binary path. Regression coverage locks `shell: false` and checks that `spawnSync` can run a binary whose path contains a space.

Supersedes #694 (same fix, rebased onto post-#857 `main`; CHANGELOG-only conflict).

## Test plan
- [x] Local Bun `test/build-script.test.ts`: 3 pass
- [x] Local Bun `test/`: 979 pass, 80 skip
- [x] Local Node `test/`: 979 pass, 73 skip
- [ ] CI Bun + Node 22/23 green