### PR TITLE
fix(cli): honor --glob as an alias for collection add --mask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@
 
 ### Fixed
 
+- `qmd collection add --glob` is no longer silently ignored. parseArgs ran
+  with `strict: false`, so OpenClaw's `--glob memory.md` (and any other
+  `--glob`) fell through, the default `**/*.md` was used, and a second
+  collection on the same path collided as a duplicate instead of indexing
+  the requested mask (#536). `--glob` is now an alias for `--mask`.
+
 - The `bin/qmd` trampoline now execs `process.execPath` instead of
   re-resolving `node` from PATH. Native addons (`better-sqlite3`) are
   compiled for the Node that installed qmd; a version manager (nvm, fnm,

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -1584,6 +1584,13 @@ function collectionList(): void {
   closeDb();
 }
 
+/** Canonical --mask, with --glob as the alias OpenClaw and others already pass (#536). */
+function collectionGlobFromCli(values: { mask?: unknown; glob?: unknown }): string {
+  const mask = typeof values.mask === "string" && values.mask.length > 0 ? values.mask : undefined;
+  const glob = typeof values.glob === "string" && values.glob.length > 0 ? values.glob : undefined;
+  return mask ?? glob ?? DEFAULT_GLOB;
+}
+
 async function collectionAdd(pwd: string, globPattern: string, name?: string): Promise<void> {
   // If name not provided, generate from pwd basename
   let collName = name;
@@ -2797,6 +2804,7 @@ function parseCLI() {
       // Collection options
       name: { type: "string" },  // collection name
       mask: { type: "string" },  // glob pattern
+      glob: { type: "string" },  // alias for --mask (OpenClaw / #536)
       // Embed options
       force: { type: "boolean", short: "f" },
       "max-docs-per-batch": { type: "string" },
@@ -4201,11 +4209,11 @@ if (isMain) {
           if (!pwd) {
             console.error("Usage: qmd collection add <path> [--name NAME] [--mask GLOB]");
             console.error("  Pass '.' to index the current directory.");
-            console.error("  --mask: glob (default **/*.md), brace group, or comma-separated list");
+            console.error("  --mask / --glob: glob (default **/*.md), brace group, or comma-separated list");
             process.exit(1);
           }
           const resolvedPwd = pwd === '.' ? getPwd() : getRealPath(resolve(pwd));
-          const globPattern = cli.values.mask as string || DEFAULT_GLOB;
+          const globPattern = collectionGlobFromCli(cli.values);
           const name = cli.values.name as string | undefined;
 
           if (!existsSync(resolvedPwd)) {
@@ -4328,7 +4336,7 @@ if (isMain) {
           console.log("");
           console.log("Commands:");
           console.log("  list                      List all collections");
-          console.log("  add <path> [--name NAME] [--mask GLOB]  Add a collection");
+          console.log("  add <path> [--name NAME] [--mask|--glob GLOB]  Add a collection");
           console.log("  remove <name>             Remove a collection");
           console.log("  rename <old> <new>        Rename a collection");
           console.log("  show <name>               Show collection details");

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -580,6 +580,40 @@ describe("CLI Add Command", () => {
     expect(stdout).toContain("notes/*.md");
   });
 
+  test("accepts --glob as an alias for --mask so same-path collections do not collide (#536)", async () => {
+    const env = await createIsolatedTestEnv("glob-alias");
+    const collectionDir = join(testDir, `glob-alias-${testCounter}`);
+    await mkdir(collectionDir, { recursive: true });
+    await writeFile(join(collectionDir, "MEMORY.md"), "root memory\n");
+    await writeFile(join(collectionDir, "memory.md"), "alt memory\n");
+    await writeFile(join(collectionDir, "other.md"), "other\n");
+
+    const root = await runQmd(
+      ["collection", "add", collectionDir, "--name", "memory-root"],
+      { dbPath: env.dbPath, configDir: env.configDir, cwd: collectionDir },
+    );
+    expect(root.exitCode).toBe(0);
+
+    const alt = await runQmd(
+      ["collection", "add", collectionDir, "--name", "memory-alt", "--glob", "memory.md"],
+      { dbPath: env.dbPath, configDir: env.configDir, cwd: collectionDir },
+    );
+    if (alt.exitCode !== 0) {
+      console.error("Command failed:", alt.stderr);
+    }
+    expect(alt.exitCode).toBe(0);
+    expect(alt.stderr).not.toContain("already exists for this path and pattern");
+    expect(alt.stdout).toContain("memory.md");
+
+    const list = await runQmd(["collection", "list"], {
+      dbPath: env.dbPath,
+      configDir: env.configDir,
+    });
+    expect(list.stdout).toContain("memory-root");
+    expect(list.stdout).toContain("memory-alt");
+    expect(list.stdout).toContain("memory.md");
+  });
+
   test("indexes comma-separated --mask patterns as a union (#557)", async () => {
     const env = await createIsolatedTestEnv("comma-mask");
     const collectionDir = join(testDir, `comma-mask-${testCounter}`);


### PR DESCRIPTION
## Summary
- `qmd collection add --glob` was silently ignored (`parseArgs` `strict: false`), so OpenClaw's `--glob memory.md` fell through to the default `**/*.md`. A second collection on the same path then collided as a duplicate instead of indexing the requested mask (#536).
- `--glob` is now an alias for `--mask`. Same-path collections with different globs work as already designed.

## Test plan
- [x] `CI=true bun test --timeout 60000 --preload ./src/test-preload.ts test/cli.test.ts -t "CLI Add Command"` (11 pass)
- [x] `CI=true node ./node_modules/vitest/vitest.mjs run --testTimeout 60000 test/cli.test.ts -t "CLI Add Command"` (11 pass)
- [ ] CI Bun/Node green