### PR TITLE
fix(bench): fail fast when the fixture collection is missing or empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@
 
 ### Fixed
 
+- `qmd bench` no longer runs to a wall of 0.00 when the fixture collection is
+  missing or empty (#716). It errors up front with the same "Collection not
+  found" / index hint as `qmd search -c`, and if every backend still scores
+  zero it warns on stderr to check `qmd ls`.
+
 - `qmd cleanup` now reclaims the content and FTS space left behind after a
   wrong-directory `qmd update`. Deactivating files (the next update in the
   right directory) only tombstoned the `documents` rows; cleanup deleted those

--- a/src/bench/bench.ts
+++ b/src/bench/bench.ts
@@ -271,9 +271,67 @@ function computeSummary(results: QueryResult[]): BenchmarkResult["summary"] {
   return summary;
 }
 
+export type BenchCollectionInfo = {
+  name: string;
+  active_count: number;
+};
+
+/**
+ * Fail fast when the fixture's collection is missing or empty so `qmd bench`
+ * does not spend minutes printing a wall of 0.00 (#716).
+ */
+export function assertBenchCollectionReady(
+  collections: BenchCollectionInfo[],
+  collection?: string,
+): void {
+  if (collection) {
+    const match = collections.find(c => c.name === collection);
+    if (!match) {
+      const names = collections.map(c => c.name);
+      const hint = names.length > 0
+        ? `Available: ${names.join(", ")}. Run 'qmd ls' to inspect.`
+        : "Run 'qmd ls' to see available collections.";
+      throw new Error(`Collection not found: ${collection}\n${hint}`);
+    }
+    if (match.active_count === 0) {
+      throw new Error(
+        `Collection '${collection}' has no indexed documents.\nRun 'qmd update', then 'qmd ls ${collection}' to confirm files are indexed before bench.`,
+      );
+    }
+    return;
+  }
+
+  const total = collections.reduce((n, c) => n + c.active_count, 0);
+  if (collections.length === 0 || total === 0) {
+    throw new Error(
+      "No indexed documents found.\nIndex a collection with 'qmd collection add' / 'qmd update' before running bench.",
+    );
+  }
+}
+
+export function benchSummaryAllZero(
+  summary: BenchmarkResult["summary"],
+): boolean {
+  const entries = Object.values(summary);
+  if (entries.length === 0) return false;
+  return entries.every(s => s.avg_precision === 0 && s.avg_recall === 0 && s.avg_mrr === 0);
+}
+
+export function allZeroBenchWarning(collection?: string): string {
+  const lsHint = collection ? `qmd ls ${collection}` : "qmd ls";
+  return `All benchmark scores were 0.00 — the collection is likely unindexed or the fixture's expected files are missing. Check with '${lsHint}'.`;
+}
+
 export async function runBenchmark(
   fixturePath: string,
-  options: { json?: boolean; collection?: string; backends?: string[]; dbPath?: string; configPath?: string } = {},
+  options: {
+    json?: boolean;
+    collection?: string;
+    backends?: string[];
+    dbPath?: string;
+    configPath?: string;
+    config?: import("../collections.js").CollectionConfig;
+  } = {},
 ): Promise<BenchmarkResult> {
   // Load fixture
   const raw = readFileSync(resolve(fixturePath), "utf-8");
@@ -287,6 +345,7 @@ export async function runBenchmark(
   const store = await createStore({
     dbPath: options.dbPath ?? getDefaultDbPath(),
     ...(options.configPath ? { configPath: options.configPath } : {}),
+    ...(options.config ? { config: options.config } : {}),
   });
 
   // Filter backends if requested
@@ -296,30 +355,35 @@ export async function runBenchmark(
 
   const collection = options.collection ?? fixture.collection;
 
-  // Run queries
   const results: QueryResult[] = [];
-  for (const query of fixture.queries) {
-    const backends: Record<string, BackendResult> = {};
+  try {
+    const collections = await store.listCollections();
+    assertBenchCollectionReady(collections, collection);
 
-    for (const backend of activeBackends) {
-      if (!options.json) {
-        process.stderr.write(`  ${query.id} / ${backend.name}...`);
+    // Run queries
+    for (const query of fixture.queries) {
+      const backends: Record<string, BackendResult> = {};
+
+      for (const backend of activeBackends) {
+        if (!options.json) {
+          process.stderr.write(`  ${query.id} / ${backend.name}...`);
+        }
+        backends[backend.name] = await runQuery(store, backend, query, collection);
+        if (!options.json) {
+          process.stderr.write(` ${Math.round(backends[backend.name]!.latency_ms)}ms\n`);
+        }
       }
-      backends[backend.name] = await runQuery(store, backend, query, collection);
-      if (!options.json) {
-        process.stderr.write(` ${Math.round(backends[backend.name]!.latency_ms)}ms\n`);
-      }
+
+      results.push({
+        id: query.id,
+        query: query.query,
+        type: query.type,
+        backends,
+      });
     }
-
-    results.push({
-      id: query.id,
-      query: query.query,
-      type: query.type,
-      backends,
-    });
+  } finally {
+    await store.close();
   }
-
-  await store.close();
 
   const summary = computeSummary(results);
   const timestamp = new Date().toISOString().replace(/[:.]/g, "").slice(0, 15);
@@ -332,6 +396,10 @@ export async function runBenchmark(
   };
 
   // Output
+  if (benchSummaryAllZero(summary)) {
+    process.stderr.write(`\n${allZeroBenchWarning(collection)}\n`);
+  }
+
   if (options.json) {
     console.log(JSON.stringify(benchResult, null, 2));
   } else {

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -4440,12 +4440,16 @@ if (isMain) {
       }
       const { runBenchmark } = await import("../bench/bench.js");
       const benchCollection = cli.opts.collection;
-      await runBenchmark(fixturePath, {
-        json: !!cli.values.json,
-        collection: Array.isArray(benchCollection) ? benchCollection[0] : benchCollection,
-        dbPath: getDbPath(),
-        configPath: configExists() ? getConfigPath() : undefined,
-      });
+      try {
+        await runBenchmark(fixturePath, {
+          json: !!cli.values.json,
+          collection: Array.isArray(benchCollection) ? benchCollection[0] : benchCollection,
+          dbPath: getDbPath(),
+          configPath: configExists() ? getConfigPath() : undefined,
+        });
+      } catch (error) {
+        exitWithError(error);
+      }
       break;
     }
 

--- a/test/bench-guard.test.ts
+++ b/test/bench-guard.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Bench collection guardrails (#716).
+ *
+ * `qmd bench` used to run every fixture query against a missing/empty
+ * collection and print a wall of 0.00. These tests lock the fail-fast
+ * checks and the all-zero stderr warning.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, writeFile, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeFileSync } from "node:fs";
+import {
+  assertBenchCollectionReady,
+  benchSummaryAllZero,
+  allZeroBenchWarning,
+  runBenchmark,
+} from "../src/bench/bench.js";
+import { createStore } from "../src/index.js";
+
+describe("assertBenchCollectionReady", () => {
+  test("throws when the named collection is missing", () => {
+    expect(() => assertBenchCollectionReady([], "eval-docs")).toThrow(/Collection not found: eval-docs/);
+    expect(() => assertBenchCollectionReady(
+      [{ name: "notes", active_count: 3 }],
+      "eval-docs",
+    )).toThrow(/Available: notes/);
+  });
+
+  test("throws when the named collection has no indexed documents", () => {
+    expect(() => assertBenchCollectionReady(
+      [{ name: "eval-docs", active_count: 0 }],
+      "eval-docs",
+    )).toThrow(/has no indexed documents/);
+  });
+
+  test("throws when no collection is named and nothing is indexed", () => {
+    expect(() => assertBenchCollectionReady([])).toThrow(/No indexed documents found/);
+    expect(() => assertBenchCollectionReady(
+      [{ name: "notes", active_count: 0 }],
+    )).toThrow(/No indexed documents found/);
+  });
+
+  test("allows a named collection that has documents", () => {
+    expect(() => assertBenchCollectionReady(
+      [{ name: "eval-docs", active_count: 6 }],
+      "eval-docs",
+    )).not.toThrow();
+  });
+
+  test("allows an unnamed bench when any collection has documents", () => {
+    expect(() => assertBenchCollectionReady(
+      [{ name: "notes", active_count: 2 }],
+    )).not.toThrow();
+  });
+});
+
+describe("benchSummaryAllZero", () => {
+  const zero = {
+    avg_precision: 0,
+    avg_recall: 0,
+    avg_recall_at_1: 0,
+    avg_recall_at_3: 0,
+    avg_recall_at_5: 0,
+    avg_mrr: 0,
+    avg_f1: 0,
+    avg_latency_ms: 12,
+  };
+
+  test("is true when every backend scored zero", () => {
+    expect(benchSummaryAllZero({ bm25: zero, vector: { ...zero } })).toBe(true);
+  });
+
+  test("is false when any backend has a hit", () => {
+    expect(benchSummaryAllZero({
+      bm25: { ...zero, avg_recall: 0.5, avg_mrr: 1 },
+      vector: zero,
+    })).toBe(false);
+  });
+
+  test("is false for an empty summary", () => {
+    expect(benchSummaryAllZero({})).toBe(false);
+  });
+});
+
+describe("allZeroBenchWarning", () => {
+  test("points at qmd ls for the fixture collection", () => {
+    expect(allZeroBenchWarning("eval-docs")).toContain("qmd ls eval-docs");
+    expect(allZeroBenchWarning()).toContain("qmd ls");
+  });
+});
+
+describe("runBenchmark collection guard", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "qmd-bench-guard-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  function writeFixture(collection: string, query = "API versioning", expected = "api.md") {
+    const fixturePath = join(dir, "fixture.json");
+    writeFileSync(fixturePath, JSON.stringify({
+      description: "guardrail fixture",
+      version: 1,
+      collection,
+      queries: [{
+        id: "exact-api",
+        query,
+        type: "exact",
+        description: "keyword",
+        expected_files: [expected],
+        expected_in_top_k: 1,
+      }],
+    }));
+    return fixturePath;
+  }
+
+  test("errors before searching when the fixture collection does not exist", async () => {
+    const fixturePath = writeFixture("eval-docs");
+    const dbPath = join(dir, "index.sqlite");
+    await expect(runBenchmark(fixturePath, {
+      json: true,
+      dbPath,
+      backends: ["bm25"],
+      config: { collections: { notes: { path: dir, pattern: "**/*.md" } } },
+    })).rejects.toThrow(/Collection not found: eval-docs/);
+  });
+
+  test("errors before searching when the collection exists but has no documents", async () => {
+    const docs = join(dir, "docs");
+    await mkdir(docs, { recursive: true });
+    const fixturePath = writeFixture("docs");
+    const dbPath = join(dir, "index.sqlite");
+    await expect(runBenchmark(fixturePath, {
+      json: true,
+      dbPath,
+      backends: ["bm25"],
+      config: { collections: { docs: { path: docs, pattern: "**/*.md" } } },
+    })).rejects.toThrow(/has no indexed documents/);
+  });
+
+  test("runs bm25 against an indexed collection", async () => {
+    const docs = join(dir, "docs");
+    await mkdir(docs, { recursive: true });
+    await writeFile(join(docs, "api.md"), "# API versioning\n\nUse /v1 and /v2 endpoints.\n");
+    const dbPath = join(dir, "index.sqlite");
+    const config = { collections: { docs: { path: docs, pattern: "**/*.md" } } };
+    const store = await createStore({ dbPath, config });
+    await store.update();
+    await store.close();
+
+    const fixturePath = writeFixture("docs", "API versioning", "api.md");
+    const stderr: string[] = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array, ...rest: unknown[]) => {
+      stderr.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString());
+      return origWrite(chunk as string, ...(rest as []));
+    }) as typeof process.stderr.write;
+    try {
+      const result = await runBenchmark(fixturePath, {
+        json: true,
+        dbPath,
+        backends: ["bm25"],
+        config,
+      });
+      expect(result.summary.bm25?.avg_recall).toBeGreaterThan(0);
+      expect(stderr.join("")).not.toContain("All benchmark scores were 0.00");
+    } finally {
+      process.stderr.write = origWrite;
+    }
+  });
+
+  test("warns on stderr when every backend scores zero", async () => {
+    const docs = join(dir, "docs");
+    await mkdir(docs, { recursive: true });
+    await writeFile(join(docs, "api.md"), "# API versioning\n\nUse /v1 and /v2 endpoints.\n");
+    const dbPath = join(dir, "index.sqlite");
+    const config = { collections: { docs: { path: docs, pattern: "**/*.md" } } };
+    const store = await createStore({ dbPath, config });
+    await store.update();
+    await store.close();
+
+    const fixturePath = writeFixture("docs", "zzzz-no-such-token-in-corpus", "missing.md");
+    const stderr: string[] = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array, ...rest: unknown[]) => {
+      stderr.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString());
+      return origWrite(chunk as string, ...(rest as []));
+    }) as typeof process.stderr.write;
+    try {
+      const result = await runBenchmark(fixturePath, {
+        json: true,
+        dbPath,
+        backends: ["bm25"],
+        config,
+      });
+      expect(result.summary.bm25?.avg_recall).toBe(0);
+      expect(stderr.join("")).toContain("All benchmark scores were 0.00");
+      expect(stderr.join("")).toContain("qmd ls docs");
+    } finally {
+      process.stderr.write = origWrite;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- `qmd bench` now errors up front when the fixture collection is missing or has no indexed documents, matching `qmd search -c <missing>` instead of running every query to a wall of `0.00` (#716).
- If every backend still scores zero, warn on stderr and point at `qmd ls` so an unindexed corpus is obvious.
- Per-command `--help` and shipping the example fixture are left for a follow-up; this is just the silent-failure bug.

## Test plan
- [x] `CI=true bun test --timeout 60000 --preload ./src/test-preload.ts test/bench-guard.test.ts`
- [x] `CI=true node ./node_modules/vitest/vitest.mjs run --testTimeout 60000 test/bench-guard.test.ts`
- [x] Full `test/` unit suite: Node 1040 pass / Bun 1040 pass