### PR TITLE
fix(nix): ship skills/ in the flake package so skill commands work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
 
 ### Fixed
 
+- The Nix flake package now ships `skills/` next to `src/` in `$out/lib/qmd/`.
+  `findPackageRoot()` walks up from the wrapped `src/cli/qmd.ts` looking for a
+  sibling `skills/` directory; without it, `qmd skill show` and `qmd skills list`
+  always failed with "QMD skill not found" on Nix-installed binaries (#722).
+
 - `/release` step 1 no longer points at a missing script. `skills/release/scripts/release-context.sh`
   now exists: it silently installs git hooks and prints version info, working-tree
   status, commits and files since the last tag, `[Unreleased]`, and the previous

--- a/flake.nix
+++ b/flake.nix
@@ -125,6 +125,7 @@
 
             cp -r node_modules $out/lib/qmd/
             cp -r src $out/lib/qmd/
+            cp -r skills $out/lib/qmd/
             cp package.json $out/lib/qmd/
 
             makeWrapper ${pkgs.bun}/bin/bun $out/bin/qmd \

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -69,3 +69,16 @@ describe("package grammar distribution", () => {
     expect(script).toContain("tree-sitter-typescript/tree-sitter-tsx.wasm");
   });
 });
+
+describe("Nix flake package layout", () => {
+  test("installPhase copies skills/ next to src/ so findPackageRoot can resolve them (#722)", () => {
+    const flake = readFileSync(new URL("flake.nix", root), "utf8");
+
+    // The bun wrapper runs $out/lib/qmd/src/cli/qmd.ts. findPackageRoot() walks
+    // up from that file looking for a sibling skills/ directory, so skills must
+    // land at the same $out/lib/qmd prefix as src — not only in the source tree.
+    expect(flake).toContain("cp -r src $out/lib/qmd/");
+    expect(flake).toContain("cp -r skills $out/lib/qmd/");
+    expect(flake).toContain("cp package.json $out/lib/qmd/");
+  });
+});


### PR DESCRIPTION
## Summary
- The Nix flake copied `node_modules`, `src/`, and `package.json` into `$out/lib/qmd/` but never `skills/`.
- `findPackageRoot()` walks up from the wrapped `src/cli/qmd.ts` looking for a sibling `skills/` directory, so `qmd skill show` and `qmd skills list` always failed on Nix-installed binaries with "QMD skill not found".
- Copy `skills/` next to `src/` so the existing lookup succeeds. `QMD_SKILLS_DIR` workaround is unchanged.

## Test plan
- [x] New unit test asserts `flake.nix` copies `skills/` to the same `$out/lib/qmd/` prefix as `src/`
- [x] `CI=true` Node vitest `test/`: 1001 passed, 74 skipped
- [x] `CI=true` Bun `test/`: 1001 pass, 81 skip, 0 fail

Fixes #722.