### PR TITLE
fix(update): warn when indexing skips unreadable files (#460)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@
 
 ### Fixed
 
+- `qmd update` / `qmd collection add` no longer swallow unreadable files
+  silently (#460). `readFileSync` failures (ETIMEDOUT on APFS compressed
+  files, EAGAIN, EACCES, …) still skip the file so the rest of the collection
+  indexes, but the CLI now warns with the path and error code and reports
+  the skip count. The SDK `update()` result includes `skipped`.
+
 - The architecture diagram no longer draws Vec expansions into BM25 search
   (#680). `lex` expansions are FTS-only; `vec` and `hyde` expansions are
   vector-only. The original query still goes to both backends.

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -763,6 +763,7 @@ async function updateCollections(): Promise<void> {
 
     progress.clear();
     console.log(`\nIndexed: ${result.indexed} new, ${result.updated} updated, ${result.unchanged} unchanged, ${result.removed} removed`);
+    reportSkippedReads(result.skippedFiles);
     if (result.orphanedCleaned > 0) {
       console.log(`Cleaned up ${result.orphanedCleaned} orphaned content hash(es)`);
     }
@@ -1715,6 +1716,7 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
   }
 
   let indexed = 0, updated = 0, unchanged = 0, processed = 0;
+  const skippedFiles: { file: string; code: string }[] = [];
   const seenPaths = new Set<string>();
   // Literal paths of every file in this scan. Passed to the legacy-path
   // migration so it never adopts a row that still belongs to a live file.
@@ -1730,9 +1732,10 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
     let content: string;
     try {
       content = readFileSync(filepath, "utf-8");
-    } catch {
-      // Skip files that can't be read (e.g. iCloud evicted files returning EAGAIN)
+    } catch (err) {
+      // Skip files that can't be read (ETIMEDOUT, EAGAIN, EACCES, …) (#460)
       processed++;
+      skippedFiles.push({ file: relativeFile, code: fsErrorCode(err) });
       progress.set((processed / total) * 100);
       continue;
     }
@@ -1803,6 +1806,7 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
 
   progress.clear();
   console.log(`\nIndexed: ${indexed} new, ${updated} updated, ${unchanged} unchanged, ${removed} removed`);
+  reportSkippedReads(skippedFiles);
   if (orphanedContent > 0) {
     console.log(`Cleaned up ${orphanedContent} orphaned content hash(es)`);
   }
@@ -1812,6 +1816,22 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
   }
 
   closeDb();
+}
+
+function fsErrorCode(err: unknown): string {
+  if (err && typeof err === "object" && "code" in err) {
+    const code = (err as { code: unknown }).code;
+    if (typeof code === "string" && code.length > 0) return code;
+  }
+  return "ERROR";
+}
+
+function reportSkippedReads(skippedFiles: { file: string; code: string }[]): void {
+  if (skippedFiles.length === 0) return;
+  for (const skipped of skippedFiles) {
+    console.warn(`⚠ Skipped unreadable file: ${skipped.file} (${skipped.code})`);
+  }
+  console.warn(`Skipped ${skippedFiles.length} unreadable file(s)`);
 }
 
 function renderProgressBar(percent: number, width: number = 30): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,7 @@ export type UpdateResult = {
   updated: number;
   unchanged: number;
   removed: number;
+  skipped: number;
   needsEmbedding: number;
 };
 
@@ -502,7 +503,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
 
       internal.clearCache();
 
