### PR TITLE
fix(llm): surface the real error when rerank context creation fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@
 
 ### Fixed
 
+- Rerank context creation no longer swallows the real failure. A VRAM OOM or
+  corrupt model previously produced only `Reranker unavailable — skipping
+  reranking` (and a dead identical retry whose comment claimed it disabled
+  flash attention, which ranking contexts never supported). The warning now
+  includes the underlying message so the two cases are distinguishable (#782).
+
 - The Nix flake package now ships `skills/` next to `src/` in `$out/lib/qmd/`.
   `findPackageRoot()` walks up from the wrapped `src/cli/qmd.ts` looking for a
   sibling `skills/` directory; without it, `qmd skill show` and `qmd skills list`

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -1199,10 +1199,8 @@ export class LlamaCpp implements LLM {
    * Load rerank contexts (lazy). Creates multiple contexts for parallel ranking.
    * Each context has its own sequence, so they can evaluate independently.
    *
-   * Tuning choices:
-   * - contextSize 1024: reranking chunks are ~800 tokens max, 1024 is plenty
-   * - flashAttention: ~20% less VRAM per context (568 vs 711 MB)
-   * - Combined: drops from 11.6 GB (auto, no flash) to 568 MB per context (20×)
+   * VRAM per context is governed by contextSize alone —
+   * LlamaRankingContextOptions has no flashAttention option.
    */
   // Qwen3 reranker template adds ~200 tokens overhead (system prompt, tags, etc.)
   // Default 2048 was too small for longer documents (e.g. session transcripts,
@@ -1223,7 +1221,6 @@ export class LlamaCpp implements LLM {
   private async ensureRerankContexts(): Promise<Awaited<ReturnType<LlamaModel["createRankingContext"]>>[]> {
     if (this.rerankContexts.length === 0) {
       const model = await this.ensureRerankModel();
-      // ~960 MB per context with flash attention at contextSize 2048
       const n = Math.min(await this.computeParallelism(1000), 4);
       const threads = await this.threadsPerContext(n);
       for (let i = 0; i < n; i++) {
@@ -1232,22 +1229,20 @@ export class LlamaCpp implements LLM {
             contextSize: LlamaCpp.RERANK_CONTEXT_SIZE,
             ...(threads > 0 ? { threads } : {}),
           }));
-        } catch {
+        } catch (error) {
           if (this.rerankContexts.length === 0) {
-            // Flash attention might not be supported — retry without it
-            try {
-              this.rerankContexts.push(await model.createRankingContext({
-                contextSize: LlamaCpp.RERANK_CONTEXT_SIZE,
-                ...(threads > 0 ? { threads } : {}),
-              }));
-            } catch {
-              console.warn(
-                "Reranker unavailable — skipping reranking. " +
-                "Use --no-rerank to silence this warning.",
-              );
-              return [];
-            }
+            // Surface the underlying failure (e.g. out of VRAM). A previous
+            // "retry without flash attention" path was dead: ranking contexts
+            // never accepted that option, so the retry repeated identical
+            // arguments and the real error was discarded.
+            const detail = error instanceof Error ? error.message : String(error);
+            console.warn(
+              `Reranker unavailable — skipping reranking (${detail}). ` +
+              "Use --no-rerank to silence this warning.",
+            );
+            return [];
           }
+          // At least one context exists — continue with reduced parallelism.
           break;
         }
       }

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -604,6 +604,56 @@ describe("LlamaCpp rerank deduping", () => {
   });
 });
 
+describe("LlamaCpp ensureRerankContexts error reporting", () => {
+  test("warns with the underlying error and does not retry identical options", async () => {
+    const llm = new LlamaCpp({}) as any;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const createRankingContext = vi.fn().mockRejectedValue(
+        new Error("A context size of 40960 is too large for the available VRAM"),
+      );
+      llm.computeParallelism = vi.fn().mockResolvedValue(2);
+      llm.threadsPerContext = vi.fn().mockResolvedValue(0);
+      llm.ensureRerankModel = vi.fn().mockResolvedValue({ createRankingContext });
+
+      const contexts = await llm.ensureRerankContexts();
+
+      expect(contexts).toEqual([]);
+      expect(createRankingContext).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("A context size of 40960 is too large for the available VRAM"),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test("keeps already-created contexts when a later createRankingContext fails", async () => {
+    const llm = new LlamaCpp({}) as any;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const ctx1 = { id: 1 };
+      let calls = 0;
+      const createRankingContext = vi.fn().mockImplementation(async () => {
+        calls++;
+        if (calls === 1) return ctx1;
+        throw new Error("out of VRAM");
+      });
+      llm.computeParallelism = vi.fn().mockResolvedValue(3);
+      llm.threadsPerContext = vi.fn().mockResolvedValue(0);
+      llm.ensureRerankModel = vi.fn().mockResolvedValue({ createRankingContext });
+
+      const contexts = await llm.ensureRerankContexts();
+
+      expect(contexts).toEqual([ctx1]);
+      expect(createRankingContext).toHaveBeenCalledTimes(2);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
 describe("LlamaCpp.getDeviceInfo", () => {
   test("can skip build attempts for status probes", async () => {
     const llm = new LlamaCpp({}) as any;


### PR DESCRIPTION
## Summary
- `ensureRerankContexts()` caught ranking-context failures with bare `catch {}`, so a VRAM OOM and a broken model both printed only `Reranker unavailable — skipping reranking`.
- The "retry without flash attention" fallback was dead code: `LlamaRankingContextOptions` has no `flashAttention` field, so the retry repeated identical options and discarded the real error.
- Keep the skip-and-continue behavior (queries still work without rerank), but include the underlying message in the warning. Later context failures still drop to reduced parallelism.

## Test plan
- [x] New unit tests: first-context failure warns with the real message and does not retry; a later failure keeps the already-created context
- [x] `CI=true` Node vitest `test/`: 1003 passed, 74 skipped
- [x] `CI=true` Bun `test/`: 1003 pass, 81 skip, 0 fail

Supersedes #782 (conflicted against current main, which warns instead of throwing).