### PR TITLE
fix(security): Origin/Host on MCP HTTP + keep index paths inside the collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@
   `~/.config/qmd/*.yml`, including anything `qmd collection update-cmd` writes,
   are unaffected.
 
+- Indexing no longer follows file symlinks or glob `../` / absolute patterns
+  out of the collection directory. `fast-glob` already skipped symlinked
+  directories, but a file symlink (or a mask like `../**/*.md`) still resolved
+  via `realpath` and ingested the target. `qmd://` filesystem resolution uses
+  the same containment check, so `qmd://collection/../../../etc/passwd` no
+  longer produces a path outside the collection.
+
+- `qmd mcp --http` now validates the `Origin` and `Host` headers on every
+  request and answers `403` when they name anything but a loopback address
+  (#881). Binding to localhost is no defence against the user's own browser:
+  a page can re-point its hostname at `127.0.0.1` (DNS rebinding) and read
+  the indexed corpus through `POST /query` or `POST /mcp`. Requests with no
+  `Origin` (curl, MCP clients, editors) are unaffected. Extend the allowlists
+  with `QMD_ALLOWED_ORIGINS` / `QMD_ALLOWED_HOSTS`, or set
+  `QMD_ALLOWED_ORIGINS=*` behind your own authenticating proxy. A wildcard
+  bind (`--host 0.0.0.0`) skips the host check and warns at startup.
+
 ### Changed
 
 - MCP server now speaks protocol revision **2026-07-28** via the official

--- a/README.md
+++ b/README.md
@@ -151,7 +151,31 @@ runs in a container and a liveness probe connects from a non-loopback address.
 
 The HTTP server exposes two endpoints:
 - `POST /mcp` — MCP Streamable HTTP (JSON responses, stateless)
+- `POST /query` (alias `/search`) — structured search without the MCP protocol
 - `GET /health` — liveness check with uptime
+
+
+##### Origin and Host validation
+
+Every request is screened before routing: a request carrying an `Origin` header
+that does not name a loopback address is rejected with `403`, as is a `Host`
+header naming something other than the address the server is bound to. This is
+what stops a web page you visit from reading your index through DNS rebinding —
+loopback binding alone does not, since the browser makes the request from your
+own machine.
+
+Requests without an `Origin` header — curl, MCP clients, editors — are
+unaffected, which covers every normal local client.
+
+| Variable | Effect |
+|----------|--------|
+| `QMD_ALLOWED_ORIGINS` | Comma-separated origins to accept in addition to loopback, e.g. `https://notes.internal`. Set to `*` to disable the check entirely. |
+| `QMD_ALLOWED_HOSTS` | Comma-separated `Host` values to accept in addition to loopback and the bind address. |
+
+`--host 0.0.0.0` cannot know which `Host` values are legitimate, so it skips the
+host check and warns at startup. Set `QMD_ALLOWED_HOSTS` to re-enable it, and
+remember the endpoints are unauthenticated — put your own auth in front of a
+server that is reachable off-host.
 
 LLM models stay loaded in VRAM across requests. Embedding/reranking contexts are disposed after 5 min idle and transparently recreated on the next request (~1s penalty, models remain loaded).
 

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -12,6 +12,7 @@ import { createInterface } from "readline/promises";
 import {
   getPwd,
   getRealPath,
+  isPathInsideDir,
   homedir,
   resolve,
   enableProductionMode,
@@ -1875,6 +1876,12 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
     const filepath = getRealPath(resolve(resolvedPwd, relativeFile));
     // Store the literal relative path — handelize() is NOT applied at index time.
     const path = relativeFile.replace(/\\/g, '/');
+    if (!isPathInsideDir(resolvedPwd, filepath)) {
+      processed++;
+      skippedFiles.push({ file: relativeFile, code: "OUTSIDE_COLLECTION" });
+      progress.set((processed / total) * 100);
+      continue;
+    }
     seenPaths.add(path);
 
     let content: string;
@@ -1977,9 +1984,16 @@ function fsErrorCode(err: unknown): string {
 function reportSkippedReads(skippedFiles: { file: string; code: string }[]): void {
   if (skippedFiles.length === 0) return;
   for (const skipped of skippedFiles) {
-    console.warn(`⚠ Skipped unreadable file: ${skipped.file} (${skipped.code})`);
+    if (skipped.code === "OUTSIDE_COLLECTION") {
+      console.warn(`⚠ Skipped file outside collection: ${skipped.file}`);
+    } else {
+      console.warn(`⚠ Skipped unreadable file: ${skipped.file} (${skipped.code})`);
+    }
   }
-  console.warn(`Skipped ${skippedFiles.length} unreadable file(s)`);
+  const escaped = skippedFiles.filter(f => f.code === "OUTSIDE_COLLECTION").length;
+  const unreadable = skippedFiles.length - escaped;
+  if (escaped) console.warn(`Skipped ${escaped} file(s) outside the collection root`);
+  if (unreadable) console.warn(`Skipped ${unreadable} unreadable file(s)`);
 }
 
 function renderProgressBar(percent: number, width: number = 30): string {

--- a/src/mcp/origin-guard.ts
+++ b/src/mcp/origin-guard.ts
@@ -1,0 +1,167 @@
+/**
+ * origin-guard.ts — DNS-rebinding protection for the HTTP MCP transport.
+ *
+ * Binding to localhost keeps *remote* clients out, but it does not keep a web
+ * page out. A page served from `attacker.example` can re-point that hostname at
+ * `127.0.0.1` after load (DNS rebinding); the browser then treats
+ * `http://attacker.example:8181` as same-origin with the page and hands the
+ * response body to attacker JavaScript. The only server-side signal that
+ * distinguishes such a request from a legitimate local client is the `Origin`
+ * and `Host` headers, so the MCP spec requires local HTTP servers to validate
+ * them.
+ *
+ * The predicates here are pure so they can be unit-tested without a socket;
+ * `startMcpHttpServer` applies them to every request before routing.
+ */
+
+/** Wildcard bind addresses — the request's legitimate `Host` is unknowable. */
+const WILDCARD_BIND_HOSTS = new Set(["", "0.0.0.0", "::", "[::]", "*"]);
+
+/**
+ * Hostnames that resolve to this machine's loopback interface.
+ *
+ * `0.0.0.0` is deliberately excluded: browsers happily route it to loopback on
+ * Linux and macOS, which makes it a rebinding-free path to local servers, so an
+ * `Origin: http://0.0.0.0:8181` is treated as untrusted like any other.
+ */
+export function isLoopbackHostname(hostname: string): boolean {
+  const h = hostname.trim().toLowerCase().replace(/^\[|\]$/g, "");
+  if (h === "localhost" || h.endsWith(".localhost")) return true;
+  if (h === "::1" || h === "0:0:0:0:0:0:0:1") return true;
+  // IPv4-mapped IPv6 (::ffff:127.0.0.1) and the whole 127.0.0.0/8 range.
+  const v4 = h.startsWith("::ffff:") ? h.slice(7) : h;
+  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(v4);
+}
+
+/** Parse an `Origin` header into its hostname, or undefined if unusable. */
+function originHostname(origin: string): string | undefined {
+  try {
+    const url = new URL(origin.trim());
+    if (url.protocol !== "http:" && url.protocol !== "https:") return undefined;
+    return url.hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Normalize an origin for comparison against the allowlist. */
+function normalizeOrigin(origin: string): string | undefined {
+  try {
+    return new URL(origin.trim()).origin.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+/** Parse a `Host` header (`name`, `name:port`, `[::1]:port`) into a hostname. */
+function hostHeaderHostname(host: string): string | undefined {
+  try {
+    return new URL(`http://${host.trim()}`).hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+export type OriginGuard = {
+  /** All checks disabled (`QMD_ALLOWED_ORIGINS=*`). */
+  disabled: boolean;
+  /** Extra origins accepted beyond the loopback defaults, normalized. */
+  allowedOrigins: string[];
+  /** Extra `Host` values accepted beyond the loopback defaults, lowercased. */
+  allowedHosts: string[];
+  /** Whether the `Host` header is checked at all — see `resolveOriginGuard`. */
+  enforceHost: boolean;
+};
+
+function splitList(value: string | undefined): string[] {
+  if (!value) return [];
+  return value.split(",").map(v => v.trim()).filter(v => v.length > 0);
+}
+
+/**
+ * Build the guard for a server bound to `host`.
+ *
+ * `Host` validation is enforced whenever the bind address names a concrete
+ * interface, since the legitimate `Host` header is then known (loopback, or the
+ * bind address itself). For a wildcard bind — `--host 0.0.0.0`, e.g. Docker —
+ * any of the container's names may legitimately appear, so the check is only
+ * enforced when the operator supplies an explicit allowlist. `Origin`
+ * validation always applies; browsers are the threat, and they always send it.
+ */
+export function resolveOriginGuard(options: {
+  host: string;
+  allowedOrigins?: string[];
+  allowedHosts?: string[];
+  env?: NodeJS.ProcessEnv;
+}): OriginGuard {
+  const env = options.env ?? process.env;
+  const rawOrigins = options.allowedOrigins ?? splitList(env.QMD_ALLOWED_ORIGINS);
+  const rawHosts = options.allowedHosts ?? splitList(env.QMD_ALLOWED_HOSTS);
+
+  if (rawOrigins.includes("*")) {
+    return { disabled: true, allowedOrigins: [], allowedHosts: [], enforceHost: false };
+  }
+
+  const allowedOrigins = rawOrigins
+    .map(o => normalizeOrigin(o))
+    .filter((o): o is string => o !== undefined);
+  const allowedHosts = rawHosts.map(h => h.toLowerCase());
+
+  const bindHost = options.host.trim().toLowerCase();
+  const isWildcardBind = WILDCARD_BIND_HOSTS.has(bindHost);
+  if (!isWildcardBind && !isLoopbackHostname(bindHost)) {
+    // Explicit non-loopback interface: its own address is a legitimate Host.
+    allowedHosts.push(bindHost);
+  }
+
+  return {
+    disabled: false,
+    allowedOrigins,
+    allowedHosts,
+    enforceHost: !isWildcardBind || allowedHosts.length > 0,
+  };
+}
+
+export type GuardVerdict = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Validate a request's `Origin` and `Host` headers against the guard.
+ *
+ * A missing `Origin` is allowed: non-browser clients (curl, the MCP SDK's HTTP
+ * client, editors) omit it, and browsers cannot. The header is the signal that
+ * a request came from page JavaScript, so its *absence* is not suspicious while
+ * a foreign *value* is conclusive.
+ */
+export function checkRequestOrigin(
+  headers: { origin?: string | undefined; host?: string | undefined },
+  guard: OriginGuard,
+): GuardVerdict {
+  if (guard.disabled) return { ok: true };
+
+  const origin = headers.origin?.trim();
+  if (origin) {
+    const normalized = normalizeOrigin(origin);
+    const hostname = originHostname(origin);
+    const allowed =
+      (hostname !== undefined && isLoopbackHostname(hostname)) ||
+      (normalized !== undefined && guard.allowedOrigins.includes(normalized));
+    if (!allowed) {
+      return { ok: false, reason: `Origin not allowed: ${origin}` };
+    }
+  }
+
+  const host = headers.host?.trim();
+  if (guard.enforceHost && host) {
+    const lowered = host.toLowerCase();
+    const hostname = hostHeaderHostname(host);
+    const allowed =
+      (hostname !== undefined && isLoopbackHostname(hostname)) ||
+      guard.allowedHosts.includes(lowered) ||
+      (hostname !== undefined && guard.allowedHosts.includes(hostname.toLowerCase()));
+    if (!allowed) {
+      return { ok: false, reason: `Host not allowed: ${host}` };
+    }
+  }
+
+  return { ok: true };
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -28,6 +28,7 @@ import {
 } from "../index.js";
 import { getConfigPath } from "../collections.js";
 import { enableProductionMode } from "../store.js";
+import { checkRequestOrigin, resolveOriginGuard } from "./origin-guard.js";
 
 // =============================================================================
 // Types for structured content
@@ -851,7 +852,7 @@ export type HttpServerHandle = {
  */
 export async function startMcpHttpServer(
   port: number,
-  options: ({ quiet?: boolean; host?: string } & McpStartupOptions) = {},
+  options: ({ quiet?: boolean; host?: string; allowedOrigins?: string[]; allowedHosts?: string[] } & McpStartupOptions) = {},
 ): Promise<HttpServerHandle> {
   // See startMcpServer() for the rationale — flip production mode here so the
   // HTTP transport resolves the real database path, without leaking state into
@@ -935,11 +936,40 @@ export async function startMcpHttpServer(
     return Buffer.concat(chunks).toString();
   }
 
+  const host = options.host ?? process.env.QMD_HOST ?? "localhost";
+  const originGuard = resolveOriginGuard({
+    host,
+    ...(options.allowedOrigins ? { allowedOrigins: options.allowedOrigins } : {}),
+    ...(options.allowedHosts ? { allowedHosts: options.allowedHosts } : {}),
+  });
+
   const httpServer = createServer(async (nodeReq: IncomingMessage, nodeRes: ServerResponse) => {
     const reqStart = Date.now();
-    const pathname = nodeReq.url || "/";
+    const pathname = (nodeReq.url || "/").split("?")[0];
 
     try {
+      // DNS-rebinding screen, ahead of routing so REST /query /search are
+      // covered too — they bypass the MCP transport entirely (#881).
+      const origin = nodeReq.headers.origin;
+      const hostHeader = nodeReq.headers.host;
+      const verdict = checkRequestOrigin(
+        {
+          origin: typeof origin === "string" ? origin : undefined,
+          host: typeof hostHeader === "string" ? hostHeader : undefined,
+        },
+        originGuard,
+      );
+      if (!verdict.ok) {
+        nodeRes.writeHead(403, { "Content-Type": "application/json" });
+        nodeRes.end(JSON.stringify({
+          jsonrpc: "2.0",
+          error: { code: -32003, message: `Forbidden: ${verdict.reason}` },
+          id: null,
+        }));
+        log(`${ts()} ${nodeReq.method} ${pathname} 403 — ${verdict.reason}`);
+        return;
+      }
+
       if (pathname === "/health" && nodeReq.method === "GET") {
         const body = JSON.stringify({ status: "ok", uptime: Math.floor((Date.now() - startTime) / 1000) });
         nodeRes.writeHead(200, { "Content-Type": "application/json" });
@@ -1047,7 +1077,6 @@ export async function startMcpHttpServer(
     }
   });
 
-  const host = options.host ?? process.env.QMD_HOST ?? "localhost";
   await new Promise<void>((resolve, reject) => {
     httpServer.on("error", reject);
     httpServer.listen(port, host, () => resolve());
@@ -1076,6 +1105,11 @@ export async function startMcpHttpServer(
   });
 
   log(`QMD MCP server listening on http://${host}:${actualPort}/mcp`);
+  if (originGuard.disabled) {
+    log("Warning: QMD_ALLOWED_ORIGINS=* — DNS-rebinding protection is off. Only do this behind your own authenticating proxy.");
+  } else if (!originGuard.enforceHost) {
+    log(`Warning: bound to ${host} with no QMD_ALLOWED_HOSTS — Host validation is off and the index is readable by anyone who can reach this port.`);
+  }
   return { httpServer, port: actualPort, stop };
 }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -670,7 +670,15 @@ export function getRealPath(path: string): string {
  * Used to keep indexing and qmd:// filesystem resolution inside a collection.
  */
 export function isPathInsideDir(dir: string, target: string): boolean {
-  return getRelativePathFromPrefix(getRealPath(target), getRealPath(dir)) !== null;
+  const realDir = getRealPath(dir);
+  try {
+    return getRelativePathFromPrefix(realpathSync(target), realDir) !== null;
+  } catch {
+    // Unreadable or dangling: realpath fails. Compare lexically so a mode-0
+    // file inside the collection is not treated as an escape (macOS /var vs
+    // /private/var). Readable out-of-tree symlinks still hit the try path.
+    return getRelativePathFromPrefix(resolve(target), resolve(dir)) !== null;
+  }
 }
 
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -665,6 +665,15 @@ export function getRealPath(path: string): string {
   }
 }
 
+/**
+ * True if `target` is `dir` or a descendant, after resolving symlinks.
+ * Used to keep indexing and qmd:// filesystem resolution inside a collection.
+ */
+export function isPathInsideDir(dir: string, target: string): boolean {
+  return getRelativePathFromPrefix(getRealPath(target), getRealPath(dir)) !== null;
+}
+
+
 // =============================================================================
 // Virtual Path Utilities (qmd://)
 // =============================================================================
@@ -769,7 +778,9 @@ export function resolveVirtualPath(db: Database, virtualPath: string): string | 
   const coll = getCollectionByName(db, parsed.collectionName);
   if (!coll) return null;
 
-  return resolve(coll.pwd, parsed.path);
+  const resolved = resolve(coll.pwd, parsed.path);
+  if (!isPathInsideDir(coll.pwd, resolved)) return null;
+  return resolved;
 }
 
 /**
@@ -1590,6 +1601,15 @@ export async function reindexCollection(
     // reconstructed as: resolve(collection.path, storedPath).
     // handelize() is NOT applied at index time — it is display-only.
     const path = normalizePathSeparators(relativeFile);
+    // Glob `../` segments, absolute patterns, and file symlinks can resolve
+    // outside the collection root. Do not ingest those files, and do not mark
+    // them seen so a previous escaped row is deactivated on this pass.
+    if (!isPathInsideDir(collectionPath, filepath)) {
+      processed++;
+      skippedFiles.push({ file: relativeFile, code: "OUTSIDE_COLLECTION" });
+      options?.onProgress?.({ file: relativeFile, current: processed, total });
+      continue;
+    }
     seenPaths.add(path);
 
     let content: string;

--- a/test/mcp-origin-guard.test.ts
+++ b/test/mcp-origin-guard.test.ts
@@ -1,0 +1,298 @@
+/**
+ * DNS-rebinding protection for the HTTP MCP transport (#881).
+ *
+ * The predicate tests run everywhere; the live-server tests boot a real
+ * `startMcpHttpServer` on an ephemeral port and drive it with spoofed headers.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import YAML from "yaml";
+import {
+  checkRequestOrigin,
+  isLoopbackHostname,
+  resolveOriginGuard,
+} from "../src/mcp/origin-guard.js";
+import { openDatabase } from "../src/db.js";
+import type { CollectionConfig } from "../src/collections.js";
+
+// =============================================================================
+// Predicates
+// =============================================================================
+
+describe("isLoopbackHostname", () => {
+  test.each([
+    "localhost",
+    "LOCALHOST",
+    "app.localhost",
+    "127.0.0.1",
+    "127.1.2.3",
+    "::1",
+    "[::1]",
+    "::ffff:127.0.0.1",
+  ])("accepts %s", (hostname) => {
+    expect(isLoopbackHostname(hostname)).toBe(true);
+  });
+
+  test.each([
+    "evil.example",
+    "notlocalhost",
+    "localhost.evil.example",
+    "127.0.0.1.evil.example",
+    "10.0.0.1",
+    "::2",
+  ])("rejects %s", (hostname) => {
+    expect(isLoopbackHostname(hostname)).toBe(false);
+  });
+
+  // 0.0.0.0 routes to loopback in browsers on Linux/macOS, which makes it a
+  // rebinding-free path to a local server — so it is not a trusted origin.
+  test("rejects 0.0.0.0", () => {
+    expect(isLoopbackHostname("0.0.0.0")).toBe(false);
+  });
+});
+
+describe("resolveOriginGuard", () => {
+  const env = {} as NodeJS.ProcessEnv;
+
+  test("loopback bind enforces the Host header", () => {
+    const guard = resolveOriginGuard({ host: "localhost", env });
+    expect(guard.disabled).toBe(false);
+    expect(guard.enforceHost).toBe(true);
+  });
+
+  test("wildcard bind without an allowlist skips Host enforcement", () => {
+    const guard = resolveOriginGuard({ host: "0.0.0.0", env });
+    expect(guard.enforceHost).toBe(false);
+  });
+
+  test("wildcard bind with an explicit allowlist enforces Host", () => {
+    const guard = resolveOriginGuard({ host: "0.0.0.0", allowedHosts: ["qmd.internal"], env });
+    expect(guard.enforceHost).toBe(true);
+    expect(guard.allowedHosts).toContain("qmd.internal");
+  });
+
+  test("a concrete non-loopback bind trusts its own address", () => {
+    const guard = resolveOriginGuard({ host: "192.168.1.5", env });
+    expect(guard.enforceHost).toBe(true);
+    expect(guard.allowedHosts).toContain("192.168.1.5");
+  });
+
+  test("QMD_ALLOWED_ORIGINS=* disables every check", () => {
+    const guard = resolveOriginGuard({ host: "localhost", env: { QMD_ALLOWED_ORIGINS: "*" } });
+    expect(guard.disabled).toBe(true);
+    expect(checkRequestOrigin({ origin: "https://evil.example", host: "evil.example" }, guard).ok).toBe(true);
+  });
+
+  test("reads comma-separated allowlists from the environment", () => {
+    const guard = resolveOriginGuard({
+      host: "localhost",
+      env: {
+        QMD_ALLOWED_ORIGINS: "https://notes.internal , https://app.internal",
+        QMD_ALLOWED_HOSTS: "notes.internal",
+      },
+    });
+    expect(guard.allowedOrigins).toEqual(["https://notes.internal", "https://app.internal"]);
+    expect(guard.allowedHosts).toEqual(["notes.internal"]);
+  });
+});
+
+describe("checkRequestOrigin", () => {
+  const guard = resolveOriginGuard({ host: "localhost", env: {} as NodeJS.ProcessEnv });
+
+  test("allows a request with no Origin header (curl, MCP clients)", () => {
+    expect(checkRequestOrigin({ host: "localhost:8181" }, guard).ok).toBe(true);
+  });
+
+  test("allows loopback origins", () => {
+    for (const origin of ["http://localhost:8181", "http://127.0.0.1:8181", "http://[::1]:8181"]) {
+      expect(checkRequestOrigin({ origin, host: "localhost:8181" }, guard).ok).toBe(true);
+    }
+  });
+
+  test("rejects a foreign Origin", () => {
+    const verdict = checkRequestOrigin({ origin: "https://evil.example", host: "localhost:8181" }, guard);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.ok === false && verdict.reason).toContain("Origin not allowed");
+  });
+
+  test("rejects a rebound Host even when Origin is absent", () => {
+    const verdict = checkRequestOrigin({ host: "evil.example:8181" }, guard);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.ok === false && verdict.reason).toContain("Host not allowed");
+  });
+
+  test("rejects an origin that merely embeds a loopback name", () => {
+    expect(checkRequestOrigin({ origin: "https://localhost.evil.example" }, guard).ok).toBe(false);
+    expect(checkRequestOrigin({ origin: "https://evil.example#localhost" }, guard).ok).toBe(false);
+  });
+
+  test("rejects the opaque null origin from sandboxed frames", () => {
+    expect(checkRequestOrigin({ origin: "null", host: "localhost:8181" }, guard).ok).toBe(false);
+  });
+
+  test("rejects non-http schemes", () => {
+    expect(checkRequestOrigin({ origin: "file://", host: "localhost:8181" }, guard).ok).toBe(false);
+  });
+
+  test("honours an explicit origin allowlist", () => {
+    const allowing = resolveOriginGuard({
+      host: "localhost",
+      allowedOrigins: ["https://notes.internal"],
+      allowedHosts: ["notes.internal"],
+      env: {} as NodeJS.ProcessEnv,
+    });
+    expect(checkRequestOrigin({ origin: "https://notes.internal", host: "notes.internal" }, allowing).ok).toBe(true);
+    expect(checkRequestOrigin({ origin: "https://other.internal", host: "notes.internal" }, allowing).ok).toBe(false);
+  });
+
+  test("skips Host validation on a wildcard bind but still screens Origin", () => {
+    const docker = resolveOriginGuard({ host: "0.0.0.0", env: {} as NodeJS.ProcessEnv });
+    expect(checkRequestOrigin({ host: "qmd-container:8181" }, docker).ok).toBe(true);
+    expect(checkRequestOrigin({ origin: "https://evil.example", host: "qmd-container:8181" }, docker).ok).toBe(false);
+  });
+});
+
+// =============================================================================
+// Live server
+// =============================================================================
+
+describe.skipIf(!!process.env.CI)("MCP HTTP server rejects cross-origin requests", () => {
+  let handle: import("../src/mcp/server.js").HttpServerHandle;
+  let baseUrl: string;
+  let workDir: string;
+  let configDir: string;
+  const origIndexPath = process.env.INDEX_PATH;
+  const origConfigDir = process.env.QMD_CONFIG_DIR;
+
+  beforeAll(async () => {
+    workDir = mkdtempSync(join(tmpdir(), "qmd-origin-"));
+    const dbPath = join(workDir, "index.sqlite");
+
+    const { createStore } = await import("../src/store.js");
+    createStore(dbPath).close();
+
+    const db = openDatabase(dbPath);
+    const now = new Date().toISOString();
+    db.prepare(`INSERT OR IGNORE INTO content (hash, doc, created_at) VALUES (?, ?, ?)`)
+      .run("hash-secret", "# Secrets\n\nThe recovery password is hunter2.\n", now);
+    db.prepare(
+      `INSERT INTO documents (collection, path, title, hash, created_at, modified_at, active) VALUES ('docs', ?, ?, ?, ?, ?, 1)`,
+    ).run("secrets.md", "Secrets", "hash-secret", now, now);
+
+    const config: CollectionConfig = {
+      collections: { docs: { path: workDir, pattern: "**/*.md" } },
+    };
+    const { syncConfigToDb } = await import("../src/store.js");
+    syncConfigToDb(db, config);
+    db.close();
+
+    configDir = mkdtempSync(join(tmpdir(), "qmd-origin-cfg-"));
+    writeFileSync(join(configDir, "index.yml"), YAML.stringify(config));
+
+    process.env.INDEX_PATH = dbPath;
+    process.env.QMD_CONFIG_DIR = configDir;
+
+    const { startMcpHttpServer } = await import("../src/mcp/server.js");
+    handle = await startMcpHttpServer(0, { quiet: true });
+    baseUrl = `http://localhost:${handle.port}`;
+  });
+
+  afterAll(async () => {
+    await handle?.stop();
+    if (origIndexPath !== undefined) process.env.INDEX_PATH = origIndexPath;
+    else delete process.env.INDEX_PATH;
+    if (origConfigDir !== undefined) process.env.QMD_CONFIG_DIR = origConfigDir;
+    else delete process.env.QMD_CONFIG_DIR;
+    for (const dir of [workDir, configDir]) {
+      // Best effort: Windows keeps the SQLite WAL handles briefly after close.
+      try { if (dir) rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+
+  const searchBody = JSON.stringify({ searches: [{ type: "lex", query: "password" }], rerank: false });
+
+  test("POST /query leaks nothing to a foreign origin", async () => {
+    const res = await fetch(`${baseUrl}/query`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Origin: "https://evil.example" },
+      body: searchBody,
+    });
+    expect(res.status).toBe(403);
+    const text = await res.text();
+    expect(text).not.toContain("hunter2");
+    expect(text).toContain("Origin not allowed");
+  });
+
+  test("POST /search is screened too", async () => {
+    const res = await fetch(`${baseUrl}/search`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Origin: "https://evil.example" },
+      body: searchBody,
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("POST /mcp initialize is rejected from a foreign origin", async () => {
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Origin: "https://evil.example",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "evil", version: "1" } },
+      }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("a rebound Host header is rejected without an Origin", async () => {
+    // fetch() forbids setting Host, so drive a raw socket for this one.
+    const { request } = await import("node:http");
+    const status = await new Promise<number>((resolve, reject) => {
+      const req = request(
+        {
+          hostname: "localhost",
+          port: handle.port,
+          path: "/query",
+          method: "POST",
+          headers: { "Content-Type": "application/json", Host: "evil.example", "Content-Length": Buffer.byteLength(searchBody) },
+        },
+        (res) => {
+          res.resume();
+          resolve(res.statusCode ?? 0);
+        },
+      );
+      req.on("error", reject);
+      req.end(searchBody);
+    });
+    expect(status).toBe(403);
+  });
+
+  test("local clients still work", async () => {
+    const noOrigin = await fetch(`${baseUrl}/query`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: searchBody,
+    });
+    expect(noOrigin.status).toBe(200);
+    expect(await noOrigin.text()).toContain("hunter2");
+
+    const loopbackOrigin = await fetch(`${baseUrl}/query`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Origin: `http://localhost:${handle.port}` },
+      body: searchBody,
+    });
+    expect(loopbackOrigin.status).toBe(200);
+
+    const health = await fetch(`${baseUrl}/health`);
+    expect(health.status).toBe(200);
+  });
+});

--- a/test/store.helpers.unit.test.ts
+++ b/test/store.helpers.unit.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, test, expect } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync, chmodSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -125,6 +125,19 @@ describe("Path Utilities", () => {
       expect(isPathInsideDir(dir, join(dir, "alias.md"))).toBe(true);
     } finally {
       rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  test("isPathInsideDir still treats an unreadable in-tree file as inside", () => {
+    const root = mkdtempSync(join(tmpdir(), "qmd-mode0-"));
+    const file = join(root, "bad.md");
+    writeFileSync(file, "x\n");
+    try {
+      chmodSync(file, 0);
+      expect(isPathInsideDir(root, file)).toBe(true);
+    } finally {
+      try { chmodSync(file, 0o644); } catch { /* ignore */ }
+      rmSync(root, { recursive: true, force: true });
     }
   });
 });

--- a/test/store.helpers.unit.test.ts
+++ b/test/store.helpers.unit.test.ts
@@ -3,6 +3,9 @@
  */
 
 import { describe, test, expect } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import {
   homedir,
   resolve,
@@ -10,6 +13,7 @@ import {
   _resetProductionModeForTesting,
   getPwd,
   getRealPath,
+  isPathInsideDir,
   isVirtualPath,
   parseVirtualPath,
   normalizeVirtualPath,
@@ -86,6 +90,42 @@ describe("Path Utilities", () => {
     const result = getRealPath("/tmp");
     expect(result).toBeTruthy();
     expect(result === "/tmp" || result === "/private/tmp").toBe(true);
+  });
+
+  test("isPathInsideDir accepts descendants and rejects escapes", () => {
+    const root = mkdtempSync(join(tmpdir(), "qmd-inside-"));
+    try {
+      mkdirSync(join(root, "sub"));
+      writeFileSync(join(root, "sub", "a.md"), "ok\n");
+      expect(isPathInsideDir(root, join(root, "sub", "a.md"))).toBe(true);
+      expect(isPathInsideDir(root, root)).toBe(true);
+      expect(isPathInsideDir(root, join(root, "..", "nope.md"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("isPathInsideDir rejects a file symlink that points outside the dir", () => {
+    const parent = mkdtempSync(join(tmpdir(), "qmd-sym-"));
+    const dir = join(parent, "col");
+    mkdirSync(dir);
+    const outside = join(parent, "secret.md");
+    writeFileSync(outside, "secret\n");
+    const link = join(dir, "link.md");
+    try {
+      symlinkSync(outside, link);
+    } catch {
+      rmSync(parent, { recursive: true, force: true });
+      return;
+    }
+    try {
+      expect(isPathInsideDir(dir, link)).toBe(false);
+      writeFileSync(join(dir, "inside.md"), "ok\n");
+      symlinkSync(join(dir, "inside.md"), join(dir, "alias.md"));
+      expect(isPathInsideDir(dir, join(dir, "alias.md"))).toBe(true);
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -9,7 +9,7 @@
 import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
 import { openDatabase, loadSqliteVec } from "../src/db.js";
 import type { Database } from "../src/db.js";
-import { unlink, mkdtemp, rmdir, writeFile, rm, mkdir, rename, chmod, readFile } from "node:fs/promises";
+import { unlink, mkdtemp, rmdir, writeFile, rm, mkdir, rename, chmod, readFile, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import YAML from "yaml";
@@ -50,6 +50,7 @@ import {
   isDocid,
   syncConfigToDb,
   reindexCollection,
+  resolveVirtualPath,
   STRONG_SIGNAL_MIN_SCORE,
   STRONG_SIGNAL_MIN_GAP,
   insertContent,
@@ -2822,6 +2823,95 @@ describe("Reindex Collection", () => {
       SELECT path FROM documents WHERE collection = ? AND active = 1 ORDER BY path
     `).all(collectionName) as { path: string }[];
     expect(paths.map(r => r.path)).toEqual(["X - b.md", "a.md"]);
+  });
+
+  test("does not index a file symlink whose target is outside the collection", async () => {
+    const store = await createTestStore();
+    const parent = join(testDir, `escape-sym-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const collectionPath = join(parent, "col");
+    await mkdir(collectionPath, { recursive: true });
+    const marker = `OUTSIDE_TOKEN_${Date.now()}`;
+    await writeFile(join(parent, "secret.md"), `# Secret\n\n${marker}\n`);
+    await writeFile(join(collectionPath, "inside.md"), "# Inside\n\nsafe\n");
+    try {
+      await symlink(join(parent, "secret.md"), join(collectionPath, "link.md"));
+    } catch {
+      await rm(parent, { recursive: true, force: true });
+      await cleanupTestDb(store);
+      return;
+    }
+    try {
+      const result = await reindexCollection(store, collectionPath, "**/*.md", "docs");
+      expect(result.indexed).toBe(1);
+      const bodies = store.db.prepare(`
+        SELECT content.doc as body FROM documents d
+        JOIN content ON content.hash = d.hash
+        WHERE d.collection = ? AND d.active = 1
+      `).all("docs") as { body: string }[];
+      expect(bodies).toHaveLength(1);
+      expect(bodies[0]!.body).toContain("safe");
+      expect(bodies.map(b => b.body).join("")).not.toContain(marker);
+      // fast-glob + onlyFiles may omit the symlink entirely; if it is listed,
+      // containment must skip it rather than ingest the target.
+      if (result.skippedFiles.length > 0) {
+        expect(result.skippedFiles.some(s => s.code === "OUTSIDE_COLLECTION")).toBe(true);
+      }
+    } finally {
+      await rm(parent, { recursive: true, force: true });
+      await cleanupTestDb(store);
+    }
+  });
+
+  test("does not index files matched by a glob that walks out of the collection", async () => {
+    const store = await createTestStore();
+    const parent = join(testDir, `escape-glob-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const collectionPath = join(parent, "col");
+    await mkdir(collectionPath, { recursive: true });
+    const marker = `GLOB_OUTSIDE_${Date.now()}`;
+    await writeFile(join(parent, "outside.md"), `# Outside\n\n${marker}\n`);
+    await writeFile(join(collectionPath, "inside.md"), "# Inside\n\nsafe\n");
+    try {
+      const result = await reindexCollection(store, collectionPath, "../outside.md,**/*.md", "docs");
+      const bodies = store.db.prepare(`
+        SELECT content.doc as body FROM documents d
+        JOIN content ON content.hash = d.hash
+        WHERE d.collection = ? AND d.active = 1
+      `).all("docs") as { body: string }[];
+      expect(bodies.map(b => b.body).join("")).not.toContain(marker);
+      expect(bodies.some(b => b.body.includes("safe"))).toBe(true);
+      expect(result.indexed).toBeGreaterThanOrEqual(1);
+
+      store.db.prepare(`DELETE FROM documents`).run();
+      const abs = await reindexCollection(store, collectionPath, join(parent, "outside.md"), "docs");
+      expect(abs.skippedFiles.some(s => s.code === "OUTSIDE_COLLECTION")).toBe(true);
+      const absBodies = store.db.prepare(`
+        SELECT content.doc as body FROM documents d
+        JOIN content ON content.hash = d.hash
+        WHERE d.collection = ? AND d.active = 1
+      `).all("docs") as { body: string }[];
+      expect(absBodies.map(b => b.body).join("")).not.toContain(marker);
+    } finally {
+      await rm(parent, { recursive: true, force: true });
+      await cleanupTestDb(store);
+    }
+  });
+
+  test("resolveVirtualPath refuses .. segments that leave the collection", async () => {
+    const store = await createTestStore();
+    const collectionPath = join(testDir, `vp-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(collectionPath, { recursive: true });
+    await writeFile(join(collectionPath, "ok.md"), "# Ok\n");
+    syncConfigToDb(store.db, {
+      collections: { docs: { path: collectionPath, pattern: "**/*.md" } },
+    });
+    try {
+      const ok = resolveVirtualPath(store.db, "qmd://docs/ok.md");
+      expect(ok).toBe(resolve(collectionPath, "ok.md"));
+      expect(resolveVirtualPath(store.db, "qmd://docs/../../../etc/passwd")).toBeNull();
+    } finally {
+      await rm(collectionPath, { recursive: true, force: true });
+      await cleanupTestDb(store);
+    }
   });
 
   test("skips unreadable files and reports the error code (#460)", async () => {


### PR DESCRIPTION
## Summary
- Reland of #885 / #881 on current main (SDK 2.0 stateless HTTP). #885 targeted the pre-#883 session transport and conflicted; the Origin/Host predicates are the same, applied in `createServer` ahead of routing so `/mcp`, `/query`, and `/search` are covered.
- Indexing skips files whose resolved path is outside the collection root (`../` globs, absolute masks, file symlinks that point out). `qmd://` filesystem resolution uses the same check.

Closes #881.

## Test plan
- [x] bun test test/mcp-origin-guard.test.ts (35, including live HTTP 403s)
- [x] npx vitest run test/mcp-origin-guard.test.ts (35)
- [x] bun test test/store.helpers.unit.test.ts (isPathInsideDir)
- [x] bun test test/store.test.ts (containment cases)
- [ ] CI Bun/Node green