### PR TITLE
fix(security): gate project-local collection paths and model URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@
   `~/.config/qmd/*.yml`, including anything `qmd collection update-cmd` writes,
   are unaffected.
 
+- The same project-local trust gate now covers collection `path` values that
+  resolve outside the project and `models.*` URIs that are not the built-in
+  defaults (#889). A checked-in `.qmd/index.yml` could previously point
+  `qmd update` at any readable directory and `qmd embed` / `qmd query` /
+  `qmd pull` at any `hf:` repo or local GGUF, with no prompt. In-project paths
+  (`./docs`) and default model URIs still apply without approval. Untrusted
+  out-of-project collections are skipped (other collections still index);
+  untrusted model URIs fall back to the built-in defaults or `QMD_*_MODEL`.
+  Approvals reuse `<config dir>/trusted.json`; a hooks-only digest is unchanged
+  so existing `qmd trust` records still match.
+
 - Indexing no longer follows file symlinks or glob `../` / absolute patterns
   out of the collection directory. `fast-glob` already skipped symlinked
   directories, but a file symlink (or a mask like `../**/*.md`) still resolved
@@ -35,6 +46,8 @@
   bind (`--host 0.0.0.0`) skips the host check and warns at startup.
 
 ### Changed
+
+- Nested picomatch min-bumps for high GHSA-c2c7-rcm5-vvqj / GHSA-3v7f-55p6-f55p: micromatch 2.3.1 -> 2.3.2, vite/tinyglobby 4.0.3 -> 4.0.5. Direct picomatch stays 4.0.5. No zod/vitest majors. flake.nix FOD hashes not updated.
 
 - Dependencies: `node-llama-cpp` 3.18.1 → **3.20.0** (llama.cpp b8390 → b10361, 2026-08-11). Also safe patch/minors: `picomatch` 4.0.4 → 4.0.5, `web-tree-sitter` 0.26.8 → 0.26.12, `tsx` 4.21.0 → 4.23.12, `vitest` 3.2.4 → 3.2.7. No zod/vitest major; `@modelcontextprotocol/server` stays 2.0.0 (no 2.x patch). `flake.nix` FOD hashes are not updated here.
 - `generate` and query expansion now await `LlamaContextSequence.dispose()` before disposing the parent context. node-llama-cpp 3.20 made sequence dispose async; the library's context-onDispose path does not wait.

--- a/README.md
+++ b/README.md
@@ -792,29 +792,33 @@ qmd collection update-cmd wiki 'git pull --ff-only'   # set
 qmd collection update-cmd wiki                         # clear
 ```
 
-##### Update commands from a checked-in `.qmd` config
+##### Checked-in `.qmd` config (update commands, paths, models)
 
 A project-local `.qmd/index.yml` travels with a `git clone`, and QMD adopts it
-automatically for any command run inside the tree. Its `update` commands are
-therefore somebody else's shell script until you say otherwise, and QMD will not
-run them unattended:
+automatically for any command run inside the tree. Three fields in that file
+are somebody else's say-so until you approve them:
 
-- On a terminal, `qmd update` lists the commands and asks before running them.
-  Approving records the approval in `~/.config/qmd/trusted.json`.
-- With no terminal to ask — agents, CI, MCP — the commands are **skipped** and
-  indexing continues, so the refresh you asked for still happens.
-- Approvals cover the exact commands you saw. Editing one, or a `git pull` that
-  rewrites it, asks again.
+- `update:` hooks, which `qmd update` would run through `bash -c`
+- `collections.*.path` that resolve **outside the project** (absolute dirs,
+  `../`, `~/...`). In-project paths like `./docs` still index without approval.
+- `models.embed` / `models.rerank` / `models.generate` that are not the
+  built-in defaults. Untrusted URIs fall back to those defaults (or `QMD_*_MODEL`).
+
+On a terminal, `qmd update` lists the gated values and asks. Approving records
+the approval in `~/.config/qmd/trusted.json`. With no terminal to ask — agents,
+CI, MCP — the gated values are **skipped** and in-project indexing continues.
+Approvals cover the exact hooks, out-of-project paths, and custom model URIs
+you saw. Editing one, or a `git pull` that rewrites it, asks again.
 
 ```sh
-qmd trust           # review and approve this project's update commands
+qmd trust           # review and approve this project's gated config
 qmd trust list      # show every approved project config
 qmd trust revoke    # drop the approval for this project
 ```
 
-Set `QMD_TRUST_UPDATE_HOOKS=1` for CI that should run them unattended. Commands
+Set `QMD_TRUST_UPDATE_HOOKS=1` for CI that should apply them unattended. Values
 in your own `~/.config/qmd/*.yml` — including anything `qmd collection
-update-cmd` writes — are never gated.
+update-cmd` or `qmd collection add` writes — are never gated.
 
 ### Search Commands
 

--- a/bun.lock
+++ b/bun.lock
@@ -561,7 +561,7 @@
 
     "is-fullwidth-code-point/get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
 
-    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+    "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "node-llama-cpp/node-addon-api": ["node-addon-api@8.9.2", "", {}, "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg=="],
 
@@ -579,7 +579,7 @@
 
     "string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
-    "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+    "tinyglobby/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
     "tree-sitter-javascript/node-addon-api": ["node-addon-api@8.5.0", "", {}, "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A=="],
 
@@ -589,7 +589,7 @@
 
     "vite/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
-    "vite/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+    "vite/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -117,13 +117,15 @@ import {
   type ModelsConfig,
 } from "../collections.js";
 import {
-  decideHookGate,
-  hookDigest,
+  collectGatedSurfaces,
+  configDigest,
+  decideConfigGate,
+  hasGatedSurfaces,
   isLocalConfigPath,
   listTrusted,
   recordTrust,
   revokeTrust,
-  type UpdateHook,
+  type GatedConfig,
 } from "../trust.js";
 
 // NOTE: enableProductionMode() is intentionally NOT called at module scope here.
@@ -696,24 +698,70 @@ async function showStatus(): Promise<void> {
   closeDb();
 }
 
-/**
- * Every `update:` hook the active config defines. Read from the YAML rather
- * than the synced SQLite copy so `qmd trust` and `qmd update` always digest the
- * same set.
- */
-function collectUpdateHooks(): UpdateHook[] {
-  const config = loadConfig();
-  return Object.entries(config.collections ?? {})
-    .filter(([, col]) => !!col.update)
-    .map(([name, col]) => ({ collection: name, command: col.update! }));
+function defaultModelsForTrust(): { embed: string; generate: string; rerank: string } {
+  return {
+    embed: DEFAULT_EMBED_MODEL,
+    generate: DEFAULT_QUERY_MODEL,
+    rerank: DEFAULT_RERANK_MODEL,
+  };
 }
 
-/** Record the active config's current hook set as approved. */
-function trustCurrentConfigHooks(): void {
+function currentGatedConfig(): { configPath: string; gated: GatedConfig } {
   const configPath = getConfigPath();
-  if (!isLocalConfigPath(configPath)) return;
-  recordTrust(configPath, hookDigest(collectUpdateHooks()));
+  return {
+    configPath,
+    gated: collectGatedSurfaces(configPath, loadConfig(), defaultModelsForTrust()),
+  };
 }
+
+/** Record the active config's current gated surfaces as approved. */
+function trustCurrentConfigHooks(): void {
+  const { configPath, gated } = currentGatedConfig();
+  if (!isLocalConfigPath(configPath)) return;
+  recordTrust(configPath, configDigest(gated));
+}
+
+function printGatedSurfaces(configPath: string, gated: GatedConfig): void {
+  if (gated.hooks.length > 0) {
+    console.log(`${c.yellow}This project's ${configPath} defines update commands:${c.reset}`);
+    for (const hook of gated.hooks) {
+      console.log(`  ${c.bold}${hook.collection}${c.reset}: ${hook.command}`);
+    }
+    console.log(`${c.dim}They run as a shell script before indexing.${c.reset}`);
+  }
+  if (gated.paths.length > 0) {
+    console.log(`${c.yellow}This project's ${configPath} names collection paths outside the project:${c.reset}`);
+    for (const p of gated.paths) {
+      console.log(`  ${c.bold}${p.collection}${c.reset}: ${p.path}`);
+    }
+    console.log(`${c.dim}Those directories would be indexed on update.${c.reset}`);
+  }
+  if (gated.models.embed || gated.models.rerank || gated.models.generate) {
+    console.log(`${c.yellow}This project's ${configPath} names model URIs:${c.reset}`);
+    if (gated.models.embed) console.log(`  embed: ${gated.models.embed}`);
+    if (gated.models.rerank) console.log(`  rerank: ${gated.models.rerank}`);
+    if (gated.models.generate) console.log(`  generate: ${gated.models.generate}`);
+    console.log(`${c.dim}Those would be downloaded or loaded on embed/query/pull.${c.reset}`);
+  }
+  console.log(`${c.dim}Config that came with a checkout is not trusted by default.${c.reset}`);
+}
+
+function warnUntrustedModels(): void {
+  const { configPath, gated } = currentGatedConfig();
+  if (!gated.models.embed && !gated.models.rerank && !gated.models.generate) return;
+  const decision = decideConfigGate({
+    configPath,
+    gated,
+    isInteractive: false,
+  });
+  if (decision.action === "run") return;
+  console.log(`${c.yellow}Skipping project-local model URIs from ${configPath} — not trusted.${c.reset}`);
+  if (gated.models.embed) console.log(`  embed: ${gated.models.embed}`);
+  if (gated.models.rerank) console.log(`  rerank: ${gated.models.rerank}`);
+  if (gated.models.generate) console.log(`  generate: ${gated.models.generate}`);
+  console.log(`${c.dim}Built-in defaults (or QMD_*_MODEL) apply instead. Approve with 'qmd trust', or set QMD_TRUST_UPDATE_HOOKS=1.${c.reset}`);
+}
+
 
 /** Ask the user a yes/no question. Only called when stdin and stdout are TTYs. */
 async function confirmOnTty(question: string): Promise<boolean> {
@@ -728,48 +776,49 @@ async function confirmOnTty(question: string): Promise<boolean> {
 }
 
 /**
- * Decide whether this run may execute the configured `update:` hooks, prompting
- * when there is a human to ask. Returns false when the hooks must be skipped —
+ * Decide whether this run may apply gated project-local config (update hooks,
+ * out-of-project collection paths, custom model URIs), prompting when there is
+ * a human to ask. Returns false when those surfaces must be skipped — in-project
  * indexing still proceeds, since that is what the caller asked for.
  */
-async function resolveUpdateHookTrust(): Promise<boolean> {
-  const hooks = collectUpdateHooks();
-  if (hooks.length === 0) return true;
+async function resolveUpdateHookTrust(): Promise<{ allowed: boolean; gated: GatedConfig }> {
+  const { configPath, gated } = currentGatedConfig();
+  if (!hasGatedSurfaces(gated)) return { allowed: true, gated };
 
-  const configPath = getConfigPath();
-  const decision = decideHookGate({
+  const decision = decideConfigGate({
     configPath,
-    hooks,
+    gated,
     isInteractive: !!process.stdin.isTTY && !!process.stdout.isTTY,
   });
 
-  if (decision.action === "run") return true;
+  if (decision.action === "run") return { allowed: true, gated };
 
-  console.log(`${c.yellow}This project's ${configPath} defines update commands:${c.reset}`);
-  for (const hook of hooks) {
-    console.log(`  ${c.bold}${hook.collection}${c.reset}: ${hook.command}`);
-  }
-  console.log(`${c.dim}They run as a shell script before indexing. Config that came with a checkout is not trusted by default.${c.reset}`);
+  printGatedSurfaces(configPath, gated);
 
   if (decision.action === "skip") {
     console.log(`${c.yellow}Skipping them — no terminal to confirm on. Indexing continues.${c.reset}`);
-    console.log(`${c.dim}Approve with 'qmd trust', or set QMD_TRUST_UPDATE_HOOKS=1 for unattended runs.${c.reset}\n`);
-    return false;
+    console.log(`${c.dim}Approve with 'qmd trust', or set QMD_TRUST_UPDATE_HOOKS=1 for unattended runs.${c.reset}` + "\n");
+    return { allowed: false, gated };
   }
 
-  const approved = await confirmOnTty("Run these update commands? [y/N] ");
+  const hooksOnly = gated.hooks.length > 0 && gated.paths.length === 0
+    && !gated.models.embed && !gated.models.rerank && !gated.models.generate;
+  const approved = await confirmOnTty(hooksOnly
+    ? "Run these update commands? [y/N] "
+    : "Apply this checked-in config? [y/N] ");
   if (!approved) {
-    console.log(`${c.yellow}Skipped. Indexing continues.${c.reset}\n`);
-    return false;
+    console.log(`${c.yellow}Skipped. Indexing continues.${c.reset}` + "\n");
+    return { allowed: false, gated };
   }
   recordTrust(configPath, decision.digest);
-  console.log(`${c.green}Trusted ${configPath}.${c.reset} ${c.dim}Editing a command will ask again.${c.reset}\n`);
-  return true;
+  console.log(`${c.green}Trusted ${configPath}.${c.reset} ${c.dim}Editing a command, path, or model URI will ask again.${c.reset}` + "\n");
+  return { allowed: true, gated };
 }
 
 /**
- * `qmd trust [list|revoke]` — approve, inspect or drop the update-hook
- * approval for the project-local config in scope.
+ * `qmd trust [list|revoke]` — approve, inspect or drop the approval for
+ * gated surfaces in the project-local config in scope (update hooks,
+ * out-of-project collection paths, custom model URIs).
  */
 function manageTrust(subcommand?: string): void {
   const configPath = getConfigPath();
@@ -806,22 +855,20 @@ function manageTrust(subcommand?: string): void {
   }
 
   if (!isLocalConfigPath(configPath)) {
-    console.log(`${c.dim}${configPath} is your own config — update commands there always run. Nothing to trust.${c.reset}`);
+    console.log(`${c.dim}${configPath} is your own config — update commands, paths, and models there always apply. Nothing to trust.${c.reset}`);
     return;
   }
 
-  const hooks = collectUpdateHooks();
-  if (hooks.length === 0) {
-    console.log(`${c.dim}${configPath} defines no update commands. Nothing to trust.${c.reset}`);
+  const { gated } = currentGatedConfig();
+  if (!hasGatedSurfaces(gated)) {
+    console.log(`${c.dim}${configPath} defines no update commands, out-of-project paths, or custom model URIs. Nothing to trust.${c.reset}`);
     return;
   }
 
-  for (const hook of hooks) {
-    console.log(`  ${c.bold}${hook.collection}${c.reset}: ${hook.command}`);
-  }
-  recordTrust(configPath, hookDigest(hooks));
+  printGatedSurfaces(configPath, gated);
+  recordTrust(configPath, configDigest(gated));
   console.log(`${c.green}✓ Trusted ${configPath}${c.reset}`);
-  console.log(`${c.dim}Editing any of these commands will ask again. Revoke with 'qmd trust revoke'.${c.reset}`);
+  console.log(`${c.dim}Editing an update command, collection path, or model URI will ask again. Revoke with 'qmd trust revoke'.${c.reset}`);
 }
 
 async function updateCollections(): Promise<void> {
@@ -841,8 +888,11 @@ async function updateCollections(): Promise<void> {
   }
 
   // A project-local .qmd/index.yml travels with a `git clone`, so its `update:`
-  // hooks are somebody else's shell commands until the user says otherwise (#886).
-  const hooksAllowed = await resolveUpdateHookTrust();
+  // hooks, out-of-project collection paths, and custom model URIs are somebody
+  // else's say-so until the user says otherwise (#886, #889).
+  const trust = await resolveUpdateHookTrust();
+  const hooksAllowed = trust.allowed;
+  const skippedPaths = new Set(trust.allowed ? [] : trust.gated.paths.map(p => p.collection));
 
   console.log(`${c.bold}Updating ${collections.length} collection(s)...${c.reset}\n`);
 
@@ -850,6 +900,11 @@ async function updateCollections(): Promise<void> {
     const col = collections[i];
     if (!col) continue;
     console.log(`${c.cyan}[${i + 1}/${collections.length}]${c.reset} ${c.bold}${col.name}${c.reset} ${c.dim}(${col.glob_pattern})${c.reset}`);
+    if (skippedPaths.has(col.name)) {
+      console.log(`${c.yellow}    Skipping — path ${col.pwd} is outside the project and this config is not trusted.${c.reset}`);
+      console.log(`${c.dim}    Approve with 'qmd trust'.${c.reset}` + "\n");
+      continue;
+    }
 
     // Execute custom update command if specified in YAML
     const yamlCol = getCollectionFromYaml(col.name);
@@ -1765,6 +1820,9 @@ async function collectionAdd(pwd: string, globPattern: string, name?: string): P
   const { addCollection } = await import("../collections.js");
   addCollection(collName, pwd, globPattern);
   resyncConfig();
+  // The user just typed this path, so an out-of-project root needs no separate
+  // approval; re-record so the digest covers the new path set (#889).
+  trustCurrentConfigHooks();
 
   // Create the collection and index files
   console.log(`Creating collection '${collName}'...`);
@@ -2033,18 +2091,31 @@ function parseEmbedTimeoutOption(value: unknown): number | undefined {
 function ensureModelsConfiguredForCli(): { embed: string; generate: string; rerank: string } {
   try {
     const config = loadConfig();
-    const models = resolveModels(config.models);
-    const current = config.models ?? {};
-    if (current.embed !== models.embed || current.generate !== models.generate || current.rerank !== models.rerank) {
-      saveConfig({
-        ...config,
-        models: {
-          ...current,
-          embed: models.embed,
-          generate: models.generate,
-          rerank: models.rerank,
-        },
-      });
+    const configPath = getConfigPath();
+    const gated = collectGatedSurfaces(configPath, config, defaultModelsForTrust());
+    const decision = decideConfigGate({
+      configPath,
+      gated,
+      isInteractive: false,
+    });
+    // Untrusted project-local model URIs are not applied (#889). Env vars and
+    // built-in defaults still work. Do not write the fallback back into the
+    // YAML — that would erase the untrusted values the user may yet approve.
+    const applyConfigModels = decision.action === "run";
+    const models = resolveModels(applyConfigModels ? config.models : undefined);
+    if (applyConfigModels) {
+      const current = config.models ?? {};
+      if (current.embed !== models.embed || current.generate !== models.generate || current.rerank !== models.rerank) {
+        saveConfig({
+          ...config,
+          models: {
+            ...current,
+            embed: models.embed,
+            generate: models.generate,
+            rerank: models.rerank,
+          },
+        });
+      }
     }
     return models;
   } catch {
@@ -3502,7 +3573,7 @@ function showHelp(): void {
   console.log("  qmd init                      - Create a project-local .qmd index");
   console.log("  qmd status                    - View index + collection health");
   console.log("  qmd update [--pull]           - Re-index collections (optionally git pull first)");
-  console.log("  qmd trust [list|revoke]       - Approve a checked-in .qmd config's update commands");
+  console.log("  qmd trust [list|revoke]       - Approve a checked-in .qmd config's hooks, paths, and models");
   console.log("  qmd embed [-f] [-c <name>]    - Generate/refresh vector embeddings");
   console.log("    --max-docs-per-batch <n>    - Cap docs loaded into memory per embedding batch");
   console.log("    --max-batch-mb <n>          - Cap UTF-8 MB loaded into memory per embedding batch");
@@ -4555,6 +4626,7 @@ if (isMain) {
         // embed operates on a single collection; only the first value is used.
         const embedValidatedCollections = resolveCollectionFilter(cli.opts.collection, false);
         const embedCollection = embedValidatedCollections[0];
+        warnUntrustedModels();
         await vectorIndex(resolveEmbedModelForCli(), !!cli.values.force, {
           maxDocsPerBatch,
           maxBatchBytes: maxBatchMb === undefined ? undefined : maxBatchMb * 1024 * 1024,
@@ -4569,6 +4641,7 @@ if (isMain) {
 
     case "pull": {
       const refresh = cli.values.refresh === undefined ? false : Boolean(cli.values.refresh);
+      warnUntrustedModels();
       const activeModels = resolveModelsForCli();
       const models = [
         activeModels.embed,
@@ -4607,6 +4680,7 @@ if (isMain) {
       if (!cli.values["min-score"]) {
         cli.opts.minScore = 0.3;
       }
+      warnUntrustedModels();
       await vectorSearch(cli.query, cli.opts);
       break;
 
@@ -4616,6 +4690,7 @@ if (isMain) {
         console.error("Usage: qmd query [options] <query>");
         process.exit(1);
       }
+      warnUntrustedModels();
       await querySearch(cli.query, cli.opts);
       break;
 

--- a/src/trust.ts
+++ b/src/trust.ts
@@ -1,25 +1,34 @@
 /**
- * trust.ts — approval gate for `update:` hooks from project-local config.
+ * trust.ts — approval gate for project-local `.qmd` config.
  *
- * A collection's `update:` field is a shell command run by `qmd update`. That
- * is fine when the command came from the user's own global config, which only
- * `qmd collection update-cmd` writes. It is not fine for a project-local
- * `.qmd/index.yml`: that file arrives with a `git clone`, and `findLocalConfigPath`
- * adopts it automatically for any command run anywhere inside the tree. Without
- * a gate, cloning a repository and running `qmd update` executes shell commands
- * chosen by whoever wrote the repo (#886).
+ * A project-local `.qmd/index.yml` arrives with a `git clone`, and
+ * `findLocalConfigPath` adopts it automatically for any command run anywhere
+ * inside the tree. Three fields in that file are somebody else's say-so until
+ * the user approves them:
  *
- * The model is the one direnv, VS Code and `git safe.directory` converged on:
- * approvals are per config file and per command set, recorded in
- * `<config dir>/trusted.json`. Editing a hook — or a `git pull` that rewrites
- * one — changes the digest and re-arms the gate, so an approval cannot be
- * silently widened after the fact.
+ * - `update:` hooks, which `qmd update` runs through `bash -c` (#886)
+ * - `collections.*.path` that resolve outside the project, which `qmd update`
+ *   would otherwise index (#889)
+ * - `models.embed` / `models.rerank` / `models.generate` that are not the
+ *   built-in defaults, which `qmd embed` / `qmd query` / `qmd pull` would
+ *   otherwise download or load (#889)
+ *
+ * Paths that stay inside the project (the usual `path: ./docs`) and model
+ * URIs that equal the built-in defaults are not gated — that is the intended
+ * use of a checked-in config. Global `~/.config/qmd` is never gated.
+ *
+ * Approvals are per config file and per gated-surface set, recorded in
+ * `<config dir>/trusted.json`. Editing a hook, an out-of-project path, or a
+ * custom model URI — or a `git pull` that rewrites one — changes the digest
+ * and re-arms the gate. A config that only has hooks keeps the #886 digest
+ * so existing approvals still match.
  */
 
 import { createHash } from "crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { basename, dirname, join, resolve } from "path";
+import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "fs";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "path";
 import { getConfigDir } from "./collections.js";
+import { qmdHomedir } from "./paths.js";
 
 /** A collection's pre-update hook, as it will be executed. */
 export type UpdateHook = {
@@ -27,8 +36,34 @@ export type UpdateHook = {
   command: string;
 };
 
+/** A collection path that resolves outside the project and needs approval. */
+export type GatedPath = {
+  collection: string;
+  path: string;
+};
+
+/** Model URIs from project-local config that are not the built-in defaults. */
+export type GatedModels = {
+  embed?: string;
+  rerank?: string;
+  generate?: string;
+};
+
+export type DefaultModels = {
+  embed: string;
+  generate: string;
+  rerank: string;
+};
+
+/** Every surface a project-local config must not apply unattended. */
+export type GatedConfig = {
+  hooks: UpdateHook[];
+  paths: GatedPath[];
+  models: GatedModels;
+};
+
 export type TrustRecord = {
-  /** Digest of the hook set that was approved. */
+  /** Digest of the gated surfaces that were approved. */
   hooks: string;
   /** ISO timestamp of the approval. */
   trustedAt: string;
@@ -54,6 +89,63 @@ export function isLocalConfigPath(configPath: string): boolean {
   return basename(dirname(resolve(configPath))) === ".qmd";
 }
 
+/** Directory that contains the `.qmd/` folder for a project-local config. */
+export function projectRootFromConfigPath(configPath: string): string {
+  return dirname(dirname(resolve(configPath)));
+}
+
+function expandUserPath(p: string): string {
+  if (p === "~") return qmdHomedir();
+  if (p.startsWith("~/")) return join(qmdHomedir(), p.slice(2));
+  return p;
+}
+
+function realOrResolve(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return resolve(p);
+  }
+}
+
+/**
+ * Resolve a collection `path` from a project-local config: `~` expands, relative
+ * paths are against the project root (parent of `.qmd`), absolute paths stay
+ * absolute.
+ */
+export function resolveConfigCollectionPath(configPath: string, collectionPath: string): string {
+  const expanded = expandUserPath(collectionPath.trim());
+  if (isAbsolute(expanded)) return resolve(expanded);
+  return resolve(projectRootFromConfigPath(configPath), expanded);
+}
+
+/** True if `target` is `dir` or a descendant. Lexical after realpath/resolve. */
+function isInsideDir(dir: string, target: string): boolean {
+  const rel = relative(dir, target);
+  if (rel === "" || rel === ".") return true;
+  if (isAbsolute(rel)) return false;
+  return rel !== ".." && !rel.startsWith(`..${sep}`);
+}
+
+/**
+ * Whether a collection path from this config stays inside the project.
+ * Used to decide if the path needs a trust approval (#889).
+ */
+export function isCollectionPathInsideProject(configPath: string, collectionPath: string): boolean {
+  if (!collectionPath.trim()) return true;
+  const projectRoot = realOrResolve(projectRootFromConfigPath(configPath));
+  const target = realOrResolve(resolveConfigCollectionPath(configPath, collectionPath));
+  return isInsideDir(projectRoot, target);
+}
+
+function comparePair(a: [string, string], b: [string, string]): number {
+  if (a[0] < b[0]) return -1;
+  if (a[0] > b[0]) return 1;
+  if (a[1] < b[1]) return -1;
+  if (a[1] > b[1]) return 1;
+  return 0;
+}
+
 /**
  * Stable digest over a hook set. Order-independent so that reordering
  * collections in the YAML does not invalidate an approval, while any change to
@@ -62,10 +154,84 @@ export function isLocalConfigPath(configPath: string): boolean {
 export function hookDigest(hooks: UpdateHook[]): string {
   const canonical = JSON.stringify(
     hooks
-      .map(h => [h.collection, h.command])
-      .sort((a, b) => (a[0]! < b[0]! ? -1 : a[0]! > b[0]! ? 1 : 0)),
+      .map(h => [h.collection, h.command] as [string, string])
+      .sort(comparePair),
   );
   return createHash("sha256").update(canonical).digest("hex");
+}
+
+/**
+ * Digest over every gated surface. When the config only has hooks (no
+ * out-of-project paths, no custom models) this equals `hookDigest`, so
+ * approvals recorded before #889 still match.
+ */
+export function configDigest(gated: GatedConfig): string {
+  const hasPaths = gated.paths.length > 0;
+  const hasModels = !!(gated.models.embed || gated.models.rerank || gated.models.generate);
+  if (!hasPaths && !hasModels) return hookDigest(gated.hooks);
+
+  const canonical = JSON.stringify({
+    hooks: gated.hooks
+      .map(h => [h.collection, h.command] as [string, string])
+      .sort(comparePair),
+    paths: gated.paths
+      .map(p => [p.collection, p.path] as [string, string])
+      .sort(comparePair),
+    models: {
+      embed: gated.models.embed ?? "",
+      rerank: gated.models.rerank ?? "",
+      generate: gated.models.generate ?? "",
+    },
+  });
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+export function hasGatedSurfaces(gated: GatedConfig): boolean {
+  return gated.hooks.length > 0
+    || gated.paths.length > 0
+    || !!(gated.models.embed || gated.models.rerank || gated.models.generate);
+}
+
+/**
+ * Collect the surfaces a project-local config must not apply unattended.
+ * Global configs and the SDK `<inline>` sentinel yield empty path/model sets
+ * (hooks are still returned so callers can display them).
+ */
+export function collectGatedSurfaces(
+  configPath: string,
+  config: {
+    collections?: Record<string, { path?: string; update?: string }>;
+    models?: GatedModels;
+  },
+  defaultModels: DefaultModels,
+): GatedConfig {
+  const hooks: UpdateHook[] = [];
+  const paths: GatedPath[] = [];
+  for (const [name, col] of Object.entries(config.collections ?? {})) {
+    if (col.update) hooks.push({ collection: name, command: col.update });
+    if (
+      col.path
+      && isLocalConfigPath(configPath)
+      && !isCollectionPathInsideProject(configPath, col.path)
+    ) {
+      paths.push({ collection: name, path: col.path });
+    }
+  }
+
+  const models: GatedModels = {};
+  if (isLocalConfigPath(configPath) && config.models) {
+    if (config.models.embed && config.models.embed !== defaultModels.embed) {
+      models.embed = config.models.embed;
+    }
+    if (config.models.rerank && config.models.rerank !== defaultModels.rerank) {
+      models.rerank = config.models.rerank;
+    }
+    if (config.models.generate && config.models.generate !== defaultModels.generate) {
+      models.generate = config.models.generate;
+    }
+  }
+
+  return { hooks, paths, models };
 }
 
 export function loadTrustStore(): TrustStore {
@@ -124,11 +290,38 @@ export type HookGateDecision =
   | { action: "skip"; digest: string };
 
 /**
- * Decide what to do with a config's `update:` hooks.
+ * Decide what to do with a config's gated surfaces (hooks, out-of-project
+ * paths, custom model URIs).
  *
  * Non-interactive callers — agents, CI, the MCP server — get `skip` rather than
  * a hard failure: indexing is what they asked for, and failing the whole
  * command would only push people toward a blanket opt-out.
+ */
+export function decideConfigGate(options: {
+  configPath: string;
+  gated: GatedConfig;
+  isInteractive: boolean;
+  env?: NodeJS.ProcessEnv;
+  trustedCheck?: (configPath: string, digest: string) => boolean;
+}): HookGateDecision {
+  const env = options.env ?? process.env;
+  const digest = configDigest(options.gated);
+
+  if (!hasGatedSurfaces(options.gated)) return { action: "run", digest };
+  if (isTruthyEnv(env.QMD_TRUST_UPDATE_HOOKS)) return { action: "run", digest };
+  if (!isLocalConfigPath(options.configPath)) return { action: "run", digest };
+
+  const trusted = options.trustedCheck ?? isTrusted;
+  if (trusted(options.configPath, digest)) return { action: "run", digest };
+
+  return { action: options.isInteractive ? "prompt" : "skip", digest };
+}
+
+/**
+ * Decide what to do with a config's `update:` hooks.
+ *
+ * Thin wrapper around `decideConfigGate` for the hooks-only surface, so the
+ * #886 tests and any caller that already has a hook list keep working.
  */
 export function decideHookGate(options: {
   configPath: string;
@@ -137,17 +330,13 @@ export function decideHookGate(options: {
   env?: NodeJS.ProcessEnv;
   trustedCheck?: (configPath: string, digest: string) => boolean;
 }): HookGateDecision {
-  const env = options.env ?? process.env;
-  const digest = hookDigest(options.hooks);
-
-  if (options.hooks.length === 0) return { action: "run", digest };
-  if (isTruthyEnv(env.QMD_TRUST_UPDATE_HOOKS)) return { action: "run", digest };
-  if (!isLocalConfigPath(options.configPath)) return { action: "run", digest };
-
-  const trusted = options.trustedCheck ?? isTrusted;
-  if (trusted(options.configPath, digest)) return { action: "run", digest };
-
-  return { action: options.isInteractive ? "prompt" : "skip", digest };
+  return decideConfigGate({
+    configPath: options.configPath,
+    gated: { hooks: options.hooks, paths: [], models: {} },
+    isInteractive: options.isInteractive,
+    env: options.env,
+    trustedCheck: options.trustedCheck,
+  });
 }
 
 function isTruthyEnv(value: string | undefined): boolean {

--- a/test/config-path-model-trust-cli.test.ts
+++ b/test/config-path-model-trust-cli.test.ts
@@ -1,0 +1,158 @@
+/**
+ * End-to-end trust gate for project-local collection paths and model URIs (#889).
+ *
+ * Spawns real `qmd update` processes against a fixture that plays the part of a
+ * freshly cloned repository shipping its own `.qmd/index.yml`.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+
+const thisDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(thisDir, "..");
+const qmdScript = join(projectRoot, "src", "cli", "qmd.ts");
+const isBunRuntime = typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
+const tsxCli = join(projectRoot, "node_modules", "tsx", "dist", "cli.mjs");
+const runnerArgs = isBunRuntime ? [qmdScript] : [tsxCli, qmdScript];
+
+let projectDir: string;
+let configDir: string;
+let outsideDir: string;
+let outsideFile: string;
+
+function runQmd(
+  args: string[],
+  env: Record<string, string> = {},
+  cwd: string = projectDir,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(process.execPath, [...runnerArgs, ...args], {
+      cwd,
+      env: {
+        ...process.env,
+        QMD_CONFIG_DIR: configDir,
+        PWD: cwd,
+        QMD_DOCTOR_DEVICE_PROBE: "0",
+        ...env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    proc.stdout.on("data", (d: Buffer) => { stdout += d.toString(); });
+    proc.stderr.on("data", (d: Buffer) => { stderr += d.toString(); });
+    proc.on("error", reject);
+    proc.on("close", (code) => resolve({ stdout, stderr, exitCode: code ?? 1 }));
+  });
+}
+
+function writeLocalConfig(opts: { path: string; embed?: string }): void {
+  const models = opts.embed
+    ? ["models:", `  embed: ${JSON.stringify(opts.embed)}`, ""]
+    : [""];
+  writeFileSync(
+    join(projectDir, ".qmd", "index.yml"),
+    [
+      "collections:",
+      "  docs:",
+      `    path: ${JSON.stringify(opts.path)}`,
+      '    pattern: "**/*.md"',
+      "",
+      ...models,
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), "qmd-hostile-repo-"));
+  configDir = mkdtempSync(join(tmpdir(), "qmd-hostile-cfg-"));
+  outsideDir = mkdtempSync(join(tmpdir(), "qmd-hostile-outside-"));
+  mkdirSync(join(projectDir, ".qmd"), { recursive: true });
+  mkdirSync(join(projectDir, "docs"), { recursive: true });
+  writeFileSync(join(projectDir, "docs", "readme.md"), "# Readme\n\nSome indexable content.\n", "utf-8");
+  outsideFile = join(outsideDir, "secret.md");
+  writeFileSync(outsideFile, "# Secret\n\nThis must not be indexed unattended.\n", "utf-8");
+  writeLocalConfig({ path: outsideDir });
+});
+
+afterEach(() => {
+  for (const dir of [projectDir, configDir, outsideDir]) {
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+});
+
+describe("qmd update with a checked-in collection path outside the project", () => {
+  test("does not index the outside path unattended", async () => {
+    const result = await runQmd(["update"]);
+
+    expect(result.stdout).toContain("names collection paths outside the project");
+    expect(result.stdout).toContain("qmd trust");
+    expect(result.stdout).toContain("Skipping");
+    expect(result.exitCode).toBe(0);
+
+    const dbPath = join(projectDir, ".qmd", "index.sqlite");
+    expect(existsSync(dbPath)).toBe(true);
+    const db = readFileSync(dbPath);
+    expect(db.includes("This must not be indexed unattended")).toBe(false);
+  }, 120_000);
+
+  test("indexes it after `qmd trust`", async () => {
+    const trust = await runQmd(["trust"]);
+    expect(trust.stdout).toContain("Trusted");
+
+    const result = await runQmd(["update"]);
+    expect(result.stdout).toContain("Indexed: 1 new");
+    expect(result.stdout).not.toContain("Skipping — path");
+  }, 120_000);
+
+  test("re-arms the gate when the path changes after approval", async () => {
+    await runQmd(["trust"]);
+    const otherOutside = mkdtempSync(join(tmpdir(), "qmd-hostile-other-"));
+    writeFileSync(join(otherOutside, "other.md"), "# Other\n\nAlso secret.\n", "utf-8");
+    writeLocalConfig({ path: otherOutside });
+
+    const result = await runQmd(["update"]);
+    expect(result.stdout).toContain("names collection paths outside the project");
+    expect(result.stdout).toContain("Skipping");
+    try { rmSync(otherOutside, { recursive: true, force: true }); } catch { /* ignore */ }
+  }, 120_000);
+
+  test("in-project paths still index without trust", async () => {
+    writeLocalConfig({ path: "./docs" });
+    const result = await runQmd(["update"]);
+    expect(result.stdout).toContain("Indexed: 1 new");
+    expect(result.stdout).not.toContain("names collection paths outside the project");
+    expect(result.exitCode).toBe(0);
+  }, 120_000);
+
+  test("QMD_TRUST_UPDATE_HOOKS=1 opts unattended path indexing back in", async () => {
+    const result = await runQmd(["update"], { QMD_TRUST_UPDATE_HOOKS: "1" });
+    expect(result.stdout).toContain("Indexed: 1 new");
+    expect(result.stdout).not.toContain("Skipping — path");
+  }, 120_000);
+});
+
+describe("qmd with checked-in custom model URIs", () => {
+  test("does not apply an untrusted model URI", async () => {
+    writeLocalConfig({ path: "./docs", embed: "hf:evil/malware.gguf" });
+    const result = await runQmd(["status"]);
+    expect(result.stdout).not.toContain("hf:evil/malware.gguf");
+    expect(result.exitCode).toBe(0);
+  }, 120_000);
+
+  test("applies it after `qmd trust`", async () => {
+    writeLocalConfig({ path: "./docs", embed: "hf:evil/malware.gguf" });
+    const trust = await runQmd(["trust"]);
+    expect(trust.stdout).toContain("Trusted");
+    expect(trust.stdout).toContain("hf:evil/malware.gguf");
+
+    const result = await runQmd(["status"]);
+    expect(result.stdout).toContain("hf:evil/malware.gguf");
+  }, 120_000);
+
+});

--- a/test/config-path-model-trust.test.ts
+++ b/test/config-path-model-trust.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Trust gate for project-local collection paths and model URIs (#889).
+ *
+ * A `.qmd/index.yml` arrives with a `git clone`. Paths that resolve outside
+ * the project, and model URIs that are not the built-in defaults, must not
+ * apply unattended just because someone typed `qmd update` or `qmd embed`.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdtempSync, rmSync, mkdirSync, symlinkSync } from "node:fs";
+import {
+  collectGatedSurfaces,
+  configDigest,
+  decideConfigGate,
+  hookDigest,
+  isCollectionPathInsideProject,
+  isLocalConfigPath,
+  projectRootFromConfigPath,
+  resolveConfigCollectionPath,
+  type GatedConfig,
+} from "../src/trust.js";
+
+let configDir: string;
+const origConfigDir = process.env.QMD_CONFIG_DIR;
+
+beforeEach(() => {
+  configDir = mkdtempSync(join(tmpdir(), "qmd-trust-cfg-"));
+  process.env.QMD_CONFIG_DIR = configDir;
+});
+
+afterEach(() => {
+  if (origConfigDir !== undefined) process.env.QMD_CONFIG_DIR = origConfigDir;
+  else delete process.env.QMD_CONFIG_DIR;
+  try { rmSync(configDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+function localConfigPath(): string {
+  const project = mkdtempSync(join(tmpdir(), "qmd-trust-proj-"));
+  mkdirSync(join(project, ".qmd"), { recursive: true });
+  return join(project, ".qmd", "index.yml");
+}
+
+const defaults = {
+  embed: "hf:default/embed.gguf",
+  generate: "hf:default/generate.gguf",
+  rerank: "hf:default/rerank.gguf",
+};
+
+describe("project root and collection path resolution", () => {
+  test("project root is the directory that contains .qmd", () => {
+    expect(projectRootFromConfigPath("/home/me/app/.qmd/index.yml")).toBe("/home/me/app");
+  });
+
+  test("relative paths resolve against the project root, not cwd", () => {
+    const configPath = "/home/me/app/.qmd/index.yml";
+    expect(resolveConfigCollectionPath(configPath, "./docs")).toBe("/home/me/app/docs");
+    expect(resolveConfigCollectionPath(configPath, "notes")).toBe("/home/me/app/notes");
+    expect(resolveConfigCollectionPath(configPath, ".")).toBe("/home/me/app");
+  });
+
+  test("absolute and ~ paths stay outside a typical project", () => {
+    const configPath = localConfigPath();
+    expect(isCollectionPathInsideProject(configPath, "./docs")).toBe(true);
+    expect(isCollectionPathInsideProject(configPath, ".")).toBe(true);
+    expect(isCollectionPathInsideProject(configPath, "/etc")).toBe(false);
+    expect(isCollectionPathInsideProject(configPath, "../outside")).toBe(false);
+    expect(isCollectionPathInsideProject(configPath, "~/notes")).toBe(false);
+  });
+
+  test("a symlink that escapes the project is treated as outside", () => {
+    const configPath = localConfigPath();
+    const project = projectRootFromConfigPath(configPath);
+    const outside = mkdtempSync(join(tmpdir(), "qmd-trust-outside-"));
+    const link = join(project, "escape");
+    symlinkSync(outside, link);
+    expect(isCollectionPathInsideProject(configPath, "./escape")).toBe(false);
+    try { rmSync(outside, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+});
+
+describe("collectGatedSurfaces", () => {
+  test("in-project paths and default models are not gated", () => {
+    const configPath = localConfigPath();
+    const gated = collectGatedSurfaces(configPath, {
+      collections: { docs: { path: "./docs", pattern: "**/*.md" } },
+      models: { ...defaults },
+    }, defaults);
+    expect(gated.paths).toEqual([]);
+    expect(gated.models).toEqual({});
+    expect(gated.hooks).toEqual([]);
+  });
+
+  test("an out-of-project path is gated", () => {
+    const configPath = localConfigPath();
+    const gated = collectGatedSurfaces(configPath, {
+      collections: {
+        docs: { path: "./docs" },
+        secrets: { path: "/etc" },
+      },
+    }, defaults);
+    expect(gated.paths).toEqual([{ collection: "secrets", path: "/etc" }]);
+  });
+
+  test("custom model URIs are gated; defaults are not", () => {
+    const configPath = localConfigPath();
+    const gated = collectGatedSurfaces(configPath, {
+      collections: {},
+      models: {
+        embed: "hf:evil/malware.gguf",
+        generate: defaults.generate,
+        rerank: "/tmp/evil.gguf",
+      },
+    }, defaults);
+    expect(gated.models).toEqual({
+      embed: "hf:evil/malware.gguf",
+      rerank: "/tmp/evil.gguf",
+    });
+  });
+
+  test("the user's own config is not gated for paths or models", () => {
+    const global = "/home/me/.config/qmd/index.yml";
+    expect(isLocalConfigPath(global)).toBe(false);
+    const gated = collectGatedSurfaces(global, {
+      collections: { notes: { path: "/etc", update: "git pull" } },
+      models: { embed: "hf:evil/malware.gguf" },
+    }, defaults);
+    expect(gated.paths).toEqual([]);
+    expect(gated.models).toEqual({});
+    expect(gated.hooks).toEqual([{ collection: "notes", command: "git pull" }]);
+  });
+});
+
+describe("configDigest", () => {
+  test("equals hookDigest when only hooks are gated", () => {
+    const gated: GatedConfig = {
+      hooks: [{ collection: "docs", command: "git pull" }],
+      paths: [],
+      models: {},
+    };
+    expect(configDigest(gated)).toBe(hookDigest(gated.hooks));
+  });
+
+  test("changes when an out-of-project path is added", () => {
+    const hooks = [{ collection: "docs", command: "git pull" }];
+    const without: GatedConfig = { hooks, paths: [], models: {} };
+    const withPath: GatedConfig = {
+      hooks,
+      paths: [{ collection: "secrets", path: "/etc" }],
+      models: {},
+    };
+    expect(configDigest(withPath)).not.toBe(configDigest(without));
+  });
+
+  test("changes when a custom model URI is edited", () => {
+    const a: GatedConfig = { hooks: [], paths: [], models: { embed: "hf:a/a.gguf" } };
+    const b: GatedConfig = { hooks: [], paths: [], models: { embed: "hf:b/b.gguf" } };
+    expect(configDigest(a)).not.toBe(configDigest(b));
+  });
+
+  test("is stable across collection ordering", () => {
+    const a: GatedConfig = {
+      hooks: [],
+      paths: [
+        { collection: "a", path: "/tmp/a" },
+        { collection: "b", path: "/tmp/b" },
+      ],
+      models: {},
+    };
+    const b: GatedConfig = {
+      hooks: [],
+      paths: [
+        { collection: "b", path: "/tmp/b" },
+        { collection: "a", path: "/tmp/a" },
+      ],
+      models: {},
+    };
+    expect(configDigest(a)).toBe(configDigest(b));
+  });
+});
+
+describe("decideConfigGate", () => {
+  const project = "/home/me/project/.qmd/index.yml";
+  const global = "/home/me/.config/qmd/index.yml";
+  const noEnv = {} as NodeJS.ProcessEnv;
+  const untrusted = () => false;
+  const gated: GatedConfig = {
+    hooks: [],
+    paths: [{ collection: "secrets", path: "/etc" }],
+    models: { embed: "hf:evil/malware.gguf" },
+  };
+
+  test("nothing gated needs no decision", () => {
+    const decision = decideConfigGate({
+      configPath: project,
+      gated: { hooks: [], paths: [], models: {} },
+      isInteractive: false,
+      env: noEnv,
+      trustedCheck: untrusted,
+    });
+    expect(decision.action).toBe("run");
+  });
+
+  test("the user's own config always applies", () => {
+    const decision = decideConfigGate({
+      configPath: global,
+      gated,
+      isInteractive: false,
+      env: noEnv,
+      trustedCheck: untrusted,
+    });
+    expect(decision.action).toBe("run");
+  });
+
+  test("an untrusted project config prompts on a terminal", () => {
+    const decision = decideConfigGate({
+      configPath: project,
+      gated,
+      isInteractive: true,
+      env: noEnv,
+      trustedCheck: untrusted,
+    });
+    expect(decision.action).toBe("prompt");
+  });
+
+  test("an untrusted project config is skipped with nobody to ask", () => {
+    const decision = decideConfigGate({
+      configPath: project,
+      gated,
+      isInteractive: false,
+      env: noEnv,
+      trustedCheck: untrusted,
+    });
+    expect(decision.action).toBe("skip");
+  });
+
+  test("a previously approved set runs unattended", () => {
+    const decision = decideConfigGate({
+      configPath: project,
+      gated,
+      isInteractive: false,
+      env: noEnv,
+      trustedCheck: (path, digest) => path === project && digest === configDigest(gated),
+    });
+    expect(decision.action).toBe("run");
+  });
+
+  test("editing an approved path re-arms the gate", () => {
+    const approved = configDigest(gated);
+    const decision = decideConfigGate({
+      configPath: project,
+      gated: {
+        ...gated,
+        paths: [{ collection: "secrets", path: "/var" }],
+      },
+      isInteractive: false,
+      env: noEnv,
+      trustedCheck: (_path, digest) => digest === approved,
+    });
+    expect(decision.action).toBe("skip");
+  });
+
+  test("QMD_TRUST_UPDATE_HOOKS opts unattended runs back in", () => {
+    const decision = decideConfigGate({
+      configPath: project,
+      gated,
+      isInteractive: false,
+      env: { QMD_TRUST_UPDATE_HOOKS: "1" } as NodeJS.ProcessEnv,
+      trustedCheck: untrusted,
+    });
+    expect(decision.action).toBe("run");
+  });
+});

--- a/test/local-config.test.ts
+++ b/test/local-config.test.ts
@@ -70,19 +70,25 @@ describe("local .qmd project config", () => {
     writeFileSync(join(root, ".qmd", "index.yaml"), `collections:\n  docs:\n    path: ${JSON.stringify(join(root, "docs"))}\n    pattern: "**/*.md"\n    context:\n      /: Local test docs\nmodels:\n  embed: local-embed-model\n  rerank: local-rerank-model\n  generate: local-generate-model\n`);
 
     const home = join(root, "home");
+    const env = {
+      ...process.env,
+      HOME: home,
+      XDG_CONFIG_HOME: join(home, ".config"),
+      XDG_CACHE_HOME: join(home, ".cache"),
+      QMD_EMBED_MODEL: "env-embed-model",
+      QMD_RERANK_MODEL: "env-rerank-model",
+      QMD_GENERATE_MODEL: "env-generate-model",
+    };
+    // Custom model URIs in a checked-in .qmd config need an explicit approval
+    // (#889). The user owns this fixture, so trust it before asserting that
+    // local config overrides env vars.
+    const trust = cliCommandArgs("trust");
+    execFileSync(trust.bin, trust.args, { cwd: root, encoding: "utf-8", env });
     const { bin, args } = cliCommandArgs("status");
     const output = execFileSync(bin, args, {
       cwd: root,
       encoding: "utf-8",
-      env: {
-        ...process.env,
-        HOME: home,
-        XDG_CONFIG_HOME: join(home, ".config"),
-        XDG_CACHE_HOME: join(home, ".cache"),
-        QMD_EMBED_MODEL: "env-embed-model",
-        QMD_RERANK_MODEL: "env-rerank-model",
-        QMD_GENERATE_MODEL: "env-generate-model",
-      },
+      env,
     });
 
     const localIndex = join(root, ".qmd", "index.sqlite");


### PR DESCRIPTION
Closes #889.

## What was wrong

#887 gates `update:` hooks from a checked-in `.qmd/index.yml`. The same file could still set `collections.*.path` to any directory the process can read, and `models.embed` / `models.rerank` / `models.generate` to any `hf:` repo or local GGUF. `qmd update` / `qmd embed` in a freshly cloned tree then indexed that path and downloaded/loaded those models, with no prompt. Global `~/.config/qmd` is unaffected. #888 contains glob/symlink escapes relative to the collection root; it does not constrain which root a local config may name.

## The fix

Reuse the #887 trust digest (`<config dir>/trusted.json`, `qmd trust`, `QMD_TRUST_UPDATE_HOOKS=1`).

- **Collection paths** that resolve *outside* the project (absolute dirs, `../`, `~/...`) are gated. In-project paths like `./docs` still index without approval.
- **`models.*`** that are not the built-in defaults are gated. Untrusted URIs fall back to those defaults (or `QMD_*_MODEL`); the YAML is not rewritten.
- On a TTY, `qmd update` lists the gated values and asks. Non-interactive: skip them and keep indexing in-project collections.
- A hooks-only digest is unchanged, so existing `qmd trust` records still match. Adding an out-of-project path or custom model URI changes the digest and re-arms the gate.
- `qmd collection add` / `qmd collection update-cmd` still record trust as they write, since the user just typed that path or command.

Left alone: remote embed/rerank, `qmd://`, prepare-hook, #821.

## Tests

`test/config-path-model-trust.test.ts` covers path resolution (relative to project root, `~`, symlink escape), `collectGatedSurfaces`, digest stability/sensitivity, and `decideConfigGate`.

`test/config-path-model-trust-cli.test.ts` spawns real `qmd update`/`qmd trust`/`qmd status` against a hostile-clone fixture: outside path not indexed unattended, indexed after `qmd trust`, re-armed when the path changes, in-project `./docs` still indexes without trust, `QMD_TRUST_UPDATE_HOOKS=1` opts in, custom model URIs skipped until trusted.

Existing #886 hook tests still pass. `tsc -p tsconfig.build.json --noEmit` is clean.

## Audit

Nested `picomatch` min-bumps for high GHSA-c2c7-rcm5-vvqj / GHSA-3v7f-55p6-f55p: micromatch 2.3.1 → 2.3.2, vite/tinyglobby 4.0.3 → 4.0.5. Direct picomatch stays 4.0.5. No zod/vitest majors. `flake.nix` not edited — Nix FOD hashes are stale after the lockfile change.