### PR TITLE
fix(llm): hide model download progress bar by default (#776)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 
+- `qmd pull` (and implicit model downloads in `embed`/`query`) no longer print
+  node-llama-cpp's download progress bar. The bar redraws every few kilobytes
+  and flooded agent transcripts with thousands of tokens (#776). Pass
+  `qmd pull --progress` to show it on an interactive terminal.
 - `--full-path` no longer degrades silently when a result cannot be resolved on
   disk (#785). A fallback there means the file moved or was deleted since the
   last index, so `search`, `query`, `get` and `multi-get` now print a notice to

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -2787,6 +2787,7 @@ function parseCLI() {
       // Update options
       pull: { type: "boolean" },  // git pull before update
       refresh: { type: "boolean" },
+      progress: { type: "boolean" },  // qmd pull: show node-llama-cpp download progress bar
       "dry-run": { type: "boolean" },  // cleanup: report what would be removed
       // Get options
       l: { type: "string" },  // max lines
@@ -3325,6 +3326,7 @@ function showHelp(): void {
   console.log("    --max-docs-per-batch <n>    - Cap docs loaded into memory per embedding batch");
   console.log("    --max-batch-mb <n>          - Cap UTF-8 MB loaded into memory per embedding batch");
   console.log("    --timeout <minutes>         - Embed session cap in minutes (0 = no limit; default 30)");
+  console.log("  qmd pull [--refresh] [--progress] - Download embedding/generation/rerank models");
   console.log("  qmd cleanup [--dry-run]       - Clear caches, vacuum DB");
   console.log("");
   console.log("Query syntax (qmd query):");
@@ -4389,6 +4391,7 @@ if (isMain) {
       const results = await pullModels(models, {
         refresh,
         cacheDir: DEFAULT_MODEL_CACHE_DIR,
+        cli: Boolean(cli.values.progress),
       });
       for (const result of results) {
         const size = formatBytes(result.sizeBytes);

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -17,7 +17,10 @@ type WriteCallback = (err?: Error | null) => void;
 type NodeLlamaCppModule = {
   getLlama: (options: Record<string, unknown>) => Promise<Llama>;
   getLlamaGpuTypes?: (include?: "supported" | "allValid") => Promise<LlamaGpuMode[]>;
-  resolveModelFile: (model: string, cacheDir: string) => Promise<string>;
+  resolveModelFile: (
+    model: string,
+    optionsOrDirectory?: string | { directory?: string; cli?: boolean },
+  ) => Promise<string>;
   LlamaChatSession: new (options: { contextSequence: unknown }) => {
     prompt: (prompt: string, options?: Record<string, unknown>) => Promise<string>;
   };
@@ -478,9 +481,20 @@ function validateGgufFile(filePath: string, modelUri: string): void {
   );
 }
 
+
+/**
+ * node-llama-cpp prints a multi-line download progress bar when the second
+ * argument is a directory string (`cli` defaults to true). Agent transcripts
+ * capture that as thousands of tokens. Always pass an options object so the
+ * bar is off unless the caller opts in (#776).
+ */
+function resolveModelFileArgs(cacheDir: string, cli = false): { directory: string; cli: boolean } {
+  return { directory: cacheDir, cli };
+}
+
 export async function pullModels(
   models: string[],
-  options: { refresh?: boolean; cacheDir?: string } = {}
+  options: { refresh?: boolean; cacheDir?: string; cli?: boolean } = {}
 ): Promise<PullResult[]> {
   const cacheDir = options.cacheDir || MODEL_CACHE_DIR;
   if (!existsSync(cacheDir)) {
@@ -523,7 +537,7 @@ export async function pullModels(
     }
 
     const { resolveModelFile } = await loadNodeLlamaCpp();
-    const path = await resolveModelFile(model, cacheDir);
+    const path = await resolveModelFile(model, resolveModelFileArgs(cacheDir, options.cli === true));
     validateGgufFile(path, model);
     const sizeBytes = existsSync(path) ? statSync(path).size : 0;
     if (hfRef && filename) {
@@ -1012,7 +1026,7 @@ export class LlamaCpp implements LLM {
     this.ensureModelCacheDir();
     // resolveModelFile handles HF URIs and downloads to the cache dir
     const { resolveModelFile } = await loadNodeLlamaCpp();
-    const modelPath = await resolveModelFile(modelUri, this.modelCacheDir);
+    const modelPath = await resolveModelFile(modelUri, resolveModelFileArgs(this.modelCacheDir));
     validateGgufFile(modelPath, modelUri);
     return modelPath;
   }

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -26,6 +26,7 @@ import {
   resolveGenerateModel,
   resolveRerankModel,
   resolveModels,
+  pullModels,
   withLLMSession,
   canUnloadLLM,
   SessionReleasedError,
@@ -93,6 +94,73 @@ describe("canWriteLlamaDir", () => {
       else process.env.QMD_LLAMA_GPU = prevGpu;
       if (prevForceCpu === undefined) delete process.env.QMD_FORCE_CPU;
       else process.env.QMD_FORCE_CPU = prevForceCpu;
+    }
+  });
+});
+
+
+describe("model download progress (#776)", () => {
+  test("pullModels hides node-llama-cpp CLI progress by default", async () => {
+    const cacheDir = mkdtempSync(join(tmpdir(), "qmd-pull-quiet-"));
+    const resolveModelFile = vi.fn(async () => join(cacheDir, "missing.gguf"));
+    setNodeLlamaCppModuleForTest({
+      LlamaLogLevel: { error: "error" },
+      resolveModelFile,
+      LlamaChatSession: vi.fn() as any,
+      getLlama: vi.fn(),
+    });
+    try {
+      await pullModels(["local-model.gguf"], { cacheDir });
+      expect(resolveModelFile).toHaveBeenCalledWith(
+        "local-model.gguf",
+        { directory: cacheDir, cli: false },
+      );
+    } finally {
+      setNodeLlamaCppModuleForTest(null);
+      rmSync(cacheDir, { recursive: true, force: true });
+    }
+  });
+
+  test("pullModels shows CLI progress only when cli: true", async () => {
+    const cacheDir = mkdtempSync(join(tmpdir(), "qmd-pull-progress-"));
+    const resolveModelFile = vi.fn(async () => join(cacheDir, "missing.gguf"));
+    setNodeLlamaCppModuleForTest({
+      LlamaLogLevel: { error: "error" },
+      resolveModelFile,
+      LlamaChatSession: vi.fn() as any,
+      getLlama: vi.fn(),
+    });
+    try {
+      await pullModels(["local-model.gguf"], { cacheDir, cli: true });
+      expect(resolveModelFile).toHaveBeenCalledWith(
+        "local-model.gguf",
+        { directory: cacheDir, cli: true },
+      );
+    } finally {
+      setNodeLlamaCppModuleForTest(null);
+      rmSync(cacheDir, { recursive: true, force: true });
+    }
+  });
+
+  test("LlamaCpp.resolveModel also hides download progress", async () => {
+    const cacheDir = mkdtempSync(join(tmpdir(), "qmd-resolve-quiet-"));
+    const resolveModelFile = vi.fn(async () => join(cacheDir, "missing.gguf"));
+    setNodeLlamaCppModuleForTest({
+      LlamaLogLevel: { error: "error" },
+      resolveModelFile,
+      LlamaChatSession: vi.fn() as any,
+      getLlama: vi.fn(),
+    });
+    try {
+      const llm = new LlamaCpp({ modelCacheDir: cacheDir });
+      await (llm as any).resolveModel("local-model.gguf");
+      expect(resolveModelFile).toHaveBeenCalledWith(
+        "local-model.gguf",
+        { directory: cacheDir, cli: false },
+      );
+    } finally {
+      setNodeLlamaCppModuleForTest(null);
+      rmSync(cacheDir, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## Summary

`resolveModelFile(model, cacheDir)` treated the second argument as a directory string, so node-llama-cpp defaulted `cli: true` and printed a redrawing download progress bar. Agent transcripts (`qmd pull` from Claude Code, first-time `embed`/`query` downloads) captured thousands of tokens of bar updates (#776).

Downloads now pass `{ directory, cli: false }`. `qmd pull --progress` opts back in for an interactive terminal. The one-line `Pulling models` / cached-or-refreshed summary is unchanged.

Fixes #776.

## Test plan

- [x] `CI=true bun test test/llm.test.ts` — 39 pass / 32 skip
- [x] `CI=true bun test test/` — 1017 pass / 81 skip
- [x] `CI=true vitest run test/` — 1017 pass / 74 skip
- [x] `tsc -p tsconfig.build.json --noEmit` clean
- [ ] GitHub Bun + Node CI green