### PR TITLE
fix(store): reclaim orphaned content and compact FTS in qmd cleanup (#550)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@
 
 ### Fixed
 
+- `qmd cleanup` now reclaims the content and FTS space left behind after a
+  wrong-directory `qmd update`. Deactivating files (the next update in the
+  right directory) only tombstoned the `documents` rows; cleanup deleted those
+  rows and vacuumed, but never dropped the unreferenced `content` hashes and
+  never ran FTS5 `optimize`, so `documents_fts_data` kept the old bodies
+  (#550). Cleanup now deletes inactive docs, then orphaned content, then
+  compact FTS, then vacuum. `--dry-run` reports the content hashes too.
+
 - Concurrent `query` calls with `rerank: true` on a cold MCP server no longer
   race `ensureRerankContexts()`. Embed already serialized context creation;
   rerank did not, so two overlapping first queries both saw an empty pool,

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -55,11 +55,9 @@ import {
   deactivateDocument,
   getActiveDocumentPaths,
   cleanupOrphanedContent,
-  deleteLLMCache,
-  deleteInactiveDocuments,
-  cleanupOrphanedVectors,
   countOrphanedVectors,
-  vacuumDatabase,
+  previewCleanup,
+  runCleanup,
   getCollectionsWithoutContext,
   getTopLevelPathsWithoutContext,
   handelize,
@@ -3327,7 +3325,7 @@ function showHelp(): void {
   console.log("    --max-batch-mb <n>          - Cap UTF-8 MB loaded into memory per embedding batch");
   console.log("    --timeout <minutes>         - Embed session cap in minutes (0 = no limit; default 30)");
   console.log("  qmd pull [--refresh] [--progress] - Download embedding/generation/rerank models");
-  console.log("  qmd cleanup [--dry-run]       - Clear caches, vacuum DB");
+  console.log("  qmd cleanup [--dry-run]       - Drop inactive docs/orphans, compact FTS, vacuum");
   console.log("");
   console.log("Query syntax (qmd query):");
   console.log("  QMD queries are either a single expand query (no prefix) or a multi-line");
@@ -4628,45 +4626,39 @@ if (isMain) {
       const dryRun = Boolean(cli.values["dry-run"]);
 
       if (dryRun) {
-        const cacheCount = (db.prepare(`SELECT COUNT(*) as c FROM llm_cache`).get() as { c: number }).c;
-        const orphanedVecs = countOrphanedVectors(db);
-        const inactiveDocs = (db.prepare(`SELECT COUNT(*) as c FROM documents WHERE active = 0`).get() as { c: number }).c;
+        const stats = previewCleanup(db);
         console.log("Dry run — no changes made.\n");
-        console.log(`Would clear ${cacheCount} cached API responses`);
-        if (orphanedVecs > 0) {
-          console.log(`Would remove ${orphanedVecs} orphaned embedding chunks`);
+        console.log(`Would clear ${stats.cacheCount} cached API responses`);
+        if (stats.orphanedVectors > 0) {
+          console.log(`Would remove ${stats.orphanedVectors} orphaned embedding chunks`);
         } else {
           console.log(`${c.dim}No orphaned embeddings to remove${c.reset}`);
         }
-        if (inactiveDocs > 0) {
-          console.log(`Would remove ${inactiveDocs} inactive document records`);
+        if (stats.inactiveDocs > 0) {
+          console.log(`Would remove ${stats.inactiveDocs} inactive document records`);
         }
-        console.log("Would vacuum the database");
+        if (stats.orphanedContent > 0) {
+          console.log(`Would remove ${stats.orphanedContent} orphaned content hashes`);
+        }
+        console.log("Would compact FTS and vacuum the database");
         closeDb();
         break;
       }
 
-      // 1. Clear llm_cache
-      const cacheCount = deleteLLMCache(db);
-      console.log(`${c.green}✓${c.reset} Cleared ${cacheCount} cached API responses`);
-
-      // 2. Remove orphaned vectors
-      const orphanedVecs = cleanupOrphanedVectors(db);
-      if (orphanedVecs > 0) {
-        console.log(`${c.green}✓${c.reset} Removed ${orphanedVecs} orphaned embedding chunks`);
+      const stats = runCleanup(db);
+      console.log(`${c.green}✓${c.reset} Cleared ${stats.cacheCount} cached API responses`);
+      if (stats.orphanedVectors > 0) {
+        console.log(`${c.green}✓${c.reset} Removed ${stats.orphanedVectors} orphaned embedding chunks`);
       } else {
         console.log(`${c.dim}No orphaned embeddings to remove${c.reset}`);
       }
-
-      // 3. Remove inactive documents
-      const inactiveDocs = deleteInactiveDocuments(db);
-      if (inactiveDocs > 0) {
-        console.log(`${c.green}✓${c.reset} Removed ${inactiveDocs} inactive document records`);
+      if (stats.inactiveDocs > 0) {
+        console.log(`${c.green}✓${c.reset} Removed ${stats.inactiveDocs} inactive document records`);
       }
-
-      // 4. Vacuum to reclaim space
-      vacuumDatabase(db);
-      console.log(`${c.green}✓${c.reset} Database vacuumed`);
+      if (stats.orphanedContent > 0) {
+        console.log(`${c.green}✓${c.reset} Removed ${stats.orphanedContent} orphaned content hashes`);
+      }
+      console.log(`${c.green}✓${c.reset} FTS compacted, database vacuumed`);
 
       closeDb();
       break;

--- a/src/maintenance.ts
+++ b/src/maintenance.ts
@@ -13,6 +13,10 @@ import {
   deleteLLMCache,
   deleteInactiveDocuments,
   clearAllEmbeddings,
+  optimizeDocumentsFts,
+  previewCleanup,
+  runCleanup,
+  type CleanupStats,
 } from "./store.js";
 
 export class Maintenance {
@@ -50,5 +54,23 @@ export class Maintenance {
   /** Clear all vector embeddings (forces re-embedding) */
   clearEmbeddings(): void {
     clearAllEmbeddings(this.store.db);
+  }
+
+  /** Compact FTS5 so deleted rows leave documents_fts_data (#550). */
+  optimizeFts(): void {
+    optimizeDocumentsFts(this.store.db);
+  }
+
+  /** Preview what {@link run} would remove, without writing. */
+  preview(): CleanupStats {
+    return previewCleanup(this.store.db);
+  }
+
+  /**
+   * Full cleanup: cache, orphaned vectors, inactive docs, orphaned content,
+   * FTS optimize, vacuum. Same sequence as `qmd cleanup`.
+   */
+  run(): CleanupStats {
+    return runCleanup(this.store.db);
   }
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -2588,6 +2588,18 @@ export function cleanupOrphanedContent(db: Database): number {
   return result.changes;
 }
 
+/**
+ * Count content hashes that would be unreferenced after inactive documents
+ * are hard-deleted. Shared hashes still used by an active document are kept.
+ */
+export function countOrphanedContent(db: Database): number {
+  const row = db.prepare(`
+    SELECT COUNT(*) as c FROM content
+    WHERE hash NOT IN (SELECT DISTINCT hash FROM documents WHERE active = 1)
+  `).get() as { c: number };
+  return row.c;
+}
+
 const ORPHANED_VECTOR_COUNT_SQL = `
   SELECT COUNT(*) as c FROM content_vectors cv
   WHERE NOT EXISTS (
@@ -2687,6 +2699,50 @@ export function cleanupOrphanedVectors(db: Database): number {
  */
 export function vacuumDatabase(db: Database): void {
   db.exec(`VACUUM`);
+}
+
+/**
+ * Merge FTS5 b-trees so deleted rows (deactivated / hard-deleted documents)
+ * leave `documents_fts_data`. VACUUM alone does not compact FTS5 (#550).
+ */
+export function optimizeDocumentsFts(db: Database): void {
+  try {
+    db.exec(`INSERT INTO documents_fts(documents_fts) VALUES('optimize')`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/no such table/i.test(message)) return;
+    throw error;
+  }
+}
+
+export type CleanupStats = {
+  cacheCount: number;
+  orphanedVectors: number;
+  inactiveDocs: number;
+  orphanedContent: number;
+};
+
+/** Counts what `runCleanup` would remove, including content only held by inactive docs. */
+export function previewCleanup(db: Database): CleanupStats {
+  const cacheCount = (db.prepare(`SELECT COUNT(*) as c FROM llm_cache`).get() as { c: number }).c;
+  const orphanedVectors = countOrphanedVectors(db);
+  const inactiveDocs = (db.prepare(`SELECT COUNT(*) as c FROM documents WHERE active = 0`).get() as { c: number }).c;
+  const orphanedContent = countOrphanedContent(db);
+  return { cacheCount, orphanedVectors, inactiveDocs, orphanedContent };
+}
+
+/**
+ * Full `qmd cleanup` sequence: drop cache, orphaned vectors, inactive document
+ * rows, then the content those rows were pinning, compact FTS5, vacuum.
+ */
+export function runCleanup(db: Database): CleanupStats {
+  const cacheCount = deleteLLMCache(db);
+  const orphanedVectors = cleanupOrphanedVectors(db);
+  const inactiveDocs = deleteInactiveDocuments(db);
+  const orphanedContent = cleanupOrphanedContent(db);
+  optimizeDocumentsFts(db);
+  vacuumDatabase(db);
+  return { cacheCount, orphanedVectors, inactiveDocs, orphanedContent };
 }
 
 // =============================================================================

--- a/test/cleanup.test.ts
+++ b/test/cleanup.test.ts
@@ -1,0 +1,109 @@
+/**
+ * qmd cleanup must drop content pinned only by inactive documents and compact
+ * FTS5 so a wrong-directory update can actually shrink the index (#550).
+ */
+import { describe, test, expect, afterEach } from "vitest";
+import { mkdtemp, unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createStore,
+  hashContent,
+  insertContent,
+  insertDocument,
+  deactivateDocument,
+  deleteInactiveDocuments,
+  cleanupOrphanedContent,
+  countOrphanedContent,
+  previewCleanup,
+  runCleanup,
+  type Store,
+} from "../src/store.js";
+
+let store: Store | null = null;
+
+async function openStore(): Promise<Store> {
+  const dir = await mkdtemp(join(tmpdir(), "qmd-cleanup-"));
+  store = createStore(join(dir, "index.sqlite"));
+  return store;
+}
+
+afterEach(async () => {
+  if (!store) return;
+  const path = store.dbPath;
+  store.close();
+  store = null;
+  try { await unlink(path); } catch { /* ignore */ }
+  try { await unlink(`${path}-wal`); } catch { /* ignore */ }
+  try { await unlink(`${path}-shm`); } catch { /* ignore */ }
+});
+
+async function seedDocs(s: Store, keepBody: string, dropBody: string) {
+  const now = new Date().toISOString();
+  const keepHash = await hashContent(keepBody);
+  const dropHash = await hashContent(dropBody);
+  insertContent(s.db, keepHash, keepBody, now);
+  insertContent(s.db, dropHash, dropBody, now);
+  insertDocument(s.db, "docs", "keep.md", "Keep", keepHash, now, now);
+  insertDocument(s.db, "docs", "drop.md", "Drop", dropHash, now, now);
+  return { keepHash, dropHash };
+}
+
+describe("qmd cleanup reclaim (#550)", () => {
+  test("deactivating a document removes it from FTS but leaves content until cleanup", async () => {
+    const s = await openStore();
+    const { dropHash } = await seedDocs(s, "keepuniquealpha body", "dropuniqueomega body");
+
+    expect(s.db.prepare(`SELECT count(*) as c FROM documents_fts`).get()).toEqual({ c: 2 });
+
+    deactivateDocument(s.db, "docs", "drop.md");
+    expect(s.db.prepare(`SELECT count(*) as c FROM documents_fts`).get()).toEqual({ c: 1 });
+    expect(countOrphanedContent(s.db)).toBe(1);
+    expect(previewCleanup(s.db)).toMatchObject({ inactiveDocs: 1, orphanedContent: 1 });
+
+    // Historical bug: deleting the tombstone did not drop the content row.
+    deleteInactiveDocuments(s.db);
+    expect(s.db.prepare(`SELECT count(*) as c FROM documents`).get()).toEqual({ c: 1 });
+    expect(s.db.prepare(`SELECT count(*) as c FROM content`).get()).toEqual({ c: 2 });
+    expect(s.db.prepare(`SELECT count(*) as c FROM content WHERE hash = ?`).get(dropHash)).toEqual({ c: 1 });
+
+    expect(cleanupOrphanedContent(s.db)).toBe(1);
+    expect(s.db.prepare(`SELECT count(*) as c FROM content`).get()).toEqual({ c: 1 });
+    expect(s.db.prepare(`SELECT count(*) as c FROM content WHERE hash = ?`).get(dropHash)).toEqual({ c: 0 });
+  });
+
+  test("runCleanup drops inactive docs, orphaned content, and leftover FTS rows", async () => {
+    const s = await openStore();
+    await seedDocs(s, "keepuniquealpha body", "dropuniqueomega body");
+    deactivateDocument(s.db, "docs", "drop.md");
+
+    const stats = runCleanup(s.db);
+    expect(stats.inactiveDocs).toBe(1);
+    expect(stats.orphanedContent).toBe(1);
+    expect(s.db.prepare(`SELECT count(*) as c FROM documents`).get()).toEqual({ c: 1 });
+    expect(s.db.prepare(`SELECT count(*) as c FROM content`).get()).toEqual({ c: 1 });
+    expect(s.db.prepare(`SELECT count(*) as c FROM documents_fts`).get()).toEqual({ c: 1 });
+    expect(s.db.prepare(`SELECT path FROM documents WHERE active = 1`).get()).toEqual({ path: "keep.md" });
+
+    const ftsHit = s.db.prepare(
+      `SELECT count(*) as c FROM documents_fts WHERE documents_fts MATCH 'keepuniquealpha'`
+    ).get() as { c: number };
+    expect(ftsHit.c).toBe(1);
+  });
+
+  test("runCleanup keeps content still referenced by an active document", async () => {
+    const s = await openStore();
+    const now = new Date().toISOString();
+    const shared = await hashContent("shareduniquebody");
+    insertContent(s.db, shared, "shareduniquebody", now);
+    insertDocument(s.db, "docs", "keep.md", "Keep", shared, now, now);
+    insertDocument(s.db, "docs", "drop.md", "Drop", shared, now, now);
+    deactivateDocument(s.db, "docs", "drop.md");
+
+    const stats = runCleanup(s.db);
+    expect(stats.inactiveDocs).toBe(1);
+    expect(stats.orphanedContent).toBe(0);
+    expect(s.db.prepare(`SELECT count(*) as c FROM content`).get()).toEqual({ c: 1 });
+    expect(s.db.prepare(`SELECT count(*) as c FROM documents`).get()).toEqual({ c: 1 });
+  });
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1357,7 +1357,8 @@ describe("orphaned embedding vectors (#768)", () => {
     expect(stdout).toContain("Would clear 2 cached API responses");
     expect(stdout).toContain("Would remove 3 orphaned embedding chunks");
     expect(stdout).toContain("Would remove 1 inactive document records");
-    expect(stdout).toContain("Would vacuum the database");
+    expect(stdout).toContain("Would remove 1 orphaned content hashes");
+    expect(stdout).toContain("Would compact FTS and vacuum the database");
     expect(stdout).not.toContain("Database vacuumed");
 
     const db = openDatabase(localDbPath);


### PR DESCRIPTION
## Summary
- `qmd cleanup` deleted inactive document rows and vacuumed, but never dropped the `content` hashes those rows were pinning, and never ran FTS5 `optimize`. After indexing from the wrong directory then the right one, the DB stayed bloated (`documents_fts_data` kept the old bodies) (#550).
- Cleanup now: cache → orphaned vectors → inactive docs → orphaned content → FTS optimize → vacuum. `--dry-run` reports the content hashes too. Shared hashes still used by an active document are kept.

## Test plan
- [x] New unit tests: deactivate leaves content until cleanup; `runCleanup` drops it and leftover FTS rows; shared hashes are kept
- [x] CLI `--dry-run` assertion updated
- [x] `CI=true` Bun `test/`: 1027 pass, 81 skip, 0 fail
- [x] `CI=true` Node vitest `test/`: 1027 passed, 74 skipped