-      let totalIndexed = 0, totalUpdated = 0, totalUnchanged = 0, totalRemoved = 0;
+      let totalIndexed = 0, totalUpdated = 0, totalUnchanged = 0, totalRemoved = 0, totalSkipped = 0;
 
       for (const col of filtered) {
         const result = await reindexCollection(internal, col.path, col.pattern || "**/*.md", col.name, {
@@ -515,6 +516,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
         totalUpdated += result.updated;
         totalUnchanged += result.unchanged;
         totalRemoved += result.removed;
+        totalSkipped += result.skipped;
       }
 
       return {
@@ -523,6 +525,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
         updated: totalUpdated,
         unchanged: totalUnchanged,
         removed: totalRemoved,
+        skipped: totalSkipped,
         needsEmbedding: internal.getHashesNeedingEmbedding(),
       };
     },

--- a/src/store.ts
+++ b/src/store.ts
@@ -1490,10 +1490,23 @@ export type Store = {
 // Reindex & Embed — pure-logic functions for SDK and CLI
 // =============================================================================
 
+function fsErrorCode(err: unknown): string {
+  if (err && typeof err === "object" && "code" in err) {
+    const code = (err as { code: unknown }).code;
+    if (typeof code === "string" && code.length > 0) return code;
+  }
+  return "ERROR";
+}
+
 export type ReindexProgress = {
   file: string;
   current: number;
   total: number;
+};
+
+export type ReindexSkippedFile = {
+  file: string;
+  code: string;
 };
 
 export type ReindexResult = {
@@ -1502,6 +1515,8 @@ export type ReindexResult = {
   unchanged: number;
   removed: number;
   orphanedCleaned: number;
+  skipped: number;
+  skippedFiles: ReindexSkippedFile[];
 };
 
 /**
@@ -1541,6 +1556,7 @@ export async function reindexCollection(
 
   const total = files.length;
   let indexed = 0, updated = 0, unchanged = 0, processed = 0;
+  const skippedFiles: ReindexSkippedFile[] = [];
   const seenPaths = new Set<string>();
   // Literal paths of every file in this scan. Passed to the legacy-path
   // migration so it never adopts a row that still belongs to a live file.
@@ -1557,8 +1573,12 @@ export async function reindexCollection(
     let content: string;
     try {
       content = readFileSync(filepath, "utf-8");
-    } catch {
+    } catch (err) {
+      // Skip files that can't be read (ETIMEDOUT on APFS compressed files,
+      // EAGAIN on iCloud evicted files, EACCES, etc.) instead of aborting
+      // the rest of the collection (#460).
       processed++;
+      skippedFiles.push({ file: relativeFile, code: fsErrorCode(err) });
       options?.onProgress?.({ file: relativeFile, current: processed, total });
       continue;
     }
@@ -1613,7 +1633,7 @@ export async function reindexCollection(
 
   const orphanedCleaned = cleanupOrphanedContent(db);
 
-  return { indexed, updated, unchanged, removed, orphanedCleaned };
+  return { indexed, updated, unchanged, removed, orphanedCleaned, skipped: skippedFiles.length, skippedFiles };
 }
 
 export type EmbedFailure = {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -617,6 +617,42 @@ describe("CLI Add Command", () => {
     expect(stdout).toContain("Indexed: 2 new");
   });
 
+  test("warns and continues when a file is unreadable (#460)", async () => {
+    const env = await createIsolatedTestEnv("skip-unreadable");
+    const collectionDir = join(testDir, `skip-unreadable-${testCounter}`);
+    await mkdir(collectionDir, { recursive: true });
+    const goodPath = join(collectionDir, "good.md");
+    const badPath = join(collectionDir, "bad.md");
+    await writeFile(goodPath, "alpha\n");
+    await writeFile(badPath, "bravo\n");
+    await chmod(badPath, 0o000);
+
+    try {
+      let stillReadable = false;
+      try {
+        readFileSync(badPath, "utf-8");
+        stillReadable = true;
+      } catch {
+        stillReadable = false;
+      }
+      if (stillReadable) return;
+
+      const { stdout, stderr, exitCode } = await runQmd(
+        ["collection", "add", collectionDir, "--name", "skip-unreadable"],
+        { dbPath: env.dbPath, configDir: env.configDir, cwd: collectionDir },
+      );
+      if (exitCode !== 0) {
+        console.error("Command failed:", stderr);
+      }
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("Indexed: 1 new");
+      expect(stderr).toMatch(/Skipped unreadable file: bad\.md \((?:EACCES|EPERM)\)/);
+      expect(stderr).toContain("Skipped 1 unreadable file(s)");
+    } finally {
+      try { await chmod(badPath, 0o644); } catch { /* restore so cleanup can unlink */ }
+    }
+  });
+
   test("can recreate collection with remove and add", async () => {
     // First add
     await runQmd(["collection", "add", "."]);

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -849,6 +849,7 @@ describe("update", () => {
     expect(result.updated).toBe(0);
     expect(result.unchanged).toBe(0);
     expect(result.removed).toBe(0);
+    expect(result.skipped).toBe(0);
     expect(typeof result.needsEmbedding).toBe("number");
 
     await store.close();

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -9,7 +9,7 @@
 import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
 import { openDatabase, loadSqliteVec } from "../src/db.js";
 import type { Database } from "../src/db.js";
-import { unlink, mkdtemp, rmdir, writeFile, rm, mkdir, rename } from "node:fs/promises";
+import { unlink, mkdtemp, rmdir, writeFile, rm, mkdir, rename, chmod, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import YAML from "yaml";
@@ -2822,6 +2822,48 @@ describe("Reindex Collection", () => {
       SELECT path FROM documents WHERE collection = ? AND active = 1 ORDER BY path
     `).all(collectionName) as { path: string }[];
     expect(paths.map(r => r.path)).toEqual(["X - b.md", "a.md"]);
+  });
+
+  test("skips unreadable files and reports the error code (#460)", async () => {
+    const store = await createTestStore();
+    const collectionName = "skip-unreadable";
+    const collectionPath = join(testDir, `skip-unreadable-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(collectionPath, { recursive: true });
+    const goodPath = join(collectionPath, "good.md");
+    const badPath = join(collectionPath, "bad.md");
+    await writeFile(goodPath, "# Good\n\nreadable body\n");
+    await writeFile(badPath, "# Bad\n\nunreadable body\n");
+    await chmod(badPath, 0o000);
+
+    try {
+      let stillReadable = false;
+      try {
+        await readFile(badPath, "utf-8");
+        stillReadable = true;
+      } catch {
+        stillReadable = false;
+      }
+      if (stillReadable) {
+        // Windows / root: mode bits are not enforced, so this repro cannot run.
+        return;
+      }
+
+      const result = await reindexCollection(store, collectionPath, "**/*.md", collectionName);
+      expect(result.indexed).toBe(1);
+      expect(result.skipped).toBe(1);
+      expect(result.skippedFiles).toHaveLength(1);
+      expect(result.skippedFiles[0]!.file).toBe("bad.md");
+      expect(["EACCES", "EPERM"]).toContain(result.skippedFiles[0]!.code);
+
+      const paths = store.db.prepare(`
+        SELECT path FROM documents WHERE collection = ? AND active = 1 ORDER BY path
+      `).all(collectionName) as { path: string }[];
+      expect(paths.map(r => r.path)).toEqual(["good.md"]);
+    } finally {
+      try { await chmod(badPath, 0o644); } catch { /* already restored / missing */ }
+      await rm(collectionPath, { recursive: true, force: true });
+      await cleanupTestDb(store);
+    }
   });
 
   test("treats a case-only rename as a new identity on a case-sensitive collection", async () => {


### PR DESCRIPTION
## Summary
- `qmd update` / `qmd collection add` already continued past `readFileSync` failures (ETIMEDOUT on APFS compressed files, EAGAIN, EACCES) so one bad file would not abort the collection, but the skip was silent (#460).
- The CLI now warns with the path and error code and reports the skip count. `reindexCollection` returns `skipped` / `skippedFiles`; SDK `update()` includes `skipped`.

## Test plan
- [x] `CI=true bun test --timeout 60000 --preload ./src/test-preload.ts test/store.test.ts test/cli.test.ts test/sdk.test.ts -t "unreadable|#460|indexes files and returns correct stats"`
- [x] Same filter on Node/vitest
- [x] Full `test/` unit suite: Bun 1043 pass / Node 1043 pass