### PR TITLE
feat(cli): add contextual command help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@
 
 ### Changed
 
+- CLI help is now contextual: top-level `qmd --help` is a concise command
+  directory, while `<command> --help` shows only that command's usage, options,
+  and examples. The query grammar appears only under `qmd query --help`, and
+  previously omitted flags such as `query --intent` and `get --from` are now
+  documented. `qmd help <command>` is also supported. `qmd bench --example`
+  prints a bundled fixture so installed users no longer need a source-checkout
+  path to discover the benchmark format (#716).
+
 - Dependencies: `node-llama-cpp` 3.18.1 → **3.20.0** (llama.cpp b8390 → b10361, 2026-08-11). Also safe patch/minors: `picomatch` 4.0.4 → 4.0.5, `web-tree-sitter` 0.26.8 → 0.26.12, `tsx` 4.21.0 → 4.23.12, `vitest` 3.2.4 → 3.2.7. No zod/vitest major; `@modelcontextprotocol/server` stays 2.0.0 (no 2.x patch). `flake.nix` FOD hashes are not updated here.
 - `generate` and query expansion now await `LlamaContextSequence.dispose()` before disposing the parent context. node-llama-cpp 3.20 made sequence dispose async; the library's context-onDispose path does not wait.
 

--- a/README.md
+++ b/README.md
@@ -1060,7 +1060,13 @@ qmd cleanup
 Measure search quality across all four backends with `qmd bench` and a fixture file
 of queries with known-relevant documents.
 
-**From a git checkout**, an example fixture and its test corpus ship in the repo:
+Print the bundled example fixture to use as a starting point:
+
+```sh
+qmd bench --example > my-fixture.json
+```
+
+**From a git checkout**, its matching test corpus also ships in the repo:
 
 ```sh
 # One-time setup (indexes the repo's test corpus into its own collection)
@@ -1068,16 +1074,15 @@ qmd collection add test/eval-docs --name eval-docs
 qmd embed -c eval-docs
 
 # Run the benchmark (table output)
-qmd bench src/bench/fixtures/example.json
+qmd bench my-fixture.json
 
 # JSON output for programmatic analysis
-qmd bench src/bench/fixtures/example.json --json
+qmd bench my-fixture.json --json
 ```
 
-> The example fixture (`src/bench/fixtures/example.json`) and its test corpus
-> (`test/eval-docs/`) exist only in a git checkout — they are **not** part of the
-> published npm package. If you installed via `npm`/`npx`, write your own fixture
-> (see below) against a collection you have already indexed:
+> The test corpus (`test/eval-docs/`) exists only in a git checkout. If you
+> installed via `npm`/`npx`, adapt the output of `qmd bench --example` to a
+> collection you have already indexed:
 >
 > ```sh
 > qmd bench my-fixture.json -c my-collection

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "scripts/check-package-grammars.mjs",
     "scripts/package-smoke.mjs",
     "scripts/test-all.mjs",
+    "src/bench/fixtures/example.json",
     "LICENSE",
     "CHANGELOG.md"
   ],

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -56,6 +56,10 @@ assertPath("dist/index.d.ts", "compiled type export");
 assertPath("dist/cli/qmd.js", "compiled CLI");
 
 run("compiled CLI under Node", process.execPath, ["dist/cli/qmd.js", "--help"], { quiet: true });
+run("bundled benchmark fixture", process.execPath, ["dist/cli/qmd.js", "bench", "--example"], {
+  quiet: true,
+  env: { ...process.env, QMD_SKILLS_DIR: join(root, "missing-skills-override") },
+});
 run("package wrapper", "sh", ["bin/qmd", "--help"], { quiet: true });
 
 if (process.env.QMD_SKIP_BUN_SMOKE === "1") {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -1,0 +1,566 @@
+import { CLI_OPTIONS, type CliOptionName } from "./options.js";
+
+export type HelpRow = readonly [label: string, description: string];
+
+export type HelpOption = {
+  /** Parser option key, used to detect help/parser drift. */
+  key: CliOptionName;
+  /** User-facing spelling, including value placeholders. */
+  flags: string;
+  description: string;
+};
+
+export type HelpSection = {
+  title: string;
+  rows?: readonly HelpRow[];
+  lines?: readonly string[];
+};
+
+export type HelpSpec = {
+  usage: string;
+  summary: string;
+  commands?: readonly HelpRow[];
+  options?: readonly HelpOption[];
+  sections?: readonly HelpSection[];
+  examples?: readonly string[];
+};
+
+const option = (key: CliOptionName, flags: string, description: string): HelpOption => ({
+  key,
+  flags,
+  description,
+});
+
+const INDEX_OPTION = option("index", "--index <name>", "Use a named index (default: index)");
+const COLLECTION_OPTION = option("collection", "-c, --collection <name>", "Restrict to a collection; repeat where supported");
+const FORMAT_OPTION = option("format", "--format <kind>", "Output: cli | json | csv | md | xml | files");
+const LIMIT_OPTION = option("n", "-n <num>", "Maximum results (default 5; 20 for files/json)");
+const MIN_SCORE_OPTION = option("min-score", "--min-score <num>", "Minimum result score");
+const ALL_OPTION = option("all", "--all", "Return all matches; usually pair with --min-score");
+const FULL_OPTION = option("full", "--full", "Return full documents instead of snippets");
+const FULL_PATH_OPTION = option("full-path", "--full-path", "Show on-disk paths instead of qmd:// URIs");
+const NO_GPU_OPTION = option("no-gpu", "--no-gpu", "Force CPU mode for llama.cpp operations");
+const CHUNK_OPTION = option("chunk-strategy", "--chunk-strategy <auto|regex>", "Choose AST-aware or regex chunking");
+const HELP_OPTION = option("help", "-h, --help", "Show help for this command");
+
+const SEARCH_OUTPUT_OPTIONS = [
+  LIMIT_OPTION,
+  ALL_OPTION,
+  MIN_SCORE_OPTION,
+  FULL_OPTION,
+  FORMAT_OPTION,
+  COLLECTION_OPTION,
+  FULL_PATH_OPTION,
+] as const;
+
+const QUERY_GRAMMAR = [
+  "query           = expand_query | query_document ;",
+  "expand_query    = text | explicit_expand ;",
+  'explicit_expand = "expand:" text ;',
+  "query_document  = [ intent_line ] { typed_line } ;",
+  'intent_line     = "intent:" text newline ;',
+  'typed_line      = type ":" text newline ;',
+  'type            = "lex" | "vec" | "hyde" ;',
+  'text            = quoted_phrase | plain_text ;',
+  'quoted_phrase   = \'"\' { character } \'"\' ;',
+  "plain_text      = { character } ;",
+  'newline         = "\\n" ;',
+] as const;
+
+/**
+ * Declarative command help. Keys are command paths, allowing the same renderer
+ * to support both top-level commands and nested commands such as collection add.
+ */
+export const HELP_SPECS: Readonly<Record<string, HelpSpec>> = {
+  root: {
+    usage: "qmd <command> [options]",
+    summary: "Quick Markdown Search — local keyword, vector, and hybrid search.",
+    sections: [
+      {
+        title: "Search and retrieval commands",
+        rows: [
+          ["query <query>", "Hybrid search with expansion and reranking (recommended)"],
+          ["search <query>", "Full-text BM25 keyword search; no LLM"],
+          ["vsearch <query>", "Vector similarity search"],
+          ["get <file>", "Retrieve one document by path or docid"],
+          ["multi-get <pattern>", "Retrieve documents by glob, list, or docids"],
+        ],
+      },
+      {
+        title: "Index and configuration commands",
+        rows: [
+          ["collection <command>", "Manage indexed folders"],
+          ["context <command>", "Attach context to indexed paths"],
+          ["ls [collection/path]", "List indexed files"],
+          ["init", "Create a project-local .qmd index"],
+          ["status", "Show index and collection health"],
+          ["doctor", "Diagnose runtime, database, model, and device setup"],
+          ["update", "Re-index configured collections"],
+          ["embed", "Generate vector embeddings"],
+          ["pull", "Download configured local models"],
+          ["cleanup", "Remove stale data and compact the index"],
+          ["trust <command>", "Approve or revoke project-local configuration"],
+        ],
+      },
+      {
+        title: "Integration and evaluation commands",
+        rows: [
+          ["mcp", "Start the MCP server over stdio or HTTP"],
+          ["bench <fixture.json>", "Run search-quality benchmarks"],
+          ["skills <command>", "Inspect bundled runtime skills"],
+          ["skill <command>", "Show or install the QMD skill"],
+        ],
+      },
+    ],
+    options: [
+      INDEX_OPTION,
+      option("no-gpu", "--no-gpu", "Force CPU mode for model-backed commands"),
+      option("help", "-h, --help", "Show help for qmd or a command"),
+      option("version", "-v, --version", "Print the installed QMD version"),
+    ],
+    examples: [
+      'qmd search "exact phrase"',
+      'qmd query "how does authentication work"',
+      "qmd collection --help",
+      "qmd query --help",
+    ],
+  },
+
+  query: {
+    usage: "qmd query [options] <query>",
+    summary: "Run hybrid retrieval with optional query expansion and LLM reranking.",
+    options: [
+      ...SEARCH_OUTPUT_OPTIONS,
+      option("candidate-limit", "-C, --candidate-limit <n>", "Maximum candidates to rerank (default 40)"),
+      option("no-rerank", "--no-rerank", "Skip reranking and use fused retrieval scores"),
+      option("intent", "--intent <text>", "Disambiguation context for ranking and snippets"),
+      option("explain", "--explain", "Include retrieval score traces"),
+      option("line-numbers", "--line-numbers", "Include line numbers in output"),
+      CHUNK_OPTION,
+      NO_GPU_OPTION,
+      INDEX_OPTION,
+    ],
+    sections: [
+      { title: "Query grammar", lines: QUERY_GRAMMAR },
+      {
+        title: "Constraints",
+        lines: [
+          "A standalone expand query cannot be mixed with typed lines.",
+          "Typed documents accept only lex:, vec:, hyde:, and one optional intent: line.",
+          "Each typed line is single-line text with balanced quotes.",
+        ],
+      },
+    ],
+    examples: [
+      'qmd query "how does auth work"',
+      "qmd query $'lex: auth token\\nvec: authentication flow'",
+      'qmd query --intent "web performance" "performance"',
+      'qmd query --no-rerank -c docs "deployment"',
+    ],
+  },
+
+  search: {
+    usage: "qmd search [options] <query>",
+    summary: "Search the SQLite FTS5 index with BM25 keyword ranking; no model required.",
+    options: [
+      ...SEARCH_OUTPUT_OPTIONS,
+      option("line-numbers", "--line-numbers", "Include line numbers in output"),
+      INDEX_OPTION,
+    ],
+    examples: [
+      'qmd search "authentication"',
+      'qmd search -c docs --min-score 0.3 "rate limiter"',
+      'qmd search --format json -n 10 "database"',
+    ],
+  },
+
+  vsearch: {
+    usage: "qmd vsearch [options] <query>",
+    summary: "Search embedded document chunks by semantic similarity.",
+    options: [
+      ...SEARCH_OUTPUT_OPTIONS,
+      option("line-numbers", "--line-numbers", "Include line numbers in output"),
+      CHUNK_OPTION,
+      NO_GPU_OPTION,
+      INDEX_OPTION,
+    ],
+    examples: [
+      'qmd vsearch "how is user identity verified"',
+      'qmd vsearch -c docs -n 10 "deployment process"',
+    ],
+  },
+
+  get: {
+    usage: "qmd get <file>[:from[:count]] [options]",
+    summary: "Retrieve one indexed document by path, qmd:// URI, or short docid.",
+    options: [
+      option("from", "--from <line>", "Start at a 1-indexed line; overrides the path suffix"),
+      option("l", "-l <lines>", "Maximum lines to return"),
+      option("no-line-numbers", "--no-line-numbers", "Hide line numbers (shown by default)"),
+      FULL_PATH_OPTION,
+      INDEX_OPTION,
+    ],
+    examples: [
+      'qmd get "docs/api.md"',
+      'qmd get "#abc123:120:40"',
+      'qmd get "docs/api.md" --from 50 -l 25',
+    ],
+  },
+
+  "multi-get": {
+    usage: "qmd multi-get <pattern> [options]",
+    summary: "Retrieve multiple documents by glob, comma-separated list, or docids.",
+    options: [
+      option("l", "-l <lines>", "Maximum lines per document"),
+      option("max-bytes", "--max-bytes <bytes>", "Skip documents larger than this limit (default 65536)"),
+      option("no-line-numbers", "--no-line-numbers", "Hide line numbers (shown by default)"),
+      FORMAT_OPTION,
+      FULL_PATH_OPTION,
+      INDEX_OPTION,
+    ],
+    examples: [
+      'qmd multi-get "journals/2025-05*.md"',
+      'qmd multi-get "#abc123,#def456" --format json',
+    ],
+  },
+
+  ls: {
+    usage: "qmd ls [collection[/path]]",
+    summary: "List collections or indexed files below an optional virtual path.",
+    options: [INDEX_OPTION],
+    examples: ["qmd ls", "qmd ls notes", "qmd ls qmd://notes/journals"],
+  },
+
+  collection: {
+    usage: "qmd collection <command> [options]",
+    summary: "Manage indexed folders and their update behavior.",
+    commands: [
+      ["list", "List configured collections"],
+      ["add <path>", "Add a folder as a collection"],
+      ["remove <name>", "Remove a collection"],
+      ["rename <old> <new>", "Rename a collection"],
+      ["show <name>", "Show collection details"],
+      ["update-cmd <name> [cmd]", "Set or clear a pre-update command"],
+      ["include <name>", "Include a collection in unscoped searches"],
+      ["exclude <name>", "Exclude a collection from unscoped searches"],
+    ],
+    options: [INDEX_OPTION],
+    examples: ["qmd collection add --help", "qmd collection list", "qmd collection show notes"],
+  },
+
+  "collection add": {
+    usage: "qmd collection add <path> [options]",
+    summary: "Add an existing directory to the index configuration.",
+    options: [
+      option("name", "--name <name>", "Set the collection name explicitly"),
+      option("mask", "--mask <glob>", "Set the file glob (default: **/*.md)"),
+      option("glob", "--glob <glob>", "Alias for --mask"),
+      INDEX_OPTION,
+    ],
+    examples: [
+      "qmd collection add . --name project",
+      "qmd collection add ~/notes --name notes --mask '**/*.md'",
+      "qmd collection add ~/docs --glob 'README.md,docs/**/*.md'",
+    ],
+  },
+
+  "collection list": {
+    usage: "qmd collection list",
+    summary: "List configured collections and their indexed-document counts.",
+    options: [INDEX_OPTION],
+  },
+
+  "collection remove": {
+    usage: "qmd collection remove <name>",
+    summary: "Remove a collection and its indexed records.",
+    options: [INDEX_OPTION],
+    examples: ["qmd collection remove archive"],
+  },
+
+  "collection rename": {
+    usage: "qmd collection rename <old-name> <new-name>",
+    summary: "Rename a configured collection.",
+    options: [INDEX_OPTION],
+    examples: ["qmd collection rename work work-notes"],
+  },
+
+  "collection show": {
+    usage: "qmd collection show <name>",
+    summary: "Show one collection's path, glob, default-search state, update command, and context count.",
+    options: [INDEX_OPTION],
+  },
+
+  "collection update-cmd": {
+    usage: "qmd collection update-cmd <name> [command]",
+    summary: "Set a command to run before re-indexing; omit command to clear it.",
+    options: [INDEX_OPTION],
+    examples: ["qmd collection update-cmd notes 'git pull --ff-only'", "qmd collection update-cmd notes"],
+  },
+
+  "collection include": {
+    usage: "qmd collection include <name>",
+    summary: "Include a collection in searches that do not specify -c.",
+    options: [INDEX_OPTION],
+  },
+
+  "collection exclude": {
+    usage: "qmd collection exclude <name>",
+    summary: "Exclude a collection from searches that do not specify -c.",
+    options: [INDEX_OPTION],
+  },
+
+  context: {
+    usage: "qmd context <command>",
+    summary: "Attach human-written context to collection paths.",
+    commands: [
+      ["add [path] <text>", "Add context; path defaults to the current directory"],
+      ["list", "List configured contexts"],
+      ["rm <path>", "Remove context from a path"],
+    ],
+    options: [INDEX_OPTION],
+    examples: ["qmd context add --help", "qmd context list"],
+  },
+
+  "context add": {
+    usage: "qmd context add [path] <text>",
+    summary: "Add context to a physical or qmd:// path; omit path to use the current directory.",
+    options: [INDEX_OPTION],
+    examples: [
+      'qmd context add "Notes from the platform team"',
+      'qmd context add qmd://journals/2024 "Journal entries from 2024"',
+      'qmd context add / "Global context for all collections"',
+    ],
+  },
+
+  "context list": {
+    usage: "qmd context list",
+    summary: "List global and path-specific context entries.",
+    options: [INDEX_OPTION],
+  },
+
+  "context rm": {
+    usage: "qmd context rm <path>",
+    summary: "Remove context from a physical or qmd:// path.",
+    options: [INDEX_OPTION],
+    examples: ["qmd context rm /", "qmd context rm qmd://journals/2024"],
+  },
+
+  init: {
+    usage: "qmd init",
+    summary: "Create a project-local .qmd/index.yml and SQLite index for the current directory.",
+    examples: ["cd my-project && qmd init"],
+  },
+
+  status: {
+    usage: "qmd status [options]",
+    summary: "Show index health, collection state, embedding state, and MCP daemon status.",
+    options: [INDEX_OPTION],
+  },
+
+  doctor: {
+    usage: "qmd doctor [options]",
+    summary: "Diagnose configuration, SQLite/vector support, models, and device acceleration.",
+    options: [NO_GPU_OPTION, INDEX_OPTION],
+  },
+
+  update: {
+    usage: "qmd update [options]",
+    summary: "Re-scan every configured collection and refresh changed documents.",
+    options: [
+      option("pull", "--pull", "Deprecated compatibility flag; configured update commands run automatically when trusted"),
+      INDEX_OPTION,
+    ],
+    examples: ["qmd update", "qmd collection update-cmd notes 'git pull --ff-only' && qmd update"],
+  },
+
+  trust: {
+    usage: "qmd trust [list|revoke]",
+    summary: "Approve the sensitive parts of a project-local .qmd configuration.",
+    commands: [
+      ["(no command)", "Review and trust the current project-local configuration"],
+      ["list", "List trusted project-local configurations"],
+      ["revoke", "Revoke trust for the current project-local configuration"],
+    ],
+    options: [INDEX_OPTION],
+  },
+
+  embed: {
+    usage: "qmd embed [options]",
+    summary: "Chunk indexed documents and generate local vector embeddings.",
+    options: [
+      option("force", "-f, --force", "Regenerate embeddings even when they are current"),
+      COLLECTION_OPTION,
+      option("max-docs-per-batch", "--max-docs-per-batch <n>", "Limit documents loaded per batch"),
+      option("max-batch-mb", "--max-batch-mb <n>", "Limit UTF-8 megabytes loaded per batch"),
+      option("timeout", "--timeout <minutes>", "Session limit; 0 disables it (default 30)"),
+      CHUNK_OPTION,
+      NO_GPU_OPTION,
+      INDEX_OPTION,
+    ],
+    examples: ["qmd embed", "qmd embed -c notes --chunk-strategy auto", "qmd embed --force --timeout 0"],
+  },
+
+  pull: {
+    usage: "qmd pull [options]",
+    summary: "Download or verify the configured embedding, generation, and reranking models.",
+    options: [
+      option("refresh", "--refresh", "Refresh model files even when cached"),
+      option("progress", "--progress", "Show node-llama-cpp download progress"),
+      NO_GPU_OPTION,
+      INDEX_OPTION,
+    ],
+    examples: ["qmd pull", "qmd pull --refresh --progress"],
+  },
+
+  cleanup: {
+    usage: "qmd cleanup [options]",
+    summary: "Clear caches and stale records, compact FTS, and vacuum SQLite.",
+    options: [option("dry-run", "--dry-run", "Preview removals without changing the database"), INDEX_OPTION],
+    examples: ["qmd cleanup --dry-run", "qmd cleanup"],
+  },
+
+  bench: {
+    usage: "qmd bench <fixture.json> [options]",
+    summary: "Measure search quality against a JSON fixture.",
+    options: [
+      option("example", "--example", "Print the bundled example fixture and exit"),
+      option("json", "--json", "Emit structured JSON results"),
+      COLLECTION_OPTION,
+      INDEX_OPTION,
+    ],
+    examples: ["qmd bench --example > fixture.json", "qmd bench fixture.json -c docs --json"],
+  },
+
+  mcp: {
+    usage: "qmd mcp [stop] [options]",
+    summary: "Expose query, get, multi_get, and status tools to MCP clients.",
+    options: [
+      option("http", "--http", "Use Streamable HTTP instead of stdio"),
+      option("daemon", "--daemon", "Run the HTTP server in the background"),
+      option("port", "--port <number>", "HTTP port (default 8181)"),
+      option("host", "--host <address>", "HTTP bind address (default localhost)"),
+      NO_GPU_OPTION,
+      INDEX_OPTION,
+    ],
+    sections: [{ title: "Subcommands", rows: [["stop", "Stop the background daemon for this index"]] }],
+    examples: ["qmd mcp", "qmd mcp --http", "qmd mcp --http --daemon", "qmd mcp stop"],
+  },
+
+  skills: {
+    usage: "qmd skills <list|get|path> [options]",
+    summary: "Inspect the version-matched runtime skills bundled with QMD.",
+    commands: [
+      ["list", "List bundled runtime skills"],
+      ["get <name>", "Print a bundled runtime skill"],
+      ["path [name]", "Print runtime skill search paths"],
+    ],
+    options: [
+      option("json", "--json", "Emit structured JSON"),
+      option("full", "--full", "Include references, templates, and scripts with get"),
+      option("all", "--all", "Print all runtime skills with get"),
+    ],
+    examples: ["qmd skills list", "qmd skills get qmd --full", "qmd skills path qmd"],
+  },
+
+  skill: {
+    usage: "qmd skill <show|install> [options]",
+    summary: "Show or install QMD's agent skill.",
+    commands: [
+      ["show", "Print the QMD skill"],
+      ["install", "Install into ./.agents/skills/qmd"],
+    ],
+    options: [
+      option("global", "--global", "Install into ~/.agents/skills/qmd"),
+      option("yes", "--yes", "Also create the .claude/skills/qmd symlink"),
+      option("force", "-f, --force", "Replace an existing install or symlink"),
+    ],
+    examples: ["qmd skill show", "qmd skill install", "qmd skill install --global --yes"],
+  },
+};
+
+const TOPIC_ALIASES: Readonly<Record<string, string>> = {
+  "deep-search": "query",
+  "vector-search": "vsearch",
+  "collection rm": "collection remove",
+  "collection mv": "collection rename",
+  "collection info": "collection show",
+  "collection set-update": "collection update-cmd",
+  "context remove": "context rm",
+};
+
+const NESTED_COMMANDS = new Set(["collection", "context"]);
+
+export function resolveHelpTopic(command?: string, args: readonly string[] = []): string {
+  if (!command) return "root";
+
+  if (command === "help") {
+    const requestedCommand = args[0];
+    return resolveHelpTopic(requestedCommand, args.slice(1));
+  }
+
+  const nested = NESTED_COMMANDS.has(command) && args[0] && args[0] !== "help"
+    ? `${command} ${args[0]}`
+    : command;
+  const canonical = TOPIC_ALIASES[nested] ?? nested;
+  return HELP_SPECS[canonical] ? canonical : "root";
+}
+
+function printRows(rows: readonly HelpRow[], write: (line: string) => void): void {
+  const width = Math.max(...rows.map(([label]) => label.length));
+  for (const [label, description] of rows) {
+    write(`  ${label.padEnd(width)}  ${description}`);
+  }
+}
+
+export function renderHelp(topic: string, options: { indexPath?: string } = {}): string {
+  const canonical = TOPIC_ALIASES[topic] ?? topic;
+  // `root` is a required registry entry and is the safe fallback for unknown topics.
+  const spec = HELP_SPECS[canonical] ?? HELP_SPECS.root!;
+  const lines: string[] = [spec.summary, "", "Usage:", `  ${spec.usage}`];
+
+  if (spec.commands?.length) {
+    lines.push("", "Commands:");
+    printRows(spec.commands, (line) => lines.push(line));
+  }
+
+  for (const section of spec.sections ?? []) {
+    lines.push("", `${section.title}:`);
+    if (section.rows?.length) printRows(section.rows, (line) => lines.push(line));
+    for (const line of section.lines ?? []) lines.push(`  ${line}`);
+  }
+
+  const renderedOptions = canonical === "root"
+    ? (spec.options ?? [])
+    : [...(spec.options ?? []), HELP_OPTION];
+  if (renderedOptions.length) {
+    lines.push("", "Options:");
+    printRows(renderedOptions.map(({ flags, description }) => [flags, description]), (line) => lines.push(line));
+  }
+
+  if (spec.examples?.length) {
+    lines.push("", "Examples:");
+    for (const example of spec.examples) lines.push(`  ${example}`);
+  }
+
+  if (canonical === "root" && options.indexPath) {
+    lines.push("", `Index: ${options.indexPath}`);
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function printHelp(topic: string, options: { indexPath?: string } = {}): void {
+  process.stdout.write(renderHelp(topic, options));
+}
+
+export function validateHelpOptionKeys(): string[] {
+  const errors: string[] = [];
+  for (const [topic, spec] of Object.entries(HELP_SPECS)) {
+    for (const documented of spec.options ?? []) {
+      if (!(documented.key in CLI_OPTIONS)) {
+        errors.push(`${topic}: unknown parser option ${documented.key}`);
+      }
+    }
+  }
+  return errors;
+}

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -1,0 +1,71 @@
+/**
+ * Canonical CLI option definitions.
+ *
+ * Keep this object separate from qmd.ts so contextual help and tests can
+ * validate documented flags without importing the full CLI entrypoint.
+ */
+export const CLI_OPTIONS = {
+  // Global options
+  index: { type: "string" },
+  context: { type: "string" },
+  help: { type: "boolean", short: "h" },
+  version: { type: "boolean", short: "v" },
+  skill: { type: "boolean" },
+  global: { type: "boolean" },
+  yes: { type: "boolean" },
+
+  // Search and output options
+  n: { type: "string" },
+  "min-score": { type: "string" },
+  all: { type: "boolean" },
+  full: { type: "boolean" },
+  format: { type: "string" },
+  csv: { type: "boolean" },
+  md: { type: "boolean" },
+  xml: { type: "boolean" },
+  files: { type: "boolean" },
+  json: { type: "boolean" },
+  explain: { type: "boolean" },
+  collection: { type: "string", short: "c", multiple: true },
+
+  // Collection options
+  name: { type: "string" },
+  mask: { type: "string" },
+  glob: { type: "string" },
+
+  // Embed options
+  force: { type: "boolean", short: "f" },
+  "max-docs-per-batch": { type: "string" },
+  "max-batch-mb": { type: "string" },
+  timeout: { type: "string" },
+
+  // Update and maintenance options
+  pull: { type: "boolean" },
+  refresh: { type: "boolean" },
+  progress: { type: "boolean" },
+  "dry-run": { type: "boolean" },
+  example: { type: "boolean" },
+
+  // Document retrieval options
+  l: { type: "string" },
+  from: { type: "string" },
+  "max-bytes": { type: "string" },
+  "line-numbers": { type: "boolean" },
+  "no-line-numbers": { type: "boolean" },
+  "full-path": { type: "boolean" },
+
+  // Query options
+  "candidate-limit": { type: "string", short: "C" },
+  "no-rerank": { type: "boolean", default: false },
+  "no-gpu": { type: "boolean", default: false },
+  intent: { type: "string" },
+  "chunk-strategy": { type: "string" },
+
+  // MCP HTTP transport options
+  http: { type: "boolean" },
+  daemon: { type: "boolean" },
+  port: { type: "string" },
+  host: { type: "string" },
+} as const;
+
+export type CliOptionName = keyof typeof CLI_OPTIONS;

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -95,6 +95,8 @@ import {
   type OutputFormat,
 } from "./formatter.js";
 import { resolveCommit } from "./version.js";
+import { CLI_OPTIONS } from "./options.js";
+import { printHelp, resolveHelpTopic } from "./help.js";
 import {
   getCollection as getCollectionFromYaml,
   listCollections as yamlListCollections,
@@ -3017,68 +3019,7 @@ async function querySearch(query: string, opts: OutputOptions, _embedModel: stri
 function parseCLI() {
   const { values, positionals } = parseArgs({
     args: process.argv.slice(2), // Skip node and script path
-    options: {
-      // Global options
-      index: {
-        type: "string",
-      },
-      context: {
-        type: "string",
-      },
-      help: { type: "boolean", short: "h" },
-      version: { type: "boolean", short: "v" },
-      skill: { type: "boolean" },
-      global: { type: "boolean" },
-      yes: { type: "boolean" },
-      // Search options
-      n: { type: "string" },
-      "min-score": { type: "string" },
-      all: { type: "boolean" },
-      full: { type: "boolean" },
-      format: { type: "string" },          // preferred: --format cli|json|csv|md|xml|files
-      // Legacy boolean format aliases. Kept working for back-compat but
-      // omitted from the documented help; prefer `--format <kind>`.
-      csv: { type: "boolean" },
-      md: { type: "boolean" },
-      xml: { type: "boolean" },
-      files: { type: "boolean" },
-      json: { type: "boolean" },
-      explain: { type: "boolean" },
-      collection: { type: "string", short: "c", multiple: true },  // Filter by collection(s)
-      // Collection options
-      name: { type: "string" },  // collection name
-      mask: { type: "string" },  // glob pattern
-      glob: { type: "string" },  // alias for --mask (OpenClaw / #536)
-      // Embed options
-      force: { type: "boolean", short: "f" },
-      "max-docs-per-batch": { type: "string" },
-      "max-batch-mb": { type: "string" },
-      timeout: { type: "string" },  // embed session cap in minutes (0 = no limit; default 30)
-      // Update options
-      pull: { type: "boolean" },  // git pull before update
-      refresh: { type: "boolean" },
-      progress: { type: "boolean" },  // qmd pull: show node-llama-cpp download progress bar
-      "dry-run": { type: "boolean" },  // cleanup: report what would be removed
-      // Get options
-      l: { type: "string" },  // max lines
-      from: { type: "string" },  // start line
-      "max-bytes": { type: "string" },  // max bytes for multi-get
-      "line-numbers": { type: "boolean" },  // add line numbers to output (search; default on for get/multi-get)
-      "no-line-numbers": { type: "boolean" },  // disable line numbers for get/multi-get
-      "full-path": { type: "boolean" },  // show on-disk paths instead of qmd:// (get/multi-get/search/query)
-      // Query options
-      "candidate-limit": { type: "string", short: "C" },
-      "no-rerank": { type: "boolean", default: false },
-      "no-gpu": { type: "boolean", default: false },
-      intent: { type: "string" },
-      // Chunking options
-      "chunk-strategy": { type: "string" },  // "regex" (default) or "auto" (AST for code files)
-      // MCP HTTP transport options
-      http: { type: "boolean" },
-      daemon: { type: "boolean" },
-      port: { type: "string" },
-      host: { type: "string" },
-    },
+    options: CLI_OPTIONS,
     allowPositionals: true,
     strict: false, // Allow unknown options to pass through
   });
@@ -3195,10 +3136,6 @@ type SkillInfo = {
 const SKILL_DIR = "skills";
 
 function findPackageRoot(): string | null {
-  if (process.env.QMD_SKILLS_DIR) {
-    return null;
-  }
-
   const start = dirname(fileURLToPath(import.meta.url));
   let current = start;
   while (true) {
@@ -3478,17 +3415,7 @@ function runSkillsCommand(args: string[], jsonMode: boolean, fullOption = false,
 }
 
 function showSkillsHelp(): void {
-  console.log("Usage: qmd skills <list|get|path> [options]");
-  console.log("");
-  console.log("Commands:");
-  console.log("  list                 List bundled runtime skills");
-  console.log("  get <name>           Print a bundled runtime skill");
-  console.log("  get <name> --full    Include references/templates/scripts");
-  console.log("  get --all            Print all bundled runtime skills");
-  console.log("  path [name]          Print runtime skill directory path(s)");
-  console.log("");
-  console.log("Options:");
-  console.log("  --json               Print structured JSON");
+  printHelp("skills");
 }
 
 function ensureClaudeSymlink(linkPath: string, targetDir: string, force: boolean): boolean {
@@ -3565,113 +3492,7 @@ async function installSkill(globalInstall: boolean, force: boolean, autoYes: boo
 }
 
 function showHelp(): void {
-  console.log("qmd — Quick Markdown Search");
-  console.log("");
-  console.log("Usage:");
-  console.log("  qmd <command> [options]");
-  console.log("");
-  console.log("Primary commands:");
-  console.log("  qmd query <query>             - Hybrid search with auto expansion + reranking (recommended)");
-  console.log("  qmd query 'lex:..\\nvec:...'   - Structured query document (you provide lex/vec/hyde lines)");
-  console.log("  qmd search <query>            - Full-text BM25 keywords (no LLM)");
-  console.log("  qmd vsearch <query>           - Vector similarity only");
-  console.log("  qmd get <file>[:from[:count]] - Show a document (line-numbered; #docid in header)");
-  console.log("  qmd multi-get <pattern>       - Batch fetch via glob or comma-separated list");
-  console.log("  qmd skills list/get/path      - List and retrieve bundled runtime skills");
-  console.log("  qmd skill show/install        - Show or install the QMD skill");
-  console.log("  qmd mcp                       - Start the MCP server (stdio transport for AI agents)");
-  console.log("  qmd bench <fixture.json>      - Run search quality benchmarks against a fixture file");
-  console.log("");
-  console.log("Collections & context:");
-  console.log("  qmd collection add/list/remove/rename/show   - Manage indexed folders");
-  console.log("  qmd context add/list/rm                      - Attach human-written summaries");
-  console.log("  qmd ls [collection[/path]]                   - Inspect indexed files");
-  console.log("");
-  console.log("Maintenance:");
-  console.log("  qmd init                      - Create a project-local .qmd index");
-  console.log("  qmd status                    - View index + collection health");
-  console.log("  qmd update [--pull]           - Re-index collections (optionally git pull first)");
-  console.log("  qmd trust [list|revoke]       - Approve a checked-in .qmd config's hooks/paths/models");
-  console.log("  qmd embed [-f] [-c <name>]    - Generate/refresh vector embeddings");
-  console.log("    --max-docs-per-batch <n>    - Cap docs loaded into memory per embedding batch");
-  console.log("    --max-batch-mb <n>          - Cap UTF-8 MB loaded into memory per embedding batch");
-  console.log("    --timeout <minutes>         - Embed session cap in minutes (0 = no limit; default 30)");
-  console.log("  qmd pull [--refresh] [--progress] - Download embedding/generation/rerank models");
-  console.log("  qmd cleanup [--dry-run]       - Drop inactive docs/orphans, compact FTS, vacuum");
-  console.log("");
-  console.log("Query syntax (qmd query):");
-  console.log("  QMD queries are either a single expand query (no prefix) or a multi-line");
-  console.log("  document where every line is typed with lex:, vec:, or hyde:. This grammar");
-  console.log("  matches the docs in docs/SYNTAX.md and is enforced in the CLI.");
-  console.log("");
-  const grammar = [
-    `query          = expand_query | query_document ;`,
-    `expand_query   = text | explicit_expand ;`,
-    `explicit_expand= "expand:" text ;`,
-    `query_document = [ intent_line ] { typed_line } ;`,
-    `intent_line    = "intent:" text newline ;`,
-    `typed_line     = type ":" text newline ;`,
-    `type           = "lex" | "vec" | "hyde" ;`,
-    `text           = quoted_phrase | plain_text ;`,
-    `quoted_phrase  = '"' { character } '"' ;`,
-    `plain_text     = { character } ;`,
-    `newline        = "\\n" ;`,
-  ];
-  console.log("  Grammar:");
-  for (const line of grammar) {
-    console.log(`    ${line}`);
-  }
-  console.log("");
-  console.log("  Examples:");
-  console.log("    qmd query \"how does auth work\"                # single-line → implicit expand");
-  console.log("    qmd query $'lex: CAP theorem\\nvec: consistency'  # typed query document");
-  console.log("    qmd query $'lex: \"exact matches\" sports -baseball'  # phrase + negation lex search");
-  console.log("    qmd query $'hyde: Hypothetical answer text'       # hyde-only document");
-  console.log("");
-  console.log("  Constraints:");
-  console.log("    - Standalone expand queries cannot mix with typed lines.");
-  console.log("    - Query documents allow only lex:, vec:, or hyde: prefixes.");
-  console.log("    - Each typed line must be single-line text with balanced quotes.");
-  console.log("");
-  console.log("AI agents & integrations:");
-  console.log("  - Run `qmd mcp` to expose the MCP server (stdio) to agents/IDEs.");
-  console.log("  - Run `qmd skills get qmd --full` for version-matched agent instructions.");
-  console.log("  - `qmd skill install` installs the QMD skill into ./.agents/skills/qmd.");
-  console.log("  - Use `qmd skill install --global` for ~/.agents/skills/qmd.");
-  console.log("  - `qmd --skill` is kept as an alias for `qmd skill show`.");
-  console.log("  - Advanced: `qmd mcp --http ...` and `qmd mcp --http --daemon` are optional for custom transports.");
-  console.log("");
-  console.log("Global options:");
-  console.log("  --index <name>             - Use a named index (default: index)");
-  console.log("  QMD_EDITOR_URI             - Editor link template for clickable TTY search output");
-  console.log("");
-  console.log("Search options:");
-  console.log("  -n <num>                   - Max results (default 5, or 20 for --format files|json)");
-  console.log("  --all                      - Return all matches (pair with --min-score)");
-  console.log("  --min-score <num>          - Minimum similarity score");
-  console.log("  --full                     - Output full document instead of snippet");
-  console.log("  -C, --candidate-limit <n>  - Max candidates to rerank (default 40, lower = faster)");
-  console.log("  --no-rerank                - Skip LLM reranking (use RRF scores only, much faster on CPU)");
-  console.log("  --no-gpu                   - Force CPU mode for llama.cpp operations (same as QMD_FORCE_CPU=1)");
-  console.log("  --line-numbers             - Include line numbers (search; get/multi-get are on by default)");
-  console.log("  --no-line-numbers          - Disable line numbers for get/multi-get");
-  console.log("  --full-path                - Show on-disk paths instead of qmd:// + docid (get/multi-get/search/query)");
-  console.log("                                Paths are ./-prefixed when under $PWD, absolute otherwise");
-  console.log("                                Results whose file is gone keep qmd:// + docid and warn on stderr");
-  console.log("  --explain                  - Include retrieval score traces (query, CLI/--format json)");
-  console.log("  --format <kind>            - Output format: cli (default) | json | csv | md | xml | files");
-  console.log("  -c, --collection <name>    - Filter by one or more collections");
-  console.log("");
-  console.log("Embed/query options:");
-  console.log("  --chunk-strategy <auto|regex> - Chunking mode (default: regex; auto uses AST for code files)");
-  console.log("  --timeout <minutes>          - Embed session cap in minutes (0 = no limit; default 30)");
-  console.log("");
-  console.log("Multi-get options:");
-  console.log("  -l <num>                   - Maximum lines per file");
-  console.log("  --max-bytes <num>          - Skip files larger than N bytes (default 65536)");
-  console.log("  --format <kind>            - Same formats as search");
-  console.log("");
-  console.log(`Index: ${getDbPath()}`);
+  printHelp("root", { indexPath: getDbPath() });
 }
 
 function doctorCheck(label: string, ok: boolean, details: string): void {
@@ -4311,23 +4132,15 @@ if (isMain) {
     process.exit(0);
   }
 
-  if (cli.values.help && cli.command === "skill") {
-    console.log("Usage: qmd skill <show|install> [options]");
-    console.log("");
-    console.log("Commands:");
-    console.log("  show                 Print the QMD skill");
-    console.log("  install              Install QMD skill into ./.agents/skills/qmd");
-    console.log("");
-    console.log("Options:");
-    console.log("  --global             Install into ~/.agents/skills/qmd");
-    console.log("  --yes                Also create the .claude/skills/qmd symlink");
-    console.log("  -f, --force          Replace existing install or symlink");
-    process.exit(0);
-  }
-
-  if (!cli.command || cli.values.help) {
+  if (!cli.command) {
     showHelp();
     process.exit(cli.values.help ? 0 : 1);
+  }
+
+  if (cli.values.help || cli.command === "help") {
+    const topic = resolveHelpTopic(cli.command, cli.args);
+    printHelp(topic, topic === "root" ? { indexPath: getDbPath() } : undefined);
+    process.exit(0);
   }
 
   switch (cli.command) {
@@ -4579,23 +4392,7 @@ if (isMain) {
 
         case "help":
         case undefined: {
-          console.log("Usage: qmd collection <command> [options]");
-          console.log("");
-          console.log("Commands:");
-          console.log("  list                      List all collections");
-          console.log("  add <path> [--name NAME] [--mask|--glob GLOB]  Add a collection");
-          console.log("  remove <name>             Remove a collection");
-          console.log("  rename <old> <new>        Rename a collection");
-          console.log("  show <name>               Show collection details");
-          console.log("  update-cmd <name> [cmd]   Set pre-update command (e.g., 'git pull')");
-          console.log("  include <name>            Include in default queries");
-          console.log("  exclude <name>            Exclude from default queries");
-          console.log("");
-          console.log("Examples:");
-          console.log("  qmd collection add ~/notes --name notes");
-          console.log("  qmd collection add ~/notes --name notes --mask 'a.md,journals/*.md'");
-          console.log("  qmd collection update-cmd brain 'git pull'");
-          console.log("  qmd collection exclude archive");
+          printHelp("collection");
           process.exit(0);
         }
 
@@ -4713,12 +4510,26 @@ if (isMain) {
       break;
 
     case "bench": {
+      if (cli.values.example) {
+        const packageRoot = findPackageRoot();
+        if (!packageRoot) {
+          exitWithError("Bundled benchmark example not found. Reinstall qmd and try again.");
+        }
+        const examplePath = resolve(packageRoot, "src", "bench", "fixtures", "example.json");
+        try {
+          process.stdout.write(readFileSync(examplePath, "utf-8"));
+        } catch {
+          exitWithError("Bundled benchmark example not found. Reinstall qmd and try again.");
+        }
+        break;
+      }
+
       const fixturePath = cli.args[0];
       if (!fixturePath) {
         console.error("Usage: qmd bench <fixture.json> [--json] [-c collection]");
         console.error("");
         console.error("Run search quality benchmarks against a fixture file.");
-        console.error("See src/bench/fixtures/example.json for the fixture format.");
+        console.error("Run 'qmd bench --example' to print an example fixture.");
         process.exit(1);
       }
       const { runBenchmark } = await import("../bench/bench.js");
@@ -4881,16 +4692,7 @@ if (isMain) {
 
         case "help":
         case undefined: {
-          console.log("Usage: qmd skill <show|install> [options]");
-          console.log("");
-          console.log("Commands:");
-          console.log("  show                 Print the QMD skill");
-          console.log("  install              Install QMD skill into ./.agents/skills/qmd");
-          console.log("");
-          console.log("Options:");
-          console.log("  --global             Install into ~/.agents/skills/qmd");
-          console.log("  --yes                Also create the .claude/skills/qmd symlink");
-          console.log("  -f, --force          Replace existing install or symlink");
+          printHelp("skill");
           process.exit(0);
         }
 

--- a/test/cli-help.test.ts
+++ b/test/cli-help.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+import {
+  HELP_SPECS,
+  renderHelp,
+  resolveHelpTopic,
+  validateHelpOptionKeys,
+} from "../src/cli/help.js";
+
+describe("contextual CLI help registry", () => {
+  test("every documented option exists in the parser option registry", () => {
+    expect(validateHelpOptionKeys()).toEqual([]);
+  });
+
+  test("every registered topic renders its own usage", () => {
+    for (const [topic, spec] of Object.entries(HELP_SPECS)) {
+      const help = renderHelp(topic);
+      expect(help, topic).toContain(`  ${spec.usage}`);
+      expect(help, topic).toContain("-h, --help");
+    }
+  });
+
+  test("resolves command aliases and nested command topics", () => {
+    expect(resolveHelpTopic("deep-search")).toBe("query");
+    expect(resolveHelpTopic("vector-search")).toBe("vsearch");
+    expect(resolveHelpTopic("collection", ["add"])).toBe("collection add");
+    expect(resolveHelpTopic("collection", ["rm"])).toBe("collection remove");
+    expect(resolveHelpTopic("context", ["remove"])).toBe("context rm");
+    expect(resolveHelpTopic("help", ["embed"])).toBe("embed");
+  });
+
+  test("keeps query grammar out of unrelated help", () => {
+    expect(renderHelp("query")).toContain("Query grammar:");
+    expect(renderHelp("query")).toContain("typed_line");
+    expect(renderHelp("root")).not.toContain("Query grammar:");
+    expect(renderHelp("embed")).not.toContain("typed_line");
+  });
+
+  test("documents the formerly missing command-specific flags", () => {
+    expect(renderHelp("query")).toContain("--intent <text>");
+    expect(renderHelp("get")).toContain("--from <line>");
+  });
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -232,20 +232,79 @@ beforeEach(async () => {
 });
 
 describe("CLI Help", () => {
-  test("shows help with --help flag", async () => {
+  test("shows a concise command directory with --help", async () => {
     const { stdout, exitCode } = await runQmd(["--help"]);
     expect(exitCode).toBe(0);
     expect(stdout).toContain("Usage:");
-    expect(stdout).toContain("qmd collection add");
-    expect(stdout).toContain("qmd search");
+    expect(stdout).toContain("collection <command>");
+    expect(stdout).toContain("search <query>");
     expect(stdout).toContain("--no-gpu");
-    expect(stdout).toContain("qmd skill show/install");
+    expect(stdout).toContain("skill <command>");
+    expect(stdout).not.toContain("Query grammar:");
+    expect(stdout).not.toContain("--candidate-limit");
   });
 
   test("shows help with no arguments", async () => {
     const { stdout, exitCode } = await runQmd([]);
     expect(exitCode).toBe(1);
     expect(stdout).toContain("Usage:");
+  });
+
+  test("shows query-specific help and grammar", async () => {
+    const { stdout, stderr, exitCode } = await runQmd(["query", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("Usage:\n  qmd query [options] <query>");
+    expect(stdout).toContain("--intent <text>");
+    expect(stdout).toContain("--candidate-limit <n>");
+    expect(stdout).toContain("Query grammar:");
+    expect(stdout).not.toContain("--max-bytes");
+  });
+
+  test("shows get-specific help including --from", async () => {
+    const { stdout, stderr, exitCode } = await runQmd(["get", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("Usage:\n  qmd get <file>[:from[:count]] [options]");
+    expect(stdout).toContain("--from <line>");
+    expect(stdout).toContain("--no-line-numbers");
+    expect(stdout).not.toContain("Query grammar:");
+  });
+
+  test("shows embed-specific resource controls", async () => {
+    const { stdout, stderr, exitCode } = await runQmd(["embed", "-h"]);
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("Usage:\n  qmd embed [options]");
+    expect(stdout).toContain("--max-docs-per-batch <n>");
+    expect(stdout).toContain("--timeout <minutes>");
+    expect(stdout).not.toContain("--max-bytes");
+  });
+
+  test("shows nested collection add help", async () => {
+    const { stdout, stderr, exitCode } = await runQmd(["collection", "add", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("Usage:\n  qmd collection add <path> [options]");
+    expect(stdout).toContain("--name <name>");
+    expect(stdout).toContain("--mask <glob>");
+    expect(stdout).not.toContain("remove <name>");
+  });
+
+  test("supports qmd help <command>", async () => {
+    const { stdout, stderr, exitCode } = await runQmd(["help", "search"]);
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("Usage:\n  qmd search [options] <query>");
+  });
+
+  test("prints the bundled benchmark fixture", async () => {
+    const { stdout, stderr, exitCode } = await runQmd(["bench", "--example"]);
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    const fixture = JSON.parse(stdout);
+    expect(fixture.collection).toBe("eval-docs");
+    expect(fixture.queries.length).toBeGreaterThan(0);
   });
 });
 
@@ -367,7 +426,7 @@ describe("CLI Skill Commands", () => {
   test("shows skill help with -h", async () => {
     const { stdout, exitCode } = await runQmd(["skill", "-h"]);
     expect(exitCode).toBe(0);
-    expect(stdout).toContain("Usage: qmd skill <show|install> [options]");
+    expect(stdout).toContain("Usage:\n  qmd skill <show|install> [options]");
     expect(stdout).toContain("install");
     expect(stdout).toContain("--global");
   });


### PR DESCRIPTION
## Overview

- Replace the monolithic top-level help output with a declarative, contextual help registry.
- Support command-specific help through `qmd <command> --help`, `qmd help <command>`, command aliases, and nested commands such as `qmd collection add --help`.
- Keep the query grammar scoped to `qmd query --help` and document previously omitted options such as `query --intent` and `get --from`.
- Move parser option definitions into a canonical registry so tests can detect drift between parsed and documented flags.
- Add `qmd bench --example` and publish the bundled fixture so installed users can discover the benchmark format without a source checkout.
- Update the README, changelog, package smoke coverage, and CLI integration tests.

Closes #716

## Testing done

- `bun run build`
- `bun run test:types`
- `bun test --timeout 60000 --preload ./src/test-preload.ts test/cli-help.test.ts`
- Focused Vitest run for the help registry, CLI help behavior, and skill help: 14 passed
- `bun run test:package`, including the compiled CLI under Node and Bun and the bundled benchmark fixture
- `npm pack --dry-run --json`, confirming `src/bench/fixtures/example.json` is included
- Full `test/cli.test.ts` run: 170 passed. Three existing MCP daemon PID identity cases failed locally, and the same failures reproduce independently of this change.

## Test plan

- Run `qmd --help` and confirm it shows a concise command directory without the query grammar.
- Run `qmd query --help` and confirm it includes query-only options, examples, and grammar.
- Run `qmd get --help` and confirm it documents `--from` and retrieval-specific options.
- Run `qmd collection add --help` and confirm it shows only collection-add usage and options.
- Run `qmd help search` and confirm it matches `qmd search --help`.
- Run `qmd bench --example`, parse the output as JSON, and confirm it contains the bundled example queries.
