### PR TITLE
fix(llm): serialize rerank context creation on cold start (#682)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@
 
 ### Fixed
 
+- Concurrent `query` calls with `rerank: true` on a cold MCP server no longer
+  race `ensureRerankContexts()`. Embed already serialized context creation;
+  rerank did not, so two overlapping first queries both saw an empty pool,
+  both created ranking contexts, and the inactivity timer disposed the loser
+  (`Object is disposed`, #682). Callers now await the in-flight create.
+
 - Embedding-context pool size no longer assumes every GGUF costs 150 MB of
   VRAM (the nomic-embed figure). Larger models such as Qwen3-Embedding-0.6B
   are ~1190 MB per 2048-token context; opening 8 of those exhausted an 8 GB

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -807,6 +807,7 @@ export class LlamaCpp implements LLM {
   private embedModelLoadPromise: Promise<LlamaModel> | null = null;
   private generateModelLoadPromise: Promise<LlamaModel> | null = null;
   private rerankModelLoadPromise: Promise<LlamaModel> | null = null;
+  private rerankContextsCreatePromise: Promise<Awaited<ReturnType<LlamaModel["createRankingContext"]>>[]> | null = null;
   // Guard against concurrent ensureLlama() calls creating duplicate Llama
   // instances. Without this, two concurrent callers each build their own
   // runtime and the last write to this.llama wins, leaving models/grammars
@@ -936,6 +937,7 @@ export class LlamaCpp implements LLM {
       this.embedModelLoadPromise = null;
       this.generateModelLoadPromise = null;
       this.rerankModelLoadPromise = null;
+      this.rerankContextsCreatePromise = null;
     }
 
     // Note: We keep llama instance alive - it's lightweight
@@ -1305,7 +1307,20 @@ export class LlamaCpp implements LLM {
     return Number.isFinite(v) && v > 0 ? v : 2048;
   })();
   private async ensureRerankContexts(): Promise<Awaited<ReturnType<LlamaModel["createRankingContext"]>>[]> {
-    if (this.rerankContexts.length === 0) {
+    if (this.rerankContexts.length > 0) {
+      this.touchActivity();
+      return this.rerankContexts;
+    }
+
+    if (this.rerankContextsCreatePromise) {
+      return await this.rerankContextsCreatePromise;
+    }
+
+    // Same mutex as ensureEmbedContexts: two overlapping query/rerank calls on a
+    // cold MCP server both saw length === 0, both created ranking contexts, and
+    // the inactivity timer disposed the loser → "Object is disposed" (#682).
+    this.rerankContextsCreatePromise = (async () => {
+      this.touchActivity();
       const model = await this.ensureRerankModel();
       const n = Math.min(await this.computeParallelism(1000), 4);
       const threads = await this.threadsPerContext(n);
@@ -1332,9 +1347,15 @@ export class LlamaCpp implements LLM {
           break;
         }
       }
+      this.touchActivity();
+      return this.rerankContexts;
+    })();
+
+    try {
+      return await this.rerankContextsCreatePromise;
+    } finally {
+      this.rerankContextsCreatePromise = null;
     }
-    this.touchActivity();
-    return this.rerankContexts;
   }
 
   // ==========================================================================
@@ -1849,6 +1870,7 @@ export class LlamaCpp implements LLM {
     this.embedContextsCreatePromise = null;
     this.generateModelLoadPromise = null;
     this.rerankModelLoadPromise = null;
+    this.rerankContextsCreatePromise = null;
     this.llamaLoadPromise = null;
   }
 }

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -768,6 +768,35 @@ describe("LlamaCpp ensureRerankContexts error reporting", () => {
       warn.mockRestore();
     }
   });
+
+  test("serializes concurrent cold-start callers so ranking contexts are created once", async () => {
+    const llm = new LlamaCpp({}) as any;
+    const ctx = { id: 1 };
+    let inflight = 0;
+    let maxInflight = 0;
+    const createRankingContext = vi.fn().mockImplementation(async () => {
+      inflight++;
+      maxInflight = Math.max(maxInflight, inflight);
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      inflight--;
+      return ctx;
+    });
+    llm.computeParallelism = vi.fn().mockResolvedValue(1);
+    llm.threadsPerContext = vi.fn().mockResolvedValue(0);
+    llm.ensureRerankModel = vi.fn().mockResolvedValue({ createRankingContext });
+
+    const [a, b, c] = await Promise.all([
+      llm.ensureRerankContexts(),
+      llm.ensureRerankContexts(),
+      llm.ensureRerankContexts(),
+    ]);
+
+    expect(a).toEqual([ctx]);
+    expect(b).toBe(a);
+    expect(c).toBe(a);
+    expect(createRankingContext).toHaveBeenCalledTimes(1);
+    expect(maxInflight).toBe(1);
+  });
 });
 
 describe("LlamaCpp.getDeviceInfo", () => {


### PR DESCRIPTION
## Summary
- `ensureRerankContexts()` had no concurrent-init guard. Embed already serializes with `embedContextsCreatePromise`; rerank did not.
- Two overlapping `query` calls with `rerank: true` on a cold MCP server both saw an empty pool, both created ranking contexts, and the inactivity timer disposed the loser → `Object is disposed` (#682).
- Callers now await the in-flight create. Failure still returns `[]` and warns with the real error (#782).

## Test plan
- [x] New unit test: three concurrent cold-start `ensureRerankContexts()` calls create ranking contexts once
- [x] Existing first-context / later-context failure tests still pass
- [x] `CI=true` Node vitest `test/`: 1024 passed, 74 skipped
- [x] `CI=true` Bun `test/`: 1024 pass, 81 skip, 0 fail

Supersedes draft #693 (stale against current `llm.ts`).