### PR TITLE
fix(nix): update qmd-node-modules FOD hashes after MCP SDK 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@
 
 ### Fixed
 
+- Nix flake `qmd-node-modules` FOD hashes updated for x86_64-linux and
+  aarch64-darwin after the MCP SDK 2.0 bump. `nix build` / Nix GHA was
+  failing with a fixed-output hash mismatch.
+
 - CJK FTS rebuild no longer skips leftover `fts5(name, body, content='documents')`
   tables when `fts_cjk_normalized_version` is already stamped, and schema
   repair now checks live FTS columns (`PRAGMA table_info`) as well as

--- a/flake.nix
+++ b/flake.nix
@@ -44,8 +44,8 @@
         });
 
         nodeModulesHashes = {
-          x86_64-linux = "sha256-sVXoNWIcx1RYRtRWB4F2j7x8/cabFBKq+plFhPU7tBc=";
-          aarch64-darwin = "sha256-gDyJ5boyH44SeXlKo+W4G36GSUejyXP5PFvW+dFS1Mk=";
+          x86_64-linux = "sha256-QRXhhDPPLZiZbD4MfmjlVvLtXCShEEmybwsyoEqEbu0=";
+          aarch64-darwin = "sha256-9J1FLCSrSsSfIt3ULaeU4jU3UHRtMJ3+NdwHeH4xFUM=";
 
           # Populate these on first build for additional hosts if/when needed.
           aarch64-linux = pkgs.lib.fakeHash;


### PR DESCRIPTION
## Summary
- Nix GHA on main (and #883) failed with a fixed-output hash mismatch for `qmd-node-modules-2.6.3` after the MCP SDK 2.0 bump.
- Updated `nodeModulesHashes` in `flake.nix`:
  - x86_64-linux: `sha256-QRXhhDPPLZiZbD4MfmjlVvLtXCShEEmybwsyoEqEbu0=`
  - aarch64-darwin: `sha256-9J1FLCSrSsSfIt3ULaeU4jU3UHRtMJ3+NdwHeH4xFUM=` (same GHA job, second platform)
- CHANGELOG Unreleased note. No TS/JS change. No release.

## Test plan
- [x] Hashes taken from the failing Nix GHA `got:` lines on `f82c674` (ubuntu-latest + macos-latest)
- [ ] Nix GHA `build-flake` green on this PR (merge gate)
- [ ] Test workflow still green (no source change; expected)