### PR TITLE
fix(store): search each collection before merging so -c A -c B is not starved (#775)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@
 
 ### Fixed
 
+- Multi-collection `-c A -c B` (and SDK/MCP `collections: [A, B]`) no longer
+  searches globally then post-filters. A large unrelated collection could fill
+  the FTS/ANN top-k so the requested collections vanished, yielding false-empty
+  results even though each collection matched on its own. `searchFTS` /
+  `searchVec` now search each requested collection, then merge by score
+  (#775). Single-collection exact-scan (#791, #803) is unchanged.
+
 - Query expansion no longer consumes caller `intent`, and a cached expansion
   whose sub-queries all miss is dropped instead of replaying forever (#818).
   Intent still steers reranking and snippet/chunk selection; it just no longer

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -2429,14 +2429,11 @@ function resolveCollectionFilter(raw: string | string[] | undefined, useDefaults
   return validated;
 }
 
-// Post-filter results to only include files from specified collections.
-function filterByCollections<T extends { filepath?: string; file?: string }>(results: T[], collectionNames: string[]): T[] {
-  if (collectionNames.length <= 1) return results;
-  const prefixes = collectionNames.map(n => `qmd://${n}/`);
-  return results.filter(r => {
-    const path = r.filepath || r.file || '';
-    return prefixes.some(p => path.startsWith(p));
-  });
+// Pass 0/1/N collection names through to store search (search each, then merge).
+function collectionSearchFilter(names: string[]): string | string[] | undefined {
+  if (names.length === 0) return undefined;
+  if (names.length === 1) return names[0];
+  return names;
 }
 
 /**
@@ -2535,14 +2532,10 @@ function search(query: string, opts: OutputOptions): void {
   // Validate collection filter (supports multiple -c flags)
   // Use default collections if none specified
   const collectionNames = resolveCollectionFilter(opts.collection, true);
-  const singleCollection = collectionNames.length === 1 ? collectionNames[0] : undefined;
 
   // Use large limit for --all, otherwise fetch more than needed and let outputResults filter
   const fetchLimit = opts.all ? 100000 : Math.max(50, opts.limit * 2);
-  const results = filterByCollections(
-    searchFTS(db, query, fetchLimit, singleCollection),
-    collectionNames
-  );
+  const results = searchFTS(db, query, fetchLimit, collectionSearchFilter(collectionNames));
 
   // Add context to results
   const resultsWithContext = results.map(r => ({
@@ -2586,13 +2579,12 @@ async function vectorSearch(query: string, opts: OutputOptions, _model: string =
   // Validate collection filter (supports multiple -c flags)
   // Use default collections if none specified
   const collectionNames = resolveCollectionFilter(opts.collection, true);
-  const singleCollection = collectionNames.length === 1 ? collectionNames[0] : undefined;
 
   checkIndexHealth(store.db);
 
   await withLLMSession(async () => {
     let results = await vectorSearchQuery(store, query, {
-      collection: singleCollection,
+      collection: collectionSearchFilter(collectionNames),
       limit: opts.all ? 500 : (opts.limit || 10),
       minScore: opts.minScore || 0.3,
       intent: opts.intent,
@@ -2603,14 +2595,6 @@ async function vectorSearch(query: string, opts: OutputOptions, _model: string =
         },
       },
     });
-
-    // Post-filter for multi-collection
-    if (collectionNames.length > 1) {
-      results = results.filter(r => {
-        const prefixes = collectionNames.map(n => `qmd://${n}/`);
-        return prefixes.some(p => r.file.startsWith(p));
-      });
-    }
 
     closeDb();
 
@@ -2637,7 +2621,6 @@ async function querySearch(query: string, opts: OutputOptions, _embedModel: stri
   // Validate collection filter (supports multiple -c flags)
   // Use default collections if none specified
   const collectionNames = resolveCollectionFilter(opts.collection, true);
-  const singleCollection = collectionNames.length === 1 ? collectionNames[0] : undefined;
 
   checkIndexHealth(store.db);
 
@@ -2667,7 +2650,7 @@ async function querySearch(query: string, opts: OutputOptions, _embedModel: stri
       process.stderr.write(`${c.dim}└─ Searching...${c.reset}\n`);
 
       results = await structuredSearch(store, structuredQueries, {
-        collections: singleCollection ? [singleCollection] : undefined,
+        collections: collectionNames.length > 0 ? collectionNames : undefined,
         limit: opts.all ? 500 : (opts.limit || 10),
         minScore: opts.minScore || 0,
         candidateLimit: opts.candidateLimit,
@@ -2695,7 +2678,7 @@ async function querySearch(query: string, opts: OutputOptions, _embedModel: stri
     } else {
       // Standard hybrid query with automatic expansion
       results = await hybridQuery(store, query, {
-        collection: singleCollection,
+        collection: collectionSearchFilter(collectionNames),
         limit: opts.all ? 500 : (opts.limit || 10),
         minScore: opts.minScore || 0,
         candidateLimit: opts.candidateLimit,
@@ -2730,14 +2713,6 @@ async function querySearch(query: string, opts: OutputOptions, _embedModel: stri
             process.stderr.write(`${c.dim} (${formatMs(ms)})${c.reset}\n`);
           },
         },
-      });
-    }
-
-    // Post-filter for multi-collection
-    if (collectionNames.length > 1) {
-      results = results.filter(r => {
-        const prefixes = collectionNames.map(n => `qmd://${n}/`);
-        return prefixes.some(p => r.file.startsWith(p));
       });
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,7 +177,7 @@ export interface SearchOptions {
  */
 export interface LexSearchOptions {
   limit?: number;
-  collection?: string;
+  collection?: string | string[];
 }
 
 /**
@@ -185,7 +185,7 @@ export interface LexSearchOptions {
  */
 export interface VectorSearchOptions {
   limit?: number;
-  collection?: string;
+  collection?: string | string[];
 }
 
 /**
@@ -421,7 +421,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
 
       // Simple query string — use hybridQuery (expand + search + rerank)
       return hybridQuery(internal, opts.query!, {
-        collection: collections[0],
+        collection: collections.length > 0 ? collections : undefined,
         limit: opts.limit,
         minScore: opts.minScore,
         explain: opts.explain,

--- a/src/store.ts
+++ b/src/store.ts
@@ -1451,8 +1451,8 @@ export type Store = {
   toVirtualPath: (absolutePath: string) => string | null;
 
   // Search
-  searchFTS: (query: string, limit?: number, collectionName?: string) => SearchResult[];
-  searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => Promise<SearchResult[]>;
+  searchFTS: (query: string, limit?: number, collectionName?: string | readonly string[]) => SearchResult[];
+  searchVec: (query: string, model: string, limit?: number, collectionName?: string | readonly string[], session?: ILLMSession, precomputedEmbedding?: number[]) => Promise<SearchResult[]>;
 
   // Query expansion & reranking
   expandQuery: (query: string, model?: string) => Promise<ExpandedQuery[]>;
@@ -2163,8 +2163,8 @@ export function createStore(dbPath?: string): Store {
     toVirtualPath: (absolutePath: string) => toVirtualPath(db, absolutePath),
 
     // Search
-    searchFTS: (query: string, limit?: number, collectionName?: string) => searchFTS(db, query, limit, collectionName),
-    searchVec: (query: string, model: string, limit?: number, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[]) => searchVec(db, query, model, limit, collectionName, session, precomputedEmbedding, getLlm(store)),
+    searchFTS: (query: string, limit?: number, collectionName?: string | readonly string[]) => searchFTS(db, query, limit, collectionName),
+    searchVec: (query: string, model: string, limit?: number, collectionName?: string | readonly string[], session?: ILLMSession, precomputedEmbedding?: number[]) => searchVec(db, query, model, limit, collectionName, session, precomputedEmbedding, getLlm(store)),
 
     // Query expansion & reranking
     expandQuery: (query: string, model?: string) => expandQuery(query, model ?? store.llm?.generateModelName ?? DEFAULT_QUERY_MODEL, db, store.llm),
@@ -3855,7 +3855,39 @@ export function validateLexQuery(query: string): string | null {
   return null;
 }
 
-export function searchFTS(db: Database, query: string, limit: number = 20, collectionName?: string): SearchResult[] {
+/** One collection, several (OR), or all (undefined). */
+export type CollectionScope = string | readonly string[] | undefined;
+
+function scopedCollectionNames(scope: CollectionScope): string[] | undefined {
+  if (scope == null) return undefined;
+  const names = (typeof scope === "string" ? [scope] : Array.from(scope))
+    .map(n => n.trim())
+    .filter(n => n.length > 0);
+  return names.length > 0 ? names : undefined;
+}
+
+function mergeSearchResultsByScore(lists: SearchResult[][], limit: number): SearchResult[] {
+  const best = new Map<string, SearchResult>();
+  for (const list of lists) {
+    for (const r of list) {
+      const prev = best.get(r.filepath);
+      if (!prev || r.score > prev.score) best.set(r.filepath, r);
+    }
+  }
+  return Array.from(best.values())
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+}
+
+export function searchFTS(db: Database, query: string, limit: number = 20, collectionName?: string | readonly string[]): SearchResult[] {
+  const names = scopedCollectionNames(collectionName);
+  // Search each requested collection before merging/truncating so a large
+  // unrelated collection cannot occupy global top-k and starve the rest (#775).
+  if (names && names.length > 1) {
+    return mergeSearchResultsByScore(names.map(name => searchFTS(db, query, limit, name)), limit);
+  }
+  const collectionFilter = names?.[0];
+
   const ftsQuery = buildFTS5Query(query);
   if (!ftsQuery) return [];
 
@@ -3869,7 +3901,7 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
   // When filtering by collection, fetch extra candidates from the FTS index
   // since some will be filtered out. Without a collection filter we can
   // fetch exactly the requested limit.
-  const ftsLimit = collectionName ? limit * 10 : limit;
+  const ftsLimit = collectionFilter ? limit * 10 : limit;
 
   let sql = `
     WITH fts_matches AS (
@@ -3892,9 +3924,9 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
     WHERE d.active = 1
   `;
 
-  if (collectionName) {
+  if (collectionFilter) {
     sql += ` AND d.collection = ?`;
-    params.push(String(collectionName));
+    params.push(String(collectionFilter));
   }
 
   // bm25 lower is better; sort ascending.
@@ -3988,12 +4020,21 @@ function annVecScan(
   `).all(new Float32Array(embedding), vecK) as { hash_seq: string; distance: number }[];
 }
 
-export async function searchVec(db: Database, query: string, model: string, limit: number = 20, collectionName?: string, session?: ILLMSession, precomputedEmbedding?: number[], llm?: LlamaCpp): Promise<SearchResult[]> {
+export async function searchVec(db: Database, query: string, model: string, limit: number = 20, collectionName?: string | readonly string[], session?: ILLMSession, precomputedEmbedding?: number[], llm?: LlamaCpp): Promise<SearchResult[]> {
   const tableExists = db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'`).get();
   if (!tableExists) return [];
 
   const embedding = precomputedEmbedding ?? await getEmbedding(query, model, true, session, llm);
   if (!embedding) return [];
+
+  const names = scopedCollectionNames(collectionName);
+  if (names && names.length > 1) {
+    const lists = await Promise.all(
+      names.map(name => searchVec(db, query, model, limit, name, session, embedding, llm)),
+    );
+    return mergeSearchResultsByScore(lists, limit);
+  }
+  const collectionFilter = names?.[0];
 
   // IMPORTANT: We use a two-step query approach here because sqlite-vec virtual tables
   // hang indefinitely when combined with JOINs in the same query. Do NOT try to
@@ -4010,14 +4051,14 @@ export async function searchVec(db: Database, query: string, model: string, limi
   // enough, and only then fall back to capped ANN + post-filter.
   let vecResults: { hash_seq: string; distance: number }[];
 
-  if (collectionName) {
+  if (collectionFilter) {
     const collectionHashSeqs = withLazyContentVectorMigration(db, () =>
       db.prepare(`
         SELECT cv.hash || '_' || cv.seq AS hash_seq
         FROM content_vectors cv
         JOIN documents d ON d.hash = cv.hash AND d.active = 1
         WHERE d.collection = ?
-      `).all(collectionName) as { hash_seq: string }[],
+      `).all(collectionFilter) as { hash_seq: string }[],
     ).map((r) => r.hash_seq);
 
     if (collectionHashSeqs.length === 0) return [];
@@ -4056,9 +4097,9 @@ export async function searchVec(db: Database, query: string, model: string, limi
   `;
   const params: string[] = [...hashSeqs];
 
-  if (collectionName) {
+  if (collectionFilter) {
     docSql += ` AND d.collection = ?`;
-    params.push(collectionName);
+    params.push(collectionFilter);
   }
 
   const docRows = withLazyContentVectorMigration(db, () => db.prepare(docSql).all(...params) as {
@@ -5177,7 +5218,7 @@ export interface SearchHooks {
 }
 
 export interface HybridQueryOptions {
-  collection?: string;
+  collection?: string | readonly string[];
   limit?: number;           // default 10
   minScore?: number;        // default 0
   candidateLimit?: number;  // default RERANK_CANDIDATE_LIMIT
@@ -5532,7 +5573,7 @@ export async function hybridQuery(
 }
 
 export interface VectorSearchOptions {
-  collection?: string;
+  collection?: string | readonly string[];
   limit?: number;           // default 10
   minScore?: number;        // default 0.3
   intent?: string;          // domain intent hint for disambiguation

--- a/test/multi-collection-filter.test.ts
+++ b/test/multi-collection-filter.test.ts
@@ -1,86 +1,13 @@
 /**
- * Unit tests for multi-collection filter logic (PR #191).
+ * Unit tests for multi-collection CLI filter input (#191, #775).
  *
- * Tests the filterByCollections post-filter and the resolveCollectionFilter
- * behavior for single-collection vs multi-collection search.
+ * Collection scoping is applied in searchFTS/searchVec (search each collection,
+ * then merge). These tests cover CLI parseArgs / input normalization only.
+ * Starvation regressions live in store.test.ts.
  */
 
 import { describe, test, expect } from "vitest";
 import { parseArgs } from "node:util";
-
-// Reproduce the filterByCollections logic from qmd.ts for testing
-// (the function is private in qmd.ts)
-function filterByCollections<T extends { filepath?: string; file?: string }>(
-  results: T[],
-  collectionNames: string[],
-): T[] {
-  if (collectionNames.length <= 1) return results;
-  const prefixes = collectionNames.map((n) => `qmd://${n}/`);
-  return results.filter((r) => {
-    const path = r.filepath || r.file || "";
-    return prefixes.some((p) => path.startsWith(p));
-  });
-}
-
-describe("filterByCollections", () => {
-  const results = [
-    { filepath: "qmd://docs/readme.md", file: "qmd://docs/readme.md" },
-    { filepath: "qmd://notes/todo.md", file: "qmd://notes/todo.md" },
-    { filepath: "qmd://journals/2024/jan.md", file: "qmd://journals/2024/jan.md" },
-    { filepath: "qmd://docs/api.md", file: "qmd://docs/api.md" },
-  ];
-
-  test("returns all results when no collections specified", () => {
-    expect(filterByCollections(results, [])).toEqual(results);
-  });
-
-  test("returns all results for single collection (no-op, handled by SQL filter)", () => {
-    expect(filterByCollections(results, ["docs"])).toEqual(results);
-  });
-
-  test("filters to matching collections when multiple specified", () => {
-    const filtered = filterByCollections(results, ["docs", "journals"]);
-    expect(filtered).toHaveLength(3);
-    expect(filtered.map((r) => r.filepath)).toEqual([
-      "qmd://docs/readme.md",
-      "qmd://journals/2024/jan.md",
-      "qmd://docs/api.md",
-    ]);
-  });
-
-  test("filters correctly with two collections", () => {
-    const filtered = filterByCollections(results, ["notes", "journals"]);
-    expect(filtered).toHaveLength(2);
-    expect(filtered.map((r) => r.filepath)).toEqual([
-      "qmd://notes/todo.md",
-      "qmd://journals/2024/jan.md",
-    ]);
-  });
-
-  test("returns empty when no results match collections", () => {
-    const filtered = filterByCollections(results, ["archive", "trash"]);
-    expect(filtered).toHaveLength(0);
-  });
-
-  test("uses file field when filepath is missing", () => {
-    const fileOnlyResults = [
-      { file: "qmd://docs/readme.md" },
-      { file: "qmd://notes/todo.md" },
-    ];
-    const filtered = filterByCollections(fileOnlyResults, ["docs", "notes"]);
-    expect(filtered).toHaveLength(2);
-  });
-
-  test("uses filepath over file when both present", () => {
-    const mixedResults = [
-      { filepath: "qmd://docs/readme.md", file: "qmd://notes/todo.md" },
-    ];
-    const filtered = filterByCollections(mixedResults, ["docs", "notes"]);
-    expect(filtered).toHaveLength(1);
-    // Should match via filepath (docs), not file (notes)
-    expect(filtered[0].filepath).toBe("qmd://docs/readme.md");
-  });
-});
 
 describe("resolveCollectionFilter input normalization", () => {
   // Test the array normalization logic without the DB dependency

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1588,6 +1588,44 @@ describe("FTS Search", () => {
     await cleanupTestDb(store);
   });
 
+  test("searchFTS multi-collection union is not starved by a third collection (#775)", async () => {
+    const store = await createTestStore();
+    const noise = await createTestCollection({ name: "noise", pwd: "/test/noise" });
+    const knowledge = await createTestCollection({ name: "knowledge-base", pwd: "/test/knowledge" });
+    const notes = await createTestCollection({ name: "project-notes", pwd: "/test/notes" });
+
+    // Unrelated collection occupies global top-k with strong title matches.
+    for (let i = 0; i < 12; i++) {
+      await insertTestDocument(store.db, noise, {
+        name: `noise-${i}`,
+        title: "memory workspace",
+        body: `Noise ${i} about memory workspace`,
+        displayPath: `noise-${i}.md`,
+      });
+    }
+    await insertTestDocument(store.db, knowledge, {
+      name: "kb",
+      title: "Notes",
+      body: "A mention of memory in the knowledge base.",
+      displayPath: "kb.md",
+    });
+    await insertTestDocument(store.db, notes, {
+      name: "pn",
+      title: "Scratch",
+      body: "project-notes also talk about memory.",
+      displayPath: "pn.md",
+    });
+
+    const global = store.searchFTS("memory", 3);
+    expect(global.every(r => r.collectionName === noise)).toBe(true);
+
+    const union = store.searchFTS("memory", 3, [knowledge, notes]);
+    expect(union.map(r => r.collectionName).sort()).toEqual([knowledge, notes].sort());
+    expect(union.every(r => r.collectionName !== noise)).toBe(true);
+
+    await cleanupTestDb(store);
+  });
+
   test("searchFTS finds CJK documents by exact and mixed queries", async () => {
     const store = await createTestStore();
     const collectionName = await createTestCollection();
@@ -3492,6 +3530,83 @@ describe("Vector Search collection filter", () => {
     );
     expect(unfiltered).toHaveLength(3);
     expect(unfiltered.every((r) => r.collectionName === large)).toBe(true);
+
+    await cleanupTestDb(store);
+  });
+
+  test("searchVec multi-collection union is not starved by a third collection (#775)", async () => {
+    const store = await createTestStore();
+    const large = await createTestCollection({ name: "large", pwd: "/test/large" });
+    const knowledge = await createTestCollection({ name: "knowledge-base", pwd: "/test/knowledge" });
+    const notes = await createTestCollection({ name: "project-notes", pwd: "/test/notes" });
+
+    const dims = 8;
+    store.ensureVecTable(dims);
+    const now = new Date().toISOString();
+    const queryEmbedding = Array(dims).fill(0);
+    queryEmbedding[0] = 1;
+
+    for (let i = 0; i < 40; i++) {
+      const hash = `largehash${String(i).padStart(3, "0")}`;
+      await insertTestDocument(store.db, large, {
+        name: `noise-${i}`,
+        hash,
+        body: `Noise document ${i}`,
+        displayPath: `noise-${i}.md`,
+      });
+      const embedding = new Float32Array(dims);
+      embedding[0] = 1;
+      store.db.prepare(`INSERT INTO content_vectors (hash, seq, pos, model, embedded_at) VALUES (?, 0, 0, 'test', ?)`).run(hash, now);
+      store.db.prepare(`INSERT INTO vectors_vec (hash_seq, embedding) VALUES (?, ?)`).run(`${hash}_0`, embedding);
+    }
+
+    const kbHash = "kbhash001";
+    await insertTestDocument(store.db, knowledge, {
+      name: "kb",
+      hash: kbHash,
+      body: "Target document in knowledge-base",
+      displayPath: "kb.md",
+    });
+    const kbEmbedding = new Float32Array(dims);
+    kbEmbedding[0] = 0.55;
+    kbEmbedding[1] = 0.84;
+    store.db.prepare(`INSERT INTO content_vectors (hash, seq, pos, model, embedded_at) VALUES (?, 0, 0, 'test', ?)`).run(kbHash, now);
+    store.db.prepare(`INSERT INTO vectors_vec (hash_seq, embedding) VALUES (?, ?)`).run(`${kbHash}_0`, kbEmbedding);
+
+    const notesHash = "noteshash001";
+    await insertTestDocument(store.db, notes, {
+      name: "pn",
+      hash: notesHash,
+      body: "Target document in project-notes",
+      displayPath: "pn.md",
+    });
+    const notesEmbedding = new Float32Array(dims);
+    notesEmbedding[0] = 0.5;
+    notesEmbedding[1] = 0.87;
+    store.db.prepare(`INSERT INTO content_vectors (hash, seq, pos, model, embedded_at) VALUES (?, 0, 0, 'test', ?)`).run(notesHash, now);
+    store.db.prepare(`INSERT INTO vectors_vec (hash_seq, embedding) VALUES (?, ?)`).run(`${notesHash}_0`, notesEmbedding);
+
+    const global = await store.searchVec(
+      "ignored — embedding precomputed",
+      "test-model",
+      3,
+      undefined,
+      undefined,
+      queryEmbedding,
+    );
+    expect(global).toHaveLength(3);
+    expect(global.every((r) => r.collectionName === large)).toBe(true);
+
+    const union = await store.searchVec(
+      "ignored — embedding precomputed",
+      "test-model",
+      3,
+      [knowledge, notes],
+      undefined,
+      queryEmbedding,
+    );
+    expect(union.map(r => r.collectionName).sort()).toEqual([knowledge, notes].sort());
+    expect(union.every((r) => r.collectionName !== large)).toBe(true);
 
     await cleanupTestDb(store);
   });


### PR DESCRIPTION
## Summary

Collection-scoped multi-search (`-c A -c B`, SDK/MCP `collections: [A, B]`) fetched a global FTS/ANN top-k and then post-filtered by `qmd://` prefix. A large unrelated collection could occupy that candidate pool, so the requested collections vanished and the query returned empty even though each collection matched on its own.

`searchFTS` / `searchVec` now accept one or many collection names, search each requested collection (reusing the single-collection exact-scan path from #791/#803), then merge by score. CLI `search` / `vsearch` / `query` and SDK `search()` pass the full list through instead of post-filtering.

Fixes #775.

## Test plan

- [x] `CI=true bun test test/store.test.ts test/multi-collection-filter.test.ts` — 246 pass / 13 skip
- [x] `CI=true bun test test/` — 1014 pass / 81 skip
- [x] `CI=true vitest run test/` — 1014 pass / 74 skip
- [x] `tsc -p tsconfig.build.json --noEmit` clean
- [ ] GitHub Bun + Node CI green