### PR TITLE
fix(store): embed searchVec queries with the store's pinned model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@
 
 ### Fixed
 
+- `store.searchVec()` (and SDK `searchVector()`) now embed the query with the
+  store's pinned embed model instead of the global `QMD_EMBED_MODEL`. A store
+  created with a non-default `models.embed` previously failed with
+  `Dimension mismatch ... Expected N ... received M` and loaded the wrong
+  (often much larger) model at query time. Hybrid/precomputed/session search
+  paths were unaffected and stay unchanged (#690).
+
 - `qmd collection add --mask "a.md,*.txt"` now indexes the union of each
   pattern. The comma-separated form was documented and commonly guessed, but
   the joined string was passed to fast-glob as one literal glob, so it

--- a/src/store.ts
+++ b/src/store.ts
@@ -2159,7 +2159,7 @@ export function createStore(dbPath?: string): Store {
 
     // Search
     searchFTS: (query: string, limit?: number, collectionName?: string) => searchFTS(db, query, limit, collectionName),
-    searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => searchVec(db, query, model, limit, collectionName, session, precomputedEmbedding),
+    searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => searchVec(db, query, model, limit, collectionName, session, precomputedEmbedding, getLlm(store)),
 
     // Query expansion & reranking
     expandQuery: (query: string, model?: string, intent?: string) => expandQuery(query, model ?? store.llm?.generateModelName ?? DEFAULT_QUERY_MODEL, db, intent, store.llm),
@@ -3968,11 +3968,11 @@ function annVecScan(
   `).all(new Float32Array(embedding), vecK) as { hash_seq: string; distance: number }[];
 }
 
-export async function searchVec(db: Database, query: string, model: string, limit: number = 20, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]): Promise<SearchResult[]> {
+export async function searchVec(db: Database, query: string, model: string, limit: number = 20, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[], llm?: LlamaCpp): Promise<SearchResult[]> {
   const tableExists = db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'`).get();
   if (!tableExists) return [];
 
-  const embedding = precomputedEmbedding ?? await getEmbedding(query, model, true, session);
+  const embedding = precomputedEmbedding ?? await getEmbedding(query, model, true, session, llm);
   if (!embedding) return [];
 
   // IMPORTANT: We use a two-step query approach here because sqlite-vec virtual tables

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -3952,6 +3952,59 @@ describe("Embedding batching", () => {
     }
   });
 
+  test("searchVec embeds the query with the store's pinned llm, not the global default (#690)", async () => {
+    const store = await createTestStore();
+    const db = store.db;
+
+    // Store is pinned to a 3-dim embed model. Docs AND the query must use it,
+    // so vectors_vec is created as float[3].
+    const storeModel = "hf:store/embeddinggemma-300M.gguf";
+    const storeLlm = {
+      embedModelName: storeModel,
+      async embed(_text: string, _options?: { model?: string }) {
+        return { embedding: [0.1, 0.2, 0.3], model: storeModel };
+      },
+      async embedBatch(texts: string[], _options?: { model?: string }) {
+        return texts.map(() => ({ embedding: [0.1, 0.2, 0.3], model: storeModel }));
+      },
+    };
+
+    // The global default (env QMD_EMBED_MODEL) is a DIFFERENT, 4-dim model.
+    // If the query is wrongly embedded with this, sqlite-vec rejects the 4-dim
+    // vector against the float[3] table (the reported dim-mismatch symptom).
+    let defaultEmbedCalls = 0;
+    const defaultLlm = {
+      // Chunking tokenizes via the global default (chunkDocumentByTokens passes
+      // no tokenizer), so the default must provide tokenize.
+      async tokenize(text: string) {
+        return new Array(Math.max(1, Math.ceil(text.length / 16))).fill(1);
+      },
+      async embed(_text: string, _options?: { model?: string }) {
+        defaultEmbedCalls++;
+        return { embedding: [9, 9, 9, 9], model: "env-8b" };
+      },
+    };
+
+    setDefaultLlamaCpp(defaultLlm as any);
+    store.llm = storeLlm as any;
+
+    try {
+      await insertTestDocument(db, "docs", { name: "alpha", body: "# Alpha\n\nvector regression doc" });
+      const embed = await generateEmbeddings(store);
+      expect(embed.chunksEmbedded).toBeGreaterThan(0);
+
+      // Inline-embed path (no session, no precomputed embedding): the query must
+      // be embedded with the store's llm. Pre-fix this threw a dim mismatch.
+      const results = await store.searchVec("find alpha", storeModel);
+
+      expect(results.length).toBeGreaterThan(0);
+      expect(defaultEmbedCalls).toBe(0);
+    } finally {
+      setDefaultLlamaCpp(null);
+      await cleanupTestDb(store);
+    }
+  });
+
   test("vectorSearchQuery uses the active llm embed model for vector lookups", async () => {
     const store = await createTestStore();
     const model = "hf:Qwen/Qwen3-Embedding-0.6B-GGUF/Qwen3-Embedding-0.6B-Q8_0.gguf";


### PR DESCRIPTION
## Summary
- Rebase of #690 onto current `main`. `store.searchVec()` (and SDK `searchVector()`) embedded the query with the global `QMD_EMBED_MODEL` instead of the store's pinned embed model, so a store created with a non-default `models.embed` hit sqlite-vec `Dimension mismatch` and loaded the wrong model at query time.
- Thread `getLlm(store)` into the inline-embed path. Hybrid/precomputed/session search is unchanged.

## Test plan
- [x] New unit test: store pinned to a 3-dim model vs global 4-dim default; `searchVec` returns hits and never calls the default llm
- [x] `CI=true` Node vitest `test/`: 994 passed, 74 skipped
- [x] `CI=true` Bun `test/`: 994 pass, 81 skip, 0 fail

Supersedes #690.