### PR TITLE
fix(release): add missing release-context.sh for /release skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@
 
 ### Fixed
 
+- `/release` step 1 no longer points at a missing script. `skills/release/scripts/release-context.sh`
+  now exists: it silently installs git hooks and prints version info, working-tree
+  status, commits and files since the last tag, `[Unreleased]`, and the previous
+  changelog entry. The skill's process list also drops the duplicate step 7 and
+  checks dependency updates before cutting the release (#796).
+
 - `store.searchVec()` (and SDK `searchVector()`) now embed the query with the
   store's pinned embed model instead of the global `QMD_EMBED_MODEL`. A store
   created with a non-default `models.embed` previously failed with

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -29,30 +29,30 @@ When the user triggers `/release <version>`:
    the commits and file changes from the context output. Follow the changelog
    standard below. Re-run the context script after committing if needed.
 
-4. **Cut the release** — run `scripts/release.sh <version>`. This renames
+4. **Check dependency updates** — before cutting the release, check for
+   updates to `sqlite-vec` (and platform packages), `node-llama-cpp`,
+   and `better-sqlite3`. Run `pnpm outdated` and report any available
+   updates for these packages. If updates exist, bump them (pinned, no
+   `^` ranges) and re-run tests before proceeding.
+
+5. **Cut the release** — run `scripts/release.sh <version>`. This renames
    `[Unreleased]` → `[X.Y.Z] - date`, inserts a fresh `[Unreleased]`,
    bumps `package.json` and the plugin version in
    `.claude-plugin/marketplace.json` (so installed plugins see the update),
    commits, and tags.
 
-5. **Show the final changelog** — print the full `[Unreleased]` +
+6. **Show the final changelog** — print the full `[Unreleased]` +
    minor series rollup via `scripts/extract-changelog.sh <version>`.
    Ask the user to confirm before pushing.
 
-6. **Push** — after explicit confirmation, run `git push origin main --tags`.
+7. **Push** — after explicit confirmation, run `git push origin main --tags`.
 
-7. **Watch CI** — after the push, start a background dispatch to watch the
+8. **Watch CI** — after the push, start a background dispatch to watch the
    publish workflow. Use `interactive_shell` in dispatch mode with:
    ```
    gh run watch $(gh run list --workflow=publish.yml --limit=1 --json databaseId --jq '.[0].databaseId') --exit-status
    ```
    The agent will be notified when CI completes and should report the result.
-
-7. **Check dependency updates** — before cutting the release, check for
-   updates to `sqlite-vec` (and platform packages), `node-llama-cpp`,
-   and `better-sqlite3`. Run `pnpm outdated` and report any available
-   updates for these packages. If updates exist, bump them (pinned, no
-   `^` ranges) and re-run tests before proceeding.
 
 If any step fails, stop and explain. Never force-push or skip validation.
 

--- a/skills/release/scripts/release-context.sh
+++ b/skills/release/scripts/release-context.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Gather release context for the /release skill (skills/release/SKILL.md step 1).
+# Silently installs git hooks, then prints version info, working-tree status,
+# commits and files since the last release tag, the current [Unreleased]
+# changelog block, and the previous release entry for style reference.
+#
+# Usage: skills/release/scripts/release-context.sh [patch|minor|major|<version>]
+
+VERSION_ARG="${1:?Usage: release-context.sh [patch|minor|major|<version>]}"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [[ -z "$REPO_ROOT" ]]; then
+  echo "Error: not in a git repository" >&2
+  exit 1
+fi
+cd "$REPO_ROOT"
+
+# Hooks are installed silently — the skill documents this as the auto-install path.
+if [[ -x "$SCRIPT_DIR/install-hooks.sh" ]]; then
+  "$SCRIPT_DIR/install-hooks.sh" >/dev/null
+fi
+
+bump_version() {
+  local current="$1" type="$2"
+  IFS='.' read -r major minor patch <<< "$current"
+  case "$type" in
+    major) echo "$((major + 1)).0.0" ;;
+    minor) echo "$major.$((minor + 1)).0" ;;
+    patch) echo "$major.$minor.$((patch + 1))" ;;
+    *)     echo "$type" ;;
+  esac
+}
+
+if [[ ! -f package.json ]]; then
+  echo "Error: package.json not found in $REPO_ROOT" >&2
+  exit 1
+fi
+
+CURRENT=$(jq -r .version package.json)
+NEXT=$(bump_version "$CURRENT" "$VERSION_ARG")
+BRANCH=$(git branch --show-current)
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+
+echo "=== Version ==="
+echo "Current:   $CURRENT"
+echo "Requested: $VERSION_ARG"
+echo "Next:      $NEXT"
+echo "Branch:    ${BRANCH:-"(detached)"}"
+if [[ -n "$LAST_TAG" ]]; then
+  echo "Last tag:  $LAST_TAG"
+else
+  echo "Last tag:  (none)"
+fi
+echo
+
+echo "=== Working tree ==="
+STATUS=$(git status --short)
+if [[ -z "$STATUS" ]]; then
+  echo "(clean)"
+else
+  printf '%s\n' "$STATUS"
+fi
+echo
+
+echo "=== Commits since last release ==="
+if [[ -n "$LAST_TAG" ]]; then
+  COMMITS=$(git log --oneline "${LAST_TAG}..HEAD")
+  if [[ -z "$COMMITS" ]]; then
+    echo "(none since $LAST_TAG)"
+  else
+    printf '%s\n' "$COMMITS"
+  fi
+else
+  echo "(no tags)"
+  git log --oneline
+fi
+echo
+
+echo "=== Files changed since last release ==="
+if [[ -n "$LAST_TAG" ]]; then
+  FILES=$(git diff --name-only "${LAST_TAG}..HEAD")
+  if [[ -z "$FILES" ]]; then
+    echo "(none since $LAST_TAG)"
+  else
+    printf '%s\n' "$FILES"
+  fi
+else
+  echo "(no tags)"
+fi
+echo
+
+echo "=== CHANGELOG [Unreleased] ==="
+if [[ -f CHANGELOG.md ]]; then
+  UNRELEASED=$(awk '
+    /^## \[Unreleased\]/ { p=1; next }
+    /^## \[/ { if (p) exit }
+    p { print }
+  ' CHANGELOG.md)
+  TRIMMED=$(printf '%s' "$UNRELEASED" | sed '/^[[:space:]]*$/d')
+  if [[ -z "$TRIMMED" ]]; then
+    echo "(empty)"
+  else
+    printf '%s\n' "$UNRELEASED"
+  fi
+else
+  echo "(CHANGELOG.md not found)"
+fi
+echo
+
+echo "=== Previous release entry ==="
+if [[ -f CHANGELOG.md ]]; then
+  PREVIOUS=$(awk '
+    /^## \[Unreleased\]/ { next }
+    /^## \[/ { if (p) exit; p=1 }
+    p { print }
+  ' CHANGELOG.md)
+  TRIMMED=$(printf '%s' "$PREVIOUS" | sed '/^[[:space:]]*$/d')
+  if [[ -z "$TRIMMED" ]]; then
+    echo "(none)"
+  else
+    printf '%s\n' "$PREVIOUS"
+  fi
+else
+  echo "(CHANGELOG.md not found)"
+fi

--- a/test/release-context.test.ts
+++ b/test/release-context.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const scriptSrc = join(repoRoot, "skills", "release", "scripts", "release-context.sh");
+const installHooksSrc = join(repoRoot, "skills", "release", "scripts", "install-hooks.sh");
+const prePushSrc = join(repoRoot, "scripts", "pre-push");
+const skillSrc = join(repoRoot, "skills", "release", "SKILL.md");
+
+const fixtures: string[] = [];
+
+afterEach(() => {
+  for (const dir of fixtures.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function git(cwd: string, args: string[]) {
+  const result = spawnSync("git", ["-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false", ...args], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "qmd-test",
+      GIT_AUTHOR_EMAIL: "qmd-test@example.com",
+      GIT_COMMITTER_NAME: "qmd-test",
+      GIT_COMMITTER_EMAIL: "qmd-test@example.com",
+      GIT_EDITOR: "true",
+    },
+  });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${result.stderr || result.stdout}`);
+  }
+  return result;
+}
+
+function makeReleaseFixture(opts?: { dirty?: boolean }) {
+  const root = mkdtempSync(join(tmpdir(), "qmd-release-context-"));
+  fixtures.push(root);
+
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  mkdirSync(join(root, "skills", "release", "scripts"), { recursive: true });
+
+  writeFileSync(join(root, "skills", "release", "scripts", "release-context.sh"), readFileSync(scriptSrc));
+  writeFileSync(join(root, "skills", "release", "scripts", "install-hooks.sh"), readFileSync(installHooksSrc));
+  writeFileSync(join(root, "scripts", "pre-push"), readFileSync(prePushSrc));
+  chmodSync(join(root, "skills", "release", "scripts", "release-context.sh"), 0o755);
+  chmodSync(join(root, "skills", "release", "scripts", "install-hooks.sh"), 0o755);
+  chmodSync(join(root, "scripts", "pre-push"), 0o755);
+
+  writeFileSync(join(root, "package.json"), JSON.stringify({ name: "qmd", version: "2.6.3" }) + "\n");
+  writeFileSync(
+    join(root, "CHANGELOG.md"),
+    [
+      "# Changelog",
+      "",
+      "## [Unreleased]",
+      "",
+      "### Fixed",
+      "",
+      "- pending fix for the next cut",
+      "",
+      "## [2.6.3] - 2026-08-12",
+      "",
+      "### Fixed",
+      "",
+      "- previous release style reference",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(join(root, "README.md"), "hello\n");
+
+  git(root, ["init", "-b", "main"]);
+  git(root, ["config", "user.name", "qmd-test"]);
+  git(root, ["config", "user.email", "qmd-test@example.com"]);
+  git(root, ["config", "commit.gpgsign", "false"]);
+  git(root, ["config", "tag.gpgsign", "false"]);
+  git(root, ["add", "package.json", "CHANGELOG.md", "README.md", "scripts", "skills"]);
+  git(root, ["commit", "-m", "initial"]);
+  git(root, ["tag", "-a", "v2.6.3", "-m", "v2.6.3"]);
+
+  writeFileSync(join(root, "NEW.md"), "post-tag change\n");
+  git(root, ["add", "NEW.md"]);
+  git(root, ["commit", "-m", "add NEW.md after tag"]);
+
+  if (opts?.dirty) {
+    writeFileSync(join(root, "dirty.txt"), "unstaged\n");
+  }
+
+  return root;
+}
+
+function runContext(cwd: string, versionArg: string) {
+  return spawnSync("bash", [join(cwd, "skills", "release", "scripts", "release-context.sh"), versionArg], {
+    cwd,
+    encoding: "utf8",
+  });
+}
+
+describe("skills/release/scripts/release-context.sh (#796)", () => {
+  test("SKILL.md step 1 points at a script that exists in the repo", () => {
+    const skill = readFileSync(skillSrc, "utf8");
+    expect(skill).toMatch(/skills\/release\/scripts\/release-context\.sh/);
+    expect(existsSync(scriptSrc)).toBe(true);
+  });
+
+  test("SKILL.md process steps are uniquely numbered", () => {
+    const skill = readFileSync(skillSrc, "utf8");
+    const process = skill.split("## Dependency Policy")[0];
+    const nums = [...process.matchAll(/^(\d+)\. \*\*/gm)].map(m => m[1]);
+    expect(nums).toEqual(["1", "2", "3", "4", "5", "6", "7", "8"]);
+  });
+
+  test("fails without a version argument", () => {
+    const root = makeReleaseFixture();
+    const result = spawnSync("bash", [join(root, "skills", "release", "scripts", "release-context.sh")], {
+      cwd: root,
+      encoding: "utf8",
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/Usage: release-context\.sh/);
+  });
+
+  test("prints version, status, commits, files, unreleased, and previous entry", () => {
+    const root = makeReleaseFixture();
+    const result = runContext(root, "patch");
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toMatch(/=== Version ===/);
+    expect(result.stdout).toMatch(/Current:\s+2\.6\.3/);
+    expect(result.stdout).toMatch(/Requested:\s+patch/);
+    expect(result.stdout).toMatch(/Next:\s+2\.6\.4/);
+    expect(result.stdout).toMatch(/Last tag:\s+v2\.6\.3/);
+    expect(result.stdout).toMatch(/=== Working tree ===/);
+    expect(result.stdout).toMatch(/\(clean\)/);
+    expect(result.stdout).toMatch(/=== Commits since last release ===/);
+    expect(result.stdout).toMatch(/add NEW\.md after tag/);
+    expect(result.stdout).toMatch(/=== Files changed since last release ===/);
+    expect(result.stdout).toMatch(/^NEW\.md$/m);
+    expect(result.stdout).toMatch(/=== CHANGELOG \[Unreleased\] ===/);
+    expect(result.stdout).toMatch(/pending fix for the next cut/);
+    expect(result.stdout).toMatch(/=== Previous release entry ===/);
+    expect(result.stdout).toMatch(/## \[2\.6\.3\] - 2026-08-12/);
+    expect(result.stdout).toMatch(/previous release style reference/);
+  });
+
+  test("silently installs the pre-push hook", () => {
+    const root = makeReleaseFixture();
+    const hook = join(root, ".git", "hooks", "pre-push");
+    expect(existsSync(hook)).toBe(false);
+    const result = runContext(root, "2.6.4");
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).not.toMatch(/pre-push hook/);
+    expect(result.stdout).not.toMatch(/^Done\.$/m);
+    expect(existsSync(hook)).toBe(true);
+  });
+
+  test("shows a dirty working tree", () => {
+    const root = makeReleaseFixture({ dirty: true });
+    const result = runContext(root, "minor");
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toMatch(/Next:\s+2\.7\.0/);
+    expect(result.stdout).toMatch(/dirty\.txt/);
+    expect(result.stdout).not.toMatch(/\(clean\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- `/release` step 1 told agents to run `skills/release/scripts/release-context.sh`, which has never existed in the repo (dangling since 63f3b68). The skill now ships that script: silent hook install plus version info, working-tree status, commits/files since the last tag, `[Unreleased]`, and the previous changelog entry.
- Renumber the process list (the duplicate step 7 is gone) and check dependency updates *before* cutting the release.

## Test plan
- [x] New unit tests for the script (version bump, sections, silent hook install, dirty tree, missing arg, unique step numbers)
- [x] `CI=true` Node vitest `test/`: 1000 passed, 74 skipped
- [x] `CI=true` Bun `test/`: 1000 pass, 81 skip, 0 fail

Fixes #796.