### PR TITLE
fix(nixos): skip llama source builds on read-only installs (#574)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@
 
 ### Fixed
 
+- NixOS / immutable-root installs no longer crash `qmd embed` with EACCES
+  when node-llama-cpp tries to compile llama.cpp into a read-only
+  `node_modules`. The flake wrapper puts Nix's glibc and libstdc++ on
+  `LD_LIBRARY_PATH` so prebuilt binaries can `dlopen` them, and
+  `getLlama()` uses `build: "never"` when the llama directory is not
+  writable (#574).
+
 - CJK FTS rebuild no longer raises "database is busy" when flushing insert
   batches. The streaming `.iterate()` cursor stayed open across
   `BEGIN` on the same connection; the scan now uses keyset-paginated

--- a/flake.nix
+++ b/flake.nix
@@ -130,7 +130,7 @@
             makeWrapper ${pkgs.bun}/bin/bun $out/bin/qmd \
               --add-flags "$out/lib/qmd/src/cli/qmd.ts" \
               --set DYLD_LIBRARY_PATH "${pkgs.sqlite.out}/lib" \
-              --set LD_LIBRARY_PATH "${pkgs.sqlite.out}/lib"
+              --set LD_LIBRARY_PATH "${pkgs.sqlite.out}/lib${pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux ":${pkgs.stdenv.cc.libc.out}/lib:${pkgs.stdenv.cc.cc.lib}/lib"}"
           '';
 
           meta = with pkgs.lib; {

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -37,6 +37,7 @@ export function setNodeLlamaCppModuleForTest(module: NodeLlamaCppModule | null):
   failedGpuInitModes.clear();
   noGpuAccelerationWarningShown = false;
   cpuForcedPrebuiltFallbackWarningShown = false;
+  llamaDirWritableOverride = undefined;
 }
 
 type StdoutWrite = typeof process.stdout.write;
@@ -71,8 +72,9 @@ export async function withNativeStdoutRedirectedToStderr<T>(fn: () => Promise<T>
 }
 
 import { homedir } from "os";
-import { join } from "path";
-import { existsSync, mkdirSync, statSync, unlinkSync, readdirSync, readFileSync, writeFileSync, openSync, readSync, closeSync } from "fs";
+import { dirname, join } from "path";
+import { accessSync, constants, existsSync, mkdirSync, statSync, unlinkSync, readdirSync, readFileSync, writeFileSync, openSync, readSync, closeSync } from "fs";
+import { createRequire } from "node:module";
 
 // =============================================================================
 // Embedding Formatting Functions
@@ -111,6 +113,31 @@ export function formatDocForEmbedding(text: string, title?: string, modelUri?: s
     return title ? `${title}\n${text}` : text;
   }
   return `title: ${title || "none"} | text: ${text}`;
+}
+
+// =============================================================================
+// Build Writability Check
+// =============================================================================
+
+const llamaCppRequire = createRequire(import.meta.url);
+
+/** Test override for canWriteLlamaDir(); `undefined` uses the real probe. */
+let llamaDirWritableOverride: boolean | undefined;
+
+export function setLlamaDirWritableForTest(writable: boolean | undefined): void {
+  llamaDirWritableOverride = writable;
+}
+
+/** Whether node-llama-cpp can write to its llama/ directory (false on NixOS). */
+export function canWriteLlamaDir(pkgDir?: string): boolean {
+  if (llamaDirWritableOverride !== undefined) return llamaDirWritableOverride;
+  try {
+    const dir = pkgDir ?? dirname(llamaCppRequire.resolve("node-llama-cpp/package.json"));
+    accessSync(join(dir, "llama"), constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 // =============================================================================
@@ -871,9 +898,11 @@ export class LlamaCpp implements LLM {
   private async loadLlamaRuntime(allowBuild = true): Promise<Llama> {
     if (!this.llama) {
       const gpuMode = resolveLlamaGpuMode();
+      // Skip source build when install dir is read-only (e.g. NixOS store).
+      const canBuild = allowBuild && canWriteLlamaDir();
 
       const { getLlama, getLlamaGpuTypes, LlamaLogLevel } = await loadNodeLlamaCpp();
-      const loadLlama = async (gpu: LlamaGpuMode, sourceBuildAllowed = allowBuild, buildOverride?: "auto" | "never") =>
+      const loadLlama = async (gpu: LlamaGpuMode, sourceBuildAllowed = canBuild, buildOverride?: "auto" | "never") =>
         await withNativeStdoutRedirectedToStderr(() => getLlama({
           // Prefer packaged prebuilt bindings before compiling llama.cpp locally.
           // node-llama-cpp documents gpu:"auto" as the best default: Metal on

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -8,12 +8,17 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import {
   LlamaCpp,
   getDefaultLlamaCpp,
   disposeDefaultLlamaCpp,
   resolveLlamaGpuMode,
   setNodeLlamaCppModuleForTest,
+  setLlamaDirWritableForTest,
+  canWriteLlamaDir,
   withNativeStdoutRedirectedToStderr,
   resolveParallelismOverride,
   resolveSafeParallelism,
@@ -27,6 +32,70 @@ import {
   type RerankDocument,
   type ILLMSession,
 } from "../src/llm.js";
+
+describe("canWriteLlamaDir", () => {
+  test("returns true when llama/ exists and is writable", () => {
+    const dir = mkdtempSync(join(tmpdir(), "qmd-llama-rw-"));
+    mkdirSync(join(dir, "llama"));
+    try {
+      expect(canWriteLlamaDir(dir)).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("returns false when the package directory is missing", () => {
+    expect(canWriteLlamaDir("/tmp/qmd-no-such-llama-pkg")).toBe(false);
+  });
+
+  test("returns false when llama/ exists but is not writable", () => {
+    const dir = mkdtempSync(join(tmpdir(), "qmd-llama-ro-"));
+    const llamaDir = join(dir, "llama");
+    mkdirSync(llamaDir, { mode: 0o555 });
+    chmodSync(llamaDir, 0o555);
+    try {
+      expect(canWriteLlamaDir(dir)).toBe(false);
+    } finally {
+      chmodSync(llamaDir, 0o755);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("ensureLlama uses build:never when the llama dir is read-only", async () => {
+    const prevGpu = process.env.QMD_LLAMA_GPU;
+    const prevForceCpu = process.env.QMD_FORCE_CPU;
+    delete process.env.QMD_LLAMA_GPU;
+    delete process.env.QMD_FORCE_CPU;
+
+    const calls: Array<Record<string, unknown>> = [];
+    setNodeLlamaCppModuleForTest({
+      LlamaLogLevel: { error: "error" },
+      resolveModelFile: vi.fn(),
+      LlamaChatSession: vi.fn() as any,
+      getLlama: vi.fn(async (options: Record<string, unknown>) => {
+        calls.push(options);
+        return { gpu: false, cpuMathCores: 4, dispose: async () => {} } as any;
+      }),
+    });
+    // After the module mock: that helper clears the writability override.
+    setLlamaDirWritableForTest(false);
+
+    try {
+      const llm = new LlamaCpp();
+      await (llm as any).ensureLlama();
+      expect(calls.length).toBeGreaterThan(0);
+      expect(calls[0]?.build).toBe("never");
+      expect(calls[0]?.skipDownload).toBe(true);
+    } finally {
+      setLlamaDirWritableForTest(undefined);
+      setNodeLlamaCppModuleForTest(null);
+      if (prevGpu === undefined) delete process.env.QMD_LLAMA_GPU;
+      else process.env.QMD_LLAMA_GPU = prevGpu;
+      if (prevForceCpu === undefined) delete process.env.QMD_FORCE_CPU;
+      else process.env.QMD_FORCE_CPU = prevForceCpu;
+    }
+  });
+});
 
 describe("model name resolution", () => {
   function withModelEnv(env: Record<string, string | undefined>, fn: () => void): void {


### PR DESCRIPTION
## Summary

On NixOS (and other immutable-root installs), `qmd embed` crashes with `EACCES` because node-llama-cpp tries to compile llama.cpp into a read-only `node_modules` under `/nix/store`. Even when that rebuild is skipped, prebuilt binaries fail because they expect FHS paths like `/lib64/libc.so.6`.

This rebases the still-valid parts of #574 onto current main without the incidental `flake.lock` nixpkgs bump:

- **flake.nix**: on Linux, the wrapper adds Nix's glibc and libstdc++ to `LD_LIBRARY_PATH` so prebuilt binaries can `dlopen` them
- **src/llm.ts**: `canWriteLlamaDir()` probes write access on node-llama-cpp's `llama/` directory; when unwritable, `getLlama()` uses `build: "never"`
- Unit tests for the probe and for `ensureLlama` passing `build: "never"` / `skipDownload: true`

Supersedes #574.

## Test plan

- [x] `CI=true bun test test/llm.test.ts` (34 pass)
- [x] Node vitest same file (34 pass)
- [x] `tsc -p tsconfig.build.json --noEmit` clean
- [x] Full unit: Bun 984 pass / Node 984 pass