### PR TITLE
fix(store): repair leftover FTS name column before CJK rebuild DELETE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@
 
 ### Fixed
 
+- CJK FTS rebuild no longer skips leftover `fts5(name, body, content='documents')`
+  tables when `fts_cjk_normalized_version` is already stamped, and schema
+  repair now checks live FTS columns (`PRAGMA table_info`) as well as
+  `sqlite_master.sql`. The MCP HTTP test helper still seeds that legacy
+  table; `startMcpHttpServer` / `createStore` on it must not throw
+  `no such column: T.name` (#792 regression).
+
 - `qmd collection add --glob` is no longer silently ignored. parseArgs ran
   with `strict: false`, so OpenClaw's `--glob memory.md` (and any other
   `--glob`) fell through, the default `**/*.md` was used, and a second

--- a/src/store.ts
+++ b/src/store.ts
@@ -956,13 +956,30 @@ function applyFtsSyncTriggers(db: Database): void {
  * then runs `DELETE FROM documents_fts`, which FTS5 compiles against the
  * external content table as `SELECT T.name FROM documents AS T` — documents
  * has no `name` column, so open throws `no such column: T.name` (#792).
+ *
+ * sqlite_master.sql is the usual signal, but PRAGMA table_info is the live
+ * virtual-table schema: a leftover `name` column with no `filepath` is never
+ * current, even if CREATE IF NOT EXISTS rewrote the sql text.
  */
+function documentsFtsColumnNames(db: Database): string[] {
+  try {
+    const cols = db.prepare(`PRAGMA table_info(documents_fts)`).all() as { name?: string }[];
+    return cols.map(c => (c.name ?? "").toLowerCase()).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
 function documentsFtsSchemaIsCurrent(db: Database): boolean {
   const row = db.prepare(
     `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'documents_fts'`
   ).get() as { sql?: string } | undefined | null;
   const sql = (row?.sql ?? "").toLowerCase().replace(/\s+/g, "");
-  return sql.includes("filepath") && sql.includes("title") && !sql.includes("content=");
+  if (!sql.includes("filepath") || !sql.includes("title") || sql.includes("content=")) {
+    return false;
+  }
+  const names = new Set(documentsFtsColumnNames(db));
+  return names.has("filepath") && names.has("title") && names.has("body") && !names.has("name");
 }
 
 function recreateDocumentsFts(db: Database): void {
@@ -1004,6 +1021,11 @@ function dropTableIfExists(db: Database, tableName: string): void {
 }
 
 function rebuildFTSForCjkNormalization(db: Database): void {
+  // Repair leftover content-external FTS *before* the version check or the
+  // later `DELETE FROM documents_fts`. A stamped CJK version with a legacy
+  // `name` column would otherwise skip the rebuild, and DELETE still compiles
+  // as SELECT T.name FROM documents (#792).
+  ensureDocumentsFtsSchema(db);
   if (cjkRebuildVersion(db) === FTS_CJK_NORMALIZED_VERSION) return;
 
   // Clean up the legacy fixed-name shadow table left by an interrupted older

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -934,7 +934,7 @@ describe("MCP Server", () => {
 // =============================================================================
 
 import { startMcpHttpServer, type HttpServerHandle } from "../src/mcp/server";
-import { enableProductionMode } from "../src/store";
+import { _resetProductionModeForTesting } from "../src/store";
 
 describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
   let handle: HttpServerHandle;
@@ -1200,6 +1200,69 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
       expect(newSid).not.toBe(sid);
     } finally {
       await ttlHandle.stop();
+    }
+  });
+});
+
+
+// =============================================================================
+// HTTP Transport — CI-visible legacy FTS open (#792)
+// =============================================================================
+//
+// The suite above is skipIf(CI) because query tests load models. The original
+// #792 failure was in that suite's beforeAll: initTestDatabase still creates
+// fts5(name, body, content='documents'), then startMcpHttpServer -> createStore
+// -> rebuildFTSForCjkNormalization ran DELETE FROM documents_fts and threw
+// `no such column: T.name`. Keep this helper seed and assert open succeeds
+// even when CI=true.
+
+describe("MCP HTTP Transport — legacy FTS seed (#792)", () => {
+  test("startMcpHttpServer opens a DB seeded like the MCP helper (name/body + content='documents')", async () => {
+    const origIndexPath = process.env.INDEX_PATH;
+    const origConfigDir = process.env.QMD_CONFIG_DIR;
+    const dbPath = `/tmp/qmd-mcp-http-legacy-fts-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`;
+    let configDir: string | undefined;
+    let handle: HttpServerHandle | undefined;
+
+    try {
+      const db = openDatabase(dbPath);
+      initTestDatabase(db);
+      seedTestData(db);
+      const testConfig: CollectionConfig = {
+        collections: {
+          docs: { path: "/test/docs", pattern: "**/*.md" },
+        },
+      };
+      syncConfigToDb(db, testConfig);
+      db.close();
+
+      const configPrefix = join(tmpdir(), `qmd-mcp-http-legacy-config-${Date.now()}-`);
+      configDir = await mkdtemp(configPrefix);
+      await writeFile(join(configDir, "index.yml"), YAML.stringify(testConfig));
+
+      process.env.INDEX_PATH = dbPath;
+      process.env.QMD_CONFIG_DIR = configDir;
+
+      handle = await startMcpHttpServer(0, { quiet: true, dbPath });
+      const res = await fetch(`http://localhost:${handle.port}/health`);
+      expect(res.status).toBe(200);
+      const body = await res.json() as { status?: string };
+      expect(body.status).toBe("ok");
+    } finally {
+      if (handle) await handle.stop();
+      _resetProductionModeForTesting();
+      if (origIndexPath !== undefined) process.env.INDEX_PATH = origIndexPath;
+      else delete process.env.INDEX_PATH;
+      if (origConfigDir !== undefined) process.env.QMD_CONFIG_DIR = origConfigDir;
+      else delete process.env.QMD_CONFIG_DIR;
+      try { unlinkSync(dbPath); } catch {}
+      if (configDir) {
+        try {
+          const files = await readdir(configDir);
+          for (const f of files) await unlink(join(configDir, f));
+          await rmdir(configDir);
+        } catch {}
+      }
     }
   });
 });

--- a/test/store-cjk-fts.test.ts
+++ b/test/store-cjk-fts.test.ts
@@ -193,6 +193,14 @@ describe("rebuildFTSForCjkNormalization — bounded source scan", () => {
     // 3.25+ re-validation of dependent trigger bodies).
     expect(fnBody).toContain("documents_fts_rebuild");
     expect(fnBody).toContain("INSERT INTO documents_fts");
+    // DELETE FROM documents_fts on leftover content-external FTS compiles as
+    // SELECT T.name FROM documents (#792). Repair must run inside this
+    // function *before* that DELETE (and before the version-stamp early
+    // return), not only in initializeDatabase.
+    const ensureIdx = fnBody.indexOf("ensureDocumentsFtsSchema");
+    const deleteIdx = fnBody.indexOf("DELETE FROM documents_fts");
+    expect(ensureIdx).toBeGreaterThan(-1);
+    expect(deleteIdx).toBeGreaterThan(ensureIdx);
   });
 });
 
@@ -644,6 +652,79 @@ describe("rebuildFTSForCjkNormalization — legacy external-content FTS schema (
       expect(ver?.value).toBe(FTS_CJK_NORMALIZED_VERSION);
 
       const hits = store.searchFTS("UNIQUE_KEYWORD_XYZ", 10, "docs");
+      expect(hits.length).toBe(1);
+      expect(hits[0]!.displayPath).toBe("docs/readme.md");
+    } finally {
+      store.close();
+    }
+  });
+
+  test("repairs leftover name/body FTS even when the CJK version is already stamped", async () => {
+    {
+      const seed = openDatabase(dbPath);
+      seed.exec(`
+        CREATE TABLE IF NOT EXISTS content (
+          hash TEXT PRIMARY KEY,
+          doc TEXT NOT NULL,
+          created_at TEXT NOT NULL
+        )
+      `);
+      seed.exec(`
+        CREATE TABLE IF NOT EXISTS documents (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          collection TEXT NOT NULL,
+          path TEXT NOT NULL,
+          title TEXT NOT NULL,
+          hash TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          modified_at TEXT NOT NULL,
+          active INTEGER NOT NULL DEFAULT 1,
+          FOREIGN KEY (hash) REFERENCES content(hash) ON DELETE CASCADE,
+          UNIQUE(collection, path)
+        )
+      `);
+      seed.exec(`
+        CREATE TABLE IF NOT EXISTS store_config (
+          key TEXT PRIMARY KEY,
+          value TEXT
+        )
+      `);
+      seed.exec(`
+        CREATE VIRTUAL TABLE documents_fts USING fts5(
+          name, body,
+          content='documents',
+          content_rowid='id',
+          tokenize='porter unicode61'
+        )
+      `);
+      seed.prepare(`
+        INSERT INTO store_config(key, value) VALUES ('fts_cjk_normalized_version', ?)
+      `).run(FTS_CJK_NORMALIZED_VERSION);
+      seedDocument(seed, {
+        id: 1,
+        collection: "docs",
+        path: "readme.md",
+        title: "Project README",
+        body: "stamped-legacy canary STAMPED_LEGACY_XYZ",
+      });
+      seed.close();
+    }
+
+    const store = createStore(dbPath);
+    try {
+      const sqlRow = store.db.prepare(
+        `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'documents_fts'`
+      ).get() as { sql?: string } | undefined;
+      const sql = (sqlRow?.sql ?? "").toLowerCase();
+      expect(sql).toContain("filepath");
+      expect(sql).not.toMatch(/content\s*=/);
+
+      const cols = store.db.prepare(`PRAGMA table_info(documents_fts)`).all() as { name: string }[];
+      const names = cols.map(c => c.name);
+      expect(names).toContain("filepath");
+      expect(names).not.toContain("name");
+
+      const hits = store.searchFTS("STAMPED_LEGACY_XYZ", 10, "docs");
       expect(hits.length).toBe(1);
       expect(hits[0]!.displayPath).toBe("docs/readme.md");
     } finally {


### PR DESCRIPTION
## Summary
- `rebuildFTSForCjkNormalization` now repairs leftover `fts5(name, body, content='documents')` *before* the CJK version-stamp early return and before `DELETE FROM documents_fts`. A stamped version with a leftover `name` column used to skip rebuild; that DELETE still compiles as `SELECT T.name FROM documents` (#792 regression).
- Schema detection also checks live FTS columns via `PRAGMA table_info`, not only `sqlite_master.sql`.
- CI-visible coverage: legacy FTS seed (including a pre-stamped CJK version) plus `startMcpHttpServer` against the MCP helper's `name`/`body` table. The existing HTTP suite remains `skipIf(CI)`.

Fixes #792 (follow-up to #849).

## Test plan
- [x] `bun test test/store-cjk-fts.test.ts` (9 pass, including stamped-legacy leftover schema)
- [x] `node ./node_modules/vitest/vitest.mjs run test/store-cjk-fts.test.ts` (9 pass)
- [x] `CI=true bun test test/mcp.test.ts -t "legacy FTS seed"` (pass; original HTTP suite skipped)
- [x] `CI=true node ./node_modules/vitest/vitest.mjs run test/mcp.test.ts -t "legacy FTS seed"` (pass)
- [x] `CI=true bun test test/` (1047 pass, 0 fail)
- [x] `CI=true node ./node_modules/vitest/vitest.mjs run test/` (1047 pass, 0 fail)
- [ ] CI Bun/Node unit tests green (ignore pre-existing nix flake hash mismatches)