### PR TITLE
fix(bin): spawn process.execPath so native addons match install ABI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@
 
 ### Fixed
 
+- The `bin/qmd` trampoline now execs `process.execPath` instead of
+  re-resolving `node` from PATH. Native addons (`better-sqlite3`) are
+  compiled for the Node that installed qmd; a version manager (nvm, fnm,
+  mise) selecting a different major in the working directory used to spawn
+  that other binary and fail with `NODE_MODULE_VERSION` / `ERR_DLOPEN_FAILED`
+  (#577 leftover; #319). `bun bin/qmd` still resolves `node` from PATH so
+  Node-ABI addons are not loaded into bun.
+
 - `qmd update` / `qmd collection add` no longer swallow unreadable files
   silently (#460). `readFileSync` failures (ETIMEDOUT on APFS compressed
   files, EAGAIN, EACCES, …) still skip the file so the rest of the collection

--- a/bin/qmd
+++ b/bin/qmd
@@ -159,7 +159,16 @@ if (existsSync(resolve(pkgDir, "package-lock.json"))) {
   runnerName = "node";
 }
 
-const runner = useSourceMode ? sourceRunner : (runnerName === "node" ? "node" : "bun");
+const selected = useSourceMode ? sourceRunner : (runnerName === "node" ? "node" : "bun");
+// Pin Node to the binary that launched this trampoline. Native addons
+// (better-sqlite3) are compiled for that install's ABI; spawning PATH
+// `node` picks up nvm/fnm/mise shims in the project directory and fails
+// with NODE_MODULE_VERSION / ERR_DLOPEN_FAILED (leftover from #577; #319).
+// If the trampoline itself is running under bun (`bun bin/qmd`), keep
+// PATH `node` so we don't load Node-ABI addons into bun.
+const runner = selected === "node" && typeof process.versions.bun !== "string"
+  ? process.execPath
+  : selected;
 const args = useSourceMode ? sourceArgs : [jsEntry, ...process.argv.slice(2)];
 const needsShell = (runner === "bun") && process.platform === "win32";
 

--- a/test/bin-wrapper.test.ts
+++ b/test/bin-wrapper.test.ts
@@ -8,6 +8,19 @@ import { fileURLToPath } from "node:url";
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 const fixtures: string[] = [];
 
+// Shebang-forward for bin/qmd must exec a real Node binary, not bun.
+// `bun test` sets process.execPath to bun; interpolating that would run the
+// trampoline under bun and hit the PATH-`node` fallback, which is the
+// opposite of the NODE_MODULE_VERSION case this suite pins.
+function realNodeExecPath(): string {
+  if (typeof process.versions.bun !== "string") return process.execPath;
+  const result = spawnSync("node", ["-p", "process.execPath"], { encoding: "utf8" });
+  const resolved = result.stdout?.trim();
+  if (result.status === 0 && resolved) return resolved;
+  return "node";
+}
+const REAL_NODE = realNodeExecPath();
+
 function makeTempFixture() {
   const root = mkdtempSync(join(tmpdir(), "qmd-bin-wrapper-"));
   fixtures.push(root);
@@ -18,18 +31,18 @@ function makeTempFixture() {
   for (const runtime of ["node", "bun"]) {
     const runtimePath = join(runtimeBin, runtime);
     if (runtime === "node") {
+      // Shebang of bin/qmd is `#!/usr/bin/env node`, so PATH `node` must
+      // still launch the trampoline. The trampoline itself must NOT
+      // re-resolve `node` from PATH for the child (#577 leftover): that
+      // is the NODE_MODULE_VERSION bug. Exit 42 if it does.
       writeFileSync(
         runtimePath,
         `#!/bin/sh
 if [ "$(basename "$1")" = "qmd" ]; then
-  exec "${process.execPath}" "$@"
+  exec "${REAL_NODE}" "$@"
 else
-  {
-    printf '%s\\n' 'node'
-    printf '%s\\n' "$1"
-    shift
-    printf '%s\\n' "$@"
-  } > "$QMD_WRAPPER_CAPTURE"
+  echo "qmd launcher must not re-resolve node from PATH" >&2
+  exit 42
 fi
 `,
       );
@@ -53,7 +66,17 @@ function makePackage(root: string, packagePath: string, lockfiles: string[] = []
   chmodSync(join(packageRoot, "bin", "qmd"), 0o755);
   if (includeDist) {
     mkdirSync(join(packageRoot, "dist", "cli"), { recursive: true });
-    writeFileSync(join(packageRoot, "dist", "cli", "qmd.js"), "// fixture\n");
+    writeFileSync(
+      join(packageRoot, "dist", "cli", "qmd.js"),
+      [
+        'const { writeFileSync } = require("node:fs");',
+        'const capture = process.env.QMD_WRAPPER_CAPTURE;',
+        'if (capture) {',
+        '  writeFileSync(capture, ["node", process.argv[1], ...process.argv.slice(2)].join("\\n") + "\\n");',
+        '}',
+        '',
+      ].join("\n"),
+    );
   }
   if (options.source) {
     mkdirSync(join(packageRoot, "src", "cli"), { recursive: true });
@@ -61,7 +84,17 @@ function makePackage(root: string, packagePath: string, lockfiles: string[] = []
   }
   if (options.tsx) {
     mkdirSync(join(packageRoot, "node_modules", "tsx", "dist"), { recursive: true });
-    writeFileSync(join(packageRoot, "node_modules", "tsx", "dist", "cli.mjs"), "// tsx fixture\n");
+    writeFileSync(
+      join(packageRoot, "node_modules", "tsx", "dist", "cli.mjs"),
+      [
+        'import { writeFileSync } from "node:fs";',
+        'const capture = process.env.QMD_WRAPPER_CAPTURE;',
+        'if (capture) {',
+        '  writeFileSync(capture, ["node", process.argv[1], ...process.argv.slice(2)].join("\\n") + "\\n");',
+        '}',
+        '',
+      ].join("\n"),
+    );
   }
   if (options.git) {
     mkdirSync(join(packageRoot, ".git"), { recursive: true });
@@ -264,6 +297,17 @@ describe("bin/qmd package wrapper", () => {
     expect(result.runtime).toBe("node");
     expect(result.scriptPath).toBe(realpathSync(join(packageRoot, "node_modules", "tsx", "dist", "cli.mjs")));
     expect(result.args).toEqual([realpathSync(join(packageRoot, "src", "cli", "qmd.ts")), "--version"]);
+  });
+
+  test("node child uses process.execPath, not a different PATH node (#577 leftover)", () => {
+    const { root, runtimeBin, capturePath } = makeTempFixture();
+    const packageRoot = makePackage(root, "node_modules/@tobilu/qmd");
+
+    const result = runWrapper(join(packageRoot, "bin", "qmd"), runtimeBin, capturePath);
+
+    expect(result.runtime).toBe("node");
+    expect(result.scriptPath).toBe(realpathSync(join(packageRoot, "dist", "cli", "qmd.js")));
+    expect(result.args).toEqual(["--version"]);
   });
 
   test("explains how to build when dist is missing and source cannot run", () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2971,17 +2971,23 @@ describe("mcp stdio launcher", () => {
     try {
       await mkdir(join(tempPackage, "bin"), { recursive: true });
       await mkdir(join(tempPackage, "dist", "cli"), { recursive: true });
-      await writeFile(join(tempPackage, "dist", "cli", "qmd.js"), "// fixture\n");
+      await writeFile(join(tempPackage, "dist", "cli", "qmd.js"), [
+        'if (process.env.GGML_BACKEND_SILENT !== "1") {',
+        '  process.stdout.write("llama.cpp native log on stdout\\n");',
+        '}',
+        'process.stdout.write(\'{"jsonrpc":"2.0","id":1,"result":{"ok":true}}\\n\');',
+        '',
+      ].join("\n"));
       await mkdir(join(tempPackage, "fake-bin"), { recursive: true });
 
       const qmdBin = join(tempPackage, "bin", "qmd");
       await copyFile(join(projectRoot, "bin", "qmd"), qmdBin);
       await chmod(qmdBin, 0o755);
 
-      // Force the wrapper down the Node branch, then put our fake `node` first
-      // in PATH. The fake node behaves like the native llama/ggml layer: it
-      // writes a non-JSON stdout line unless qmd pre-seeded the documented
-      // quiet env vars before launching JS.
+      // Force the wrapper down the Node branch. The trampoline now execs
+      // process.execPath (not PATH `node`) so the dist fixture is the child
+      // that observes the quiet env. Fake PATH `node` remains only to satisfy
+      // `#!/usr/bin/env node` and the bun-test fallback (`bun bin/qmd`).
       await writeFile(join(tempPackage, "package-lock.json"), "{}\n");
       const fakeNode = join(tempPackage, "fake-bin", "node");
       await writeFile(fakeNode, `#!/bin/sh


### PR DESCRIPTION
## Summary
- Leftover from #577: `bin/qmd` already runs as Node, but it still spawned PATH `node` for the CLI child. Native addons (`better-sqlite3`) are compiled for the Node that installed qmd; nvm/fnm/mise selecting a different major in the working directory then failed with `NODE_MODULE_VERSION` / `ERR_DLOPEN_FAILED`.
- Spawn `process.execPath` instead. `bun bin/qmd` still resolves `node` from PATH so Node-ABI addons are not loaded into bun.
- Wrapper tests now fail if PATH `node` is used as the child; the MCP stdio quiet-env check observes the real execPath child.

## Test plan
- [x] `bun test test/bin-wrapper.test.ts` (16 pass)
- [x] `node vitest run test/bin-wrapper.test.ts` (16 pass)
- [x] `bash test/launcher-detection.test.sh` (10 pass)
- [x] `node vitest run test/cli.test.ts` (166 pass), including MCP quiet-env
- [x] `bun test test/cli.test.ts -t "quiet env"`
- [ ] CI Bun/Node unit jobs green