### PR TITLE
fix(cli): split comma-separated --mask globs into a union (#557)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@
 
 ### Fixed
 
+- `qmd collection add --mask "a.md,*.txt"` now indexes the union of each
+  pattern. The comma-separated form was documented and commonly guessed, but
+  the joined string was passed to fast-glob as one literal glob, so it
+  matched zero files with no error. Brace form `{a.md,*.txt}` is unchanged.
+  The same split applies on `qmd update` for stored comma-list masks (#557).
+
 - NixOS / immutable-root installs no longer crash `qmd embed` with EACCES
   when node-llama-cpp tries to compile llama.cpp into a read-only
   `node_modules`. The flake wrapper puts Nix's glibc and libstdc++ on

--- a/README.md
+++ b/README.md
@@ -572,6 +572,9 @@ qmd collection add . --name myproject
 # Create a collection with explicit path and custom glob mask
 qmd collection add ~/Documents/notes --name notes --mask "**/*.md"
 
+# Comma-separated masks are a union (brace form `{a,b}` also works)
+qmd collection add ~/notes --name notes --mask "sources/**/*.md,CO - *.md"
+
 # List all collections
 qmd collection list
 
@@ -707,7 +710,7 @@ collections:
 | `editor_uri` (alias `editor_uri_template`) | top-level | Hyperlink template for clickable result paths; `QMD_EDITOR_URI` overrides. |
 | `models.embed` / `.rerank` / `.generate` | top-level | HuggingFace GGUF URIs (`hf:<user>/<repo>/<file>`) overriding the built-in defaults per role. |
 | `collections.<name>.path` | per-collection | Absolute directory to index. |
-| `collections.<name>.pattern` | per-collection | Glob mask. Set via `qmd collection add --mask`. Default `**/*.md`. |
+| `collections.<name>.pattern` | per-collection | Glob mask. Set via `qmd collection add --mask`. Default `**/*.md`. Comma-separated lists and brace groups (`{a,b}`) are a union of patterns. |
 | `collections.<name>.ignore` | per-collection | Glob patterns excluded from indexing — useful to stop nested collections double-indexing. **YAML-only — no CLI command sets this.** Additive with QMD's built-in exclusions (`node_modules`, `.git`, `.cache`, `vendor`, `dist`, `build`), which you cannot un-ignore. |
 | `collections.<name>.update` | per-collection | Bash command run before `qmd update` re-indexes this collection. Set via `qmd collection update-cmd`. |
 | `collections.<name>.includeByDefault` | per-collection | Whether unscoped queries search it. Toggle with `qmd collection include`/`exclude`. Default `true`. |

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -75,6 +75,7 @@ import {
   DEFAULT_RERANK_MODEL,
   DEFAULT_QUERY_MODEL,
   DEFAULT_GLOB,
+  splitGlobMask,
   DEFAULT_MULTI_GET_MAX_BYTES,
   createStore,
   getDefaultDbPath,
@@ -1742,7 +1743,7 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
     ...excludeDirs.map(d => `**/${d}/**`),
     ...(ignorePatterns || []),
   ];
-  const allFiles: string[] = await fastGlob(globPattern, {
+  const allFiles: string[] = await fastGlob(splitGlobMask(globPattern), {
     cwd: resolvedPwd,
     onlyFiles: true,
     followSymbolicLinks: false,
@@ -4247,8 +4248,9 @@ if (isMain) {
         case "add": {
           const pwd = cli.args[1];
           if (!pwd) {
-            console.error("Usage: qmd collection add <path> [--name NAME]");
+            console.error("Usage: qmd collection add <path> [--name NAME] [--mask GLOB]");
             console.error("  Pass '.' to index the current directory.");
+            console.error("  --mask: glob (default **/*.md), brace group, or comma-separated list");
             process.exit(1);
           }
           const resolvedPwd = pwd === '.' ? getPwd() : getRealPath(resolve(pwd));
@@ -4375,7 +4377,7 @@ if (isMain) {
           console.log("");
           console.log("Commands:");
           console.log("  list                      List all collections");
-          console.log("  add <path> [--name NAME]  Add a collection");
+          console.log("  add <path> [--name NAME] [--mask GLOB]  Add a collection");
           console.log("  remove <name>             Remove a collection");
           console.log("  rename <old> <new>        Rename a collection");
           console.log("  show <name>               Show collection details");
@@ -4385,6 +4387,7 @@ if (isMain) {
           console.log("");
           console.log("Examples:");
           console.log("  qmd collection add ~/notes --name notes");
+          console.log("  qmd collection add ~/notes --name notes --mask 'a.md,journals/*.md'");
           console.log("  qmd collection update-cmd brain 'git pull'");
           console.log("  qmd collection exclude archive");
           process.exit(0);

--- a/src/store.ts
+++ b/src/store.ts
@@ -46,6 +46,51 @@ export const DEFAULT_EMBED_MODEL = DEFAULT_EMBED_MODEL_URI;
 export const DEFAULT_RERANK_MODEL = DEFAULT_RERANK_MODEL_URI;
 export const DEFAULT_QUERY_MODEL = DEFAULT_GENERATE_MODEL_URI;
 export const DEFAULT_GLOB = "**/*.md";
+
+/**
+ * Split a collection glob mask into fast-glob patterns.
+ *
+ * `--mask "a.md,*.txt"` is a comma-separated union (issue #557), but
+ * fast-glob treats a comma outside `{...}` as a literal character, so
+ * the joined string matches nothing. Brace form `{a.md,*.txt}` is
+ * already valid glob syntax and is left intact.
+ *
+ * Commas inside `{...}` or `[...]` are not separators. Empty segments
+ * after the split are dropped.
+ */
+export function splitGlobMask(mask: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let braceDepth = 0;
+  let bracketDepth = 0;
+
+  for (const ch of mask) {
+    if (ch === "{") {
+      braceDepth++;
+      current += ch;
+    } else if (ch === "}" && braceDepth > 0) {
+      braceDepth--;
+      current += ch;
+    } else if (ch === "[") {
+      bracketDepth++;
+      current += ch;
+    } else if (ch === "]" && bracketDepth > 0) {
+      bracketDepth--;
+      current += ch;
+    } else if (ch === "," && braceDepth === 0 && bracketDepth === 0) {
+      const trimmed = current.trim();
+      if (trimmed) parts.push(trimmed);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+
+  const trimmed = current.trim();
+  if (trimmed) parts.push(trimmed);
+  return parts.length > 0 ? parts : [mask];
+}
+
 export const DEFAULT_MULTI_GET_MAX_BYTES = 64 * 1024; // 64KB
 export const DEFAULT_EMBED_MAX_DOCS_PER_BATCH = 64;
 export const DEFAULT_EMBED_MAX_BATCH_BYTES = 64 * 1024 * 1024; // 64MB
@@ -1479,7 +1524,7 @@ export async function reindexCollection(
     ...excludeDirs.map(d => `**/${d}/**`),
     ...(options?.ignorePatterns || []),
   ];
-  const allFiles: string[] = await fastGlob(globPattern, {
+  const allFiles: string[] = await fastGlob(splitGlobMask(globPattern), {
     cwd: collectionPath,
     onlyFiles: true,
     followSymbolicLinks: false,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -580,6 +580,43 @@ describe("CLI Add Command", () => {
     expect(stdout).toContain("notes/*.md");
   });
 
+  test("indexes comma-separated --mask patterns as a union (#557)", async () => {
+    const env = await createIsolatedTestEnv("comma-mask");
+    const collectionDir = join(testDir, `comma-mask-${testCounter}`);
+    await mkdir(collectionDir, { recursive: true });
+    await writeFile(join(collectionDir, "a.md"), "alpha\n");
+    await writeFile(join(collectionDir, "X - b.md"), "bravo\n");
+    await writeFile(join(collectionDir, "skip.txt"), "nope\n");
+
+    const { stdout, stderr, exitCode } = await runQmd(
+      ["collection", "add", collectionDir, "--name", "bug-demo", "--mask", "a.md,X - *.md"],
+      { dbPath: env.dbPath, configDir: env.configDir, cwd: collectionDir },
+    );
+    if (exitCode !== 0) {
+      console.error("Command failed:", stderr);
+    }
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Indexed: 2 new");
+  });
+
+  test("still accepts brace-expansion --mask (#557)", async () => {
+    const env = await createIsolatedTestEnv("brace-mask");
+    const collectionDir = join(testDir, `brace-mask-${testCounter}`);
+    await mkdir(collectionDir, { recursive: true });
+    await writeFile(join(collectionDir, "a.md"), "alpha\n");
+    await writeFile(join(collectionDir, "X - b.md"), "bravo\n");
+
+    const { stdout, stderr, exitCode } = await runQmd(
+      ["collection", "add", collectionDir, "--name", "bug-demo", "--mask", "{a.md,X - *.md}"],
+      { dbPath: env.dbPath, configDir: env.configDir, cwd: collectionDir },
+    );
+    if (exitCode !== 0) {
+      console.error("Command failed:", stderr);
+    }
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Indexed: 2 new");
+  });
+
   test("can recreate collection with remove and add", async () => {
     // First add
     await runQmd(["collection", "add", "."]);

--- a/test/store.helpers.unit.test.ts
+++ b/test/store.helpers.unit.test.ts
@@ -19,6 +19,7 @@ import {
   cleanupOrphanedVectors,
   countOrphanedVectors,
   sanitizeFTS5Term,
+  splitGlobMask,
 } from "../src/store";
 
 // =============================================================================
@@ -306,5 +307,43 @@ describe("sanitizeFTS5Term", () => {
   test("handles unicode letters and numbers", () => {
     expect(sanitizeFTS5Term("café")).toBe("café");
     expect(sanitizeFTS5Term("日本語")).toBe("日本語");
+  });
+});
+
+// =============================================================================
+// splitGlobMask (#557)
+// =============================================================================
+
+describe("splitGlobMask", () => {
+  test("splits comma-separated patterns into a union", () => {
+    expect(splitGlobMask("a.md,X - *.md")).toEqual(["a.md", "X - *.md"]);
+    expect(splitGlobMask("sources/**/*.md,CO - *.md")).toEqual([
+      "sources/**/*.md",
+      "CO - *.md",
+    ]);
+  });
+
+  test("leaves brace expansion intact", () => {
+    expect(splitGlobMask("{a.md,X - *.md}")).toEqual(["{a.md,X - *.md}"]);
+    expect(splitGlobMask("**/*.{md,txt}")).toEqual(["**/*.{md,txt}"]);
+  });
+
+  test("splits only top-level commas", () => {
+    expect(splitGlobMask("a.md,{b,c}.md")).toEqual(["a.md", "{b,c}.md"]);
+  });
+
+  test("does not split commas inside character classes", () => {
+    expect(splitGlobMask("file[a,b].md")).toEqual(["file[a,b].md"]);
+  });
+
+  test("trims whitespace and drops empty segments", () => {
+    expect(splitGlobMask(" a.md , *.txt ")).toEqual(["a.md", "*.txt"]);
+    expect(splitGlobMask("a.md,")).toEqual(["a.md"]);
+    expect(splitGlobMask("a.md,,b.md")).toEqual(["a.md", "b.md"]);
+  });
+
+  test("returns a single pattern unchanged", () => {
+    expect(splitGlobMask("**/*.md")).toEqual(["**/*.md"]);
+    expect(splitGlobMask("notes/*.md")).toEqual(["notes/*.md"]);
   });
 });

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -2611,6 +2611,24 @@ describe("Reciprocal Rank Fusion", () => {
 // =============================================================================
 
 describe("Reindex Collection", () => {
+  test("indexes comma-separated glob masks as a union (#557)", async () => {
+    const store = await createTestStore();
+    const collectionName = "comma-mask";
+    const collectionPath = join(testDir, `comma-mask-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(collectionPath, { recursive: true });
+    await writeFile(join(collectionPath, "a.md"), "alpha\n");
+    await writeFile(join(collectionPath, "X - b.md"), "bravo\n");
+    await writeFile(join(collectionPath, "skip.txt"), "nope\n");
+
+    const result = await reindexCollection(store, collectionPath, "a.md,X - *.md", collectionName);
+    expect(result.indexed).toBe(2);
+
+    const paths = store.db.prepare(`
+      SELECT path FROM documents WHERE collection = ? AND active = 1 ORDER BY path
+    `).all(collectionName) as { path: string }[];
+    expect(paths.map(r => r.path)).toEqual(["X - b.md", "a.md"]);
+  });
+
   test("treats a case-only rename as a new identity on a case-sensitive collection", async () => {
     const store = await createTestStore();
     const collectionName = "docs";


### PR DESCRIPTION
## Summary

`--mask "a.md,X - *.md"` silently indexed **zero files** even though each pattern would match on its own. Help text and common usage treat the comma-separated form as a union, but the joined string was passed to fast-glob as one literal glob (which matches nothing). Brace form `{a.md,X - *.md}` already worked.

- `splitGlobMask()` splits top-level commas and leaves `{...}` / `[...]` intact
- Applied at both `collection add` (`indexFiles`) and `qmd update` (`reindexCollection`) so stored comma-list masks start working too
- Usage/README mention the comma-union form

Fixes #557.

## Test plan

- [x] `CI=true bun test test/store.helpers.unit.test.ts test/store.test.ts test/cli.test.ts` (435 pass)
- [x] `tsc -p tsconfig.build.json --noEmit` clean
- [x] Full unit: Bun 993 pass / Node 993 pass
- [ ] CI Bun + Node green