### PR TITLE
fix(store): keep caller intent out of query expansion (#818)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@
 
 ### Fixed
 
+- Query expansion no longer consumes caller `intent`, and a cached expansion
+  whose sub-queries all miss is dropped instead of replaying forever (#818).
+  Intent still steers reranking and snippet/chunk selection; it just no longer
+  enters the expansion prompt or cache key, where the model copied meta-language
+  ("so I can compare spend settings") into lex/vec terms that matched nothing.
+
 - Files whose names differ only in the characters the legacy slug collapsed to
   `-` (spaces, underscores) no longer evict each other from the index (#717).
   The handalized-path migration now skips any row whose path is still owned by

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ export interface SearchOptions {
   query?: string;
   /** Pre-expanded queries (from expandQuery) — skips auto-expansion */
   queries?: ExpandedQuery[];
-  /** Domain intent hint — steers expansion and reranking */
+  /** Domain intent hint — steers reranking and snippet/chunk selection */
   intent?: string;
   /** Rerank results using LLM (default: true) */
   rerank?: boolean;
@@ -192,6 +192,12 @@ export interface VectorSearchOptions {
  * Options for expandQuery() — manual query expansion.
  */
 export interface ExpandQueryOptions {
+  /**
+   * @deprecated Ignored. Intent no longer feeds the expansion model — caller
+   * intent is meta-language the model reproduced verbatim as sub-queries.
+   * Pass intent via SearchOptions instead, where it shapes reranking and
+   * snippet selection.
+   */
   intent?: string;
 }
 
@@ -427,7 +433,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
     },
     searchLex: async (q, opts) => internal.searchFTS(q, opts?.limit, opts?.collection),
     searchVector: async (q, opts) => internal.searchVec(q, llm.embedModelName, opts?.limit, opts?.collection),
-    expandQuery: async (q, opts) => internal.expandQuery(q, undefined, opts?.intent),
+    expandQuery: async (q) => internal.expandQuery(q),
     get: async (pathOrDocid, opts) => internal.findDocument(pathOrDocid, opts),
     getDocumentBody: async (pathOrDocid, opts) => {
       const result = internal.findDocument(pathOrDocid, { includeBody: false });

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -1480,7 +1480,7 @@ export class LlamaCpp implements LLM {
   // High-level abstractions
   // ==========================================================================
 
-  async expandQuery(query: string, options: { context?: string, includeLexical?: boolean, intent?: string } = {}): Promise<Queryable[]> {
+  async expandQuery(query: string, options: { context?: string, includeLexical?: boolean } = {}): Promise<Queryable[]> {
     if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();
@@ -1491,10 +1491,12 @@ export class LlamaCpp implements LLM {
     const includeLexical = options.includeLexical ?? true;
     const context = options.context;
 
-    const intent = options.intent;
-    const prompt = intent
-      ? `/no_think Expand this search query: ${query}\nQuery intent: ${intent}`
-      : `/no_think Expand this search query: ${query}`;
+    // The expansion prompt consumes ONLY the query text. Caller intent is
+    // free-form meta-language that the expansion model reproduced verbatim as
+    // lex/vec sub-queries — degenerate terms that match nothing. Intent still
+    // shapes retrieval where it belongs: the reranker query prefix and
+    // keyword-based chunk/snippet selection.
+    const prompt = `/no_think Expand this search query: ${query}`;
 
     // Set up inside the try so any failure (grammar creation, context
     // allocation/VRAM, session prompt) falls back to the original query

--- a/src/store.ts
+++ b/src/store.ts
@@ -1455,7 +1455,9 @@ export type Store = {
   searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => Promise<SearchResult[]>;
 
   // Query expansion & reranking
-  expandQuery: (query: string, model?: string, intent?: string) => Promise<ExpandedQuery[]>;
+  expandQuery: (query: string, model?: string) => Promise<ExpandedQuery[]>;
+  /** Drop the cached expansion for a query so the next call regenerates. */
+  invalidateExpansionCache: (query: string) => void;
   rerank: (query: string, documents: { file: string; text: string }[], model?: string, intent?: string) => Promise<{ file: string; score: number }[]>;
 
   // Document retrieval
@@ -2165,7 +2167,8 @@ export function createStore(dbPath?: string): Store {
     searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => searchVec(db, query, model, limit, collectionName, session, precomputedEmbedding, getLlm(store)),
 
     // Query expansion & reranking
-    expandQuery: (query: string, model?: string, intent?: string) => expandQuery(query, model ?? store.llm?.generateModelName ?? DEFAULT_QUERY_MODEL, db, intent, store.llm),
+    expandQuery: (query: string, model?: string) => expandQuery(query, model ?? store.llm?.generateModelName ?? DEFAULT_QUERY_MODEL, db, store.llm),
+    invalidateExpansionCache: (query: string) => deleteExpansionCacheEntry(db, query, store.llm?.generateModelName ?? DEFAULT_QUERY_MODEL),
     rerank: (query: string, documents: { file: string; text: string }[], model?: string, intent?: string) => {
       // Cache keys must use the resolved rerank model (store.llm or the global
       // singleton from models.rerank). Falling back to DEFAULT_RERANK_MODEL when
@@ -4260,9 +4263,13 @@ function removeIncompleteEmbeddings(db: Database, expectedChunksByHash: Map<stri
 // Query expansion
 // =============================================================================
 
-export async function expandQuery(query: string, model: string = DEFAULT_QUERY_MODEL, db: Database, intent?: string, llmOverride?: LlamaCpp): Promise<ExpandedQuery[]> {
-  // Check cache first — stored as JSON preserving types
-  const cacheKey = getCacheKey("expandQuery", { query, model, ...(intent && { intent }) });
+export async function expandQuery(query: string, model: string = DEFAULT_QUERY_MODEL, db: Database, llmOverride?: LlamaCpp): Promise<ExpandedQuery[]> {
+  // Check cache first — stored as JSON preserving types. Intent is
+  // deliberately absent from both the cache key and the generation call:
+  // feeding caller intent to the expansion model contaminates sub-queries
+  // with intent meta-language (see LlamaCpp.expandQuery), and keying the
+  // cache by intent multiplied the poisoned entries per (query, intent) pair.
+  const cacheKey = getCacheKey("expandQuery", { query, model });
   const cached = getCachedResult(db, cacheKey);
   if (cached) {
     try {
@@ -4282,7 +4289,7 @@ export async function expandQuery(query: string, model: string = DEFAULT_QUERY_M
 
   const llm = llmOverride ?? getDefaultLlamaCpp();
   // Note: LlamaCpp uses hardcoded model, model parameter is ignored
-  const results = await llm.expandQuery(query, { intent });
+  const results = await llm.expandQuery(query);
 
   // Map Queryable[] → ExpandedQuery[] (same shape, decoupled from llm.ts internals).
   // Filter out entries that duplicate the original query text.
@@ -4295,6 +4302,16 @@ export async function expandQuery(query: string, model: string = DEFAULT_QUERY_M
   }
 
   return expanded;
+}
+
+/**
+ * Delete the cached expansion for a query. hybridQuery() calls this when an
+ * expansion's sub-queries all came back empty — left in place, the dud entry
+ * would replay the same misses on every warm repeat of the query.
+ */
+export function deleteExpansionCacheEntry(db: Database, query: string, model: string = DEFAULT_QUERY_MODEL): void {
+  const cacheKey = getCacheKey("expandQuery", { query, model });
+  db.prepare(`DELETE FROM llm_cache WHERE hash = ?`).run(cacheKey);
 }
 
 // =============================================================================
@@ -5258,7 +5275,7 @@ export async function hybridQuery(
   const expandStart = Date.now();
   const expanded = hasStrongSignal
     ? []
-    : await store.expandQuery(query, undefined, intent);
+    : await store.expandQuery(query);
 
   hooks?.onExpand?.(query, expanded, Date.now() - expandStart);
 
@@ -5334,6 +5351,19 @@ export async function hybridQuery(
           query: vecQueries[i]!.text,
         });
       }
+    }
+  }
+
+  // Step 3c: drop a cached expansion whose sub-queries all came back empty —
+  // the dud is cached per (query, model), so left in place it deterministically
+  // replays the same misses on every warm repeat. Only judge sub-queries the
+  // store could actually run: on FTS-only stores, vec/hyde expansions never
+  // execute and say nothing about the expansion's quality.
+  if (expanded.length > 0) {
+    const runnable = expanded.filter(q => q.type === "lex" || hasVectors);
+    const expansionContributed = rankedListMeta.some(m => m.queryType !== "original");
+    if (runnable.length > 0 && !expansionContributed) {
+      store.invalidateExpansionCache(query);
     }
   }
 
@@ -5545,7 +5575,7 @@ export async function vectorSearchQuery(
 
   // Expand query — filter to vec/hyde only (lex queries target FTS, not vector)
   const expandStart = Date.now();
-  const allExpanded = await store.expandQuery(query, undefined, intent);
+  const allExpanded = await store.expandQuery(query);
   const vecExpanded = allExpanded.filter(q => q.type !== 'lex');
   options?.hooks?.onExpand?.(query, vecExpanded, Date.now() - expandStart);
 

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -17,6 +17,7 @@ import * as llmModule from "../src/llm.js";
 import { disposeDefaultLlamaCpp, setDefaultLlamaCpp } from "../src/llm.js";
 import {
   createStore,
+  DEFAULT_QUERY_MODEL,
   DEFAULT_RERANK_MODEL,
   verifySqliteVecLoaded,
   getDefaultDbPath,
@@ -1305,6 +1306,70 @@ describe("Caching", () => {
     }
   });
 });
+
+describe("Query expansion cache (#818)", () => {
+  test("expandQuery serves cached expansions without invoking the LLM", async () => {
+    const store = await createTestStore();
+    try {
+      const model = store.llm?.generateModelName ?? DEFAULT_QUERY_MODEL;
+      const seeded = [{ type: "lex", query: "seeded-term" }];
+      store.setCachedResult(getCacheKey("expandQuery", { query: "cached question", model }), JSON.stringify(seeded));
+
+      // CI mode makes any real generation throw, so a passing call proves the
+      // cache path; locally the seed always hits, so the LLM is never
+      // consulted either way.
+      const out = await store.expandQuery("cached question");
+      expect(out).toEqual([{ type: "lex", query: "seeded-term" }]);
+    } finally {
+      await cleanupTestDb(store);
+    }
+  });
+
+  test("hybridQuery drops a cached expansion whose sub-queries contributed nothing", async () => {
+    const store = await createTestStore();
+    try {
+      await insertTestDocument(store.db, "docs", {
+        name: "alpha",
+        title: "Alpha Bravo",
+        body: "# Alpha\n\nalpha bravo charlie content.",
+      });
+      const model = store.llm?.generateModelName ?? DEFAULT_QUERY_MODEL;
+      const cacheKey = getCacheKey("expandQuery", { query: "alpha bravo", model });
+      store.setCachedResult(cacheKey, JSON.stringify([{ type: "lex", query: "zzzqqq wwwuuu" }]));
+
+      // intent disables the strong-signal bypass so the cached expansion is
+      // actually consulted; it no longer reaches the expansion model itself.
+      await hybridQuery(store, "alpha bravo", { limit: 5, minScore: 0, skipRerank: true, intent: "unrelated meta commentary" });
+
+      // The dud expansion found nothing — it must not survive to poison the
+      // next warm repeat of this query.
+      expect(store.getCachedResult(cacheKey)).toBeNull();
+    } finally {
+      await cleanupTestDb(store);
+    }
+  });
+
+  test("hybridQuery keeps a cached expansion that contributed results", async () => {
+    const store = await createTestStore();
+    try {
+      await insertTestDocument(store.db, "docs", {
+        name: "alpha",
+        title: "Alpha Bravo",
+        body: "# Alpha\n\nalpha bravo charlie content.",
+      });
+      const model = store.llm?.generateModelName ?? DEFAULT_QUERY_MODEL;
+      const cacheKey = getCacheKey("expandQuery", { query: "alpha bravo", model });
+      store.setCachedResult(cacheKey, JSON.stringify([{ type: "lex", query: "charlie" }]));
+
+      await hybridQuery(store, "alpha bravo", { limit: 5, minScore: 0, skipRerank: true, intent: "unrelated meta commentary" });
+
+      expect(store.getCachedResult(cacheKey)).not.toBeNull();
+    } finally {
+      await cleanupTestDb(store);
+    }
+  });
+});
+
 
 // =============================================================================
 // Context Tests


### PR DESCRIPTION
## Summary

Rebases the still-valid #818 fix onto current `main`. Caller `intent` no longer enters query expansion or the expansion cache key — the expansion model was copying that meta-language into lex/vec sub-queries that matched nothing. Intent still steers reranking and snippet/chunk selection.

`hybridQuery` also drops a cached expansion whose runnable sub-queries all came back empty, so a dud entry cannot replay forever on warm repeats.

Supersedes #818 (conflicted against current main).

## Test plan

- [x] `CI=true bun test test/store.test.ts` — 237 pass / 13 skip
- [x] `CI=true vitest run test/store.test.ts` — 237 pass / 13 skip
- [x] `CI=true bun test test/llm.test.ts` — 36 pass / 32 skip
- [x] `CI=true bun test test/mcp.test.ts` — 45 pass / 17 skip
- [x] `tsc -p tsconfig.build.json --noEmit` clean
- [ ] GitHub Bun + Node CI green