### PR TITLE
fix(store): match quoted FTS phrases containing dotted tokens (#757)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@
 
 ### Fixed
 
+- Quoted FTS phrases containing dotted tokens (e.g. `"1.0.21"`) now match the
+  indexed document. The porter unicode61 tokenizer stores dotted strings as
+  adjacent parts, but phrase sanitization stripped the dots into a single
+  token (`1021`) that could never hit. Dotted tokens inside quotes are split
+  into adjacent phrase terms, matching the bare-term rewrite from #563 (#757).
+
 - `scripts/build.mjs` no longer passes `shell: true` to `spawnSync` on Windows.
   With the default Node install path (`C:\Program Files\nodejs\node.exe`),
   `cmd.exe` split the unquoted `process.execPath` at the space, the `tsc`

--- a/src/store.ts
+++ b/src/store.ts
@@ -816,10 +816,18 @@ function containsCjk(text: string): boolean {
 }
 
 function sanitizeFTS5Phrase(phrase: string): string {
+  // Dotted tokens (1.0.21, 2026.4.10) are indexed as adjacent parts by the
+  // porter unicode61 tokenizer. Stripping the dots would produce "1021",
+  // which never matches — split them into phrase terms instead (#757).
   return normalizeCjkForFTS(phrase)
     .split(/\s+/)
-    .map(t => sanitizeFTS5Term(t))
-    .filter(t => t)
+    .flatMap(t => {
+      if (isDottedToken(t)) {
+        return t.split('.').map(p => sanitizeFTS5Term(p)).filter(p => p);
+      }
+      const sanitized = sanitizeFTS5Term(t);
+      return sanitized ? [sanitized] : [];
+    })
     .join(' ');
 }
 

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1790,6 +1790,38 @@ describe("FTS Search", () => {
 
     await cleanupTestDb(store);
   });
+
+  test("searchFTS matches quoted phrases containing dotted tokens (#757)", async () => {
+    // Phrase-path half of #563: quoted "1.0.21" used to strip dots into "1021",
+    // which never matches the adjacent 1/0/21 tokens the tokenizer stored.
+    const store = await createTestStore();
+    const collectionName = await createTestCollection();
+
+    await insertTestDocument(store.db, collectionName, {
+      name: "staging-notes",
+      title: "Staging Notes",
+      body: "Staging RapidLEI was `1.0.21`.",
+      displayPath: "test/staging.md",
+    });
+
+    await insertTestDocument(store.db, collectionName, {
+      name: "other-doc",
+      title: "Other Document",
+      body: "Unrelated content about gardening and cooking.",
+      displayPath: "test/other.md",
+    });
+
+    const quoted = store.searchFTS('"1.0.21"', 10);
+    expect(quoted.map(r => r.displayPath)).toContain(`${collectionName}/test/staging.md`);
+
+    const phrase = store.searchFTS('"RapidLEI was 1.0.21"', 10);
+    expect(phrase.map(r => r.displayPath)).toContain(`${collectionName}/test/staging.md`);
+
+    const bare = store.searchFTS("1.0.21", 10);
+    expect(bare.map(r => r.displayPath)).toContain(`${collectionName}/test/staging.md`);
+
+    await cleanupTestDb(store);
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Quoted FTS phrases containing dotted tokens (e.g. `"1.0.21"`) returned zero hits even when the literal text was indexed. This is the phrase-path half of #563.

The porter `unicode61` tokenizer stores `1.0.21` as adjacent `1` / `0` / `21` tokens. Bare-term search already splits on dots (`sanitizeDottedTerm`), but `sanitizeFTS5Phrase` ran each token through `sanitizeFTS5Term`, which strips dots into a single token (`1021`) that can never match.

Quoted dotted tokens are now split into adjacent phrase terms (`"1 0 21"`), so `"1.0.21"` and `"RapidLEI was 1.0.21"` match the indexed document.

Fixes #757.

## Test plan

- [x] `CI=true bun test test/store.test.ts -t dotted` (Bun: 2 pass)
- [x] Node vitest same filter (2 pass)
- [x] `tsc -p tsconfig.build.json --noEmit` clean
- [x] Full unit: Bun 980 pass / Node 980 pass