### PR TITLE
fix(nix): seed bin/qmd pre-import env in the flake wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@
 
 ### Fixed
 
+- The Nix flake wrapper now seeds the same pre-import env as `bin/qmd`.
+  Nix installs exec `bun src/cli/qmd.ts` directly, so they previously skipped
+  the launcher: `qmd mcp` could leak llama/ggml native logs onto JSON-RPC
+  stdio, and Darwin CLI exits dumped a ggml Metal residency-set stack trace
+  after an otherwise successful query. The wrapper now quiets those logs for
+  `mcp` and sets `GGML_METAL_NO_RESIDENCY=1` on Darwin unless
+  `QMD_METAL_KEEP_RESIDENCY=1` (#723).
+
 - Rerank context creation no longer swallows the real failure. A VRAM OOM or
   corrupt model previously produced only `Reranker unavailable — skipping
   reranking` (and a dead identical retry whose comment claimed it disabled

--- a/flake.nix
+++ b/flake.nix
@@ -128,10 +128,19 @@
             cp -r skills $out/lib/qmd/
             cp package.json $out/lib/qmd/
 
+            # The flake wraps `bun src/cli/qmd.ts` directly, so bin/qmd never
+            # runs. Mirror its pre-import env here (#723): quiet llama/ggml
+            # native logs for `qmd mcp` (stdio is JSON-RPC), and disable Metal
+            # residency sets on Darwin so ggml's process-static destructor
+            # does not dump a stack trace after a successful query
+            # (ggml-org/llama.cpp#22593). `--run` fires before bun starts, so
+            # the env is in place before the native binding loads. Preserve
+            # explicit user values; QMD_METAL_KEEP_RESIDENCY=1 opts back in.
             makeWrapper ${pkgs.bun}/bin/bun $out/bin/qmd \
               --add-flags "$out/lib/qmd/src/cli/qmd.ts" \
               --set DYLD_LIBRARY_PATH "${pkgs.sqlite.out}/lib" \
-              --set LD_LIBRARY_PATH "${pkgs.sqlite.out}/lib${pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux ":${pkgs.stdenv.cc.libc.out}/lib:${pkgs.stdenv.cc.cc.lib}/lib"}"
+              --set LD_LIBRARY_PATH "${pkgs.sqlite.out}/lib${pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux ":${pkgs.stdenv.cc.libc.out}/lib:${pkgs.stdenv.cc.cc.lib}/lib"}" \
+              --run 'if [ "$1" = mcp ]; then export LLAMA_LOG_LEVEL="''${LLAMA_LOG_LEVEL:-error}"; export GGML_LOG_LEVEL="''${GGML_LOG_LEVEL:-error}"; export GGML_BACKEND_SILENT="''${GGML_BACKEND_SILENT:-1}"; fi; if [ "$(uname -s)" = Darwin ] && [ "''${QMD_METAL_KEEP_RESIDENCY:-}" != 1 ]; then export GGML_METAL_NO_RESIDENCY="''${GGML_METAL_NO_RESIDENCY:-1}"; fi'
           '';
 
           meta = with pkgs.lib; {

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -752,9 +752,10 @@ export class LlamaCpp implements LLM {
 
 
   constructor(config: LlamaCppConfig = {}) {
-    // STRUCTURAL INVARIANT: the launcher (bin/qmd) sets GGML_METAL_NO_RESIDENCY=1
-    // on darwin BEFORE the native binding loads, which prevents the libggml-metal
-    // static destructor assertion at process exit (ggml-org/llama.cpp#22593).
+    // STRUCTURAL INVARIANT: the launcher (bin/qmd) and the Nix flake wrapper
+    // set GGML_METAL_NO_RESIDENCY=1 on darwin BEFORE the native binding loads,
+    // which prevents the libggml-metal static destructor assertion at process
+    // exit (ggml-org/llama.cpp#22593). Nix installs skip bin/qmd (#723).
     // See isDarwinMetalMitigationActive() for the runtime check exposed to
     // diagnostics. No constructor-time guard installation is needed.
 

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -81,4 +81,30 @@ describe("Nix flake package layout", () => {
     expect(flake).toContain("cp -r skills $out/lib/qmd/");
     expect(flake).toContain("cp package.json $out/lib/qmd/");
   });
+
+  test("makeWrapper seeds the same pre-import env as bin/qmd (#723)", () => {
+    const flake = readFileSync(new URL("flake.nix", root), "utf8");
+    const launcher = readFileSync(new URL("bin/qmd", root), "utf8");
+
+    // Nix installs skip bin/qmd and exec bun src/cli/qmd.ts. The wrapper must
+    // still set these BEFORE the native binding loads, matching the launcher.
+    for (const env of [
+      "LLAMA_LOG_LEVEL",
+      "GGML_LOG_LEVEL",
+      "GGML_BACKEND_SILENT",
+      "GGML_METAL_NO_RESIDENCY",
+      "QMD_METAL_KEEP_RESIDENCY",
+    ]) {
+      expect(launcher, `bin/qmd should set ${env}`).toContain(env);
+      expect(flake, `flake.nix wrapper should set ${env}`).toContain(env);
+    }
+
+    expect(flake).toContain('--run');
+    expect(flake).toContain('$1" = mcp');
+    expect(flake).toContain('$(uname -s)" = Darwin');
+    expect(flake).toContain('LLAMA_LOG_LEVEL:-error');
+    expect(flake).toContain('GGML_LOG_LEVEL:-error');
+    expect(flake).toContain('GGML_BACKEND_SILENT:-1');
+    expect(flake).toContain('GGML_METAL_NO_RESIDENCY:-1');
+  });
 });


### PR DESCRIPTION
## Summary
- The Nix flake wraps `bun src/cli/qmd.ts` directly, so `bin/qmd` never runs on Nix installs.
- That skipped two pre-import env seeds the launcher sets before the native binding loads: quiet llama/ggml logs for `qmd mcp` (stdio is JSON-RPC) and `GGML_METAL_NO_RESIDENCY=1` on Darwin (ggml-org/llama.cpp#22593).
- `makeWrapper --run` now mirrors those defaults, preserving explicit user values. `QMD_METAL_KEEP_RESIDENCY=1` still opts back into Metal residency sets.

## Test plan
- [x] New unit test asserts the flake wrapper sets the same env vars as `bin/qmd`
- [x] `CI=true` Node vitest `test/`: 1004 passed, 74 skipped
- [x] `CI=true` Bun `test/`: 1004 pass, 81 skip, 0 fail

Fixes #723.