### PR TITLE
fix(trust): gate project-local collection paths and model URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@
   `~/.config/qmd/*.yml`, including anything `qmd collection update-cmd` writes,
   are unaffected.
 
+- The same project-local trust gate now covers collection `path` values that
+  resolve outside the project and non-default `models.embed` / `models.rerank`
+  / `models.generate` URIs (#889). In-project paths still index unattended;
+  out-of-project directories are skipped until `qmd trust`, and custom model
+  URIs are not loaded or downloaded. `QMD_TRUST_LOCAL_CONFIG=1` opts unattended
+  runs back in (and `QMD_TRUST_UPDATE_HOOKS=1` still does). `qmd collection
+  add` records trust as it writes, the same way `update-cmd` does.
+
 - Indexing no longer follows file symlinks or glob `../` / absolute patterns
   out of the collection directory. `fast-glob` already skipped symlinked
   directories, but a file symlink (or a mask like `../**/*.md`) still resolved

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ qmd multi-get <pattern>           # Get multiple docs by glob or comma-separated
 qmd status                        # Show index status and collections
 qmd doctor                        # Diagnose config, index, model, and device issues
 qmd update                        # Re-index collections; configured update hooks run first
-qmd trust [list|revoke]           # Approve a checked-in .qmd config's update hooks
+qmd trust [list|revoke]           # Approve a checked-in .qmd config's hooks/paths/models
 qmd embed                         # Generate vector embeddings (uses node-llama-cpp)
 qmd query <query>                 # Search with query expansion + reranking (recommended)
 qmd search <query>                # Full-text keyword search (BM25, no LLM)

--- a/README.md
+++ b/README.md
@@ -792,29 +792,36 @@ qmd collection update-cmd wiki 'git pull --ff-only'   # set
 qmd collection update-cmd wiki                         # clear
 ```
 
-##### Update commands from a checked-in `.qmd` config
+##### Checked-in `.qmd` config is not trusted by default
 
 A project-local `.qmd/index.yml` travels with a `git clone`, and QMD adopts it
-automatically for any command run inside the tree. Its `update` commands are
-therefore somebody else's shell script until you say otherwise, and QMD will not
-run them unattended:
+automatically for any command run inside the tree. Three fields in that file can
+reach outside the project, and QMD will not use them unattended:
 
-- On a terminal, `qmd update` lists the commands and asks before running them.
-  Approving records the approval in `~/.config/qmd/trusted.json`.
-- With no terminal to ask — agents, CI, MCP — the commands are **skipped** and
-  indexing continues, so the refresh you asked for still happens.
-- Approvals cover the exact commands you saw. Editing one, or a `git pull` that
-  rewrites it, asks again.
+- `update` commands — somebody else's shell script, run by `qmd update`
+- `collections.*.path` pointing **outside** the project directory
+- `models.embed` / `models.rerank` / `models.generate` other than the built-in
+  defaults (any `hf:` repo or local GGUF path)
+
+In-project collection paths (for example `./docs`) still index. On a terminal
+`qmd update` (and `qmd embed` / `qmd pull` / `qmd query`) lists the gated
+fields and asks. Approving records the approval in `~/.config/qmd/trusted.json`.
+With no terminal to ask — agents, CI, MCP — those fields are **skipped** and
+in-project indexing continues.
+
+Approvals cover the exact gated set you saw. Editing a command, pointing a
+collection outside the project, or changing a custom model URI asks again.
 
 ```sh
-qmd trust           # review and approve this project's update commands
+qmd trust           # review and approve this project's gated fields
 qmd trust list      # show every approved project config
 qmd trust revoke    # drop the approval for this project
 ```
 
-Set `QMD_TRUST_UPDATE_HOOKS=1` for CI that should run them unattended. Commands
-in your own `~/.config/qmd/*.yml` — including anything `qmd collection
-update-cmd` writes — are never gated.
+Set `QMD_TRUST_LOCAL_CONFIG=1` (or `QMD_TRUST_UPDATE_HOOKS=1`) for CI that
+should allow them unattended. Your own `~/.config/qmd/*.yml` — including
+anything `qmd collection update-cmd` or `qmd collection add` writes — is
+never gated.
 
 ### Search Commands
 

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -117,13 +117,20 @@ import {
   type ModelsConfig,
 } from "../collections.js";
 import {
-  decideHookGate,
-  hookDigest,
+  decideLocalConfigGate,
+  gatedItems,
+  hasGatedItems,
+  isCollectionPathInsideProject,
   isLocalConfigPath,
+  isLocalConfigTrustOptedIn,
+  isTrusted,
   listTrusted,
   recordTrust,
   revokeTrust,
-  type UpdateHook,
+  sensitiveDigest,
+  type BuiltinModels,
+  type GatedItems,
+  type SensitiveSnapshot,
 } from "../trust.js";
 
 // NOTE: enableProductionMode() is intentionally NOT called at module scope here.
@@ -149,10 +156,13 @@ function getStore(): ReturnType<typeof createStore> {
       const activeModels = ensureModelsConfiguredForCli();
       const config = loadConfig();
       syncConfigToDb(store.db, config);
+      // Untrusted project-local custom model URIs must not be loaded; status
+      // still displays the YAML values via resolveModelsForCli (#889).
+      const modelsForLlm = localConfigIsFullyTrusted() ? activeModels : resolveModels();
       const llm = new LlamaCpp({
-        embedModel: activeModels.embed,
-        generateModel: activeModels.generate,
-        rerankModel: activeModels.rerank,
+        embedModel: modelsForLlm.embed,
+        generateModel: modelsForLlm.generate,
+        rerankModel: modelsForLlm.rerank,
       });
       setDefaultLlamaCpp(llm);
       store.llm = llm;
@@ -696,23 +706,61 @@ async function showStatus(): Promise<void> {
   closeDb();
 }
 
-/**
- * Every `update:` hook the active config defines. Read from the YAML rather
- * than the synced SQLite copy so `qmd trust` and `qmd update` always digest the
- * same set.
- */
-function collectUpdateHooks(): UpdateHook[] {
-  const config = loadConfig();
-  return Object.entries(config.collections ?? {})
-    .filter(([, col]) => !!col.update)
-    .map(([name, col]) => ({ collection: name, command: col.update! }));
+function builtinModels(): BuiltinModels {
+  return {
+    embed: DEFAULT_EMBED_MODEL,
+    rerank: DEFAULT_RERANK_MODEL,
+    generate: DEFAULT_QUERY_MODEL,
+  };
 }
 
-/** Record the active config's current hook set as approved. */
-function trustCurrentConfigHooks(): void {
+/**
+ * Gated surface of the active YAML: hooks, collection paths, models.
+ * Read from the YAML rather than the synced SQLite copy so `qmd trust`
+ * and `qmd update` always digest the same set.
+ */
+function collectSensitiveSnapshot(): SensitiveSnapshot {
+  const config = loadConfig();
+  return {
+    hooks: Object.entries(config.collections ?? {})
+      .filter(([, col]) => !!col.update)
+      .map(([name, col]) => ({ collection: name, command: col.update! })),
+    paths: Object.entries(config.collections ?? {}).map(([name, col]) => ({
+      collection: name,
+      path: col.path,
+    })),
+    models: {
+      embed: config.models?.embed,
+      rerank: config.models?.rerank,
+      generate: config.models?.generate,
+    },
+  };
+}
+
+function localConfigDigest(configPath: string, snapshot: SensitiveSnapshot): string {
+  return sensitiveDigest(snapshot, configPath, builtinModels());
+}
+
+function localConfigGated(configPath: string, snapshot: SensitiveSnapshot): GatedItems {
+  return gatedItems(configPath, snapshot, builtinModels());
+}
+
+/** True when this process may use the local config's gated fields. */
+function localConfigIsFullyTrusted(): boolean {
+  const configPath = getConfigPath();
+  if (!isLocalConfigPath(configPath)) return true;
+  if (isLocalConfigTrustOptedIn()) return true;
+  const snapshot = collectSensitiveSnapshot();
+  const gated = localConfigGated(configPath, snapshot);
+  if (!hasGatedItems(gated)) return true;
+  return isTrusted(configPath, localConfigDigest(configPath, snapshot));
+}
+
+/** Record the active config's current gated set as approved. */
+function trustCurrentConfig(): void {
   const configPath = getConfigPath();
   if (!isLocalConfigPath(configPath)) return;
-  recordTrust(configPath, hookDigest(collectUpdateHooks()));
+  recordTrust(configPath, localConfigDigest(configPath, collectSensitiveSnapshot()));
 }
 
 /** Ask the user a yes/no question. Only called when stdin and stdout are TTYs. */
@@ -727,49 +775,70 @@ async function confirmOnTty(question: string): Promise<boolean> {
   }
 }
 
-/**
- * Decide whether this run may execute the configured `update:` hooks, prompting
- * when there is a human to ask. Returns false when the hooks must be skipped —
- * indexing still proceeds, since that is what the caller asked for.
- */
-async function resolveUpdateHookTrust(): Promise<boolean> {
-  const hooks = collectUpdateHooks();
-  if (hooks.length === 0) return true;
+function printGatedItems(gated: GatedItems): void {
+  if (gated.hooks.length > 0) {
+    console.log(`${c.yellow}This project's config defines update commands:${c.reset}`);
+    for (const hook of gated.hooks) {
+      console.log(`  ${c.bold}${hook.collection}${c.reset}: ${hook.command}`);
+    }
+  }
+  if (gated.paths.length > 0) {
+    console.log(`${c.yellow}Collection paths outside this project:${c.reset}`);
+    for (const item of gated.paths) {
+      console.log(`  ${c.bold}${item.collection}${c.reset}: ${item.path}`);
+    }
+  }
+  if (gated.models.length > 0) {
+    console.log(`${c.yellow}Custom models:${c.reset}`);
+    for (const item of gated.models) {
+      console.log(`  ${c.bold}${item.slot}${c.reset}: ${item.uri}`);
+    }
+  }
+}
 
+/**
+ * Decide whether this run may use gated fields from a project-local config
+ * (update hooks, out-of-project collection paths, custom model URIs).
+ * Returns false when those must be skipped — in-project indexing still
+ * proceeds, since that is what the caller asked for.
+ */
+async function resolveLocalConfigTrust(): Promise<boolean> {
   const configPath = getConfigPath();
-  const decision = decideHookGate({
+  const snapshot = collectSensitiveSnapshot();
+  const gated = localConfigGated(configPath, snapshot);
+  if (!hasGatedItems(gated)) return true;
+
+  const decision = decideLocalConfigGate({
     configPath,
-    hooks,
+    snapshot,
+    builtins: builtinModels(),
     isInteractive: !!process.stdin.isTTY && !!process.stdout.isTTY,
   });
 
   if (decision.action === "run") return true;
 
-  console.log(`${c.yellow}This project's ${configPath} defines update commands:${c.reset}`);
-  for (const hook of hooks) {
-    console.log(`  ${c.bold}${hook.collection}${c.reset}: ${hook.command}`);
-  }
-  console.log(`${c.dim}They run as a shell script before indexing. Config that came with a checkout is not trusted by default.${c.reset}`);
+  printGatedItems(gated);
+  console.log(`${c.dim}Config that came with a checkout is not trusted by default.${c.reset}`);
 
   if (decision.action === "skip") {
-    console.log(`${c.yellow}Skipping them — no terminal to confirm on. Indexing continues.${c.reset}`);
-    console.log(`${c.dim}Approve with 'qmd trust', or set QMD_TRUST_UPDATE_HOOKS=1 for unattended runs.${c.reset}\n`);
+    console.log(`${c.yellow}Skipping them — no terminal to confirm on. Indexing of this project continues.${c.reset}`);
+    console.log(`${c.dim}Approve with 'qmd trust', or set QMD_TRUST_LOCAL_CONFIG=1 for unattended runs.${c.reset}\n`);
     return false;
   }
 
-  const approved = await confirmOnTty("Run these update commands? [y/N] ");
+  const approved = await confirmOnTty("Trust this project's .qmd config? [y/N] ");
   if (!approved) {
-    console.log(`${c.yellow}Skipped. Indexing continues.${c.reset}\n`);
+    console.log(`${c.yellow}Skipped. Indexing of this project continues.${c.reset}\n`);
     return false;
   }
   recordTrust(configPath, decision.digest);
-  console.log(`${c.green}Trusted ${configPath}.${c.reset} ${c.dim}Editing a command will ask again.${c.reset}\n`);
+  console.log(`${c.green}Trusted ${configPath}.${c.reset} ${c.dim}Editing a hook, path, or model will ask again.${c.reset}\n`);
   return true;
 }
 
 /**
- * `qmd trust [list|revoke]` — approve, inspect or drop the update-hook
- * approval for the project-local config in scope.
+ * `qmd trust [list|revoke]` — approve, inspect or drop the approval for
+ * the project-local config in scope (hooks, out-of-project paths, custom models).
  */
 function manageTrust(subcommand?: string): void {
   const configPath = getConfigPath();
@@ -806,25 +875,27 @@ function manageTrust(subcommand?: string): void {
   }
 
   if (!isLocalConfigPath(configPath)) {
-    console.log(`${c.dim}${configPath} is your own config — update commands there always run. Nothing to trust.${c.reset}`);
+    console.log(`${c.dim}${configPath} is your own config — it is never gated. Nothing to trust.${c.reset}`);
     return;
   }
 
-  const hooks = collectUpdateHooks();
-  if (hooks.length === 0) {
-    console.log(`${c.dim}${configPath} defines no update commands. Nothing to trust.${c.reset}`);
+  const snapshot = collectSensitiveSnapshot();
+  const gated = localConfigGated(configPath, snapshot);
+  if (!hasGatedItems(gated)) {
+    console.log(`${c.dim}${configPath} defines no update commands, out-of-project collection paths, or custom models. Nothing to trust.${c.reset}`);
     return;
   }
 
-  for (const hook of hooks) {
-    console.log(`  ${c.bold}${hook.collection}${c.reset}: ${hook.command}`);
-  }
-  recordTrust(configPath, hookDigest(hooks));
+  printGatedItems(gated);
+  recordTrust(configPath, localConfigDigest(configPath, snapshot));
   console.log(`${c.green}✓ Trusted ${configPath}${c.reset}`);
-  console.log(`${c.dim}Editing any of these commands will ask again. Revoke with 'qmd trust revoke'.${c.reset}`);
+  console.log(`${c.dim}Editing a hook, out-of-project path, or custom model will ask again. Revoke with 'qmd trust revoke'.${c.reset}`);
 }
 
 async function updateCollections(): Promise<void> {
+  // Prompt before opening the store so an approval is visible to getStore (#889).
+  const allowed = await resolveLocalConfigTrust();
+
   const db = getDb();
   const storeInstance = getStore();
   // Collections are defined in YAML; no duplicate cleanup needed.
@@ -841,8 +912,10 @@ async function updateCollections(): Promise<void> {
   }
 
   // A project-local .qmd/index.yml travels with a `git clone`, so its `update:`
-  // hooks are somebody else's shell commands until the user says otherwise (#886).
-  const hooksAllowed = await resolveUpdateHookTrust();
+  // hooks, out-of-project collection paths, and custom model URIs are somebody
+  // else's choices until the user says otherwise (#886, #889).
+  const hooksAllowed = allowed;
+  const configPath = getConfigPath();
 
   console.log(`${c.bold}Updating ${collections.length} collection(s)...${c.reset}\n`);
 
@@ -853,6 +926,12 @@ async function updateCollections(): Promise<void> {
 
     // Execute custom update command if specified in YAML
     const yamlCol = getCollectionFromYaml(col.name);
+    const rawPath = yamlCol?.path ?? col.pwd;
+    if (!hooksAllowed && isLocalConfigPath(configPath) && !isCollectionPathInsideProject(configPath, rawPath)) {
+      console.log(`${c.yellow}Skipping collection '${col.name}' — path ${rawPath} is outside this project and this .qmd config is not trusted.${c.reset}`);
+      console.log(`${c.dim}Approve with 'qmd trust'.${c.reset}\n`);
+      continue;
+    }
     if (yamlCol?.update && hooksAllowed) {
       console.log(`${c.dim}    Running update command: ${yamlCol.update}${c.reset}`);
       try {
@@ -1764,6 +1843,8 @@ async function collectionAdd(pwd: string, globPattern: string, name?: string): P
   // Add to YAML config + sync to SQLite
   const { addCollection } = await import("../collections.js");
   addCollection(collName, pwd, globPattern);
+  // The user just typed this path, so it needs no separate approval (#889).
+  trustCurrentConfig();
   resyncConfig();
 
   // Create the collection and index files
@@ -2066,6 +2147,14 @@ export function resolveRerankModelForCli(): string {
 
 function resolveModelsForCli(): { embed: string; generate: string; rerank: string } {
   return ensureModelsConfiguredForCli();
+}
+
+/** Models that may actually be loaded. Falls back to defaults/env when a
+ *  project-local config's custom URIs are not trusted (#889). */
+function resolveModelsForRuntime(): { embed: string; generate: string; rerank: string } {
+  const configured = ensureModelsConfiguredForCli();
+  if (localConfigIsFullyTrusted()) return configured;
+  return resolveModels();
 }
 
 async function vectorIndex(
@@ -3502,7 +3591,7 @@ function showHelp(): void {
   console.log("  qmd init                      - Create a project-local .qmd index");
   console.log("  qmd status                    - View index + collection health");
   console.log("  qmd update [--pull]           - Re-index collections (optionally git pull first)");
-  console.log("  qmd trust [list|revoke]       - Approve a checked-in .qmd config's update commands");
+  console.log("  qmd trust [list|revoke]       - Approve a checked-in .qmd config's hooks/paths/models");
   console.log("  qmd embed [-f] [-c <name>]    - Generate/refresh vector embeddings");
   console.log("    --max-docs-per-batch <n>    - Cap docs loaded into memory per embedding batch");
   console.log("    --max-batch-mb <n>          - Cap UTF-8 MB loaded into memory per embedding batch");
@@ -4432,7 +4521,7 @@ if (isMain) {
           updateCollectionSettings(name, { update: cmd });
           // The user just typed this command, so it needs no separate approval;
           // re-record so the digest covers the new hook set (#886).
-          trustCurrentConfigHooks();
+          trustCurrentConfig();
           if (cmd) {
             console.log(`✓ Set update command for '${name}': ${cmd}`);
           } else {
@@ -4545,6 +4634,7 @@ if (isMain) {
 
     case "embed":
       try {
+        await resolveLocalConfigTrust();
         const maxDocsPerBatch = parseEmbedBatchOption("maxDocsPerBatch", cli.values["max-docs-per-batch"]);
         const maxBatchMb = parseEmbedBatchOption("maxBatchBytes", cli.values["max-batch-mb"]);
         const embedChunkStrategy = parseChunkStrategy(cli.values["chunk-strategy"]);
@@ -4555,7 +4645,7 @@ if (isMain) {
         // embed operates on a single collection; only the first value is used.
         const embedValidatedCollections = resolveCollectionFilter(cli.opts.collection, false);
         const embedCollection = embedValidatedCollections[0];
-        await vectorIndex(resolveEmbedModelForCli(), !!cli.values.force, {
+        await vectorIndex(resolveModelsForRuntime().embed, !!cli.values.force, {
           maxDocsPerBatch,
           maxBatchBytes: maxBatchMb === undefined ? undefined : maxBatchMb * 1024 * 1024,
           chunkStrategy: embedChunkStrategy,
@@ -4568,8 +4658,9 @@ if (isMain) {
       break;
 
     case "pull": {
+      await resolveLocalConfigTrust();
       const refresh = cli.values.refresh === undefined ? false : Boolean(cli.values.refresh);
-      const activeModels = resolveModelsForCli();
+      const activeModels = resolveModelsForRuntime();
       const models = [
         activeModels.embed,
         activeModels.generate,
@@ -4607,6 +4698,7 @@ if (isMain) {
       if (!cli.values["min-score"]) {
         cli.opts.minScore = 0.3;
       }
+      await resolveLocalConfigTrust();
       await vectorSearch(cli.query, cli.opts);
       break;
 
@@ -4616,6 +4708,7 @@ if (isMain) {
         console.error("Usage: qmd query [options] <query>");
         process.exit(1);
       }
+      await resolveLocalConfigTrust();
       await querySearch(cli.query, cli.opts);
       break;
 

--- a/src/trust.ts
+++ b/src/trust.ts
@@ -1,25 +1,28 @@
 /**
- * trust.ts — approval gate for `update:` hooks from project-local config.
+ * trust.ts — approval gate for project-local `.qmd` config.
  *
- * A collection's `update:` field is a shell command run by `qmd update`. That
- * is fine when the command came from the user's own global config, which only
- * `qmd collection update-cmd` writes. It is not fine for a project-local
- * `.qmd/index.yml`: that file arrives with a `git clone`, and `findLocalConfigPath`
- * adopts it automatically for any command run anywhere inside the tree. Without
- * a gate, cloning a repository and running `qmd update` executes shell commands
- * chosen by whoever wrote the repo (#886).
+ * A project-local `.qmd/index.yml` arrives with a `git clone`, and
+ * `findLocalConfigPath` adopts it automatically for any command run inside the
+ * tree. Three fields in that file can reach outside the project:
  *
- * The model is the one direnv, VS Code and `git safe.directory` converged on:
- * approvals are per config file and per command set, recorded in
- * `<config dir>/trusted.json`. Editing a hook — or a `git pull` that rewrites
- * one — changes the digest and re-arms the gate, so an approval cannot be
- * silently widened after the fact.
+ * - `update:` — a shell command run by `qmd update` (#886)
+ * - `collections.*.path` — any directory the process can read (#889)
+ * - `models.embed` / `models.rerank` / `models.generate` — any `hf:` repo or
+ *   local GGUF path (#889)
+ *
+ * Global `~/.config/qmd` is never gated. In-project collection paths and the
+ * built-in default model URIs are also allowed without approval: those are
+ * what a local config is for. Approvals are per config file and per gated
+ * set, recorded in `<config dir>/trusted.json`. Editing a hook, pointing a
+ * collection outside the project, or changing a custom model URI changes the
+ * digest and re-arms the gate.
  */
 
 import { createHash } from "crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { basename, dirname, join, resolve } from "path";
+import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "fs";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "path";
 import { getConfigDir } from "./collections.js";
+import { qmdHomedir } from "./paths.js";
 
 /** A collection's pre-update hook, as it will be executed. */
 export type UpdateHook = {
@@ -27,8 +30,35 @@ export type UpdateHook = {
   command: string;
 };
 
+export type CollectionPath = {
+  collection: string;
+  path: string;
+};
+
+export type ModelSlot = "embed" | "rerank" | "generate";
+
+export type ModelsSnapshot = {
+  embed?: string;
+  rerank?: string;
+  generate?: string;
+};
+
+export type SensitiveSnapshot = {
+  hooks: UpdateHook[];
+  paths: CollectionPath[];
+  models: ModelsSnapshot;
+};
+
+export type GatedItems = {
+  hooks: UpdateHook[];
+  paths: CollectionPath[];
+  models: Array<{ slot: ModelSlot; uri: string }>;
+};
+
+export type BuiltinModels = Required<ModelsSnapshot>;
+
 export type TrustRecord = {
-  /** Digest of the hook set that was approved. */
+  /** Digest of the gated set that was approved. */
   hooks: string;
   /** ISO timestamp of the approval. */
   trustedAt: string;
@@ -54,6 +84,90 @@ export function isLocalConfigPath(configPath: string): boolean {
   return basename(dirname(resolve(configPath))) === ".qmd";
 }
 
+/** Directory that contains the `.qmd` folder for a project-local config. */
+export function projectRootFromConfig(configPath: string): string {
+  return dirname(dirname(resolve(configPath)));
+}
+
+/** Expand a leading `~` to the user home directory. */
+export function expandUserPath(raw: string): string {
+  if (raw === "~") return qmdHomedir();
+  if (raw.startsWith("~/") || raw.startsWith("~\\")) {
+    return join(qmdHomedir(), raw.slice(2));
+  }
+  return raw;
+}
+
+/**
+ * Resolve a collection `path` from a project-local config: `~` expansion,
+ * then relative paths against the project root (the directory that contains
+ * `.qmd`), not against the process cwd.
+ */
+export function resolveConfigCollectionPath(rawPath: string, configPath: string): string {
+  const expanded = expandUserPath(String(rawPath ?? "").trim());
+  if (!expanded) return projectRootFromConfig(configPath);
+  if (isAbsolute(expanded)) return resolve(expanded);
+  return resolve(projectRootFromConfig(configPath), expanded);
+}
+
+function realOrResolve(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+/**
+ * True if `rawPath` from a project-local config stays inside that project
+ * (the directory containing `.qmd`), after `~` expansion, relative
+ * resolution, and symlink realpath.
+ */
+export function isCollectionPathInsideProject(configPath: string, rawPath: string): boolean {
+  const root = realOrResolve(projectRootFromConfig(configPath));
+  const target = realOrResolve(resolveConfigCollectionPath(rawPath, configPath));
+  const rel = relative(root, target);
+  if (rel === "") return true;
+  if (isAbsolute(rel)) return false;
+  return !rel.split(/[/\\]/).includes("..");
+}
+
+export function gatedModels(
+  models: ModelsSnapshot,
+  builtins: BuiltinModels,
+): Array<{ slot: ModelSlot; uri: string }> {
+  const out: Array<{ slot: ModelSlot; uri: string }> = [];
+  for (const slot of ["embed", "rerank", "generate"] as const) {
+    const uri = models[slot];
+    if (!uri) continue;
+    if (uri === builtins[slot]) continue;
+    out.push({ slot, uri });
+  }
+  return out;
+}
+
+export function gatedItems(
+  configPath: string,
+  snapshot: SensitiveSnapshot,
+  builtins: BuiltinModels,
+): GatedItems {
+  return {
+    hooks: snapshot.hooks,
+    paths: snapshot.paths.filter(p => !isCollectionPathInsideProject(configPath, p.path)),
+    models: gatedModels(snapshot.models, builtins),
+  };
+}
+
+export function hasGatedItems(gated: GatedItems): boolean {
+  return gated.hooks.length > 0 || gated.paths.length > 0 || gated.models.length > 0;
+}
+
+function byFirst(a: string[], b: string[]): number {
+  const left = a[0] ?? "";
+  const right = b[0] ?? "";
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
 /**
  * Stable digest over a hook set. Order-independent so that reordering
  * collections in the YAML does not invalidate an approval, while any change to
@@ -63,8 +177,32 @@ export function hookDigest(hooks: UpdateHook[]): string {
   const canonical = JSON.stringify(
     hooks
       .map(h => [h.collection, h.command])
-      .sort((a, b) => (a[0]! < b[0]! ? -1 : a[0]! > b[0]! ? 1 : 0)),
+      .sort(byFirst),
   );
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+/**
+ * Digest of the gated surface of a project-local config: hooks, resolved
+ * collection paths, and non-default model URIs. Missing model keys and the
+ * built-in default URIs are equivalent so that `qmd init` filling defaults
+ * into the YAML does not invalidate an approval.
+ */
+export function sensitiveDigest(
+  snapshot: SensitiveSnapshot,
+  configPath: string,
+  builtins: BuiltinModels,
+): string {
+  const gated = gatedItems(configPath, snapshot, builtins);
+  const canonical = JSON.stringify({
+    hooks: gated.hooks.map(h => [h.collection, h.command]).sort(byFirst),
+    paths: gated.paths
+      .map(p => [p.collection, resolveConfigCollectionPath(p.path, configPath)] as [string, string])
+      .sort(byFirst),
+    models: gated.models
+      .map(m => [m.slot, m.uri] as [string, string])
+      .sort(byFirst),
+  });
   return createHash("sha256").update(canonical).digest("hex");
 }
 
@@ -123,6 +261,18 @@ export type HookGateDecision =
   | { action: "prompt"; digest: string }
   | { action: "skip"; digest: string };
 
+export type LocalConfigGateDecision = HookGateDecision;
+
+function isTruthyEnv(value: string | undefined): boolean {
+  if (!value) return false;
+  return !["0", "false", "off", "no", "none"].includes(value.trim().toLowerCase());
+}
+
+/** True when the process has opted in to trusting project-local config unattended. */
+export function isLocalConfigTrustOptedIn(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isTruthyEnv(env.QMD_TRUST_LOCAL_CONFIG) || isTruthyEnv(env.QMD_TRUST_UPDATE_HOOKS);
+}
+
 /**
  * Decide what to do with a config's `update:` hooks.
  *
@@ -141,7 +291,9 @@ export function decideHookGate(options: {
   const digest = hookDigest(options.hooks);
 
   if (options.hooks.length === 0) return { action: "run", digest };
-  if (isTruthyEnv(env.QMD_TRUST_UPDATE_HOOKS)) return { action: "run", digest };
+  if (isTruthyEnv(env.QMD_TRUST_UPDATE_HOOKS) || isTruthyEnv(env.QMD_TRUST_LOCAL_CONFIG)) {
+    return { action: "run", digest };
+  }
   if (!isLocalConfigPath(options.configPath)) return { action: "run", digest };
 
   const trusted = options.trustedCheck ?? isTrusted;
@@ -150,7 +302,32 @@ export function decideHookGate(options: {
   return { action: options.isInteractive ? "prompt" : "skip", digest };
 }
 
-function isTruthyEnv(value: string | undefined): boolean {
-  if (!value) return false;
-  return !["0", "false", "off", "no", "none"].includes(value.trim().toLowerCase());
+/**
+ * Decide whether a project-local config may use its gated fields (hooks,
+ * out-of-project collection paths, non-default model URIs).
+ *
+ * In-project paths and built-in default models do not need a decision.
+ * Non-interactive callers get `skip`: in-project indexing still proceeds,
+ * hooks/outside paths/custom models do not.
+ */
+export function decideLocalConfigGate(options: {
+  configPath: string;
+  snapshot: SensitiveSnapshot;
+  builtins: BuiltinModels;
+  isInteractive: boolean;
+  env?: NodeJS.ProcessEnv;
+  trustedCheck?: (configPath: string, digest: string) => boolean;
+}): LocalConfigGateDecision {
+  const env = options.env ?? process.env;
+  const digest = sensitiveDigest(options.snapshot, options.configPath, options.builtins);
+  const gated = gatedItems(options.configPath, options.snapshot, options.builtins);
+
+  if (!hasGatedItems(gated)) return { action: "run", digest };
+  if (isLocalConfigTrustOptedIn(env)) return { action: "run", digest };
+  if (!isLocalConfigPath(options.configPath)) return { action: "run", digest };
+
+  const trusted = options.trustedCheck ?? isTrusted;
+  if (trusted(options.configPath, digest)) return { action: "run", digest };
+
+  return { action: options.isInteractive ? "prompt" : "skip", digest };
 }

--- a/test/local-config-trust-cli.test.ts
+++ b/test/local-config-trust-cli.test.ts
@@ -1,0 +1,186 @@
+/**
+ * End-to-end trust gate for project-local collection paths and model URIs (#889).
+ *
+ * Spawns real `qmd update` processes against a fixture that plays the part of a
+ * freshly cloned repository shipping its own `.qmd/index.yml`.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+
+const thisDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(thisDir, "..");
+const qmdScript = join(projectRoot, "src", "cli", "qmd.ts");
+const isBunRuntime = typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
+const tsxCli = join(projectRoot, "node_modules", "tsx", "dist", "cli.mjs");
+const runnerArgs = isBunRuntime ? [qmdScript] : [tsxCli, qmdScript];
+
+let projectDir: string;
+let configDir: string;
+let outsideDir: string;
+
+function runQmd(
+  args: string[],
+  env: Record<string, string> = {},
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(process.execPath, [...runnerArgs, ...args], {
+      cwd: projectDir,
+      env: {
+        ...process.env,
+        QMD_CONFIG_DIR: configDir,
+        PWD: projectDir,
+        QMD_DOCTOR_DEVICE_PROBE: "0",
+        ...env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    proc.stdout.on("data", (d: Buffer) => { stdout += d.toString(); });
+    proc.stderr.on("data", (d: Buffer) => { stderr += d.toString(); });
+    proc.on("error", reject);
+    proc.on("close", (code) => resolve({ stdout, stderr, exitCode: code ?? 1 }));
+  });
+}
+
+function writeLocalConfig(body: string): void {
+  writeFileSync(join(projectDir, ".qmd", "index.yml"), body, "utf-8");
+}
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), "qmd-path-trust-proj-"));
+  configDir = mkdtempSync(join(tmpdir(), "qmd-path-trust-cfg-"));
+  outsideDir = mkdtempSync(join(tmpdir(), "qmd-path-trust-out-"));
+  mkdirSync(join(projectDir, ".qmd"), { recursive: true });
+  mkdirSync(join(projectDir, "docs"), { recursive: true });
+  writeFileSync(join(projectDir, "docs", "readme.md"), "# Readme\n\nSome indexable content.\n", "utf-8");
+  writeFileSync(join(outsideDir, "secret.md"), "# Secret\n\nShould not be indexed unattended.\n", "utf-8");
+});
+
+afterEach(() => {
+  for (const dir of [projectDir, configDir, outsideDir]) {
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+});
+
+describe("qmd update with a checked-in collection path outside the project", () => {
+  function outsideConfig(): string {
+    return [
+      "collections:",
+      "  secrets:",
+      `    path: ${JSON.stringify(outsideDir)}`,
+      '    pattern: "**/*.md"',
+      "",
+    ].join("\n");
+  }
+
+  test("does not index the outside path unattended", async () => {
+    writeLocalConfig(outsideConfig());
+    const result = await runQmd(["update"]);
+
+    expect(result.stdout).toContain("Collection paths outside this project");
+    expect(result.stdout).toContain("qmd trust");
+    expect(result.stdout).toContain(`Skipping collection 'secrets'`);
+    expect(result.stdout).not.toContain("Indexed: 1 new");
+    expect(result.exitCode).toBe(0);
+  }, 120_000);
+
+  test("indexes it after `qmd trust`", async () => {
+    writeLocalConfig(outsideConfig());
+    const trust = await runQmd(["trust"]);
+    expect(trust.stdout).toContain("Trusted");
+    expect(trust.stdout).toContain(outsideDir);
+
+    const result = await runQmd(["update"]);
+    expect(result.stdout).toContain("Indexed: 1 new");
+    expect(result.stdout).not.toContain("Skipping collection 'secrets'");
+  }, 120_000);
+
+  test("re-arms the gate when the path is rewritten after approval", async () => {
+    writeLocalConfig(outsideConfig());
+    await runQmd(["trust"]);
+    const other = mkdtempSync(join(tmpdir(), "qmd-path-trust-other-"));
+    writeFileSync(join(other, "other.md"), "# Other\n\nAlso outside.\n", "utf-8");
+    writeLocalConfig([
+      "collections:",
+      "  secrets:",
+      `    path: ${JSON.stringify(other)}`,
+      '    pattern: "**/*.md"',
+      "",
+    ].join("\n"));
+
+    const result = await runQmd(["update"]);
+    expect(result.stdout).toContain("Skipping collection 'secrets'");
+    expect(result.stdout).not.toContain("Indexed: 1 new");
+    try { rmSync(other, { recursive: true, force: true }); } catch { /* ignore */ }
+  }, 120_000);
+
+  test("QMD_TRUST_LOCAL_CONFIG=1 opts unattended runs back in", async () => {
+    writeLocalConfig(outsideConfig());
+    const result = await runQmd(["update"], { QMD_TRUST_LOCAL_CONFIG: "1" });
+    expect(result.stdout).toContain("Indexed: 1 new");
+    expect(result.stdout).not.toContain("Skipping collection 'secrets'");
+  }, 120_000);
+});
+
+describe("qmd update with a checked-in custom model URI", () => {
+  test("does not treat the custom model as trusted, but still indexes the project", async () => {
+    writeLocalConfig([
+      "collections:",
+      "  docs:",
+      "    path: ./docs",
+      '    pattern: "**/*.md"',
+      "models:",
+      "  embed: hf:evil/embed/x.gguf",
+      "",
+    ].join("\n"));
+
+    const result = await runQmd(["update"]);
+    expect(result.stdout).toContain("Custom models");
+    expect(result.stdout).toContain("hf:evil/embed/x.gguf");
+    expect(result.stdout).toContain("Indexed: 1 new");
+    expect(result.exitCode).toBe(0);
+  }, 120_000);
+
+  test("`qmd trust` records the custom model", async () => {
+    writeLocalConfig([
+      "collections:",
+      "  docs:",
+      "    path: ./docs",
+      '    pattern: "**/*.md"',
+      "models:",
+      "  embed: hf:evil/embed/x.gguf",
+      "",
+    ].join("\n"));
+
+    const trust = await runQmd(["trust"]);
+    expect(trust.stdout).toContain("hf:evil/embed/x.gguf");
+    expect(trust.stdout).toContain("Trusted");
+
+    const result = await runQmd(["update"]);
+    expect(result.stdout).not.toContain("Custom models");
+    expect(result.stdout).toContain("Indexed: 1 new");
+  }, 120_000);
+});
+
+describe("qmd update with only in-project paths", () => {
+  test("indexes without a trust prompt", async () => {
+    writeLocalConfig([
+      "collections:",
+      "  docs:",
+      "    path: ./docs",
+      '    pattern: "**/*.md"',
+      "",
+    ].join("\n"));
+
+    const result = await runQmd(["update"]);
+    expect(result.stdout).toContain("Indexed: 1 new");
+    expect(result.stdout).not.toContain("qmd trust");
+    expect(result.exitCode).toBe(0);
+  }, 120_000);
+});

--- a/test/update-hook-trust.test.ts
+++ b/test/update-hook-trust.test.ts
@@ -11,14 +11,20 @@ import { join } from "node:path";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readFileSync } from "node:fs";
 import {
   decideHookGate,
+  decideLocalConfigGate,
   getTrustFilePath,
   hookDigest,
+  isCollectionPathInsideProject,
   isLocalConfigPath,
   isTrusted,
   listTrusted,
   loadTrustStore,
   recordTrust,
+  resolveConfigCollectionPath,
   revokeTrust,
+  sensitiveDigest,
+  type BuiltinModels,
+  type SensitiveSnapshot,
   type UpdateHook,
 } from "../src/trust.js";
 
@@ -195,5 +201,210 @@ describe("decideHookGate", () => {
       trustedCheck: untrusted,
     });
     expect(decision.action).toBe("skip");
+  });
+});
+
+const builtins: BuiltinModels = {
+  embed: "hf:default/embed/model.gguf",
+  rerank: "hf:default/rerank/model.gguf",
+  generate: "hf:default/generate/model.gguf",
+};
+
+function snapshot(overrides: Partial<SensitiveSnapshot> = {}): SensitiveSnapshot {
+  return {
+    hooks: [],
+    paths: [{ collection: "docs", path: "./docs" }],
+    models: {},
+    ...overrides,
+  };
+}
+
+describe("isCollectionPathInsideProject", () => {
+  test("allows relative paths inside the project", () => {
+    const configPath = "/home/me/project/.qmd/index.yml";
+    expect(isCollectionPathInsideProject(configPath, "./docs")).toBe(true);
+    expect(isCollectionPathInsideProject(configPath, ".")).toBe(true);
+    expect(isCollectionPathInsideProject(configPath, "docs/notes")).toBe(true);
+  });
+
+  test("rejects paths that leave the project", () => {
+    const configPath = "/home/me/project/.qmd/index.yml";
+    expect(isCollectionPathInsideProject(configPath, "..")).toBe(false);
+    expect(isCollectionPathInsideProject(configPath, "../other")).toBe(false);
+    expect(isCollectionPathInsideProject(configPath, "/etc")).toBe(false);
+    expect(isCollectionPathInsideProject(configPath, "/home/me/secrets")).toBe(false);
+  });
+
+  test("expands ~ to the home directory, which is outside the project", () => {
+    const configPath = "/home/me/project/.qmd/index.yml";
+    const origHome = process.env.HOME;
+    process.env.HOME = "/home/me";
+    try {
+      expect(isCollectionPathInsideProject(configPath, "~/secrets")).toBe(false);
+      expect(resolveConfigCollectionPath("~/secrets", configPath)).toBe("/home/me/secrets");
+    } finally {
+      if (origHome === undefined) delete process.env.HOME;
+      else process.env.HOME = origHome;
+    }
+  });
+});
+
+describe("sensitiveDigest", () => {
+  const project = "/home/me/project/.qmd/index.yml";
+
+  test("is stable across collection ordering", () => {
+    const a = snapshot({
+      paths: [
+        { collection: "docs", path: "./docs" },
+        { collection: "notes", path: "./notes" },
+      ],
+    });
+    const b = snapshot({
+      paths: [
+        { collection: "notes", path: "./notes" },
+        { collection: "docs", path: "./docs" },
+      ],
+    });
+    expect(sensitiveDigest(a, project, builtins)).toBe(sensitiveDigest(b, project, builtins));
+  });
+
+  test("in-project paths and default models do not change the digest", () => {
+    const empty = snapshot({ paths: [], models: {} });
+    const inProject = snapshot({
+      paths: [{ collection: "docs", path: "./docs" }],
+      models: { embed: builtins.embed, rerank: builtins.rerank, generate: builtins.generate },
+    });
+    expect(sensitiveDigest(empty, project, builtins)).toBe(sensitiveDigest(inProject, project, builtins));
+  });
+
+  test("changes when a collection path leaves the project", () => {
+    const inside = snapshot({ paths: [{ collection: "docs", path: "./docs" }] });
+    const outside = snapshot({ paths: [{ collection: "docs", path: "/etc" }] });
+    expect(sensitiveDigest(inside, project, builtins)).not.toBe(sensitiveDigest(outside, project, builtins));
+  });
+
+  test("changes when a custom model URI is set", () => {
+    const defaults = snapshot({ models: {} });
+    const custom = snapshot({ models: { embed: "hf:evil/embed/x.gguf" } });
+    expect(sensitiveDigest(defaults, project, builtins)).not.toBe(sensitiveDigest(custom, project, builtins));
+  });
+});
+
+describe("decideLocalConfigGate", () => {
+  const project = "/home/me/project/.qmd/index.yml";
+  const global = "/home/me/.config/qmd/index.yml";
+  const noEnv = {} as NodeJS.ProcessEnv;
+  const untrusted = () => false;
+  const outside = snapshot({ paths: [{ collection: "secrets", path: "/etc" }] });
+  const customModel = snapshot({ models: { embed: "hf:evil/embed/x.gguf" } });
+
+  test("in-project paths and default models need no decision", () => {
+    const decision = decideLocalConfigGate({
+      configPath: project,
+      snapshot: snapshot(),
+      builtins,
+      isInteractive: false,
+      env: noEnv,
+      trustedCheck: untrusted,
+    });
+    expect(decision.action).toBe("run");
+  });
+
+  test("the user's own config always runs, even with an outside path", () => {
+    const decision = decideLocalConfigGate({
+      configPath: global,
+      snapshot: outside,
+      builtins,
+      isInteractive: false,
+      env: noEnv,
+      trustedCheck: untrusted,
+    });
+    expect(decision.action).toBe("run");
+  });
+
+  test("an untrusted outside path prompts on a terminal", () => {
+    const decision = decideLocalConfigGate({
+      configPath: project,
+      snapshot: outside,
+      builtins,
+      isInteractive: true,
+      env: noEnv,
+      trustedCheck: untrusted,
+    });
+    expect(decision.action).toBe("prompt");
+  });
+
+  test("an untrusted outside path is skipped with nobody to ask", () => {
+    const decision = decideLocalConfigGate({
+      configPath: project,
+      snapshot: outside,
+      builtins,
+      isInteractive: false,
+      env: noEnv,
+      trustedCheck: untrusted,
+    });
+    expect(decision.action).toBe("skip");
+  });
+
+  test("an untrusted custom model is skipped with nobody to ask", () => {
+    const decision = decideLocalConfigGate({
+      configPath: project,
+      snapshot: customModel,
+      builtins,
+      isInteractive: false,
+      env: noEnv,
+      trustedCheck: untrusted,
+    });
+    expect(decision.action).toBe("skip");
+  });
+
+  test("a previously approved snapshot runs unattended", () => {
+    const digest = sensitiveDigest(outside, project, builtins);
+    const decision = decideLocalConfigGate({
+      configPath: project,
+      snapshot: outside,
+      builtins,
+      isInteractive: false,
+      env: noEnv,
+      trustedCheck: (path, d) => path === project && d === digest,
+    });
+    expect(decision.action).toBe("run");
+  });
+
+  test("pointing an approved collection outside the project re-arms the gate", () => {
+    const approved = sensitiveDigest(snapshot({ paths: [{ collection: "docs", path: "./docs" }] }), project, builtins);
+    const decision = decideLocalConfigGate({
+      configPath: project,
+      snapshot: snapshot({ paths: [{ collection: "docs", path: "/etc" }] }),
+      builtins,
+      isInteractive: false,
+      env: noEnv,
+      trustedCheck: (_path, d) => d === approved,
+    });
+    expect(decision.action).toBe("skip");
+  });
+
+  test("QMD_TRUST_LOCAL_CONFIG opts unattended runs back in", () => {
+    const decision = decideLocalConfigGate({
+      configPath: project,
+      snapshot: outside,
+      builtins,
+      isInteractive: false,
+      env: { QMD_TRUST_LOCAL_CONFIG: "1" } as NodeJS.ProcessEnv,
+      trustedCheck: untrusted,
+    });
+    expect(decision.action).toBe("run");
+  });
+
+  test("QMD_TRUST_UPDATE_HOOKS also opts the path/model gate in", () => {
+    const decision = decideLocalConfigGate({
+      configPath: project,
+      snapshot: customModel,
+      builtins,
+      isInteractive: false,
+      env: { QMD_TRUST_UPDATE_HOOKS: "1" } as NodeJS.ProcessEnv,
+      trustedCheck: untrusted,
+    });
+    expect(decision.action).toBe("run");
   });
 });


### PR DESCRIPTION
Closes #889 (duplicate of #890).

## What was wrong

#887 gates `update:` hooks from a checked-in `.qmd/index.yml`. The same file can still set `collections.*.path` to any directory the process can read, and `models.embed` / `models.rerank` / `models.generate` to any `hf:` repo or local GGUF. `qmd update` / `qmd embed` in a freshly cloned tree then indexes that path and would load those models, with no prompt. Global `~/.config/qmd` is unaffected. #888 contains glob/symlink escapes relative to the collection root; it does not constrain which root a local config may name.

## The fix

Reuse the #887 approval (same `trusted.json`, per-config digest):

- **In-project paths** (e.g. `./docs`) and the built-in default model URIs still run unattended — that is what a local config is for.
- **Out-of-project collection paths** are skipped until `qmd trust` (or a TTY yes). Indexing of in-project collections continues.
- **Custom model URIs** are not loaded or downloaded until approved; LlamaCpp falls back to defaults/env.
- Editing a hook, pointing a collection outside the project, or changing a custom model URI changes the digest and re-arms the gate. Filling defaults into the YAML does not.
- `QMD_TRUST_LOCAL_CONFIG=1` opts unattended runs back in; `QMD_TRUST_UPDATE_HOOKS=1` still does. `qmd collection add` / `update-cmd` record trust as they write.

## Tests

`test/update-hook-trust.test.ts` covers path containment (`~`, `..`, `/etc`), digest stability, and the `decideLocalConfigGate` table.

`test/local-config-trust-cli.test.ts` spawns real `qmd update` against a hostile-clone fixture: outside path not indexed unattended, indexed after `qmd trust`, re-armed when rewritten, allowed under `QMD_TRUST_LOCAL_CONFIG=1`; custom models listed but in-project indexing continues; in-project-only configs need no prompt.

Existing hook CLI tests still pass. `tsc -p tsconfig.build.json --noEmit` is clean. 56 trust/local-config tests pass on Bun and Node.