### PR TITLE
fix(store): unify multi-get comma-list path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@
 
 ### Fixed
 
+- CLI `multi-get` and SDK/MCP `multi_get` now share one comma-list resolver.
+  Collection-prefixed paths (`qmd/docs/SYNTAX.md`) work in both transports,
+  unanchored `LIKE '%name'` no longer silently fetches a different document
+  for a filename fragment (`NTAX.md` ≠ `SYNTAX.md`), and ambiguous names
+  across collections error with the candidate list instead of `LIMIT 1` (#759).
+
 - The Nix flake wrapper now seeds the same pre-import env as `bin/qmd`.
   Nix installs exec `bun src/cli/qmd.ts` directly, so they previously skipped
   the launcher: `qmd mcp` could leak llama/ggml native logs onto JSON-RPC

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -24,7 +24,7 @@ import {
   renameCollection,
   findSimilarFiles,
   findDocument,
-  findDocumentByDocid,
+  resolveCommaListName,
   matchFilesByGlob,
   getHashesNeedingEmbedding,
   clearAllEmbeddings,
@@ -1141,66 +1141,17 @@ function multiGet(pattern: string, maxLines?: number, maxBytes: number = DEFAULT
       : [pattern.trim()].filter(Boolean);
     files = [];
     for (const name of names) {
-      let doc: { virtual_path: string; body_length: number; collection: string; path: string } | null = null;
-      const docidMatch = isDocid(name) ? findDocumentByDocid(db, name) : null;
-      const lookupName = docidMatch?.filepath ?? name;
-
-      // Handle virtual paths
-      if (isVirtualPath(lookupName)) {
-        const parsed = parseVirtualPath(lookupName);
-        if (parsed) {
-          // Try exact match on collection + path
-          doc = db.prepare(`
-            SELECT
-              'qmd://' || d.collection || '/' || d.path as virtual_path,
-              LENGTH(content.doc) as body_length,
-              d.collection,
-              d.path
-            FROM documents d
-            JOIN content ON content.hash = d.hash
-            WHERE d.collection = ? AND d.path = ? AND d.active = 1
-          `).get(parsed.collectionName, parsed.path) as typeof doc;
-        }
-      } else if (!docidMatch) {
-        // Try exact match on path
-        doc = db.prepare(`
-          SELECT
-            'qmd://' || d.collection || '/' || d.path as virtual_path,
-            LENGTH(content.doc) as body_length,
-            d.collection,
-            d.path
-          FROM documents d
-          JOIN content ON content.hash = d.hash
-          WHERE d.path = ? AND d.active = 1
-          LIMIT 1
-        `).get(lookupName) as { virtual_path: string; body_length: number; collection: string; path: string } | null;
-
-        // Try suffix match
-        if (!doc) {
-          doc = db.prepare(`
-            SELECT
-              'qmd://' || d.collection || '/' || d.path as virtual_path,
-              LENGTH(content.doc) as body_length,
-              d.collection,
-              d.path
-            FROM documents d
-            JOIN content ON content.hash = d.hash
-            WHERE d.path LIKE ? AND d.active = 1
-            LIMIT 1
-          `).get(`%${lookupName}`) as { virtual_path: string; body_length: number; collection: string; path: string } | null;
-        }
-      }
-
-      if (doc) {
+      const resolved = resolveCommaListName(db, name);
+      if (resolved.ok) {
         files.push({
-          filepath: doc.virtual_path,
-          displayPath: doc.virtual_path,
-          bodyLength: doc.body_length,
-          collection: doc.collection,
-          path: doc.path
+          filepath: resolved.match.virtualPath,
+          displayPath: resolved.match.virtualPath,
+          bodyLength: resolved.match.bodyLength,
+          collection: resolved.match.collection,
+          path: resolved.match.path
         });
       } else {
-        console.error(`File not found: ${name}`);
+        console.error(resolved.error);
       }
     }
     if (isSingleDocid && files.length === 0) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -4688,6 +4688,128 @@ export function getDocumentBody(db: Database, doc: DocumentResult | { filepath: 
   return body;
 }
 
+
+/**
+ * Escape a user-supplied string so it is matched literally by SQLite LIKE.
+ * Uses '#' as the ESCAPE character (avoids quote-escaping pitfalls with '\\').
+ */
+export function escapeLikePattern(value: string): string {
+  return value.replace(/#/g, "##").replace(/%/g, "#%").replace(/_/g, "#_");
+}
+
+export type CommaListMatch = {
+  collection: string;
+  path: string;
+  virtualPath: string;
+  bodyLength: number;
+};
+
+export type CommaListResolve =
+  | { ok: true; match: CommaListMatch }
+  | { ok: false; error: string };
+
+type CommaListRow = {
+  collection: string;
+  path: string;
+  virtual_path: string;
+  body_length: number;
+};
+
+function commaListSelect(db: Database, whereSql: string, params: string[]): CommaListRow[] {
+  return db.prepare(`
+    SELECT
+      d.collection,
+      d.path,
+      'qmd://' || d.collection || '/' || d.path as virtual_path,
+      LENGTH(content.doc) as body_length
+    FROM documents d
+    JOIN content ON content.hash = d.hash
+    WHERE d.active = 1 AND (${whereSql})
+    ORDER BY d.collection, d.path
+  `).all(...params) as CommaListRow[];
+}
+
+function finishCommaListResolve(db: Database, name: string, rows: CommaListRow[]): CommaListResolve {
+  if (rows.length === 1) {
+    const row = rows[0]!;
+    return {
+      ok: true,
+      match: {
+        collection: row.collection,
+        path: row.path,
+        virtualPath: row.virtual_path,
+        bodyLength: row.body_length,
+      },
+    };
+  }
+  if (rows.length > 1) {
+    return {
+      ok: false,
+      error: `Ambiguous path ${name}: ${rows.map(r => r.virtual_path).join(", ")}`,
+    };
+  }
+  const similar = findSimilarFiles(db, name, 5, 3);
+  let msg = `File not found: ${name}`;
+  if (similar.length > 0) {
+    msg += ` (did you mean: ${similar.join(", ")}?)`;
+  }
+  return { ok: false, error: msg };
+}
+
+/**
+ * Resolve one comma-list name for multi-get (shared by CLI and SDK/MCP).
+ *
+ * Match order: docid / qmd:// URI (exact only), then exact collection-prefixed
+ * path, then exact document path, then a path-boundary suffix (`.../name`).
+ * Unanchored LIKE is never used, so a fragment like `NTAX.md` cannot silently
+ * fetch `SYNTAX.md`. Multiple hits at the same tier error with the candidate
+ * list instead of `LIMIT 1` (#759).
+ */
+export function resolveCommaListName(db: Database, name: string): CommaListResolve {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return { ok: false, error: `File not found: ${name}` };
+  }
+
+  if (isDocid(trimmed)) {
+    const docidMatch = findDocumentByDocid(db, trimmed);
+    if (!docidMatch) return finishCommaListResolve(db, trimmed, []);
+    const rows = commaListSelect(
+      db,
+      `'qmd://' || d.collection || '/' || d.path = ?`,
+      [docidMatch.filepath],
+    );
+    return finishCommaListResolve(db, trimmed, rows);
+  }
+
+  if (isVirtualPath(trimmed)) {
+    const parsed = parseVirtualPath(trimmed);
+    if (!parsed) return finishCommaListResolve(db, trimmed, []);
+    const rows = commaListSelect(
+      db,
+      `d.collection = ? AND d.path = ?`,
+      [parsed.collectionName, parsed.path],
+    );
+    return finishCommaListResolve(db, trimmed, rows);
+  }
+
+  // 1. Exact collection-prefixed path (collection/relpath)
+  let rows = commaListSelect(db, `d.collection || '/' || d.path = ?`, [trimmed]);
+  if (rows.length > 0) return finishCommaListResolve(db, trimmed, rows);
+
+  // 2. Exact document path
+  rows = commaListSelect(db, `d.path = ?`, [trimmed]);
+  if (rows.length > 0) return finishCommaListResolve(db, trimmed, rows);
+
+  // 3. Path-boundary suffix: matches `dir/name`, not mid-filename fragments
+  rows = commaListSelect(
+    db,
+    `d.path LIKE ? ESCAPE '#'`,
+    [`%/${escapeLikePattern(trimmed)}`],
+  );
+  return finishCommaListResolve(db, trimmed, rows);
+}
+
 /**
  * Find multiple documents by glob pattern or comma-separated list
  * Returns documents without body by default (use getDocumentBody to load)
@@ -4722,32 +4844,21 @@ export function findDocuments(
       : [pattern.trim()].filter(Boolean);
     fileRows = [];
     for (const name of names) {
-      const docidMatch = isDocid(name) ? findDocumentByDocid(db, name) : null;
-      const lookupName = docidMatch?.filepath ?? name;
-      let doc = db.prepare(`
+      const resolved = resolveCommaListName(db, name);
+      if (!resolved.ok) {
+        errors.push(resolved.error);
+        continue;
+      }
+      const doc = db.prepare(`
         SELECT ${selectCols}
         FROM documents d
         JOIN content ON content.hash = d.hash
-        WHERE 'qmd://' || d.collection || '/' || d.path = ? AND d.active = 1
-      `).get(lookupName) as DbDocRow | null;
-      if (!doc && !docidMatch) {
-        doc = db.prepare(`
-          SELECT ${selectCols}
-          FROM documents d
-          JOIN content ON content.hash = d.hash
-          WHERE 'qmd://' || d.collection || '/' || d.path LIKE ? AND d.active = 1
-          LIMIT 1
-        `).get(`%${lookupName}`) as DbDocRow | null;
-      }
+        WHERE d.collection = ? AND d.path = ? AND d.active = 1
+      `).get(resolved.match.collection, resolved.match.path) as DbDocRow | null;
       if (doc) {
         fileRows.push(doc);
       } else {
-        const similar = findSimilarFiles(db, name, 5, 3);
-        let msg = `File not found: ${name}`;
-        if (similar.length > 0) {
-          msg += ` (did you mean: ${similar.join(', ')}?)`;
-        }
-        errors.push(msg);
+        errors.push(`File not found: ${name}`);
       }
     }
   } else {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1036,6 +1036,28 @@ describe("CLI Multi-Get Command", () => {
     expect(stdout).toContain("Team Meeting");
   });
 
+  test("comma-list accepts collection-prefixed paths (#759)", async () => {
+    const { stdout, stderr, exitCode } = await runQmd([
+      "multi-get",
+      "fixtures/docs/api.md, fixtures/README.md",
+    ], { dbPath: localDbPath });
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toContain("File not found");
+    expect(stdout).toContain("API Documentation");
+    expect(stdout).toContain("Test Project");
+  });
+
+  test("comma-list does not fetch a document from a filename fragment (#759)", async () => {
+    const { stdout, stderr, exitCode } = await runQmd([
+      "multi-get",
+      "pi.md, ZZZ-nonexistent.md",
+    ], { dbPath: localDbPath });
+    expect(stdout).not.toContain("API Documentation");
+    expect(stderr).toContain("File not found: pi.md");
+    expect(stderr).toContain("File not found: ZZZ-nonexistent.md");
+    expect(stderr).not.toMatch(/api\.md/i);
+  });
+
   test("--md output includes a #docid for each file", async () => {
     const { stdout, exitCode } = await runQmd(["multi-get", "notes/*.md", "--md"], { dbPath: localDbPath });
     expect(exitCode).toBe(0);

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -2313,6 +2313,98 @@ describe("Document Retrieval", () => {
 
       await cleanupTestDb(store);
     });
+
+    test("findDocuments matches collection-prefixed paths (#759)", async () => {
+      const store = await createTestStore();
+      const collectionName = await createTestCollection({ name: "qmd", pwd: "/test/qmd" });
+
+      await insertTestDocument(store.db, collectionName, {
+        name: "syntax",
+        displayPath: "docs/SYNTAX.md",
+        body: "# Syntax\n\nThe real document.",
+      });
+
+      const { docs, errors } = store.findDocuments(`${collectionName}/docs/SYNTAX.md, missing.md`);
+      expect(docs).toHaveLength(1);
+      expect(docs[0]!.doc.displayPath).toBe(`${collectionName}/docs/SYNTAX.md`);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain("File not found: missing.md");
+
+      await cleanupTestDb(store);
+    });
+
+    test("findDocuments does not suffix-match a filename fragment (#759)", async () => {
+      const store = await createTestStore();
+      const collectionName = await createTestCollection({ name: "qmd", pwd: "/test/qmd" });
+
+      await insertTestDocument(store.db, collectionName, {
+        name: "syntax",
+        displayPath: "docs/SYNTAX.md",
+        body: "# Syntax\n\nThe real document.",
+      });
+
+      const { docs, errors } = store.findDocuments("NTAX.md, ZZZ-nonexistent.md");
+      expect(docs).toHaveLength(0);
+      expect(errors).toHaveLength(2);
+      expect(errors[0]).toContain("File not found: NTAX.md");
+      expect(errors[0]).not.toContain("SYNTAX.md");
+
+      await cleanupTestDb(store);
+    });
+
+    test("findDocuments suffix-matches at a path boundary (#759)", async () => {
+      const store = await createTestStore();
+      const collectionName = await createTestCollection({ name: "qmd", pwd: "/test/qmd" });
+
+      await insertTestDocument(store.db, collectionName, {
+        name: "syntax",
+        displayPath: "docs/SYNTAX.md",
+        body: "# Syntax\n\nThe real document.",
+      });
+
+      const { docs, errors } = store.findDocuments("SYNTAX.md, missing.md");
+      expect(docs).toHaveLength(1);
+      expect(docs[0]!.doc.displayPath).toBe(`${collectionName}/docs/SYNTAX.md`);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain("File not found: missing.md");
+
+      await cleanupTestDb(store);
+    });
+
+    test("findDocuments errors on ambiguous names instead of LIMIT 1 (#759)", async () => {
+      const store = await createTestStore();
+      const collA = await createTestCollection({ name: "tweet", pwd: "/test/tweet" });
+      const collB = await createTestCollection({ name: "bird", pwd: "/test/bird" });
+
+      await insertTestDocument(store.db, collA, {
+        name: "readme-a",
+        displayPath: "README.md",
+        body: "# Tweet readme",
+      });
+      await insertTestDocument(store.db, collB, {
+        name: "readme-b",
+        displayPath: "README.md",
+        body: "# Bird readme",
+      });
+
+      const { docs, errors } = store.findDocuments("README.md, missing.md");
+      expect(docs).toHaveLength(0);
+      expect(errors).toHaveLength(2);
+      expect(errors[0]).toContain("Ambiguous path README.md");
+      expect(errors[0]).toContain("qmd://bird/README.md");
+      expect(errors[0]).toContain("qmd://tweet/README.md");
+      expect(errors[1]).toContain("File not found: missing.md");
+
+      const prefixed = store.findDocuments("tweet/README.md, bird/README.md");
+      expect(prefixed.errors).toHaveLength(0);
+      expect(prefixed.docs).toHaveLength(2);
+      expect(prefixed.docs.map(d => d.doc.displayPath).sort()).toEqual([
+        "bird/README.md",
+        "tweet/README.md",
+      ]);
+
+      await cleanupTestDb(store);
+    });
   });
 
 });


### PR DESCRIPTION
## Summary
- CLI `multi-get` and SDK/MCP `multi_get` had two comma-list resolvers with different semantics.
- Collection-prefixed paths (`qmd/docs/SYNTAX.md`) failed on the CLI but worked over MCP. Unanchored `LIKE '%name'` could silently fetch the wrong document (`NTAX.md` → `SYNTAX.md`). `LIMIT 1` with no `ORDER BY` picked an arbitrary collection on collisions.
- Both transports now share one resolver: exact URI / collection-prefixed / path, then a path-boundary suffix. Ambiguous names error with the candidate list.

## Test plan
- [x] New store tests for collection-prefixed paths, fragment false-positives, path-boundary suffix, and multi-collection ambiguity
- [x] New CLI tests for collection-prefixed comma-lists and fragment non-matches
- [x] `CI=true` Node vitest `test/`: 1010 passed, 74 skipped
- [x] `CI=true` Bun `test/`: 1010 pass, 81 skip, 0 fail

Fixes #759.