### PR TITLE
fix(llm): size embed context pool from the GGUF, not a 150 MB constant (#799)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@
 
 ### Fixed
 
+- Embedding-context pool size no longer assumes every GGUF costs 150 MB of
+  VRAM (the nomic-embed figure). Larger models such as Qwen3-Embedding-0.6B
+  are ~1190 MB per 2048-token context; opening 8 of those exhausted an 8 GB
+  card so `qmd query` failed with `Failed to create any rerank context` even
+  though the reranker itself was fine. The pool is now sized from the weight
+  file, and 1 GB is reserved for the reranker (#799). Default
+  embeddinggemma/nomic throughput is unchanged. `QMD_EMBED_PARALLELISM` still
+  overrides.
+
 - Multi-collection `-c A -c B` (and SDK/MCP `collections: [A, B]`) no longer
   searches globally then post-filters. A large unrelated collection could fill
   the FTS/ANN top-k so the requested collections vanished, yielding false-empty

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -667,6 +667,62 @@ export function resolveSafeParallelism(options: ParallelismOptions): number {
   return Math.max(1, options.computed);
 }
 
+/** Measured nomic-embed / embeddinggemma-300M embedding-context cost at 2048 tokens. */
+export const BASELINE_EMBED_CONTEXT_MB = 150;
+
+/**
+ * VRAM to leave free when sizing the embedding-context pool so `query` can
+ * still create a rerank context afterwards. Matches the 1000 MB figure
+ * `ensureRerankContexts` already uses as its per-context cost.
+ */
+export const EMBED_POOL_RERANK_RESERVE_MB = 1000;
+
+/**
+ * GPU embedding-context pool size from free VRAM.
+ *
+ * Uses 25% of (free − reserve), then clamps to `[1, cap]`. The reserve keeps
+ * the pool from consuming the memory `query` needs next for the reranker (#799).
+ */
+export function computeGpuContextPoolSize(options: {
+  freeMB: number;
+  perContextMB: number;
+  reserveMB?: number;
+  cap?: number;
+}): number {
+  const perContextMB = Math.max(1, options.perContextMB);
+  const reserveMB = Math.max(0, options.reserveMB ?? 0);
+  const cap = options.cap ?? 8;
+  const usableMB = Math.max(0, options.freeMB - reserveMB);
+  const maxByVram = Math.floor((usableMB * 0.25) / perContextMB);
+  return Math.max(1, Math.min(cap, maxByVram));
+}
+
+/**
+ * Estimate one embedding context's VRAM from the GGUF weight-file size.
+ *
+ * Small models (nomic / embeddinggemma-class, ≲350 MB) stay at the measured
+ * 150 MB baseline so default `qmd embed` throughput is unchanged. Larger
+ * files — Qwen3-Embedding-0.6B-Q8 is ~640 MB — were measured at ~1190 MB per
+ * 2048-token context, about 1.85× the weight file, because the KV cache
+ * dominates (#799).
+ */
+export function estimateEmbedContextMB(options: {
+  modelBytes: number;
+  contextSize?: number;
+}): number {
+  const contextSize = options.contextSize && options.contextSize > 0 ? options.contextSize : 2048;
+  const modelMB = options.modelBytes / (1024 * 1024);
+  const ctxScale = contextSize / 2048;
+  if (!(modelMB > 0) || !Number.isFinite(modelMB)) {
+    return Math.max(1, Math.round(BASELINE_EMBED_CONTEXT_MB * ctxScale));
+  }
+  const SMALL_MODEL_MB = 350;
+  if (modelMB <= SMALL_MODEL_MB) {
+    return Math.max(1, Math.round(BASELINE_EMBED_CONTEXT_MB * ctxScale));
+  }
+  return Math.max(1, Math.round(modelMB * 1.85 * ctxScale));
+}
+
 export function resolveLlamaGpuMode(
   envValue = process.env.QMD_LLAMA_GPU,
   forceCpuValue = process.env.QMD_FORCE_CPU
@@ -735,6 +791,7 @@ export class LlamaCpp implements LLM {
   private readonly _ciMode = !!process.env.CI;
   private llama: Llama | null = null;
   private embedModel: LlamaModel | null = null;
+  private embedModelPath: string | null = null;
   private embedContexts: LlamaEmbeddingContext[] = [];
   private generateModel: LlamaModel | null = null;
   private rerankModel: LlamaModel | null = null;
@@ -865,6 +922,7 @@ export class LlamaCpp implements LLM {
       if (this.embedModel) {
         await this.embedModel.dispose();
         this.embedModel = null;
+        this.embedModelPath = null;
       }
       if (this.generateModel) {
         await this.generateModel.dispose();
@@ -1047,6 +1105,7 @@ export class LlamaCpp implements LLM {
       const modelPath = await this.resolveModel(this.embedModelUri);
       const model = await llama.loadModel(this.modelLoadOptions(modelPath));
       this.embedModel = model;
+      this.embedModelPath = modelPath;
       // Model loading counts as activity - ping to keep alive
       this.touchActivity();
       return model;
@@ -1068,15 +1127,14 @@ export class LlamaCpp implements LLM {
    *      true parallelism (each context runs on its own cores). Use at most
    *      half the math cores, with at least 4 threads per context.
    */
-  private async computeParallelism(perContextMB: number): Promise<number> {
+  private async computeParallelism(perContextMB: number, reserveMB = 0): Promise<number> {
     const llama = await this.ensureLlama();
 
     if (!this.isCpuOffloadForced() && llama.gpu) {
       try {
         const vram = await llama.getVramState();
         const freeMB = vram.free / (1024 * 1024);
-        const maxByVram = Math.floor((freeMB * 0.25) / perContextMB);
-        const computed = Math.max(1, Math.min(8, maxByVram));
+        const computed = computeGpuContextPoolSize({ freeMB, perContextMB, reserveMB });
         return resolveSafeParallelism({ gpu: llama.gpu, computed });
       } catch {
         return resolveSafeParallelism({ gpu: llama.gpu, computed: 2 });
@@ -1119,8 +1177,21 @@ export class LlamaCpp implements LLM {
 
     this.embedContextsCreatePromise = (async () => {
       const model = await this.ensureEmbedModel();
-      // Embed contexts are ~143 MB each (nomic-embed 2048 ctx)
-      const n = await this.computeParallelism(150);
+      // Per-context cost depends on the loaded GGUF. The old hardcoded 150 MB
+      // figure was measured for nomic-embed; Qwen3-Embedding-0.6B is ~1190 MB
+      // and opening 8 of those exhausted VRAM so the reranker could not load (#799).
+      let perContextMB = BASELINE_EMBED_CONTEXT_MB;
+      if (this.embedModelPath) {
+        try {
+          perContextMB = estimateEmbedContextMB({
+            modelBytes: statSync(this.embedModelPath).size,
+            contextSize: LlamaCpp.EMBED_CONTEXT_SIZE,
+          });
+        } catch {
+          // Keep the baseline if the file cannot be stat'd.
+        }
+      }
+      const n = await this.computeParallelism(perContextMB, EMBED_POOL_RERANK_RESERVE_MB);
       const threads = await this.threadsPerContext(n);
       for (let i = 0; i < n; i++) {
         try {
@@ -1757,6 +1828,7 @@ export class LlamaCpp implements LLM {
     if (this.embedModel) {
       await disposeWithTimeout("embedding model", () => this.embedModel!.dispose());
       this.embedModel = null;
+      this.embedModelPath = null;
     }
     if (this.generateModel) {
       await disposeWithTimeout("generation model", () => this.generateModel!.dispose());

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -22,6 +22,10 @@ import {
   withNativeStdoutRedirectedToStderr,
   resolveParallelismOverride,
   resolveSafeParallelism,
+  computeGpuContextPoolSize,
+  estimateEmbedContextMB,
+  BASELINE_EMBED_CONTEXT_MB,
+  EMBED_POOL_RERANK_RESERVE_MB,
   resolveEmbedModel,
   resolveGenerateModel,
   resolveRerankModel,
@@ -505,6 +509,50 @@ describe("LLM context parallelism safety", () => {
     } finally {
       stderrSpy.mockRestore();
     }
+  });
+});
+
+describe("embedding context VRAM pool (#799)", () => {
+  test("keeps the nomic/embeddinggemma baseline for small GGUFs so default embed throughput is unchanged", () => {
+    const gemmaBytes = 308 * 1024 * 1024;
+    expect(estimateEmbedContextMB({ modelBytes: gemmaBytes })).toBe(BASELINE_EMBED_CONTEXT_MB);
+    expect(estimateEmbedContextMB({ modelBytes: 137 * 1024 * 1024 })).toBe(BASELINE_EMBED_CONTEXT_MB);
+  });
+
+  test("scales Qwen3-Embedding-0.6B-class GGUFs to ~1190 MB per context", () => {
+    const qwenBytes = 640 * 1024 * 1024;
+    expect(estimateEmbedContextMB({ modelBytes: qwenBytes })).toBe(Math.round(640 * 1.85));
+    expect(estimateEmbedContextMB({ modelBytes: qwenBytes, contextSize: 1024 })).toBe(Math.round(640 * 1.85 * 0.5));
+  });
+
+  test("falls back to the baseline when the file size is unknown", () => {
+    expect(estimateEmbedContextMB({ modelBytes: 0 })).toBe(BASELINE_EMBED_CONTEXT_MB);
+    expect(estimateEmbedContextMB({ modelBytes: Number.NaN })).toBe(BASELINE_EMBED_CONTEXT_MB);
+  });
+
+  test("on 8 GB VRAM, a Qwen 0.6B pool is 1 context so the reranker still fits", () => {
+    const perContextMB = estimateEmbedContextMB({ modelBytes: 640 * 1024 * 1024 });
+    expect(computeGpuContextPoolSize({
+      freeMB: 7500,
+      perContextMB,
+      reserveMB: EMBED_POOL_RERANK_RESERVE_MB,
+    })).toBe(1);
+  });
+
+  test("on 8 GB VRAM, the default 150 MB estimate still allows the 8-context cap", () => {
+    expect(computeGpuContextPoolSize({
+      freeMB: 7500,
+      perContextMB: BASELINE_EMBED_CONTEXT_MB,
+      reserveMB: EMBED_POOL_RERANK_RESERVE_MB,
+    })).toBe(8);
+  });
+
+  test("the old hardcoded 150 MB estimate would still open 8 Qwen contexts and OOM the reranker", () => {
+    expect(computeGpuContextPoolSize({
+      freeMB: 7500,
+      perContextMB: 150,
+      reserveMB: EMBED_POOL_RERANK_RESERVE_MB,
+    })).toBe(8);
   });
 });
 


### PR DESCRIPTION
## Summary

`computeParallelism()` sized the embedding-context pool from a hardcoded 150 MB per context (measured for nomic-embed). Qwen3-Embedding-0.6B costs ~1190 MB at 2048 tokens, so the default 8-wide pool exhausted 8 GB cards and `qmd query` failed with `Failed to create any rerank context` — the reranker was the victim, not the cause (#799).

The pool is now sized from the GGUF weight-file size (small nomic/embeddinggemma models stay at 150 MB so default `qmd embed` throughput is unchanged). 1 GB is reserved for the reranker that `query` loads next. `QMD_EMBED_PARALLELISM` still overrides.

Fixes #799.

## Test plan

- [x] `CI=true bun test test/llm.test.ts` — 45 pass / 32 skip
- [x] `CI=true bun test test/` — 1023 pass / 81 skip
- [x] `CI=true vitest run test/` — 1023 pass / 74 skip
- [x] `tsc -p tsconfig.build.json --noEmit` clean
- [ ] GitHub Bun + Node CI green