### PR TITLE
fix(store): don't let legacy slug migration evict live files (#717)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@
 
 ### Fixed
 
+- Files whose names differ only in the characters the legacy slug collapsed to
+  `-` (spaces, underscores) no longer evict each other from the index (#717).
+  The handalized-path migration now skips any row whose path is still owned by
+  a file in the current scan, so it only adopts genuinely stale pre-2.6 rows.
+  `qmd get` and `qmd ls <prefix>` also match `_` and `%` in paths literally
+  instead of as SQL `LIKE` wildcards, so `qmd get 2026_06_16.md` no longer
+  returns a sibling `2026-06-16.md`.
+
 - CLI `multi-get` and SDK/MCP `multi_get` now share one comma-list resolver.
   Collection-prefixed paths (`qmd/docs/SYNTAX.md`) work in both transports,
   unanchored `LIKE '%name'` no longer silently fetches a different document

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -63,6 +63,7 @@ import {
   getCollectionsWithoutContext,
   getTopLevelPathsWithoutContext,
   handelize,
+  escapeLikePattern,
   hybridQuery,
   vectorSearchQuery,
   structuredSearch,
@@ -1485,10 +1486,10 @@ function listFiles(pathArg?: string): void {
       SELECT d.path, d.title, d.modified_at, LENGTH(ct.doc) as size
       FROM documents d
       JOIN content ct ON d.hash = ct.hash
-      WHERE d.collection = ? AND d.path LIKE ? AND d.active = 1
+      WHERE d.collection = ? AND d.path LIKE ? ESCAPE '#' AND d.active = 1
       ORDER BY d.path
     `;
-    params = [coll.name, `${pathPrefix}%`];
+    params = [coll.name, `${escapeLikePattern(pathPrefix)}%`];
   } else {
     // List all files in the collection
     query = `
@@ -1717,6 +1718,9 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
 
   let indexed = 0, updated = 0, unchanged = 0, processed = 0;
   const seenPaths = new Set<string>();
+  // Literal paths of every file in this scan. Passed to the legacy-path
+  // migration so it never adopts a row that still belongs to a live file.
+  const livePaths = new Set(files.map(f => f.replace(/\\/g, '/')));
   const startTime = Date.now();
 
   for (const relativeFile of files) {
@@ -1745,7 +1749,7 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
     const title = extractTitle(content, relativeFile);
 
     // Check if document exists (also migrates legacy lowercase paths)
-    const existing = findOrMigrateLegacyDocument(db, collectionName, path);
+    const existing = findOrMigrateLegacyDocument(db, collectionName, path, livePaths);
 
     if (existing) {
       if (existing.hash === hash) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1540,6 +1540,9 @@ export async function reindexCollection(
   const total = files.length;
   let indexed = 0, updated = 0, unchanged = 0, processed = 0;
   const seenPaths = new Set<string>();
+  // Literal paths of every file in this scan. Passed to the legacy-path
+  // migration so it never adopts a row that still belongs to a live file.
+  const livePaths = new Set(files.map(f => normalizePathSeparators(f)));
 
   for (const relativeFile of files) {
     const filepath = getRealPath(resolve(collectionPath, relativeFile));
@@ -1566,7 +1569,7 @@ export async function reindexCollection(
     const hash = await hashContent(content);
     const title = extractTitle(content, relativeFile);
 
-    const existing = findOrMigrateLegacyDocument(db, collectionName, path);
+    const existing = findOrMigrateLegacyDocument(db, collectionName, path, livePaths);
 
     if (existing) {
       if (existing.hash === hash) {
@@ -2802,10 +2805,15 @@ export function findActiveDocument(
 }
 
 /**
- * Find an active document, falling back to a case-insensitive path match.
- * If found under a different casing, renames it in-place and rebuilds the
+ * Find an active document, falling back to a legacy handalized-path match.
+ * If found under the pre-2.6 slug, renames it in-place and rebuilds the
  * FTS entry. Embeddings are keyed by content hash, so the rename is
  * safe — no re-embedding required.
+ *
+ * `livePaths`, when given, is the set of literal paths of every file in the
+ * current scan of this collection. A legacy row whose path is in that set
+ * belongs to a *different* file that still exists on disk, so it must never be
+ * adopted — renaming it would evict that file from the index (#717).
  *
  * @internal Used by reindexCollection and indexFiles during qmd update.
  * Returns null if the document does not exist under either path.
@@ -2813,7 +2821,8 @@ export function findActiveDocument(
 export function findOrMigrateLegacyDocument(
   db: Database,
   collectionName: string,
-  path: string
+  path: string,
+  livePaths?: ReadonlySet<string>
 ): { id: number; hash: string; title: string } | null {
   const existing = findActiveDocument(db, collectionName, path);
   if (existing) return existing;
@@ -2827,16 +2836,24 @@ export function findOrMigrateLegacyDocument(
   // like "Budget-Revenue-Q4-2024.md" for a raw path like "Budget & Revenue (Q4) [2024].md".
   // Try matching the handalized form of the incoming raw path against the DB so that
   // qmd update on an old index can rename the row to the literal path.
-  let legacyHandalized: { id: number; hash: string; title: string } | undefined;
+  //
+  // Many literal paths map onto the same slug ("a b.md", "a_b.md", "a-b.md"), so
+  // a match is only evidence of a stale row when no live file already owns that
+  // path. Without this guard, indexing "2026_06_16.md" next to an existing
+  // "2026-06-16.md" renames the latter's row and the hyphenated file silently
+  // disappears from the index (#717).
+  type LegacyRow = { id: number; hash: string; title: string; path: string };
+  let legacyHandalized: LegacyRow | undefined;
   try {
     const handleized = handelize(path);
     if (handleized !== path) {
-      legacyHandalized = db.prepare(`
-        SELECT id, hash, title FROM documents
+      const row = db.prepare(`
+        SELECT id, hash, title, path FROM documents
         WHERE collection = ? AND path = ? AND active = 1
         ORDER BY id
         LIMIT 1
-      `).get(collectionName, handleized) as { id: number; hash: string; title: string } | undefined;
+      `).get(collectionName, handleized) as LegacyRow | undefined;
+      if (row && !livePaths?.has(row.path)) legacyHandalized = row;
     }
   } catch {
     // handelize throws on invalid paths; just skip
@@ -4580,9 +4597,9 @@ export function findDocument(db: Database, filename: string, options: { includeB
       SELECT ${selectCols}
       FROM documents d
       JOIN content ON content.hash = d.hash
-      WHERE 'qmd://' || d.collection || '/' || d.path LIKE ? AND d.active = 1
+      WHERE 'qmd://' || d.collection || '/' || d.path LIKE ? ESCAPE '#' AND d.active = 1
       LIMIT 1
-    `).get(`%${filepath}`) as DbDocRow | null;
+    `).get(`%${escapeLikePattern(filepath)}`) as DbDocRow | null;
   }
 
   // Try to match by absolute path (requires looking up collection paths from DB)

--- a/test/path-fidelity.test.ts
+++ b/test/path-fidelity.test.ts
@@ -38,6 +38,9 @@ import {
   handelize,
   normalizePathSeparators,
   syncConfigToDb,
+  findOrMigrateLegacyDocument,
+  findActiveDocument,
+  findDocument,
 } from "../src/store.js";
 import type { CollectionConfig } from "../src/collections.js";
 
@@ -329,6 +332,181 @@ describe("Path fidelity — CLI integration", () => {
     const hit = results.find((r) => r.file.includes("normal-file"));
     expect(hit).toBeDefined();
     expect(hit!.file).toContain("normal-file.md");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Separator collisions: files whose names differ only in the characters the
+// legacy slug collapsed to "-" (spaces, underscores) must all survive indexing.
+// Regression for #717 — the legacy-path migration used to adopt the row of a
+// live file, evicting it from the index. `qmd get` / `qmd ls` also treated "_"
+// as a SQL LIKE wildcard.
+// ---------------------------------------------------------------------------
+
+function activePaths(dbPath: string): string[] {
+  const db = openDatabase(dbPath);
+  const rows = db.prepare(
+    "SELECT path FROM documents WHERE active = 1 ORDER BY path"
+  ).all() as { path: string }[];
+  db.close();
+  return rows.map((r) => r.path);
+}
+
+async function createCollectionWith(
+  prefix: string,
+  files: Array<{ name: string; content: string }>
+): Promise<{ collectionDir: string; dbPath: string; configDir: string }> {
+  const envDir = join(testDir, prefix);
+  const collectionDir = join(envDir, "corpus");
+  const dbPath = join(envDir, "test.sqlite");
+  const configDir = join(envDir, "config");
+
+  await mkdir(collectionDir, { recursive: true });
+  await mkdir(configDir, { recursive: true });
+  for (const f of files) {
+    await writeFile(join(collectionDir, f.name), f.content);
+  }
+  await writeFile(join(configDir, "index.yml"), "collections: {}\n");
+
+  return { collectionDir: realpathSync(collectionDir), dbPath, configDir };
+}
+
+describe("Path fidelity — separator collisions (#717)", () => {
+  const twins: Array<{ name: string; content: string }> = [
+    { name: "2026-06-16.md", content: "# Hyphen\n\nJournal searchterm-twin hyphenated.\n" },
+    { name: "2026_06_16.md", content: "# Underscore\n\nJournal searchterm-twin underscored.\n" },
+    { name: "my file.md", content: "# Spaced\n\nFile searchterm-twin with spaces.\n" },
+    { name: "my-file.md", content: "# Hyphenated\n\nFile searchterm-twin hyphenated.\n" },
+  ];
+
+  test("legacy migration does not adopt a row owned by a live file", async () => {
+    const dbPath = join(testDir, "live-guard.sqlite");
+    const store = createStore(dbPath);
+    const now = new Date().toISOString();
+    const hyphen = twins[0]!;
+    const underscore = twins[1]!;
+    const hyphenHash = await hashContent(hyphen.content);
+    insertContent(store.db, hyphenHash, hyphen.content, now);
+    insertDocument(store.db, "collide", hyphen.name, "Hyphen", hyphenHash, now, now);
+
+    const livePaths = new Set([hyphen.name, underscore.name]);
+    const migrated = findOrMigrateLegacyDocument(
+      store.db, "collide", underscore.name, livePaths
+    );
+    expect(migrated).toBeNull();
+    expect(findActiveDocument(store.db, "collide", hyphen.name)?.hash).toBe(hyphenHash);
+    expect(findActiveDocument(store.db, "collide", underscore.name)).toBeNull();
+    store.close();
+  });
+
+  test("legacy rows still migrate when no live file owns the slug", async () => {
+    const dbPath = join(testDir, "legacy-migrate.sqlite");
+    const store = createStore(dbPath);
+    const now = new Date().toISOString();
+    const underscore = twins[1]!;
+    const slug = handelize(underscore.name);
+    expect(slug).toBe("2026-06-16.md");
+    const hash = await hashContent(underscore.content);
+    insertContent(store.db, hash, underscore.content, now);
+    insertDocument(store.db, "collide", slug, "Underscore", hash, now, now);
+
+    const livePaths = new Set([underscore.name]);
+    const migrated = findOrMigrateLegacyDocument(
+      store.db, "collide", underscore.name, livePaths
+    );
+    expect(migrated).not.toBeNull();
+    expect(findActiveDocument(store.db, "collide", underscore.name)?.hash).toBe(hash);
+    expect(findActiveDocument(store.db, "collide", slug)).toBeNull();
+    store.close();
+  });
+
+  test("findDocument matches underscores literally, not as LIKE wildcards", async () => {
+    const dbPath = join(testDir, "like-get.sqlite");
+    const store = createStore(dbPath);
+    const now = new Date().toISOString();
+    for (const f of [twins[0]!, twins[1]!]) {
+      const hash = await hashContent(f.content);
+      insertContent(store.db, hash, f.content, now);
+      insertDocument(store.db, "collide", f.name, f.name, hash, now, now);
+    }
+
+    const underscore = findDocument(store.db, "2026_06_16.md", { includeBody: true });
+    expect("error" in underscore).toBe(false);
+    if (!("error" in underscore)) {
+      expect(underscore.displayPath).toBe("collide/2026_06_16.md");
+      expect(underscore.body).toContain("underscored");
+    }
+
+    const hyphen = findDocument(store.db, "2026-06-16.md", { includeBody: true });
+    expect("error" in hyphen).toBe(false);
+    if (!("error" in hyphen)) {
+      expect(hyphen.displayPath).toBe("collide/2026-06-16.md");
+      expect(hyphen.body).toContain("hyphenated");
+    }
+    store.close();
+  });
+
+  test("a fresh index keeps every file whose name differs only by separators", async () => {
+    const { collectionDir, dbPath, configDir } = await createCollectionWith("collide-fresh", twins);
+
+    const add = await runQmd(
+      ["collection", "add", collectionDir, "--name", "collide"],
+      { cwd: collectionDir, dbPath, configDir }
+    );
+    expect(add.exitCode, `collection add failed: ${add.stderr}`).toBe(0);
+
+    const paths = activePaths(dbPath);
+    for (const f of twins) {
+      expect(paths, `${f.name} missing from index`).toContain(f.name);
+    }
+    expect(paths).toHaveLength(twins.length);
+  });
+
+  test("adding an underscore twin to an indexed collection does not evict the hyphen file", async () => {
+    const { collectionDir, dbPath, configDir } = await createCollectionWith(
+      "collide-incremental",
+      [twins[0]!]
+    );
+
+    const add = await runQmd(
+      ["collection", "add", collectionDir, "--name", "collide"],
+      { cwd: collectionDir, dbPath, configDir }
+    );
+    expect(add.exitCode, `collection add failed: ${add.stderr}`).toBe(0);
+    expect(activePaths(dbPath)).toEqual(["2026-06-16.md"]);
+
+    await writeFile(join(collectionDir, twins[1]!.name), twins[1]!.content);
+    const update = await runQmd(["update"], { cwd: collectionDir, dbPath, configDir });
+    expect(update.exitCode, `qmd update failed: ${update.stderr}`).toBe(0);
+
+    expect(activePaths(dbPath)).toEqual(["2026-06-16.md", "2026_06_16.md"]);
+
+    const hyphen = await runQmd(["get", "2026-06-16.md"], { cwd: collectionDir, dbPath, configDir });
+    expect(hyphen.exitCode, `get hyphen failed: ${hyphen.stderr}`).toBe(0);
+    expect(hyphen.stdout).toContain("hyphenated");
+
+    const underscore = await runQmd(["get", "2026_06_16.md"], { cwd: collectionDir, dbPath, configDir });
+    expect(underscore.exitCode, `get underscore failed: ${underscore.stderr}`).toBe(0);
+    expect(underscore.stdout).toContain("underscored");
+  });
+
+  test("underscores in a path are matched literally, not as LIKE wildcards", async () => {
+    const { collectionDir, dbPath, configDir } = await createCollectionWith("collide-like", twins);
+    const add = await runQmd(
+      ["collection", "add", collectionDir, "--name", "collide"],
+      { cwd: collectionDir, dbPath, configDir }
+    );
+    expect(add.exitCode, `collection add failed: ${add.stderr}`).toBe(0);
+
+    const got = await runQmd(["get", "2026_06_16.md"], { cwd: collectionDir, dbPath, configDir });
+    expect(got.exitCode, `get failed: ${got.stderr}`).toBe(0);
+    expect(got.stdout).toContain("underscored");
+    expect(got.stdout).not.toContain("hyphenated");
+
+    const ls = await runQmd(["ls", "collide/2026_06"], { cwd: collectionDir, dbPath, configDir });
+    expect(ls.exitCode, `ls failed: ${ls.stderr}`).toBe(0);
+    expect(ls.stdout).toContain("2026_06_16.md");
+    expect(ls.stdout).not.toContain("2026-06-16.md");
   });
 });
 


### PR DESCRIPTION
## Summary
- Legacy `handelize()` migration no longer adopts a row whose path is still owned by a live file in the current scan, so indexing `2026_06_16.md` next to `2026-06-16.md` no longer evicts the hyphenated file (#717).
- `qmd get` and `qmd ls <prefix>` treat `_` and `%` as literals (`ESCAPE '#'`), matching the multi-get resolver from #759.

This lands the remaining pieces of conflicted #784 that still apply after #759/#801. Genuine pre-2.6 slug rows still migrate when no live file owns the slug.

## Test plan
- [x] `CI=true bun test --timeout 60000 --preload ./src/test-preload.ts test/path-fidelity.test.ts test/store.test.ts test/cli.test.ts test/store.helpers.unit.test.ts`
- [x] `CI=true node ./node_modules/vitest/vitest.mjs run --testTimeout 60000 test/path-fidelity.test.ts test/store.test.ts`
- [ ] CI Bun/Node green