### PR TITLE
fix(mcp): validate Origin and Host on the HTTP transport (DNS rebinding)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### Security
+
+- `qmd mcp --http` now validates the `Origin` and `Host` headers on every
+  request and answers `403` when they name anything but a loopback address
+  (#881). Without this, any web page the user visited could re-point its own
+  hostname at `127.0.0.1` (DNS rebinding) and read the entire indexed corpus
+  through `POST /query` or `POST /mcp` — binding to localhost is no defence
+  against a request made by the user's own browser. Requests with no `Origin`
+  header (curl, MCP clients, editors) are unaffected. Extend the allowlists with
+  `QMD_ALLOWED_ORIGINS` / `QMD_ALLOWED_HOSTS`, or set `QMD_ALLOWED_ORIGINS=*`
+  to opt out behind your own authenticating proxy. A wildcard bind
+  (`--host 0.0.0.0`) skips the host check, since the legitimate `Host` is then
+  unknowable, and warns at startup.
+
 ### Changed
 
 - `qmd pull` (and implicit model downloads in `embed`/`query`) no longer print

--- a/README.md
+++ b/README.md
@@ -153,6 +153,28 @@ The HTTP server exposes two endpoints:
 - `POST /mcp` — MCP Streamable HTTP (JSON responses, stateless)
 - `GET /health` — liveness check with uptime
 
+##### Origin and Host validation
+
+Every request is screened before routing: a request carrying an `Origin` header
+that does not name a loopback address is rejected with `403`, as is a `Host`
+header naming something other than the address the server is bound to. This is
+what stops a web page you visit from reading your index through DNS rebinding —
+loopback binding alone does not, since the browser makes the request from your
+own machine.
+
+Requests without an `Origin` header — curl, MCP clients, editors — are
+unaffected, which covers every normal local client.
+
+| Variable | Effect |
+|----------|--------|
+| `QMD_ALLOWED_ORIGINS` | Comma-separated origins to accept in addition to loopback, e.g. `https://notes.internal`. Set to `*` to disable the check entirely. |
+| `QMD_ALLOWED_HOSTS` | Comma-separated `Host` values to accept in addition to loopback and the bind address. |
+
+`--host 0.0.0.0` cannot know which `Host` values are legitimate, so it skips the
+host check and warns at startup. Set `QMD_ALLOWED_HOSTS` to re-enable it, and
+remember the endpoints are unauthenticated — put your own auth in front of a
+server that is reachable off-host.
+
 LLM models stay loaded in VRAM across requests. Embedding/reranking contexts are disposed after 5 min idle and transparently recreated on the next request (~1s penalty, models remain loaded).
 
 Point any MCP client at `http://localhost:8181/mcp` to connect.

--- a/src/mcp/origin-guard.ts
+++ b/src/mcp/origin-guard.ts
@@ -1,0 +1,167 @@
+/**
+ * origin-guard.ts — DNS-rebinding protection for the HTTP MCP transport.
+ *
+ * Binding to localhost keeps *remote* clients out, but it does not keep a web
+ * page out. A page served from `attacker.example` can re-point that hostname at
+ * `127.0.0.1` after load (DNS rebinding); the browser then treats
+ * `http://attacker.example:8181` as same-origin with the page and hands the
+ * response body to attacker JavaScript. The only server-side signal that
+ * distinguishes such a request from a legitimate local client is the `Origin`
+ * and `Host` headers, so the MCP spec requires local HTTP servers to validate
+ * them.
+ *
+ * The predicates here are pure so they can be unit-tested without a socket;
+ * `startMcpHttpServer` applies them to every request before routing.
+ */
+
+/** Wildcard bind addresses — the request's legitimate `Host` is unknowable. */
+const WILDCARD_BIND_HOSTS = new Set(["", "0.0.0.0", "::", "[::]", "*"]);
+
+/**
+ * Hostnames that resolve to this machine's loopback interface.
+ *
+ * `0.0.0.0` is deliberately excluded: browsers happily route it to loopback on
+ * Linux and macOS, which makes it a rebinding-free path to local servers, so an
+ * `Origin: http://0.0.0.0:8181` is treated as untrusted like any other.
+ */
+export function isLoopbackHostname(hostname: string): boolean {
+  const h = hostname.trim().toLowerCase().replace(/^\[|\]$/g, "");
+  if (h === "localhost" || h.endsWith(".localhost")) return true;
+  if (h === "::1" || h === "0:0:0:0:0:0:0:1") return true;
+  // IPv4-mapped IPv6 (::ffff:127.0.0.1) and the whole 127.0.0.0/8 range.
+  const v4 = h.startsWith("::ffff:") ? h.slice(7) : h;
+  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(v4);
+}
+
+/** Parse an `Origin` header into its hostname, or undefined if unusable. */
+function originHostname(origin: string): string | undefined {
+  try {
+    const url = new URL(origin.trim());
+    if (url.protocol !== "http:" && url.protocol !== "https:") return undefined;
+    return url.hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Normalize an origin for comparison against the allowlist. */
+function normalizeOrigin(origin: string): string | undefined {
+  try {
+    return new URL(origin.trim()).origin.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+/** Parse a `Host` header (`name`, `name:port`, `[::1]:port`) into a hostname. */
+function hostHeaderHostname(host: string): string | undefined {
+  try {
+    return new URL(`http://${host.trim()}`).hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+export type OriginGuard = {
+  /** All checks disabled (`QMD_ALLOWED_ORIGINS=*`). */
+  disabled: boolean;
+  /** Extra origins accepted beyond the loopback defaults, normalized. */
+  allowedOrigins: string[];
+  /** Extra `Host` values accepted beyond the loopback defaults, lowercased. */
+  allowedHosts: string[];
+  /** Whether the `Host` header is checked at all — see `resolveOriginGuard`. */
+  enforceHost: boolean;
+};
+
+function splitList(value: string | undefined): string[] {
+  if (!value) return [];
+  return value.split(",").map(v => v.trim()).filter(v => v.length > 0);
+}
+
+/**
+ * Build the guard for a server bound to `host`.
+ *
+ * `Host` validation is enforced whenever the bind address names a concrete
+ * interface, since the legitimate `Host` header is then known (loopback, or the
+ * bind address itself). For a wildcard bind — `--host 0.0.0.0`, e.g. Docker —
+ * any of the container's names may legitimately appear, so the check is only
+ * enforced when the operator supplies an explicit allowlist. `Origin`
+ * validation always applies; browsers are the threat, and they always send it.
+ */
+export function resolveOriginGuard(options: {
+  host: string;
+  allowedOrigins?: string[];
+  allowedHosts?: string[];
+  env?: NodeJS.ProcessEnv;
+}): OriginGuard {
+  const env = options.env ?? process.env;
+  const rawOrigins = options.allowedOrigins ?? splitList(env.QMD_ALLOWED_ORIGINS);
+  const rawHosts = options.allowedHosts ?? splitList(env.QMD_ALLOWED_HOSTS);
+
+  if (rawOrigins.includes("*")) {
+    return { disabled: true, allowedOrigins: [], allowedHosts: [], enforceHost: false };
+  }
+
+  const allowedOrigins = rawOrigins
+    .map(o => normalizeOrigin(o))
+    .filter((o): o is string => o !== undefined);
+  const allowedHosts = rawHosts.map(h => h.toLowerCase());
+
+  const bindHost = options.host.trim().toLowerCase();
+  const isWildcardBind = WILDCARD_BIND_HOSTS.has(bindHost);
+  if (!isWildcardBind && !isLoopbackHostname(bindHost)) {
+    // Explicit non-loopback interface: its own address is a legitimate Host.
+    allowedHosts.push(bindHost);
+  }
+
+  return {
+    disabled: false,
+    allowedOrigins,
+    allowedHosts,
+    enforceHost: !isWildcardBind || allowedHosts.length > 0,
+  };
+}
+
+export type GuardVerdict = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Validate a request's `Origin` and `Host` headers against the guard.
+ *
+ * A missing `Origin` is allowed: non-browser clients (curl, the MCP SDK's HTTP
+ * client, editors) omit it, and browsers cannot. The header is the signal that
+ * a request came from page JavaScript, so its *absence* is not suspicious while
+ * a foreign *value* is conclusive.
+ */
+export function checkRequestOrigin(
+  headers: { origin?: string | undefined; host?: string | undefined },
+  guard: OriginGuard,
+): GuardVerdict {
+  if (guard.disabled) return { ok: true };
+
+  const origin = headers.origin?.trim();
+  if (origin) {
+    const normalized = normalizeOrigin(origin);
+    const hostname = originHostname(origin);
+    const allowed =
+      (hostname !== undefined && isLoopbackHostname(hostname)) ||
+      (normalized !== undefined && guard.allowedOrigins.includes(normalized));
+    if (!allowed) {
+      return { ok: false, reason: `Origin not allowed: ${origin}` };
+    }
+  }
+
+  const host = headers.host?.trim();
+  if (guard.enforceHost && host) {
+    const lowered = host.toLowerCase();
+    const hostname = hostHeaderHostname(host);
+    const allowed =
+      (hostname !== undefined && isLoopbackHostname(hostname)) ||
+      guard.allowedHosts.includes(lowered) ||
+      (hostname !== undefined && guard.allowedHosts.includes(hostname.toLowerCase()));
+    if (!allowed) {
+      return { ok: false, reason: `Host not allowed: ${host}` };
+    }
+  }
+
+  return { ok: true };
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -31,6 +31,7 @@ import {
 } from "../index.js";
 import { getConfigPath } from "../collections.js";
 import { enableProductionMode } from "../store.js";
+import { checkRequestOrigin, resolveOriginGuard } from "./origin-guard.js";
 
 // =============================================================================
 // Types for structured content
@@ -859,6 +860,11 @@ function resolveSessionTtlMs(sessionTtlSeconds?: number): number {
  * env var) — set "0.0.0.0" to accept connections from other hosts, e.g. a
  * container liveness probe. Returns a handle for shutdown and port discovery.
  *
+ * Every request is screened for DNS rebinding before routing: a foreign
+ * `Origin` (or, on a concrete bind address, a foreign `Host`) is rejected with
+ * 403. See origin-guard.ts; extend the allowlists with QMD_ALLOWED_ORIGINS /
+ * QMD_ALLOWED_HOSTS, or set QMD_ALLOWED_ORIGINS=* to opt out.
+ *
  * Sessions idle for longer than the TTL (default 1 hour; see
  * `resolveSessionTtlMs`) are closed by a background reaper. Ephemeral clients
  * that connect once and never come back — agents, cron jobs, health probes —
@@ -869,7 +875,13 @@ function resolveSessionTtlMs(sessionTtlSeconds?: number): number {
  */
 export async function startMcpHttpServer(
   port: number,
-  options: ({ quiet?: boolean; host?: string; sessionTtlSeconds?: number } & McpStartupOptions) = {},
+  options: ({
+    quiet?: boolean;
+    host?: string;
+    sessionTtlSeconds?: number;
+    allowedOrigins?: string[];
+    allowedHosts?: string[];
+  } & McpStartupOptions) = {},
 ): Promise<HttpServerHandle> {
   // See startMcpServer() for the rationale — flip production mode here so the
   // HTTP transport resolves the real database path, without leaking state into
@@ -986,11 +998,35 @@ export async function startMcpHttpServer(
     return Buffer.concat(chunks).toString();
   }
 
+  const host = options.host ?? process.env.QMD_HOST ?? "localhost";
+  const originGuard = resolveOriginGuard({
+    host,
+    ...(options.allowedOrigins ? { allowedOrigins: options.allowedOrigins } : {}),
+    ...(options.allowedHosts ? { allowedHosts: options.allowedHosts } : {}),
+  });
+
   const httpServer = createServer(async (nodeReq: IncomingMessage, nodeRes: ServerResponse) => {
     const reqStart = Date.now();
     const pathname = nodeReq.url || "/";
 
     try {
+      // DNS-rebinding screen, ahead of routing so the REST endpoints are
+      // covered too — they bypass the MCP transport entirely.
+      const verdict = checkRequestOrigin(
+        { origin: nodeReq.headers.origin, host: nodeReq.headers.host },
+        originGuard,
+      );
+      if (!verdict.ok) {
+        nodeRes.writeHead(403, { "Content-Type": "application/json" });
+        nodeRes.end(JSON.stringify({
+          jsonrpc: "2.0",
+          error: { code: -32003, message: `Forbidden: ${verdict.reason}` },
+          id: null,
+        }));
+        log(`${ts()} ${nodeReq.method} ${pathname} 403 — ${verdict.reason}`);
+        return;
+      }
+
       if (pathname === "/health" && nodeReq.method === "GET") {
         const body = JSON.stringify({ status: "ok", uptime: Math.floor((Date.now() - startTime) / 1000) });
         nodeRes.writeHead(200, { "Content-Type": "application/json" });
@@ -1152,7 +1188,6 @@ export async function startMcpHttpServer(
     }
   });
 
-  const host = options.host ?? process.env.QMD_HOST ?? "localhost";
   await new Promise<void>((resolve, reject) => {
     httpServer.on("error", reject);
     httpServer.listen(port, host, () => resolve());
@@ -1187,6 +1222,11 @@ export async function startMcpHttpServer(
   });
 
   log(`QMD MCP server listening on http://${host}:${actualPort}/mcp`);
+  if (originGuard.disabled) {
+    log("Warning: QMD_ALLOWED_ORIGINS=* — DNS-rebinding protection is off. Only do this behind your own authenticating proxy.");
+  } else if (!originGuard.enforceHost) {
+    log(`Warning: bound to ${host} with no QMD_ALLOWED_HOSTS — Host validation is off and the index is readable by anyone who can reach this port.`);
+  }
   return { httpServer, port: actualPort, stop };
 }
 

--- a/test/mcp-origin-guard.test.ts
+++ b/test/mcp-origin-guard.test.ts
@@ -1,0 +1,298 @@
+/**
+ * DNS-rebinding protection for the HTTP MCP transport (#881).
+ *
+ * The predicate tests run everywhere; the live-server tests boot a real
+ * `startMcpHttpServer` on an ephemeral port and drive it with spoofed headers.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import YAML from "yaml";
+import {
+  checkRequestOrigin,
+  isLoopbackHostname,
+  resolveOriginGuard,
+} from "../src/mcp/origin-guard.js";
+import { openDatabase } from "../src/db.js";
+import type { CollectionConfig } from "../src/collections.js";
+
+// =============================================================================
+// Predicates
+// =============================================================================
+
+describe("isLoopbackHostname", () => {
+  test.each([
+    "localhost",
+    "LOCALHOST",
+    "app.localhost",
+    "127.0.0.1",
+    "127.1.2.3",
+    "::1",
+    "[::1]",
+    "::ffff:127.0.0.1",
+  ])("accepts %s", (hostname) => {
+    expect(isLoopbackHostname(hostname)).toBe(true);
+  });
+
+  test.each([
+    "evil.example",
+    "notlocalhost",
+    "localhost.evil.example",
+    "127.0.0.1.evil.example",
+    "10.0.0.1",
+    "::2",
+  ])("rejects %s", (hostname) => {
+    expect(isLoopbackHostname(hostname)).toBe(false);
+  });
+
+  // 0.0.0.0 routes to loopback in browsers on Linux/macOS, which makes it a
+  // rebinding-free path to a local server — so it is not a trusted origin.
+  test("rejects 0.0.0.0", () => {
+    expect(isLoopbackHostname("0.0.0.0")).toBe(false);
+  });
+});
+
+describe("resolveOriginGuard", () => {
+  const env = {} as NodeJS.ProcessEnv;
+
+  test("loopback bind enforces the Host header", () => {
+    const guard = resolveOriginGuard({ host: "localhost", env });
+    expect(guard.disabled).toBe(false);
+    expect(guard.enforceHost).toBe(true);
+  });
+
+  test("wildcard bind without an allowlist skips Host enforcement", () => {
+    const guard = resolveOriginGuard({ host: "0.0.0.0", env });
+    expect(guard.enforceHost).toBe(false);
+  });
+
+  test("wildcard bind with an explicit allowlist enforces Host", () => {
+    const guard = resolveOriginGuard({ host: "0.0.0.0", allowedHosts: ["qmd.internal"], env });
+    expect(guard.enforceHost).toBe(true);
+    expect(guard.allowedHosts).toContain("qmd.internal");
+  });
+
+  test("a concrete non-loopback bind trusts its own address", () => {
+    const guard = resolveOriginGuard({ host: "192.168.1.5", env });
+    expect(guard.enforceHost).toBe(true);
+    expect(guard.allowedHosts).toContain("192.168.1.5");
+  });
+
+  test("QMD_ALLOWED_ORIGINS=* disables every check", () => {
+    const guard = resolveOriginGuard({ host: "localhost", env: { QMD_ALLOWED_ORIGINS: "*" } });
+    expect(guard.disabled).toBe(true);
+    expect(checkRequestOrigin({ origin: "https://evil.example", host: "evil.example" }, guard).ok).toBe(true);
+  });
+
+  test("reads comma-separated allowlists from the environment", () => {
+    const guard = resolveOriginGuard({
+      host: "localhost",
+      env: {
+        QMD_ALLOWED_ORIGINS: "https://notes.internal , https://app.internal",
+        QMD_ALLOWED_HOSTS: "notes.internal",
+      },
+    });
+    expect(guard.allowedOrigins).toEqual(["https://notes.internal", "https://app.internal"]);
+    expect(guard.allowedHosts).toEqual(["notes.internal"]);
+  });
+});
+
+describe("checkRequestOrigin", () => {
+  const guard = resolveOriginGuard({ host: "localhost", env: {} as NodeJS.ProcessEnv });
+
+  test("allows a request with no Origin header (curl, MCP clients)", () => {
+    expect(checkRequestOrigin({ host: "localhost:8181" }, guard).ok).toBe(true);
+  });
+
+  test("allows loopback origins", () => {
+    for (const origin of ["http://localhost:8181", "http://127.0.0.1:8181", "http://[::1]:8181"]) {
+      expect(checkRequestOrigin({ origin, host: "localhost:8181" }, guard).ok).toBe(true);
+    }
+  });
+
+  test("rejects a foreign Origin", () => {
+    const verdict = checkRequestOrigin({ origin: "https://evil.example", host: "localhost:8181" }, guard);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.ok === false && verdict.reason).toContain("Origin not allowed");
+  });
+
+  test("rejects a rebound Host even when Origin is absent", () => {
+    const verdict = checkRequestOrigin({ host: "evil.example:8181" }, guard);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.ok === false && verdict.reason).toContain("Host not allowed");
+  });
+
+  test("rejects an origin that merely embeds a loopback name", () => {
+    expect(checkRequestOrigin({ origin: "https://localhost.evil.example" }, guard).ok).toBe(false);
+    expect(checkRequestOrigin({ origin: "https://evil.example#localhost" }, guard).ok).toBe(false);
+  });
+
+  test("rejects the opaque null origin from sandboxed frames", () => {
+    expect(checkRequestOrigin({ origin: "null", host: "localhost:8181" }, guard).ok).toBe(false);
+  });
+
+  test("rejects non-http schemes", () => {
+    expect(checkRequestOrigin({ origin: "file://", host: "localhost:8181" }, guard).ok).toBe(false);
+  });
+
+  test("honours an explicit origin allowlist", () => {
+    const allowing = resolveOriginGuard({
+      host: "localhost",
+      allowedOrigins: ["https://notes.internal"],
+      allowedHosts: ["notes.internal"],
+      env: {} as NodeJS.ProcessEnv,
+    });
+    expect(checkRequestOrigin({ origin: "https://notes.internal", host: "notes.internal" }, allowing).ok).toBe(true);
+    expect(checkRequestOrigin({ origin: "https://other.internal", host: "notes.internal" }, allowing).ok).toBe(false);
+  });
+
+  test("skips Host validation on a wildcard bind but still screens Origin", () => {
+    const docker = resolveOriginGuard({ host: "0.0.0.0", env: {} as NodeJS.ProcessEnv });
+    expect(checkRequestOrigin({ host: "qmd-container:8181" }, docker).ok).toBe(true);
+    expect(checkRequestOrigin({ origin: "https://evil.example", host: "qmd-container:8181" }, docker).ok).toBe(false);
+  });
+});
+
+// =============================================================================
+// Live server
+// =============================================================================
+
+describe.skipIf(!!process.env.CI)("MCP HTTP server rejects cross-origin requests", () => {
+  let handle: import("../src/mcp/server.js").HttpServerHandle;
+  let baseUrl: string;
+  let workDir: string;
+  let configDir: string;
+  const origIndexPath = process.env.INDEX_PATH;
+  const origConfigDir = process.env.QMD_CONFIG_DIR;
+
+  beforeAll(async () => {
+    workDir = mkdtempSync(join(tmpdir(), "qmd-origin-"));
+    const dbPath = join(workDir, "index.sqlite");
+
+    const { createStore } = await import("../src/store.js");
+    createStore(dbPath).close();
+
+    const db = openDatabase(dbPath);
+    const now = new Date().toISOString();
+    db.prepare(`INSERT OR IGNORE INTO content (hash, doc, created_at) VALUES (?, ?, ?)`)
+      .run("hash-secret", "# Secrets\n\nThe recovery password is hunter2.\n", now);
+    db.prepare(
+      `INSERT INTO documents (collection, path, title, hash, created_at, modified_at, active) VALUES ('docs', ?, ?, ?, ?, ?, 1)`,
+    ).run("secrets.md", "Secrets", "hash-secret", now, now);
+
+    const config: CollectionConfig = {
+      collections: { docs: { path: workDir, pattern: "**/*.md" } },
+    };
+    const { syncConfigToDb } = await import("../src/store.js");
+    syncConfigToDb(db, config);
+    db.close();
+
+    configDir = mkdtempSync(join(tmpdir(), "qmd-origin-cfg-"));
+    writeFileSync(join(configDir, "index.yml"), YAML.stringify(config));
+
+    process.env.INDEX_PATH = dbPath;
+    process.env.QMD_CONFIG_DIR = configDir;
+
+    const { startMcpHttpServer } = await import("../src/mcp/server.js");
+    handle = await startMcpHttpServer(0, { quiet: true });
+    baseUrl = `http://localhost:${handle.port}`;
+  });
+
+  afterAll(async () => {
+    await handle?.stop();
+    if (origIndexPath !== undefined) process.env.INDEX_PATH = origIndexPath;
+    else delete process.env.INDEX_PATH;
+    if (origConfigDir !== undefined) process.env.QMD_CONFIG_DIR = origConfigDir;
+    else delete process.env.QMD_CONFIG_DIR;
+    for (const dir of [workDir, configDir]) {
+      // Best effort: Windows keeps the SQLite WAL handles briefly after close.
+      try { if (dir) rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+
+  const searchBody = JSON.stringify({ searches: [{ type: "lex", query: "password" }], rerank: false });
+
+  test("POST /query leaks nothing to a foreign origin", async () => {
+    const res = await fetch(`${baseUrl}/query`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Origin: "https://evil.example" },
+      body: searchBody,
+    });
+    expect(res.status).toBe(403);
+    const text = await res.text();
+    expect(text).not.toContain("hunter2");
+    expect(text).toContain("Origin not allowed");
+  });
+
+  test("POST /search is screened too", async () => {
+    const res = await fetch(`${baseUrl}/search`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Origin: "https://evil.example" },
+      body: searchBody,
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("POST /mcp initialize is rejected from a foreign origin", async () => {
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Origin: "https://evil.example",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "evil", version: "1" } },
+      }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("a rebound Host header is rejected without an Origin", async () => {
+    // fetch() forbids setting Host, so drive a raw socket for this one.
+    const { request } = await import("node:http");
+    const status = await new Promise<number>((resolve, reject) => {
+      const req = request(
+        {
+          hostname: "localhost",
+          port: handle.port,
+          path: "/query",
+          method: "POST",
+          headers: { "Content-Type": "application/json", Host: "evil.example", "Content-Length": Buffer.byteLength(searchBody) },
+        },
+        (res) => {
+          res.resume();
+          resolve(res.statusCode ?? 0);
+        },
+      );
+      req.on("error", reject);
+      req.end(searchBody);
+    });
+    expect(status).toBe(403);
+  });
+
+  test("local clients still work", async () => {
+    const noOrigin = await fetch(`${baseUrl}/query`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: searchBody,
+    });
+    expect(noOrigin.status).toBe(200);
+    expect(await noOrigin.text()).toContain("hunter2");
+
+    const loopbackOrigin = await fetch(`${baseUrl}/query`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Origin: `http://localhost:${handle.port}` },
+      body: searchBody,
+    });
+    expect(loopbackOrigin.status).toBe(200);
+
+    const health = await fetch(`${baseUrl}/health`);
+    expect(health.status).toBe(200);
+  });
+});

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -253,7 +253,7 @@ describe("MCP Server", () => {
     };
     await writeFile(join(testConfigDir, "index.yml"), YAML.stringify(testConfig));
 
-    testDbPath = `/tmp/qmd-mcp-test-${Date.now()}.sqlite`;
+    testDbPath = join(tmpdir(), `qmd-mcp-test-${Date.now()}.sqlite`);
     testDb = openDatabase(testDbPath);
     initTestDatabase(testDb);
     seedTestData(testDb);
@@ -947,7 +947,7 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
 
   beforeAll(async () => {
     // Create isolated test database with seeded data
-    httpTestDbPath = `/tmp/qmd-mcp-http-test-${Date.now()}.sqlite`;
+    httpTestDbPath = join(tmpdir(), `qmd-mcp-http-test-${Date.now()}.sqlite`);
     const db = openDatabase(httpTestDbPath);
     initTestDatabase(db);
     seedTestData(db);


### PR DESCRIPTION
Closes #881.

## What was wrong

`startMcpHttpServer` served `POST /mcp`, `POST /query` and `POST /search` without ever looking at `Origin` or `Host`. Binding to `localhost` keeps *remote* clients out; it does nothing about the user's own browser. A page served from `attacker.example` can re-point that hostname at `127.0.0.1` after load — at which point the browser considers `http://attacker.example:8181` same-origin with the page and hands the full response body to attacker JavaScript. Every indexed document, silently, for as long as `qmd mcp --http --daemon` is running.

Verified against `main` before the fix — `Origin: https://evil.example` returned `200` with document snippets from `/query`, and `initialize` succeeded on `/mcp`.

## The fix

The check lives in the `createServer` handler, ahead of routing. That placement matters: the REST endpoints bypass the MCP transport entirely, so the SDK's own `enableDnsRebindingProtection` flag would have covered `/mcp` and left `/query` wide open.

- **`Origin` absent → allowed.** curl, MCP clients and editors omit the header; browsers cannot. Absence is not the signal — a foreign value is. This is what keeps every existing local client working unchanged.
- **`Origin` present → must be loopback** (`localhost`, `*.localhost`, `127.0.0.0/8`, `::1`, `::ffff:127.0.0.1`) or explicitly allowlisted. Otherwise `403`.
- **`Host` enforced when the bind address names a concrete interface.** For a wildcard bind (`--host 0.0.0.0`, the Docker case from #743) the legitimate `Host` is unknowable, so the check is skipped and startup warns; setting `QMD_ALLOWED_HOSTS` re-enables it. A concrete non-loopback bind (`--host 192.168.1.5`) trusts its own address automatically.
- **`0.0.0.0` is not treated as loopback.** Browsers route it to the loopback interface on Linux and macOS, which makes it a rebinding-free path to a local server, so it stays untrusted as an origin.
- **Escape hatches:** `QMD_ALLOWED_ORIGINS` / `QMD_ALLOWED_HOSTS` (comma-separated) extend the allowlists; `QMD_ALLOWED_ORIGINS=*` disables the screen for anyone fronting QMD with their own auth proxy, and warns at startup.

The predicates live in `src/mcp/origin-guard.ts` as pure functions so they are testable without a socket.

## Tests

New `test/mcp-origin-guard.test.ts` — 35 tests, all passing:

- Unit coverage of the hostname/origin/host predicates, including the near-misses that a naive substring check would let through (`localhost.evil.example`, `127.0.0.1.evil.example`, `https://evil.example#localhost`), the opaque `null` origin from sandboxed frames, non-http schemes, and `0.0.0.0`.
- Guard resolution across bind modes: loopback, wildcard, wildcard + allowlist, concrete LAN address, `*`.
- Live-server integration: boots `startMcpHttpServer` on an ephemeral port against a seeded scratch index and asserts `403` (and no leaked document text) for a foreign `Origin` on `/query`, `/search` and `/mcp`; `403` for a rebound `Host` sent over a raw socket, since `fetch()` forbids setting that header; and `200` for the paths that must keep working — no `Origin`, a loopback `Origin`, and `/health`.

Existing MCP HTTP transport tests still pass (`initialize`, `tools/list`, `tools/call get`, absolute line numbers, session TTL, REST URI prefix, `/health`, 404). `tools/call query` is the one test I could not run here — it needs the query-expansion GGUF and the HF CDN 403s mid-download on this machine; it is unrelated to this change.

`tsc -p tsconfig.build.json --noEmit` is clean.

## Drive-by

`test/mcp.test.ts` had two hardcoded `/tmp/...` database paths, which made the whole file fail at `beforeAll` on Windows with `SQLITE_CANTOPEN` — including the HTTP transport block I needed as a regression baseline. Both now use `tmpdir()`. No behaviour change on POSIX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
