### PR TITLE
feat(mcp): add shared API v1 admission daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@
 
 ### Changed
 
+- The HTTP MCP daemon now owns one versioned QMD work service. It bounds model-heavy search admission, deduplicates identical requests, serializes maintenance with reads, coalesces updates, and exposes `/v1/search`, `/v1/update`, `/v1/embed`, `/v1/operations/:id`, `/v1/collections`, and `/v1/collections/ensure`. Busy or failed semantic work uses typed lexical degradation when possible; unavailable lexical work is reported as non-authoritative instead of starting a local semantic process.
+
 - Dependencies: `node-llama-cpp` 3.18.1 → **3.20.0** (llama.cpp b8390 → b10361, 2026-08-11). Also safe patch/minors: `picomatch` 4.0.4 → 4.0.5, `web-tree-sitter` 0.26.8 → 0.26.12, `tsx` 4.21.0 → 4.23.12, `vitest` 3.2.4 → 3.2.7. No zod/vitest major; `@modelcontextprotocol/server` stays 2.0.0 (no 2.x patch). `flake.nix` FOD hashes are not updated here.
 - `generate` and query expansion now await `LlamaContextSequence.dispose()` before disposing the parent context. node-llama-cpp 3.20 made sequence dispose async; the library's context-onDispose path does not wait.
 

--- a/README.md
+++ b/README.md
@@ -149,10 +149,28 @@ The server binds to `localhost` by default. Pass `--host` (or set the `QMD_HOST`
 environment variable) to override — `--host 0.0.0.0` is useful when the server
 runs in a container and a liveness probe connects from a non-loopback address.
 
-The HTTP server exposes two endpoints:
+The HTTP server exposes these endpoints:
 - `POST /mcp` — MCP Streamable HTTP (JSON responses, stateless)
-- `POST /query` (alias `/search`) — structured search without the MCP protocol
-- `GET /health` — liveness check with uptime
+- `POST /query` (alias `/search`) — compatible structured search without the MCP protocol
+- `GET /health` — liveness and daemon capability information
+- `POST /v1/search` — versioned search with typed semantic or lexical-degraded outcomes
+- `POST /v1/update` — schedule a coalesced collection update
+- `POST /v1/embed` — schedule an explicit embedding operation
+- `GET /v1/operations/:id` — inspect an update, embed, or collection setup operation
+- `GET /v1/collections` — list collection metadata
+- `POST /v1/collections/ensure` — schedule collection setup and optional context changes
+
+The HTTP daemon is the single owner of the QMD store and local models. Plain queries,
+vector or HyDE searches, and reranking use one bounded work queue. Only an explicit
+`lex` search with `rerank: false` bypasses that queue. Queue saturation, queue timeouts,
+or semantic errors return a lexical result with a `reason` when the lexical store is
+available. An empty degraded result is not authoritative. Automatic lexical degradation
+is limited to two concurrent searches. Excess
+work returns `status: "unavailable"` and `authoritativeEmpty: false`; callers should use
+their own keyword fallback. Collection updates, embedding, and collection setup are
+exclusive with all reads. Embedding is never started automatically by the daemon.
+Request logs contain only fixed route labels and duration. They omit request
+bodies, query text, collection paths, and raw errors.
 
 
 ##### Origin and Host validation

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -240,7 +240,7 @@ async function loadGrammar(language: SupportedLanguage): Promise<LanguageType | 
     grammarCache.delete(wasmKey);
     const message = formatGrammarLoadError(language, err);
     grammarLoadErrors.set(language, message);
-    console.warn(`[qmd] AST grammar unavailable for ${language}: ${message}`);
+    console.warn(`[qmd] AST grammar unavailable for ${language}.`);
     return null;
   }
 }
@@ -316,8 +316,8 @@ export async function getASTBreakPoints(
     parser.delete();
 
     return Array.from(seen.values()).sort((a, b) => a.pos - b.pos);
-  } catch (err) {
-    console.warn(`[qmd] AST parse failed for ${filepath}, falling back to regex: ${err instanceof Error ? err.message : err}`);
+  } catch {
+    console.warn("[qmd] AST parse failed; falling back to regex.");
     return [];
   }
 }

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -4826,15 +4826,16 @@ if (isMain) {
           } catch { /* ignore */ }
         };
         process.on("exit", unlinkOwnPidfile);
-        const { startMcpHttpServer } = await import("../mcp/server.js");
         try {
+          const { startMcpHttpServer } = await import("../mcp/server.js");
           await startMcpHttpServer(port, { dbPath: getDbPath(), host });
         } catch (e: unknown) {
           if (typeof e === "object" && e !== null && "code" in e && e.code === "EADDRINUSE") {
             console.error(`Port ${port} already in use. Try a different port with --port.`);
             process.exit(1);
           }
-          throw e;
+          console.error("QMD MCP server failed to start.");
+          process.exit(1);
         }
       } else {
         // Default: stdio transport

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -209,7 +209,11 @@ export function loadConfig(): CollectionConfig {
 export function saveConfig(config: CollectionConfig): void {
   // SDK inline config mode: update in place, no file I/O
   if (configSource.type === 'inline') {
-    configSource.config = config;
+    const target = configSource.config;
+    if (target !== config) {
+      for (const key of Object.keys(target)) Reflect.deleteProperty(target, key);
+      Object.assign(target, config);
+    }
     return;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,9 +71,8 @@ import {
 import {
   setConfigSource,
   loadConfig,
-  addCollection as collectionsAddCollection,
+  saveConfig,
   removeCollection as collectionsRemoveCollection,
-  renameCollection as collectionsRenameCollection,
   addContext as collectionsAddContext,
   removeContext as collectionsRemoveContext,
   setGlobalContext as collectionsSetGlobalContext,
@@ -218,6 +217,17 @@ export interface StoreOptions {
   config?: CollectionConfig;
 }
 
+export type CollectionMutation =
+  | {
+      kind: "upsert";
+      name: string;
+      path: string;
+      pattern?: string;
+      ignore?: string[];
+    }
+  | { kind: "rename"; from: string; to: string }
+  | { kind: "context"; collection: string; path: string; context: string };
+
 /**
  * The QMD SDK store — provides search, retrieval, collection management,
  * context management, and indexing operations.
@@ -266,6 +276,9 @@ export interface QMDStore {
 
   /** Rename a collection */
   renameCollection(oldName: string, newName: string): Promise<boolean>;
+
+  /** Apply collection changes as one database transaction and one config write */
+  applyCollectionMutations(mutations: CollectionMutation[]): Promise<void>;
 
   /** List all collections with document stats */
   listCollections(): Promise<{ name: string; pwd: string; glob_pattern: string; doc_count: number; active_count: number; last_modified: string | null; includeByDefault: boolean }[]>;
@@ -445,10 +458,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
 
     // Collection Management — write to SQLite + write-through to YAML/inline if configured
     addCollection: async (name, opts) => {
-      upsertStoreCollection(db, name, { path: opts.path, pattern: opts.pattern, ignore: opts.ignore });
-      if (hasYamlConfig || options.config) {
-        collectionsAddCollection(name, opts.path, opts.pattern);
-      }
+      await store.applyCollectionMutations([{ kind: "upsert", name, ...opts }]);
     },
     removeCollection: async (name) => {
       const result = deleteStoreCollection(db, name);
@@ -458,11 +468,117 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
       return result;
     },
     renameCollection: async (oldName, newName) => {
-      const result = renameStoreCollection(db, oldName, newName);
-      if (hasYamlConfig || options.config) {
-        collectionsRenameCollection(oldName, newName);
+      if (!getStoreCollection(db, oldName)) return false;
+      await store.applyCollectionMutations([
+        { kind: "rename", from: oldName, to: newName },
+      ]);
+      return true;
+    },
+    applyCollectionMutations: async (mutations) => {
+      const writesConfig = hasYamlConfig || options.config !== undefined;
+      const previousConfig = writesConfig
+        ? structuredClone(loadConfig())
+        : undefined;
+      const nextConfig = previousConfig
+        ? structuredClone(previousConfig)
+        : undefined;
+      const apply = db.transaction(() => {
+        for (const mutation of mutations) {
+          if (mutation.kind === "rename") {
+            if (!renameStoreCollection(db, mutation.from, mutation.to)) {
+              throw new Error("collection rename failed");
+            }
+            if (nextConfig) {
+              const source = nextConfig.collections[mutation.from];
+              if (!source || nextConfig.collections[mutation.to]) {
+                throw new Error("collection rename failed");
+              }
+              nextConfig.collections[mutation.to] = source;
+              delete nextConfig.collections[mutation.from];
+            }
+            continue;
+          }
+
+          if (mutation.kind === "upsert") {
+            const current = getStoreCollection(db, mutation.name);
+            upsertStoreCollection(db, mutation.name, {
+              ...(current ?? {}),
+              path: mutation.path,
+              pattern: mutation.pattern ?? current?.pattern,
+              ...(mutation.ignore !== undefined
+                ? { ignore: mutation.ignore }
+                : {}),
+            });
+            if (nextConfig) {
+              const configured = nextConfig.collections[mutation.name];
+              nextConfig.collections[mutation.name] = {
+                ...configured,
+                path: mutation.path,
+                pattern:
+                  mutation.pattern ??
+                  configured?.pattern ??
+                  current?.pattern ??
+                  "**/*.md",
+                ...(mutation.ignore !== undefined
+                  ? { ignore: mutation.ignore }
+                  : {}),
+              };
+            }
+            continue;
+          }
+
+          if (!getStoreCollection(db, mutation.collection)) {
+            throw new Error("collection context update failed");
+          }
+          if (mutation.context.length === 0) {
+            removeStoreContext(db, mutation.collection, mutation.path);
+          } else if (
+            !updateStoreContext(
+              db,
+              mutation.collection,
+              mutation.path,
+              mutation.context,
+            )
+          ) {
+            throw new Error("collection context update failed");
+          }
+          if (nextConfig) {
+            const configured = nextConfig.collections[mutation.collection];
+            if (!configured) {
+              throw new Error("collection context update failed");
+            }
+            if (mutation.context.length === 0) {
+              if (configured.context) {
+                delete configured.context[mutation.path];
+                if (Object.keys(configured.context).length === 0) {
+                  delete configured.context;
+                }
+              }
+            } else {
+              configured.context = {
+                ...configured.context,
+                [mutation.path]: mutation.context,
+              };
+            }
+          }
+        }
+        if (nextConfig) {
+          saveConfig(nextConfig);
+        }
+      });
+
+      try {
+        apply();
+      } catch (error) {
+        if (previousConfig) {
+          try {
+            saveConfig(previousConfig);
+          } catch {
+            // Preserve the original mutation failure.
+          }
+        }
+        throw error;
       }
-      return result;
     },
     listCollections: async () => storeListCollections(db),
     getDefaultCollectionNames: async () => {

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -764,9 +764,9 @@ async function disposeWithTimeout(resourceName: string, dispose: () => Promise<v
     if (result === "timeout") {
       process.stderr.write(`QMD Warning: timed out disposing ${resourceName}; continuing shutdown.\n`);
     }
-  } catch (error) {
+  } catch {
     process.stderr.write(
-      `QMD Warning: failed to dispose ${resourceName} (${error instanceof Error ? error.message : String(error)}); continuing shutdown.\n`
+      `QMD Warning: failed to dispose ${resourceName}; continuing shutdown.\n`
     );
   }
 }
@@ -887,8 +887,8 @@ export class LlamaCpp implements LLM {
           this.touchActivity();
           return;
         }
-        this.unloadIdleResources().catch(err => {
-          console.error("Error unloading idle resources:", err);
+        this.unloadIdleResources().catch(() => {
+          console.error("Failed to unload idle resources.");
         });
       }, this.inactivityTimeoutMs);
       // Don't keep process alive just for this timer
@@ -1006,7 +1006,7 @@ export class LlamaCpp implements LLM {
       const loadCpuCompatibleLlama = async () => {
         try {
           return await loadLlama(false, false);
-        } catch (err) {
+        } catch {
           // Some platforms, notably Apple Silicon, ship a Metal prebuilt but no
           // CPU-only prebuilt. Do a fast no-build lookup for an actual CPU
           // binding first; if it does not exist, use the packaged auto/Metal
@@ -1014,7 +1014,7 @@ export class LlamaCpp implements LLM {
           if (!cpuForcedPrebuiltFallbackWarningShown) {
             cpuForcedPrebuiltFallbackWarningShown = true;
             process.stderr.write(
-              `QMD Warning: CPU-only llama.cpp prebuilt not available (${err instanceof Error ? err.message : String(err)}); using packaged backend with GPU offloading disabled.\n`
+              "QMD Warning: CPU-only llama.cpp prebuilt not available; using packaged backend with GPU offloading disabled.\n"
             );
           }
           return await loadLlama("auto", false);
@@ -1056,13 +1056,13 @@ export class LlamaCpp implements LLM {
               }
             }
           }
-        } catch (err) {
+        } catch {
           // GPU backend (e.g. Vulkan/CUDA on headless/driverless machines) can throw at init.
           // Fall back to CPU so qmd still works, and cache the failure to avoid repeated
           // expensive native build/probe attempts in this process.
           failedGpuInitModes.add(gpuMode);
           process.stderr.write(
-            `QMD Warning: GPU init failed${gpuMode === "auto" ? "" : ` for QMD_LLAMA_GPU=${gpuMode}`} (${err instanceof Error ? err.message : String(err)}), falling back to CPU.\n`
+            `QMD Warning: GPU init failed${gpuMode === "auto" ? "" : ` for QMD_LLAMA_GPU=${gpuMode}`}; falling back to CPU.\n`
           );
           llama = await loadCpuCompatibleLlama();
         }
@@ -1345,13 +1345,8 @@ export class LlamaCpp implements LLM {
           }));
         } catch (error) {
           if (this.rerankContexts.length === 0) {
-            // Surface the underlying failure (e.g. out of VRAM). A previous
-            // "retry without flash attention" path was dead: ranking contexts
-            // never accepted that option, so the retry repeated identical
-            // arguments and the real error was discarded.
-            const detail = error instanceof Error ? error.message : String(error);
             console.warn(
-              `Reranker unavailable — skipping reranking (${detail}). ` +
+              "Reranker unavailable — skipping reranking. " +
               "Use --no-rerank to silence this warning.",
             );
             return [];
@@ -1461,8 +1456,8 @@ export class LlamaCpp implements LLM {
         embedding: Array.from(embedding.vector),
         model: options.model ?? this.embedModelUri,
       };
-    } catch (error) {
-      console.error("Embedding error:", error);
+    } catch {
+      console.error("Embedding failed.");
       return null;
     }
   }
@@ -1495,8 +1490,8 @@ export class LlamaCpp implements LLM {
             const embedding = await context.getEmbeddingFor(safeText);
             this.touchActivity();
             embeddings.push({ embedding: Array.from(embedding.vector), model: options.model ?? this.embedModelUri });
-          } catch (err) {
-            console.error("Embedding error for text:", err);
+          } catch {
+            console.error("Embedding failed.");
             embeddings.push(null);
           }
         }
@@ -1522,8 +1517,8 @@ export class LlamaCpp implements LLM {
               const embedding = await ctx.getEmbeddingFor(safeText);
               this.touchActivity();
               results.push({ embedding: Array.from(embedding.vector), model: options.model ?? this.embedModelUri });
-            } catch (err) {
-              console.error("Embedding error for text:", err);
+            } catch {
+              console.error("Embedding failed.");
               results.push(null);
             }
           }
@@ -1532,8 +1527,8 @@ export class LlamaCpp implements LLM {
       );
 
       return chunkResults.flat();
-    } catch (error) {
-      console.error("Batch embedding error:", error);
+    } catch {
+      console.error("Batch embedding failed.");
       return texts.map(() => null);
     }
   }
@@ -1685,8 +1680,8 @@ export class LlamaCpp implements LLM {
         { type: 'vec', text: query },
       ];
       return includeLexical ? fallback : fallback.filter(q => q.type !== 'lex');
-    } catch (error) {
-      console.error("Structured query expansion failed:", error);
+    } catch {
+      console.error("Structured query expansion failed.");
       // Fallback to original query
       const fallback: Queryable[] = [{ type: 'vec', text: query }];
       if (includeLexical) fallback.unshift({ type: 'lex', text: query });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,11 +8,23 @@
  * 2025-era clients via the official SDK entries (`serveStdio` / `createMcpHandler`).
  */
 
-import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "url";
-import { createMcpHandler, McpServer, ResourceTemplate } from "@modelcontextprotocol/server";
+import {
+  createMcpHandler,
+  isLegacyRequest,
+  McpServer,
+  ResourceTemplate,
+  WebStandardStreamableHTTPServerTransport,
+} from "@modelcontextprotocol/server";
 import { serveStdio } from "@modelcontextprotocol/server/stdio";
 import { z } from "zod";
 import { existsSync } from "fs";
@@ -22,25 +34,36 @@ import {
   addLineNumbers,
   getDefaultDbPath,
   DEFAULT_MULTI_GET_MAX_BYTES,
-  type QMDStore,
-  type ExpandedQuery,
-  type IndexStatus,
 } from "../index.js";
+import {
+  API_VERSION,
+  DAEMON_FEATURES,
+  QMDWorkService,
+  WorkServiceError,
+  type CollectionEnsureRequest,
+  type UpdateScope,
+  type DaemonEmbedRequest,
+  type DaemonSearchRequest,
+  type DaemonSearchResult,
+} from "./work-service.js";
 import { getConfigPath } from "../collections.js";
 import { enableProductionMode } from "../store.js";
 import { checkRequestOrigin, resolveOriginGuard } from "./origin-guard.js";
+
+const MAX_HTTP_REQUEST_BODY_BYTES = 1_048_576;
+const HTTP_REQUEST_BODY_TIMEOUT_MS = 30_000;
 
 // =============================================================================
 // Types for structured content
 // =============================================================================
 
 type SearchResultItem = {
-  docid: string;  // Short docid (#abc123) for quick reference
+  docid: string; // Short docid (#abc123) for quick reference
   file: string;
   title: string;
   score: number;
   context: string | null;
-  line: number;   // Absolute line in source markdown
+  line: number; // Absolute line in source markdown
   snippet: string;
 };
 
@@ -67,26 +90,84 @@ type StatusResult = {
  */
 function encodeQmdPath(path: string): string {
   // Encode each path segment separately to preserve slashes
-  return path.split('/').map(segment => encodeURIComponent(segment)).join('/');
+  return path
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+function formatSearchResults(
+  results: readonly DaemonSearchResult[],
+  query: string,
+  intent: string | undefined,
+  uriPaths: boolean,
+): SearchResultItem[] {
+  return results.map((result) => {
+    const bestChunkPos =
+      "bestChunkPos" in result ? result.bestChunkPos : result.chunkPos;
+    const bestChunkLength =
+      "bestChunk" in result ? result.bestChunk.length : undefined;
+    const { line, snippet } = extractSnippet(
+      result.body ?? "",
+      query,
+      300,
+      bestChunkPos,
+      bestChunkLength,
+      intent,
+    );
+    return {
+      docid: `#${result.docid}`,
+      file: uriPaths
+        ? `qmd://${encodeQmdPath(result.displayPath)}`
+        : result.displayPath,
+      title: result.title,
+      score: Math.round(result.score * 100) / 100,
+      context: result.context,
+      line,
+      snippet: addLineNumbers(snippet, line),
+    };
+  });
+}
+
+function primarySearchQuery(
+  request: Pick<DaemonSearchRequest, "query" | "searches">,
+): string {
+  return (
+    request.query ||
+    request.searches?.find((search) => search.type === "lex")?.query ||
+    request.searches?.find((search) => search.type === "vec")?.query ||
+    request.searches?.[0]?.query ||
+    ""
+  );
 }
 
 /**
  * Format search results as human-readable text summary
  */
-function formatSearchSummary(results: SearchResultItem[], query: string): string {
+function formatSearchSummary(
+  results: SearchResultItem[],
+  query: string,
+): string {
   if (results.length === 0) {
     return `No results found for "${query}"`;
   }
-  const lines = [`Found ${results.length} result${results.length === 1 ? '' : 's'} for "${query}":\n`];
+  const lines = [
+    `Found ${results.length} result${results.length === 1 ? "" : "s"} for "${query}":\n`,
+  ];
   for (const r of results) {
-    lines.push(`${r.docid} ${Math.round(r.score * 100)}% ${r.file} - ${r.title}`);
+    lines.push(
+      `${r.docid} ${Math.round(r.score * 100)}% ${r.file} - ${r.title}`,
+    );
   }
-  return lines.join('\n');
+  return lines.join("\n");
 }
 
 function getPackageVersion(): string {
   try {
-    const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "../../package.json");
+    const pkgPath = join(
+      dirname(fileURLToPath(import.meta.url)),
+      "../../package.json",
+    );
     const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
     return pkg.version ?? "unknown";
   } catch {
@@ -104,13 +185,24 @@ function getPackageVersion(): string {
  * server/discover (2026-07-28) — gives the LLM immediate context about what's
  * searchable without a tool call.
  */
-async function buildInstructions(store: QMDStore): Promise<string> {
-  const status = await store.getStatus();
-  const globalCtx = await store.getGlobalContext();
+async function buildInstructions(service: QMDWorkService): Promise<string> {
+  let status: Awaited<ReturnType<QMDWorkService["getStatus"]>>;
+  let globalCtx: string | undefined;
+  try {
+    status = await service.getStatus();
+    globalCtx = await service.getGlobalContext();
+  } catch (error) {
+    if (error instanceof WorkServiceError) {
+      return "QMD is temporarily unavailable while maintenance is running.";
+    }
+    throw error;
+  }
   const lines: string[] = [];
 
   // --- What is this? ---
-  lines.push(`QMD is your local search engine over ${status.totalDocuments} markdown documents.`);
+  lines.push(
+    `QMD is your local search engine over ${status.totalDocuments} markdown documents.`,
+  );
   if (globalCtx) lines.push(`Context: ${globalCtx}`);
 
   // --- What's searchable? ---
@@ -118,18 +210,24 @@ async function buildInstructions(store: QMDStore): Promise<string> {
   // across a dozen collections, and the same info is available on demand via the `status` tool.
   if (status.collections.length > 0) {
     lines.push("");
-    const names = status.collections.map(c => c.name).join(", ");
+    const names = status.collections.map((c) => c.name).join(", ");
     lines.push(`Collections (scope with \`collections\` parameter): ${names}`);
-    lines.push("Call the `status` tool for collection descriptions, paths, and per-collection doc counts.");
+    lines.push(
+      "Call the `status` tool for collection descriptions, paths, and per-collection doc counts.",
+    );
   }
 
   // --- Capability gaps ---
   if (!status.hasVectorIndex) {
     lines.push("");
-    lines.push("Note: No vector embeddings yet. Run `qmd embed` to enable semantic search (vec/hyde).");
+    lines.push(
+      "Note: Vector embeddings are not ready; semantic searches use lexical fallback.",
+    );
   } else if (status.needsEmbedding > 0) {
     lines.push("");
-    lines.push(`Note: ${status.needsEmbedding} documents need embedding. Run \`qmd embed\` to update.`);
+    lines.push(
+      `Note: ${status.needsEmbedding} documents await embedding, so semantic coverage may be incomplete.`,
+    );
   }
 
   // --- Search tool ---
@@ -137,28 +235,44 @@ async function buildInstructions(store: QMDStore): Promise<string> {
   lines.push("Search: Use `query` with sub-queries (lex/vec/hyde):");
   lines.push("  - type:'lex' — BM25 keyword search (exact terms, fast)");
   lines.push("  - type:'vec' — semantic vector search (meaning-based)");
-  lines.push("  - type:'hyde' — hypothetical document (write what the answer looks like)");
+  lines.push(
+    "  - type:'hyde' — hypothetical document (write what the answer looks like)",
+  );
   lines.push("");
-  lines.push("  Always provide `intent` on every search call to disambiguate and improve snippets.");
+  lines.push(
+    "  Always provide `intent` on every search call to disambiguate and improve snippets.",
+  );
   lines.push("");
   lines.push("Examples:");
   lines.push("  Quick keyword lookup: [{type:'lex', query:'error handling'}]");
-  lines.push("  Semantic search: [{type:'vec', query:'how to handle errors gracefully'}]");
-  lines.push("  Best results: [{type:'lex', query:'error'}, {type:'vec', query:'error handling best practices'}]");
-  lines.push("  With intent: searches=[{type:'lex', query:'performance'}], intent='web page load times'");
+  lines.push(
+    "  Semantic search: [{type:'vec', query:'how to handle errors gracefully'}]",
+  );
+  lines.push(
+    "  Best results: [{type:'lex', query:'error'}, {type:'vec', query:'error handling best practices'}]",
+  );
+  lines.push(
+    "  With intent: searches=[{type:'lex', query:'performance'}], intent='web page load times'",
+  );
 
   // --- Retrieval workflow ---
   lines.push("");
   lines.push("Retrieval:");
-  lines.push("  - `get` — single document by path or docid (#abc123). Supports a line-range suffix: `file.md:100` (from line 100) or `file.md:100:40` (40 lines from line 100).");
-  lines.push("  - `multi_get` — batch retrieve by glob (`journals/2025-05*.md`), comma-separated list, or docids (#abc123).");
+  lines.push(
+    "  - `get` — single document by path or docid (#abc123). Supports a line-range suffix: `file.md:100` (from line 100) or `file.md:100:40` (40 lines from line 100).",
+  );
+  lines.push(
+    "  - `multi_get` — batch retrieve by glob (`journals/2025-05*.md`), comma-separated list, or docids (#abc123).",
+  );
 
   // --- Non-obvious things that prevent mistakes ---
   lines.push("");
   lines.push("Tips:");
   lines.push("  - File paths in results are relative to their collection.");
   lines.push("  - Use `minScore: 0.5` to filter low-confidence results.");
-  lines.push("  - Results include a `context` field describing the content type.");
+  lines.push(
+    "  - Results include a `context` field describing the content type.",
+  );
 
   return lines.join("\n");
 }
@@ -167,14 +281,17 @@ async function buildInstructions(store: QMDStore): Promise<string> {
  * Create an MCP server with all QMD tools, resources, and prompts registered.
  * Shared by both stdio and HTTP transports.
  */
-async function createMcpServer(store: QMDStore, inflight?: InflightGate): Promise<McpServer> {
+async function createMcpServer(
+  service: QMDWorkService,
+  inflight?: InflightGate,
+): Promise<McpServer> {
   // Wraps request handlers so a stdio EOF shutdown can wait for in-flight
   // work to settle before disposing the store/llm underneath it.
-  const track = inflight?.track ?? (<T,>(fn: T): T => fn);
+  const track = inflight?.track ?? (<T>(fn: T): T => fn);
   const server = new McpServer(
     { name: "qmd", version: getPackageVersion() },
     {
-      instructions: await buildInstructions(store),
+      instructions: await buildInstructions(service),
       // tools/list is static for the process lifetime; resources/read stays
       // uncacheable because the index can change under us.
       cacheHints: {
@@ -184,9 +301,6 @@ async function createMcpServer(store: QMDStore, inflight?: InflightGate): Promis
       },
     },
   );
-
-  // Pre-fetch default collection names for search tools
-  const defaultCollectionNames = await store.getDefaultCollectionNames();
 
   // ---------------------------------------------------------------------------
   // Resource: qmd://{path} - read-only access to documents by path
@@ -198,39 +312,39 @@ async function createMcpServer(store: QMDStore, inflight?: InflightGate): Promis
     new ResourceTemplate("qmd://{+path}", { list: undefined }),
     {
       title: "QMD Document",
-      description: "A markdown document from your QMD knowledge base. Use search tools to discover documents.",
+      description:
+        "A markdown document from your QMD knowledge base. Use search tools to discover documents.",
       mimeType: "text/markdown",
     },
     track(async (uri, { path }) => {
       // Decode URL-encoded path (MCP clients send encoded URIs)
-      const pathStr = Array.isArray(path) ? path.join('/') : (path || '');
+      const pathStr = Array.isArray(path) ? path.join("/") : path || "";
       const decodedPath = decodeURIComponent(pathStr);
 
       // Use SDK to find document — findDocument handles collection/path resolution
-      const result = await store.get(decodedPath, { includeBody: true });
+      const result = await service.get(decodedPath, { includeBody: true });
 
       if ("error" in result) {
-        const text = result.error === "excluded_by_ignore"
-          ? `Document excluded by ignore rule: ${decodedPath}\nCollection: ${result.collection}\nMatched path: ${result.path}\nIgnore rule: ${result.rule}`
-          : `Document not found: ${decodedPath}`;
-        return { contents: [{ uri: uri.href, text }] };
+        return { contents: [{ uri: uri.href, text: "Document unavailable" }] };
       }
 
-      let text = addLineNumbers(result.body || "");  // Default to line numbers
+      let text = addLineNumbers(result.body || ""); // Default to line numbers
       if (result.context) {
         text = `<!-- Context: ${result.context} -->\n\n` + text;
       }
 
       return {
-        contents: [{
-          uri: uri.href,
-          name: result.displayPath,
-          title: result.title || result.displayPath,
-          mimeType: "text/markdown",
-          text,
-        }],
+        contents: [
+          {
+            uri: uri.href,
+            name: result.displayPath,
+            title: result.title || result.displayPath,
+            mimeType: "text/markdown",
+            text,
+          },
+        ],
       };
-    })
+    }),
   );
 
   // ---------------------------------------------------------------------------
@@ -238,14 +352,18 @@ async function createMcpServer(store: QMDStore, inflight?: InflightGate): Promis
   // ---------------------------------------------------------------------------
 
   const subSearchSchema = z.object({
-    type: z.enum(['lex', 'vec', 'hyde']).describe(
-      "lex = BM25 keywords (supports \"phrase\" and -negation); " +
-      "vec = semantic question; hyde = hypothetical answer passage"
-    ),
-    query: z.string().describe(
-      "The query text. For lex: use keywords, \"quoted phrases\", and -negation. " +
-      "For vec: natural language question. For hyde: 50-100 word answer passage."
-    ),
+    type: z
+      .enum(["lex", "vec", "hyde"])
+      .describe(
+        'lex = BM25 keywords (supports "phrase" and -negation); ' +
+          "vec = semantic question; hyde = hypothetical answer passage",
+      ),
+    query: z
+      .string()
+      .describe(
+        'The query text. For lex: use keywords, "quoted phrases", and -negation. ' +
+          "For vec: natural language question. For hyde: 50-100 word answer passage.",
+      ),
   });
 
   server.registerTool(
@@ -314,87 +432,135 @@ Intent-aware lex (C++ performance, not sports):
 \`\`\``,
       annotations: { readOnlyHint: true, openWorldHint: false },
       inputSchema: z.object({
-        query: z.string().optional().describe(
-          "Plain-text query, auto-expanded by the SDK into lex/vec/hyde variants, fused via " +
-          "RRF and reranked. Recommended default for most searches. Mutually exclusive with 'searches'."
-        ),
-        searches: z.array(subSearchSchema).max(10).optional().describe(
-          "Typed sub-queries to execute (lex/vec/hyde). First gets 2x weight. Use for precise " +
-          "control over retrieval strategy. Mutually exclusive with 'query'."
-        ),
-        limit: z.number().optional().default(10).describe("Max results (default: 10)"),
-        minScore: z.number().optional().default(0).describe("Min relevance 0-1 (default: 0)"),
-        candidateLimit: z.number().optional().describe(
-          "Maximum candidates to rerank (default: 40, lower = faster but may miss results)"
-        ),
-        collections: z.array(z.string()).optional().describe("Filter to collections (OR match)"),
-        intent: z.string().optional().describe(
-          "Background context to disambiguate the query. Example: query='performance', intent='web page load times and Core Web Vitals'. Does not search on its own."
-        ),
-        rerank: z.boolean().optional().default(true).describe(
-          "Rerank results using LLM (default: true). Set to false for faster results on CPU-only machines."
-        ),
+        query: z
+          .string()
+          .optional()
+          .describe(
+            "Plain-text query, auto-expanded by the SDK into lex/vec/hyde variants, fused via " +
+              "RRF and reranked. Recommended default for most searches. Mutually exclusive with 'searches'.",
+          ),
+        searches: z
+          .array(subSearchSchema)
+          .max(10)
+          .optional()
+          .describe(
+            "Typed sub-queries to execute (lex/vec/hyde). First gets 2x weight. Use for precise " +
+              "control over retrieval strategy. Mutually exclusive with 'query'.",
+          ),
+        limit: z
+          .number()
+          .optional()
+          .default(10)
+          .describe("Max results (default: 10)"),
+        minScore: z
+          .number()
+          .optional()
+          .default(0)
+          .describe("Min relevance 0-1 (default: 0)"),
+        candidateLimit: z
+          .number()
+          .optional()
+          .describe(
+            "Maximum candidates to rerank (default: 40, lower = faster but may miss results)",
+          ),
+        collections: z
+          .array(z.string())
+          .optional()
+          .describe("Filter to collections (OR match)"),
+        intent: z
+          .string()
+          .optional()
+          .describe(
+            "Background context to disambiguate the query. Example: query='performance', intent='web page load times and Core Web Vitals'. Does not search on its own.",
+          ),
+        rerank: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Rerank results using LLM (default: true). Set to false for faster results on CPU-only machines.",
+          ),
       }),
     },
-    track(async ({ query, searches, limit, minScore, candidateLimit, collections, intent, rerank }) => {
-      // Require exactly one of `query` (plain text, auto-expanded) or `searches` (typed sub-queries).
-      if (!query && (!searches || searches.length === 0)) {
+    track(
+      async (
+        {
+          query,
+          searches,
+          limit,
+          minScore,
+          candidateLimit,
+          collections,
+          intent,
+          rerank,
+        },
+        ctx,
+      ) => {
+        // Require exactly one of `query` (plain text, auto-expanded) or `searches` (typed sub-queries).
+        if (!query && (!searches || searches.length === 0)) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: "Error: provide either 'query' (plain text) or 'searches' (typed sub-queries)",
+              },
+            ],
+            isError: true,
+          };
+        }
+        if (query && searches && searches.length > 0) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: "Error: 'query' and 'searches' are mutually exclusive; provide only one",
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const outcome = await service.search(
+          {
+            ...(query
+              ? { query }
+              : { searches: (searches ?? []).map((s) => ({ ...s })) }),
+            ...(collections !== undefined ? { collections } : {}),
+            limit,
+            minScore,
+            candidateLimit,
+            rerank,
+            intent,
+          },
+          ctx.mcpReq.signal,
+        );
+        if (outcome.status === "unavailable") {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Search unavailable (${outcome.reason})`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const primaryQuery = primarySearchQuery({ query, searches });
+        const filtered = formatSearchResults(
+          outcome.results,
+          primaryQuery,
+          intent,
+          false,
+        );
         return {
-          content: [{ type: "text" as const, text: "Error: provide either 'query' (plain text) or 'searches' (typed sub-queries)" }],
-          isError: true,
+          content: [
+            { type: "text", text: formatSearchSummary(filtered, primaryQuery) },
+          ],
+          structuredContent: { results: filtered },
         };
-      }
-      if (query && searches && searches.length > 0) {
-        return {
-          content: [{ type: "text" as const, text: "Error: 'query' and 'searches' are mutually exclusive; provide only one" }],
-          isError: true,
-        };
-      }
-
-      // Use default collections if none specified
-      const effectiveCollections = collections ?? defaultCollectionNames;
-
-      // Plain `query` is auto-expanded by the SDK (expand → fuse → rerank);
-      // `searches` runs the caller's typed sub-queries directly.
-      const searchOptions = query
-        ? { query }
-        : { queries: (searches ?? []).map(s => ({ type: s.type, query: s.query })) };
-
-      const results = await store.search({
-        ...searchOptions,
-        collections: effectiveCollections.length > 0 ? effectiveCollections : undefined,
-        limit,
-        minScore,
-        candidateLimit,
-        rerank,
-        intent,
-      });
-
-      // Use the plain query, or the first lex/vec sub-query, for snippet extraction
-      const primaryQuery = query
-        || searches?.find(s => s.type === 'lex')?.query
-        || searches?.find(s => s.type === 'vec')?.query
-        || searches?.[0]?.query
-        || "";
-
-      const filtered: SearchResultItem[] = results.map(r => {
-        const { line, snippet } = extractSnippet(r.body, primaryQuery, 300, r.bestChunkPos, r.bestChunk.length, intent);
-        return {
-          docid: `#${r.docid}`,
-          file: r.displayPath,
-          title: r.title,
-          score: Math.round(r.score * 100) / 100,
-          context: r.context,
-          line,
-          snippet: addLineNumbers(snippet, line),
-        };
-      });
-
-      return {
-        content: [{ type: "text", text: formatSearchSummary(filtered, primaryQuery) }],
-        structuredContent: { results: filtered },
-      };
-    })
+      },
+    ),
   );
 
   // ---------------------------------------------------------------------------
@@ -405,13 +571,30 @@ Intent-aware lex (C++ performance, not sports):
     "get",
     {
       title: "Get Document",
-      description: "Retrieve the full content of a document by its file path or docid. Use paths or docids (#abc123) from search results. Suggests similar files if not found.",
+      description:
+        "Retrieve the full content of a document by its file path or docid. Use paths or docids (#abc123) from search results. Suggests similar files if not found.",
       annotations: { readOnlyHint: true, openWorldHint: false },
       inputSchema: z.object({
-        file: z.string().describe("File path or docid from search results. Supports a line-range suffix: 'pages/meeting.md:100' starts at line 100; 'pages/meeting.md:100:40' (or '#abc123:100:40') reads 40 lines from line 100."),
-        fromLine: z.number().optional().describe("Start from this line number (1-indexed)"),
-        maxLines: z.number().optional().describe("Maximum number of lines to return"),
-        lineNumbers: z.boolean().optional().default(true).describe("Add line numbers to output (format: 'N: content'). On by default; set false for raw content."),
+        file: z
+          .string()
+          .describe(
+            "File path or docid from search results. Supports a line-range suffix: 'pages/meeting.md:100' starts at line 100; 'pages/meeting.md:100:40' (or '#abc123:100:40') reads 40 lines from line 100.",
+          ),
+        fromLine: z
+          .number()
+          .optional()
+          .describe("Start from this line number (1-indexed)"),
+        maxLines: z
+          .number()
+          .optional()
+          .describe("Maximum number of lines to return"),
+        lineNumbers: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Add line numbers to output (format: 'N: content'). On by default; set false for raw content.",
+          ),
       }),
     },
     track(async ({ file, fromLine, maxLines, lineNumbers }) => {
@@ -422,8 +605,10 @@ Intent-aware lex (C++ performance, not sports):
       let lookup = file;
       const rangeMatch = lookup.match(/:(\d+):(\d+)$/);
       if (rangeMatch) {
-        if (parsedFromLine === undefined) parsedFromLine = parseInt(rangeMatch[1]!, 10);
-        if (parsedMaxLines === undefined) parsedMaxLines = parseInt(rangeMatch[2]!, 10);
+        if (parsedFromLine === undefined)
+          parsedFromLine = parseInt(rangeMatch[1]!, 10);
+        if (parsedMaxLines === undefined)
+          parsedMaxLines = parseInt(rangeMatch[2]!, 10);
         lookup = lookup.slice(0, -rangeMatch[0].length);
       } else {
         const colonMatch = lookup.match(/:(\d+)$/);
@@ -432,24 +617,23 @@ Intent-aware lex (C++ performance, not sports):
           lookup = lookup.slice(0, -colonMatch[0].length);
         }
       }
-      if (parsedFromLine !== undefined) parsedFromLine = Math.max(1, parsedFromLine);
+      if (parsedFromLine !== undefined)
+        parsedFromLine = Math.max(1, parsedFromLine);
 
-      const result = await store.get(lookup, { includeBody: false });
+      const result = await service.get(lookup, { includeBody: false });
 
       if ("error" in result) {
-        let msg = result.error === "excluded_by_ignore"
-          ? `Document excluded by ignore rule: ${file}\nCollection: ${result.collection}\nMatched path: ${result.path}\nIgnore rule: ${result.rule}`
-          : `Document not found: ${file}`;
-        if (result.error === "not_found" && result.similarFiles.length > 0) {
-          msg += `\n\nDid you mean one of these?\n${result.similarFiles.map(s => `  - ${s}`).join('\n')}`;
-        }
         return {
-          content: [{ type: "text", text: msg }],
+          content: [{ type: "text", text: "Document unavailable" }],
           isError: true,
         };
       }
 
-      const body = await store.getDocumentBody(result.filepath, { fromLine: parsedFromLine, maxLines: parsedMaxLines }) ?? "";
+      const body =
+        (await service.getDocumentBody(result.filepath, {
+          fromLine: parsedFromLine,
+          maxLines: parsedMaxLines,
+        })) ?? "";
       let text = body;
       if (lineNumbers) {
         const startLine = parsedFromLine || 1;
@@ -460,18 +644,20 @@ Intent-aware lex (C++ performance, not sports):
       }
 
       return {
-        content: [{
-          type: "resource",
-          resource: {
-            uri: `qmd://${encodeQmdPath(result.displayPath)}`,
-            name: result.displayPath,
-            title: result.title,
-            mimeType: "text/markdown",
-            text,
+        content: [
+          {
+            type: "resource",
+            resource: {
+              uri: `qmd://${encodeQmdPath(result.displayPath)}`,
+              name: result.displayPath,
+              title: result.title,
+              mimeType: "text/markdown",
+              text,
+            },
           },
-        }],
+        ],
       };
-    })
+    }),
   );
 
   // ---------------------------------------------------------------------------
@@ -482,36 +668,66 @@ Intent-aware lex (C++ performance, not sports):
     "multi_get",
     {
       title: "Multi-Get Documents",
-      description: "Retrieve multiple documents by glob pattern (e.g., 'journals/2025-05*.md'), comma-separated list, or docids. Skips files larger than maxBytes.",
+      description:
+        "Retrieve multiple documents by glob pattern (e.g., 'journals/2025-05*.md'), comma-separated list, or docids. Skips files larger than maxBytes.",
       annotations: { readOnlyHint: true, openWorldHint: false },
       inputSchema: z.object({
-        pattern: z.string().describe("Glob pattern, docid, or comma-separated list of file paths/docids"),
+        pattern: z
+          .string()
+          .describe(
+            "Glob pattern, docid, or comma-separated list of file paths/docids",
+          ),
         maxLines: z.number().optional().describe("Maximum lines per file"),
-        maxBytes: z.number().optional().default(DEFAULT_MULTI_GET_MAX_BYTES).describe("Skip files larger than this (default: 65536 = 64KB)"),
-        lineNumbers: z.boolean().optional().default(true).describe("Add line numbers to output (format: 'N: content'). On by default; set false for raw content."),
+        maxBytes: z
+          .number()
+          .optional()
+          .default(DEFAULT_MULTI_GET_MAX_BYTES)
+          .describe("Skip files larger than this (default: 65536 = 64KB)"),
+        lineNumbers: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe(
+            "Add line numbers to output (format: 'N: content'). On by default; set false for raw content.",
+          ),
       }),
     },
     track(async ({ pattern, maxLines, maxBytes, lineNumbers }) => {
-      const { docs, errors } = await store.multiGet(pattern, { includeBody: true, maxBytes: maxBytes || DEFAULT_MULTI_GET_MAX_BYTES });
+      const { docs, errors } = await service.multiGet(pattern, {
+        includeBody: true,
+        maxBytes: maxBytes || DEFAULT_MULTI_GET_MAX_BYTES,
+      });
 
       if (docs.length === 0 && errors.length === 0) {
         return {
-          content: [{ type: "text", text: `No files matched pattern: ${pattern}` }],
+          content: [{ type: "text", text: "No matching documents" }],
           isError: true,
         };
       }
 
-      const content: ({ type: "text"; text: string } | { type: "resource"; resource: { uri: string; name: string; title?: string; mimeType: string; text: string } })[] = [];
+      const content: (
+        | { type: "text"; text: string }
+        | {
+            type: "resource";
+            resource: {
+              uri: string;
+              name: string;
+              title?: string;
+              mimeType: string;
+              text: string;
+            };
+          }
+      )[] = [];
 
       if (errors.length > 0) {
-        content.push({ type: "text", text: `Errors:\n${errors.join('\n')}` });
+        content.push({ type: "text", text: "Some documents were unavailable" });
       }
 
       for (const result of docs) {
         if (result.skipped) {
           content.push({
             type: "text",
-            text: `[SKIPPED: ${result.doc.displayPath} - ${result.skipReason}. Use 'qmd_get' with file="${result.doc.displayPath}" to retrieve.]`,
+            text: "[SKIPPED: document exceeds the configured size limit]",
           });
           continue;
         }
@@ -544,7 +760,7 @@ Intent-aware lex (C++ performance, not sports):
       }
 
       return { content };
-    })
+    }),
   );
 
   // ---------------------------------------------------------------------------
@@ -555,18 +771,19 @@ Intent-aware lex (C++ performance, not sports):
     "status",
     {
       title: "Index Status",
-      description: "Show the status of the QMD index: collections, document counts, and health information.",
+      description:
+        "Show the status of the QMD index: collections, document counts, and health information.",
       annotations: { readOnlyHint: true, openWorldHint: false },
       inputSchema: z.object({}),
     },
     track(async () => {
-      const status: StatusResult = await store.getStatus();
+      const status: StatusResult = await service.getStatus();
 
       const summary = [
         `QMD Index Status:`,
         `  Total documents: ${status.totalDocuments}`,
         `  Needs embedding: ${status.needsEmbedding}`,
-        `  Vector index: ${status.hasVectorIndex ? 'yes' : 'no'}`,
+        `  Vector index: ${status.hasVectorIndex ? "yes" : "no"}`,
         `  Collections: ${status.collections.length}`,
       ];
 
@@ -575,10 +792,10 @@ Intent-aware lex (C++ performance, not sports):
       }
 
       return {
-        content: [{ type: "text", text: summary.join('\n') }],
+        content: [{ type: "text", text: summary.join("\n") }],
         structuredContent: status,
       };
-    })
+    }),
   );
 
   return server;
@@ -601,8 +818,8 @@ export type McpStartupOptions = {
 export type InflightGate = {
   /** Wraps a handler so the gate counts it while it runs. */
   track<T extends (...args: never[]) => unknown>(fn: T): T;
-  /** Resolves once no tracked handler runs, or after timeoutMs. Returns whether idle was reached. */
-  waitForIdle(timeoutMs: number): Promise<boolean>;
+  /** Resolves once no tracked handler runs, or after an optional timeout. */
+  waitForIdle(timeoutMs?: number): Promise<boolean>;
 };
 
 export function createInflightGate(): InflightGate {
@@ -629,19 +846,22 @@ export function createInflightGate(): InflightGate {
       };
       return wrapped as typeof fn;
     },
-    waitForIdle(timeoutMs: number): Promise<boolean> {
+    waitForIdle(timeoutMs?: number): Promise<boolean> {
       if (active === 0) return Promise.resolve(true);
       return new Promise((resolve) => {
+        let timer: ReturnType<typeof setTimeout> | undefined;
         const onIdle = () => {
-          clearTimeout(timer);
+          if (timer) clearTimeout(timer);
           resolve(true);
         };
-        const timer = setTimeout(() => {
-          const i = waiters.indexOf(onIdle);
-          if (i >= 0) waiters.splice(i, 1);
-          resolve(false);
-        }, timeoutMs);
-        timer.unref?.();
+        if (timeoutMs !== undefined) {
+          timer = setTimeout(() => {
+            const i = waiters.indexOf(onIdle);
+            if (i >= 0) waiters.splice(i, 1);
+            resolve(false);
+          }, timeoutMs);
+          timer.unref?.();
+        }
         waiters.push(onIdle);
       });
     },
@@ -681,7 +901,10 @@ export type StdioShutdownOptions = {
   /** Defaults to reading process.exitCode. */
   getExitCode?: () => number | undefined;
   /** Defaults to process.stderr. */
-  stderr?: { write(chunk: string): unknown; on?(event: "error", listener: (err: unknown) => void): unknown };
+  stderr?: {
+    write(chunk: string): unknown;
+    on?(event: "error", listener: (err: unknown) => void): unknown;
+  };
 };
 
 /**
@@ -712,11 +935,20 @@ export type StdioShutdownOptions = {
  * "close", or already-ended stdin) shares one promise, and the promise never
  * rejects.
  */
-export function registerStdioEofShutdown(options: StdioShutdownOptions): () => Promise<void> {
+export function registerStdioEofShutdown(
+  options: StdioShutdownOptions,
+): () => Promise<void> {
   const stdin = options.stdin ?? process.stdin;
   const stderr = options.stderr ?? process.stderr;
-  const setExitCode = options.setExitCode ?? ((code: number) => { process.exitCode = code; });
-  const getExitCode = options.getExitCode ?? (() => (typeof process.exitCode === "number" ? process.exitCode : undefined));
+  const setExitCode =
+    options.setExitCode ??
+    ((code: number) => {
+      process.exitCode = code;
+    });
+  const getExitCode =
+    options.getExitCode ??
+    (() =>
+      typeof process.exitCode === "number" ? process.exitCode : undefined);
   let shutdownPromise: Promise<void> | null = null;
 
   // If the parent died, its stderr pipe may be gone: writes can throw
@@ -744,13 +976,16 @@ export function registerStdioEofShutdown(options: StdioShutdownOptions): () => P
     safeWrite("Shutting down (stdin closed)...\n");
 
     let failed = false;
-    const step = async (name: string, run: () => void | Promise<void>): Promise<void> => {
+    const step = async (
+      name: string,
+      run: () => void | Promise<void>,
+    ): Promise<void> => {
       try {
         await run();
       } catch (error) {
         failed = true;
         safeWrite(
-          `QMD Warning: ${name} failed during stdio shutdown (${error instanceof Error ? error.message : String(error)}); continuing shutdown.\n`
+          `QMD Warning: ${name} failed during stdio shutdown; continuing shutdown.\n`,
         );
       }
     };
@@ -760,7 +995,9 @@ export function registerStdioEofShutdown(options: StdioShutdownOptions): () => P
       await step("in-flight drain", async () => {
         const idle = await options.waitForIdle!(options.idleTimeoutMs ?? 5000);
         if (!idle) {
-          safeWrite("QMD Warning: in-flight request did not settle before the shutdown deadline; continuing shutdown.\n");
+          safeWrite(
+            "QMD Warning: in-flight request did not settle before the shutdown deadline; continuing shutdown.\n",
+          );
         }
       });
     }
@@ -783,7 +1020,9 @@ export function registerStdioEofShutdown(options: StdioShutdownOptions): () => P
   };
 
   const shutdown = (): Promise<void> => (shutdownPromise ??= performShutdown());
-  const onStdinEof = (): void => { void shutdown().catch(() => {}); };
+  const onStdinEof = (): void => {
+    void shutdown().catch(() => {});
+  };
 
   stdin.once("end", onStdinEof);
   stdin.once("close", onStdinEof);
@@ -797,7 +1036,9 @@ export function registerStdioEofShutdown(options: StdioShutdownOptions): () => P
   return shutdown;
 }
 
-export async function startMcpServer(options: McpStartupOptions = {}): Promise<void> {
+export async function startMcpServer(
+  options: McpStartupOptions = {},
+): Promise<void> {
   // Opt into production mode when the MCP server is actually started, not
   // when this module is merely imported for its exports. Importing the module
   // at the top level flipped the global production flag and broke test
@@ -809,11 +1050,12 @@ export async function startMcpServer(options: McpStartupOptions = {}): Promise<v
     dbPath: options.dbPath ?? getDefaultDbPath(),
     ...(existsSync(configPath) ? { configPath } : {}),
   });
+  const service = new QMDWorkService(store);
   const inflight = createInflightGate();
   // serveStdio dual-speaks 2026-07-28 and 2025-era clients on one connection
   // (opening exchange pins the era). A hand-wired StdioServerTransport would
   // stay 2025-only even on SDK 2.x.
-  const handle = serveStdio(() => createMcpServer(store, inflight));
+  const handle = serveStdio(() => createMcpServer(service, inflight));
 
   // Follow the parent's lifecycle: when stdin reaches EOF the client is gone
   // and the server must exit instead of orphaning to PID 1 (#751). No
@@ -823,7 +1065,7 @@ export async function startMcpServer(options: McpStartupOptions = {}): Promise<v
   registerStdioEofShutdown({
     closeServer: () => handle.close(),
     waitForIdle: (timeoutMs) => inflight.waitForIdle(timeoutMs),
-    closeStore: () => store.close(),
+    closeStore: () => service.close(),
   });
 }
 
@@ -852,7 +1094,12 @@ export type HttpServerHandle = {
  */
 export async function startMcpHttpServer(
   port: number,
-  options: ({ quiet?: boolean; host?: string; allowedOrigins?: string[]; allowedHosts?: string[] } & McpStartupOptions) = {},
+  options: {
+    quiet?: boolean;
+    host?: string;
+    allowedOrigins?: string[];
+    allowedHosts?: string[];
+  } & McpStartupOptions = {},
 ): Promise<HttpServerHandle> {
   // See startMcpServer() for the rationale — flip production mode here so the
   // HTTP transport resolves the real database path, without leaking state into
@@ -863,55 +1110,50 @@ export async function startMcpHttpServer(
     dbPath: options.dbPath ?? getDefaultDbPath(),
     ...(existsSync(configPath) ? { configPath } : {}),
   });
-
-  // Pre-fetch default collection names for REST endpoint
-  const defaultCollectionNames = await store.getDefaultCollectionNames();
+  const service = new QMDWorkService(store);
 
   // Official 2026-07-28 HTTP entry: one factory, per-request instance, JSON
-  // responses (matches the previous enableJsonResponse: true). Dual-speaks
-  // 2025-era traffic statelessly by default (`legacy: "stateless"`).
-  const mcpHandler = createMcpHandler(
-    () => createMcpServer(store),
-    { responseMode: "json" },
-  );
+  // responses. Modern and legacy traffic share the same process-wide service.
+  const mcpHandler = createMcpHandler(() => createMcpServer(service), {
+    responseMode: "json",
+  });
+
+  async function handleLegacyMcpRequest(
+    request: Request,
+    parsedBody: unknown,
+  ): Promise<Response> {
+    if (request.method.toUpperCase() !== "POST") {
+      return Response.json(
+        {
+          jsonrpc: "2.0",
+          error: { code: -32000, message: "Method not allowed." },
+          id: null,
+        },
+        { status: 405 },
+      );
+    }
+
+    const server = await createMcpServer(service);
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    });
+    try {
+      await server.connect(transport);
+      return await transport.handleRequest(request, { parsedBody });
+    } finally {
+      await transport.close().catch(() => {});
+      await server.close().catch(() => {});
+    }
+  }
 
   const startTime = Date.now();
   const quiet = options?.quiet ?? false;
+  const requestControllers = new Set<AbortController>();
 
   /** Format timestamp for request logging */
   function ts(): string {
     return new Date().toISOString().slice(11, 23); // HH:mm:ss.SSS
-  }
-
-  type JsonRpcLikeBody = {
-    method?: unknown;
-    params?: {
-      name?: unknown;
-      arguments?: Record<string, unknown>;
-    };
-  };
-  type RestSearchInput = {
-    type?: unknown;
-    query?: unknown;
-  };
-
-  /** Extract a human-readable label from a JSON-RPC body */
-  function describeRequest(body: JsonRpcLikeBody): string {
-    const method = typeof body.method === "string" ? body.method : "unknown";
-    if (method === "tools/call") {
-      const tool = body.params?.name ?? "?";
-      const args = body.params?.arguments;
-      // Show query string if present, truncated
-      if (args?.query) {
-        const q = String(args.query).slice(0, 80);
-        return `tools/call ${tool} "${q}"`;
-      }
-      if (args?.file) return `tools/call ${tool} ${args.file}`;
-      if (args?.path) return `tools/call ${tool} ${args.path}`;
-      if (args?.pattern) return `tools/call ${tool} ${args.pattern}`;
-      return `tools/call ${tool}`;
-    }
-    return method;
   }
 
   function log(msg: string): void {
@@ -929,191 +1171,488 @@ export async function startMcpHttpServer(
     return headers;
   }
 
-  // Helper to collect request body
   async function collectBody(req: IncomingMessage): Promise<string> {
-    const chunks: Buffer[] = [];
-    for await (const chunk of req) chunks.push(chunk as Buffer);
-    return Buffer.concat(chunks).toString();
+    const declaredLength = req.headers["content-length"];
+    if (declaredLength !== undefined) {
+      const parsedLength = Number(declaredLength);
+      if (
+        !Number.isSafeInteger(parsedLength) ||
+        parsedLength < 0 ||
+        parsedLength > MAX_HTTP_REQUEST_BODY_BYTES
+      ) {
+        req.resume();
+        throw new WorkServiceError("malformed");
+      }
+    }
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      let size = 0;
+      const timer = setTimeout(() => {
+        cleanup();
+        req.destroy();
+        reject(new WorkServiceError("malformed"));
+      }, HTTP_REQUEST_BODY_TIMEOUT_MS);
+      timer.unref?.();
+      const cleanup = () => {
+        clearTimeout(timer);
+        req.removeListener("data", onData);
+        req.removeListener("end", onEnd);
+        req.removeListener("aborted", onAborted);
+        req.removeListener("close", onClose);
+        req.removeListener("error", onError);
+      };
+      const onData = (chunk: Buffer | string) => {
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        size += buffer.length;
+        if (size > MAX_HTTP_REQUEST_BODY_BYTES) {
+          cleanup();
+          req.resume();
+          reject(new WorkServiceError("malformed"));
+          return;
+        }
+        chunks.push(buffer);
+      };
+      const onEnd = () => {
+        cleanup();
+        resolve(Buffer.concat(chunks, size).toString());
+      };
+      const onAborted = () => {
+        cleanup();
+        reject(new WorkServiceError("closed"));
+      };
+      const onClose = () => {
+        if (req.complete) return;
+        cleanup();
+        reject(new WorkServiceError("closed"));
+      };
+      const onError = () => {
+        cleanup();
+        reject(new WorkServiceError("malformed"));
+      };
+      req.on("data", onData);
+      req.once("end", onEnd);
+      req.once("aborted", onAborted);
+      req.once("close", onClose);
+      req.once("error", onError);
+    });
+  }
+
+  function createRequestAbort(
+    req: IncomingMessage,
+    res: ServerResponse,
+  ): {
+    signal: AbortSignal;
+    cleanup: () => void;
+  } {
+    const controller = new AbortController();
+    requestControllers.add(controller);
+    const abort = () => controller.abort();
+    const onRequestClose = () => {
+      if (!req.complete) abort();
+    };
+    const onResponseClose = () => {
+      if (!res.writableEnded) abort();
+    };
+    req.once("aborted", abort);
+    req.once("close", onRequestClose);
+    res.once("close", onResponseClose);
+    return {
+      signal: controller.signal,
+      cleanup: () => {
+        req.removeListener("aborted", abort);
+        req.removeListener("close", onRequestClose);
+        res.removeListener("close", onResponseClose);
+        requestControllers.delete(controller);
+      },
+    };
+  }
+
+  function writeJson(res: ServerResponse, status: number, body: unknown): void {
+    if (res.destroyed || res.headersSent) return;
+    res.writeHead(status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(body));
+  }
+
+  function workErrorReason(error: unknown): string {
+    return error instanceof WorkServiceError ? error.reason : "store_error";
+  }
+
+  function workErrorStatus(error: unknown): number {
+    return error instanceof WorkServiceError && error.reason === "malformed"
+      ? 400
+      : 503;
+  }
+
+  function writeWorkError(res: ServerResponse, error: unknown): void {
+    writeJson(res, workErrorStatus(error), {
+      status: "unavailable",
+      reason: workErrorReason(error),
+      authoritativeEmpty: false,
+    });
+  }
+
+  function parseJsonObject(rawBody: string): Record<string, unknown> {
+    let value: unknown;
+    try {
+      value = JSON.parse(rawBody);
+    } catch {
+      throw new WorkServiceError("malformed");
+    }
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      throw new WorkServiceError("malformed");
+    }
+    return value as Record<string, unknown>;
+  }
+
+  function writeSearchOutcome(
+    res: ServerResponse,
+    outcome: Awaited<ReturnType<QMDWorkService["search"]>>,
+    request: DaemonSearchRequest,
+    uriPaths: boolean,
+  ): void {
+    if (outcome.status === "unavailable") {
+      writeJson(res, 503, outcome);
+      return;
+    }
+    const query = primarySearchQuery(request);
+    writeJson(res, 200, {
+      ...outcome,
+      results: formatSearchResults(
+        outcome.results,
+        query,
+        request.intent,
+        uriPaths,
+      ),
+    });
   }
 
   const host = options.host ?? process.env.QMD_HOST ?? "localhost";
   const originGuard = resolveOriginGuard({
     host,
-    ...(options.allowedOrigins ? { allowedOrigins: options.allowedOrigins } : {}),
+    ...(options.allowedOrigins
+      ? { allowedOrigins: options.allowedOrigins }
+      : {}),
     ...(options.allowedHosts ? { allowedHosts: options.allowedHosts } : {}),
   });
 
-  const httpServer = createServer(async (nodeReq: IncomingMessage, nodeRes: ServerResponse) => {
-    const reqStart = Date.now();
-    const pathname = (nodeReq.url || "/").split("?")[0];
+  const httpInflight = createInflightGate();
+  let accepting = true;
+  const httpServer = createServer(
+    httpInflight.track(
+      async (nodeReq: IncomingMessage, nodeRes: ServerResponse) => {
+        const reqStart = Date.now();
+        const pathname = (nodeReq.url || "/").split("?")[0] ?? "/";
+        const requestAbort = createRequestAbort(nodeReq, nodeRes);
 
-    try {
-      // DNS-rebinding screen, ahead of routing so REST /query /search are
-      // covered too — they bypass the MCP transport entirely (#881).
-      const origin = nodeReq.headers.origin;
-      const hostHeader = nodeReq.headers.host;
-      const verdict = checkRequestOrigin(
-        {
-          origin: typeof origin === "string" ? origin : undefined,
-          host: typeof hostHeader === "string" ? hostHeader : undefined,
-        },
-        originGuard,
-      );
-      if (!verdict.ok) {
-        nodeRes.writeHead(403, { "Content-Type": "application/json" });
-        nodeRes.end(JSON.stringify({
-          jsonrpc: "2.0",
-          error: { code: -32003, message: `Forbidden: ${verdict.reason}` },
-          id: null,
-        }));
-        log(`${ts()} ${nodeReq.method} ${pathname} 403 — ${verdict.reason}`);
-        return;
-      }
-
-      if (pathname === "/health" && nodeReq.method === "GET") {
-        const body = JSON.stringify({ status: "ok", uptime: Math.floor((Date.now() - startTime) / 1000) });
-        nodeRes.writeHead(200, { "Content-Type": "application/json" });
-        nodeRes.end(body);
-        log(`${ts()} GET /health (${Date.now() - reqStart}ms)`);
-        return;
-      }
-
-      // REST endpoint: POST /search — structured search without MCP protocol
-      // REST endpoint: POST /query (alias: /search) — structured search without MCP protocol
-      if ((pathname === "/query" || pathname === "/search") && nodeReq.method === "POST") {
-        const rawBody = await collectBody(nodeReq);
-        const params = JSON.parse(rawBody) as Record<string, unknown>;
-
-        // Validate required fields
-        if (!params.searches || !Array.isArray(params.searches)) {
-          nodeRes.writeHead(400, { "Content-Type": "application/json" });
-          nodeRes.end(JSON.stringify({ error: "Missing required field: searches (array)" }));
-          return;
-        }
-
-        // Map to internal format
-        const searches = params.searches as RestSearchInput[];
-        const queries: ExpandedQuery[] = searches.map((s) => ({
-          type: s.type as 'lex' | 'vec' | 'hyde',
-          query: String(s.query || ""),
-        }));
-
-        // Use default collections if none specified
-        const effectiveCollections = Array.isArray(params.collections) ? params.collections.map(String) : defaultCollectionNames;
-
-        const results = await store.search({
-          queries,
-          collections: effectiveCollections.length > 0 ? effectiveCollections : undefined,
-          limit: typeof params.limit === "number" ? params.limit : 10,
-          minScore: typeof params.minScore === "number" ? params.minScore : 0,
-          candidateLimit: typeof params.candidateLimit === "number" ? params.candidateLimit : undefined,
-          intent: typeof params.intent === "string" ? params.intent : undefined,
-          rerank: typeof params.rerank === "boolean" ? params.rerank : undefined,
-        });
-
-        // Use first lex or vec query for snippet extraction
-        const primaryQuery = searches.find((s) => s.type === 'lex')?.query
-          || searches.find((s) => s.type === 'vec')?.query
-          || searches[0]?.query || "";
-
-        const formatted = results.map(r => {
-          const { line, snippet } = extractSnippet(r.body, String(primaryQuery), 300, r.bestChunkPos, r.bestChunk.length, typeof params.intent === "string" ? params.intent : undefined);
-          return {
-            docid: `#${r.docid}`,
-            file: `qmd://${encodeQmdPath(r.displayPath)}`,
-            title: r.title,
-            score: Math.round(r.score * 100) / 100,
-            context: r.context,
-            line,
-            snippet: addLineNumbers(snippet, line),
-          };
-        });
-
-        nodeRes.writeHead(200, { "Content-Type": "application/json" });
-        nodeRes.end(JSON.stringify({ results: formatted }));
-        log(`${ts()} POST /query ${params.searches.length} queries (${Date.now() - reqStart}ms)`);
-        return;
-      }
-
-      if (pathname === "/mcp") {
-        const rawBody = nodeReq.method !== "GET" && nodeReq.method !== "HEAD"
-          ? await collectBody(nodeReq)
-          : undefined;
-        let parsedBody: unknown;
-        if (rawBody) {
-          try {
-            parsedBody = JSON.parse(rawBody);
-          } catch {
-            parsedBody = undefined;
+        try {
+          if (!accepting) {
+            writeJson(nodeRes, 503, {
+              status: "unavailable",
+              reason: "closed",
+              authoritativeEmpty: false,
+            });
+            return;
           }
+          const origin = nodeReq.headers.origin;
+          const hostHeader = nodeReq.headers.host;
+          const verdict = checkRequestOrigin(
+            {
+              origin: typeof origin === "string" ? origin : undefined,
+              host: typeof hostHeader === "string" ? hostHeader : undefined,
+            },
+            originGuard,
+          );
+          if (!verdict.ok) {
+            writeJson(nodeRes, 403, {
+              jsonrpc: "2.0",
+              error: { code: -32003, message: "Forbidden: Origin not allowed" },
+              id: null,
+            });
+            log(`${ts()} request rejected 403 (${Date.now() - reqStart}ms)`);
+            return;
+          }
+
+          if (pathname === "/health" && nodeReq.method === "GET") {
+            const state = await service.health();
+            writeJson(nodeRes, 200, {
+              status: "ok",
+              version: getPackageVersion(),
+              apiVersion: API_VERSION,
+              features: [...DAEMON_FEATURES],
+              uptime: Math.floor((Date.now() - startTime) / 1000),
+              admission: state.admission,
+              indexGeneration: state.indexGeneration,
+            });
+            log(`${ts()} health (${Date.now() - reqStart}ms)`);
+            return;
+          }
+
+          if (nodeReq.method === "POST" && pathname === "/v1/search") {
+            const request = parseJsonObject(
+              await collectBody(nodeReq),
+            ) as DaemonSearchRequest;
+            const outcome = await service.search(request, requestAbort.signal);
+            writeSearchOutcome(nodeRes, outcome, request, true);
+            log(`${ts()} v1 search (${Date.now() - reqStart}ms)`);
+            return;
+          }
+
+          if (
+            nodeReq.method === "POST" &&
+            (pathname === "/query" || pathname === "/search")
+          ) {
+            const params = parseJsonObject(await collectBody(nodeReq));
+            if (!Array.isArray(params.searches))
+              throw new WorkServiceError("malformed");
+            const request: DaemonSearchRequest = {
+              searches: params.searches as DaemonSearchRequest["searches"],
+              ...(Array.isArray(params.collections)
+                ? { collections: params.collections.map(String) }
+                : {}),
+              ...(typeof params.limit === "number"
+                ? { limit: params.limit }
+                : {}),
+              ...(typeof params.minScore === "number"
+                ? { minScore: params.minScore }
+                : {}),
+              ...(typeof params.candidateLimit === "number"
+                ? { candidateLimit: params.candidateLimit }
+                : {}),
+              ...(typeof params.intent === "string"
+                ? { intent: params.intent }
+                : {}),
+              ...(typeof params.rerank === "boolean"
+                ? { rerank: params.rerank }
+                : {}),
+            };
+            const outcome = await service.search(request, requestAbort.signal);
+            writeSearchOutcome(nodeRes, outcome, request, true);
+            log(`${ts()} legacy search (${Date.now() - reqStart}ms)`);
+            return;
+          }
+
+          if (nodeReq.method === "POST" && pathname === "/v1/update") {
+            const request = parseJsonObject(
+              await collectBody(nodeReq),
+            ) as UpdateScope;
+            const operation = service.scheduleUpdate(request);
+            writeJson(nodeRes, 202, operation);
+            log(`${ts()} v1 update (${Date.now() - reqStart}ms)`);
+            return;
+          }
+
+          if (nodeReq.method === "POST" && pathname === "/v1/embed") {
+            const request = parseJsonObject(
+              await collectBody(nodeReq),
+            ) as DaemonEmbedRequest;
+            const operation = service.scheduleEmbed(request);
+            writeJson(nodeRes, 202, operation);
+            log(`${ts()} v1 embed (${Date.now() - reqStart}ms)`);
+            return;
+          }
+
+          if (
+            nodeReq.method === "POST" &&
+            pathname === "/v1/collections/ensure"
+          ) {
+            const request = parseJsonObject(
+              await collectBody(nodeReq),
+            ) as CollectionEnsureRequest;
+            const operation = service.scheduleEnsure(request);
+            writeJson(nodeRes, 202, operation);
+            log(`${ts()} v1 ensure (${Date.now() - reqStart}ms)`);
+            return;
+          }
+
+          if (nodeReq.method === "GET" && pathname === "/v1/collections") {
+            const collections = await service.listCollections();
+            writeJson(nodeRes, 200, { collections });
+            log(`${ts()} v1 collections (${Date.now() - reqStart}ms)`);
+            return;
+          }
+
+          if (
+            nodeReq.method === "GET" &&
+            pathname.startsWith("/v1/operations/")
+          ) {
+            let operationId: string;
+            try {
+              operationId = decodeURIComponent(
+                pathname.slice("/v1/operations/".length),
+              );
+            } catch {
+              throw new WorkServiceError("malformed");
+            }
+            const operation = service.getOperation(operationId);
+            if (!operation) {
+              writeJson(nodeRes, 404, {
+                status: "unavailable",
+                reason: "malformed",
+                authoritativeEmpty: false,
+              });
+              return;
+            }
+            writeJson(nodeRes, 200, operation);
+            log(`${ts()} v1 operation (${Date.now() - reqStart}ms)`);
+            return;
+          }
+
+          if (pathname === "/mcp") {
+            const rawBody =
+              nodeReq.method !== "GET" && nodeReq.method !== "HEAD"
+                ? await collectBody(nodeReq)
+                : undefined;
+            let parsedBody: unknown;
+            if (rawBody) {
+              try {
+                parsedBody = JSON.parse(rawBody);
+              } catch {
+                parsedBody = undefined;
+              }
+            }
+            const hostHeader =
+              typeof nodeReq.headers.host === "string"
+                ? nodeReq.headers.host
+                : `localhost:${port}`;
+            const url = `http://${hostHeader}${pathname}`;
+            const request = new Request(url, {
+              method: nodeReq.method || "GET",
+              headers: nodeHeadersToWeb(nodeReq),
+              ...(rawBody !== undefined ? { body: rawBody } : {}),
+              signal: requestAbort.signal,
+            });
+            const response = (await isLegacyRequest(request, parsedBody))
+              ? await handleLegacyMcpRequest(request, parsedBody)
+              : await mcpHandler.fetch(
+                  request,
+                  parsedBody !== undefined ? { parsedBody } : undefined,
+                );
+
+            if (!nodeRes.destroyed) {
+              nodeRes.writeHead(
+                response.status,
+                Object.fromEntries(response.headers),
+              );
+              if (response.body) {
+                await pipeline(Readable.fromWeb(response.body), nodeRes);
+              } else {
+                nodeRes.end();
+              }
+            }
+            log(`${ts()} mcp request (${Date.now() - reqStart}ms)`);
+            return;
+          }
+
+          nodeRes.writeHead(404);
+          nodeRes.end("Not Found");
+        } catch (error) {
+          if (requestAbort.signal.aborted) return;
+          if (error instanceof WorkServiceError) {
+            writeWorkError(nodeRes, error);
+          } else {
+            writeJson(nodeRes, 500, {
+              status: "unavailable",
+              reason: "store_error",
+              authoritativeEmpty: false,
+            });
+          }
+          log(`${ts()} request failed (${Date.now() - reqStart}ms)`);
+        } finally {
+          requestAbort.cleanup();
         }
-        const label = parsedBody && typeof parsedBody === "object" && parsedBody !== null
-          ? describeRequest(parsedBody as JsonRpcLikeBody)
-          : (nodeReq.method || "GET");
-        const hostHeader = typeof nodeReq.headers.host === "string" ? nodeReq.headers.host : `localhost:${port}`;
-        const url = `http://${hostHeader}${pathname}`;
-        const request = new Request(url, {
-          method: nodeReq.method || "GET",
-          headers: nodeHeadersToWeb(nodeReq),
-          ...(rawBody !== undefined ? { body: rawBody } : {}),
-        });
-        const response = await mcpHandler.fetch(
-          request,
-          parsedBody !== undefined ? { parsedBody } : undefined,
-        );
+      },
+    ),
+  );
 
-        nodeRes.writeHead(response.status, Object.fromEntries(response.headers));
-        nodeRes.end(Buffer.from(await response.arrayBuffer()));
-        log(`${ts()} ${nodeReq.method} /mcp ${label} (${Date.now() - reqStart}ms)`);
-        return;
-      }
-
-      nodeRes.writeHead(404);
-      nodeRes.end("Not Found");
-    } catch (err) {
-      console.error("HTTP handler error:", err);
-      nodeRes.writeHead(500);
-      nodeRes.end("Internal Server Error");
-    }
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    httpServer.on("error", reject);
-    httpServer.listen(port, host, () => resolve());
-  });
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: Error) => {
+        httpServer.removeListener("listening", onListening);
+        reject(error);
+      };
+      const onListening = () => {
+        httpServer.removeListener("error", onError);
+        resolve();
+      };
+      httpServer.once("error", onError);
+      httpServer.once("listening", onListening);
+      httpServer.listen(port, host);
+    });
+  } catch (error) {
+    await service.close().catch(() => {});
+    throw error;
+  }
 
   const actualPort = (httpServer.address() as import("net").AddressInfo).port;
 
-  let stopping = false;
-  const stop = async () => {
-    if (stopping) return;
-    stopping = true;
-    await mcpHandler.close();
-    httpServer.close();
-    await store.close();
-  };
+  let stopPromise: Promise<void> | undefined;
+  const stop = (): Promise<void> =>
+    (stopPromise ??= (async () => {
+      accepting = false;
+      process.off("SIGTERM", onSigterm);
+      process.off("SIGINT", onSigint);
+      for (const controller of requestControllers) controller.abort();
+      const httpClosed = new Promise<void>((resolve, reject) => {
+        httpServer.close((error) => (error ? reject(error) : resolve()));
+      });
+      httpServer.closeAllConnections();
+      let firstError: unknown;
+      const step = async (run: () => Promise<unknown>): Promise<void> => {
+        try {
+          await run();
+        } catch (error) {
+          firstError ??= error;
+        }
+      };
+      await step(async () => {
+        if (!(await httpInflight.waitForIdle(5_000))) {
+          throw new Error("HTTP request drain timed out");
+        }
+      });
+      httpServer.closeAllConnections();
+      await step(() => mcpHandler.close());
+      await step(() => service.close());
+      await step(() => httpClosed);
+      if (firstError) throw firstError;
+    })());
 
-  process.on("SIGTERM", async () => {
-    console.error("Shutting down (SIGTERM)...");
-    await stop();
-    process.exit(0);
-  });
-  process.on("SIGINT", async () => {
-    console.error("Shutting down (SIGINT)...");
-    await stop();
-    process.exit(0);
-  });
+  const stopForSignal = (signal: "SIGTERM" | "SIGINT"): void => {
+    log(`Shutting down (${signal})...`);
+    void stop().then(
+      () => {
+        process.exitCode = 0;
+      },
+      () => {
+        process.exitCode = 1;
+      },
+    );
+  };
+  const onSigterm = (): void => stopForSignal("SIGTERM");
+  const onSigint = (): void => stopForSignal("SIGINT");
+  process.on("SIGTERM", onSigterm);
+  process.on("SIGINT", onSigint);
 
   log(`QMD MCP server listening on http://${host}:${actualPort}/mcp`);
   if (originGuard.disabled) {
-    log("Warning: QMD_ALLOWED_ORIGINS=* — DNS-rebinding protection is off. Only do this behind your own authenticating proxy.");
+    log(
+      "Warning: QMD_ALLOWED_ORIGINS=* — DNS-rebinding protection is off. Only do this behind your own authenticating proxy.",
+    );
   } else if (!originGuard.enforceHost) {
-    log(`Warning: bound to ${host} with no QMD_ALLOWED_HOSTS — Host validation is off and the index is readable by anyone who can reach this port.`);
+    log(
+      `Warning: bound to ${host} with no QMD_ALLOWED_HOSTS — Host validation is off and the index is readable by anyone who can reach this port.`,
+    );
   }
   return { httpServer, port: actualPort, stop };
 }
 
 // Run if this is the main module
-if (fileURLToPath(import.meta.url) === process.argv[1] || process.argv[1]?.endsWith("/server.ts") || process.argv[1]?.endsWith("/server.js")) {
-  startMcpServer().catch(console.error);
+if (
+  fileURLToPath(import.meta.url) === process.argv[1] ||
+  process.argv[1]?.endsWith("/server.ts") ||
+  process.argv[1]?.endsWith("/server.js")
+) {
+  startMcpServer().catch(() => {
+    console.error("QMD MCP server failed to start.");
+    process.exitCode = 1;
+  });
 }

--- a/src/mcp/work-service.ts
+++ b/src/mcp/work-service.ts
@@ -1,0 +1,1506 @@
+import { randomUUID } from "node:crypto";
+import type {
+  EmbedResult,
+  ExpandedQuery,
+  HybridQueryResult,
+  IndexStatus,
+  QMDStore,
+  SearchResult,
+  CollectionMutation,
+  UpdateResult,
+} from "../index.js";
+import {
+  DEFAULT_EMBED_MAX_BATCH_BYTES,
+  DEFAULT_EMBED_MAX_DOCS_PER_BATCH,
+  type ChunkStrategy,
+} from "../store.js";
+import { isValidCollectionName } from "../collections.js";
+
+export const INTERACTIVE_QUEUE_LIMIT = 8;
+export const INTERACTIVE_QUEUE_TIMEOUT_MS = 2_000;
+export const LEXICAL_FALLBACK_CONCURRENCY_LIMIT = 2;
+export const MAINTENANCE_QUEUE_LIMIT = 8;
+export const API_VERSION = 1;
+
+const MAX_SEARCH_LIMIT = 500;
+const MAX_CANDIDATE_LIMIT = 500;
+export const DAEMON_FEATURES = [
+  "admission",
+  "operations",
+  "coalesced-update",
+  "daemon-embed",
+  "collection-ensure",
+] as const;
+
+export type DaemonSearchRequest = {
+  query?: string;
+  searches?: readonly ExpandedQuery[];
+  collections?: readonly string[];
+  limit?: number;
+  minScore?: number;
+  candidateLimit?: number;
+  intent?: string;
+  rerank?: boolean;
+  explain?: boolean;
+  chunkStrategy?: ChunkStrategy;
+};
+
+export type DaemonSearchResult = HybridQueryResult | SearchResult;
+export type SearchMode = "semantic" | "lexical";
+export type SearchDegradationReason =
+  | "queue_full"
+  | "queue_timeout"
+  | "maintenance_busy"
+  | "semantic_error"
+  | "store_error"
+  | "closed"
+  | "malformed";
+
+export type DaemonSearchResponse =
+  | {
+      status: "ok";
+      mode: SearchMode;
+      reason?: SearchDegradationReason;
+      authoritativeEmpty: boolean;
+      indexGeneration: number;
+      results: DaemonSearchResult[];
+    }
+  | {
+      status: "unavailable";
+      reason: SearchDegradationReason;
+      authoritativeEmpty: false;
+      indexGeneration: number;
+    };
+
+export type AdmissionMetrics = {
+  activeHeavy: number;
+  queuedInteractive: number;
+  maintenanceActive: boolean;
+  queuedMaintenance: number;
+  deduplicated: number;
+  queueFull: number;
+  queueTimeout: number;
+  degraded: number;
+};
+
+export type OperationState = "queued" | "running" | "completed" | "failed";
+export type OperationKind = "update" | "embed" | "ensure";
+
+export type OperationStatus = {
+  operationId: string;
+  kind: OperationKind;
+  state: OperationState;
+  createdAt: string;
+  startedAt?: string;
+  completedAt?: string;
+  generation?: number;
+  result?: Record<string, number | boolean | string>;
+  error?: { reason: "closed" | "maintenance_failed" };
+};
+
+export type UpdateScope = { collections?: readonly string[] | null };
+
+export type DaemonEmbedRequest = {
+  force?: boolean;
+  model?: string;
+  collection?: string;
+  maxDocsPerBatch?: number;
+  maxBatchBytes?: number;
+  chunkStrategy?: ChunkStrategy;
+};
+
+export type CollectionEnsureItem = {
+  name: string;
+  path: string;
+  pattern?: string;
+};
+
+export type CollectionRename = {
+  from: string;
+  to: string;
+};
+
+export type CollectionContext = {
+  collection: string;
+  path: string;
+  context: string;
+};
+
+export type CollectionEnsureRequest = {
+  adds?: readonly CollectionEnsureItem[];
+  updates?: readonly CollectionEnsureItem[];
+  renames?: readonly CollectionRename[];
+  contexts?: readonly CollectionContext[];
+  markDirty?: boolean;
+};
+
+export class WorkServiceError extends Error {
+  constructor(
+    public readonly reason: SearchDegradationReason,
+    message?: string,
+  ) {
+    super(message ?? reason);
+    this.name = "WorkServiceError";
+  }
+}
+
+type NormalizedSearchRequest = {
+  query?: string;
+  searches?: ExpandedQuery[];
+  collections: string[];
+  limit: number;
+  minScore: number;
+  candidateLimit: number;
+  intent?: string;
+  rerank: boolean;
+  explain: boolean;
+  chunkStrategy: ChunkStrategy;
+  resultMode: SearchMode;
+  modelConfigIdentity: string;
+};
+
+type SearchWaiter = {
+  resolve: (response: DaemonSearchResponse) => void;
+  reject: (error: unknown) => void;
+  signal?: AbortSignal;
+  onAbort?: () => void;
+};
+
+type HeavyJob = {
+  key: string;
+  request: NormalizedSearchRequest;
+  state: "queued" | "running" | "fallback";
+  waiters: Set<SearchWaiter>;
+  timer?: ReturnType<typeof setTimeout>;
+};
+
+type MaintenanceJob = {
+  operation: OperationStatus;
+  run: () => Promise<Record<string, number | boolean | string>>;
+  key?: string;
+};
+
+type UpdateJob = MaintenanceJob & {
+  scope: { all: boolean; collections: Set<string> };
+};
+
+type EnsureJob = MaintenanceJob & {
+  request: CollectionEnsureRequest;
+  reservedUpdate: boolean;
+};
+
+const DEFAULT_LIMIT = 10;
+const DEFAULT_MIN_SCORE = 0;
+const DEFAULT_CANDIDATE_LIMIT = 40;
+const DEFAULT_CHUNK_STRATEGY: ChunkStrategy = "regex";
+
+function abortError(): Error {
+  const error = new Error("The search request was aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+function raceAbort<T>(
+  work: Promise<T>,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  if (!signal) return work;
+  if (signal.aborted) return Promise.reject(abortError());
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(abortError());
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    void work.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+function isAbortSignalAborted(signal: AbortSignal | undefined): boolean {
+  return signal?.aborted === true;
+}
+
+function errorReason(error: unknown): "closed" | "maintenance_failed" {
+  return error instanceof WorkServiceError && error.reason === "closed"
+    ? "closed"
+    : "maintenance_failed";
+}
+
+function cloneOperation(operation: OperationStatus): OperationStatus {
+  return {
+    operationId: operation.operationId,
+    kind: operation.kind,
+    state: operation.state,
+    createdAt: operation.createdAt,
+    ...(operation.startedAt ? { startedAt: operation.startedAt } : {}),
+    ...(operation.completedAt ? { completedAt: operation.completedAt } : {}),
+    ...(operation.generation !== undefined
+      ? { generation: operation.generation }
+      : {}),
+    ...(operation.result ? { result: { ...operation.result } } : {}),
+    ...(operation.error ? { error: { ...operation.error } } : {}),
+  };
+}
+
+function validateOptionalNumber(
+  value: number | undefined,
+  name: string,
+  minimum: number,
+  maximum?: number,
+): void {
+  if (
+    value !== undefined &&
+    (!Number.isFinite(value) ||
+      value < minimum ||
+      (maximum !== undefined && value > maximum) ||
+      !Number.isInteger(value))
+  ) {
+    throw new WorkServiceError(
+      "malformed",
+      `${name} is outside its allowed range`,
+    );
+  }
+}
+
+export function validateDaemonSearchRequest(
+  request: DaemonSearchRequest,
+): void {
+  if (typeof request !== "object" || request === null || Array.isArray(request))
+    throw new WorkServiceError("malformed", "request must be an object");
+  const hasQuery = request.query !== undefined;
+  const hasSearches = request.searches !== undefined;
+  if (hasQuery === hasSearches) {
+    throw new WorkServiceError(
+      "malformed",
+      "exactly one of query or searches is required",
+    );
+  }
+  if (
+    hasQuery &&
+    (typeof request.query !== "string" || request.query.trim().length === 0)
+  ) {
+    throw new WorkServiceError("malformed", "query must be a non-empty string");
+  }
+  if (hasSearches) {
+    if (
+      !Array.isArray(request.searches) ||
+      request.searches.length === 0 ||
+      request.searches.length > 10
+    ) {
+      throw new WorkServiceError(
+        "malformed",
+        "searches must contain between one and ten items",
+      );
+    }
+    for (const search of request.searches) {
+      if (
+        !search ||
+        !["lex", "vec", "hyde"].includes(search.type) ||
+        typeof search.query !== "string" ||
+        search.query.trim().length === 0
+      ) {
+        throw new WorkServiceError(
+          "malformed",
+          "each search must have a supported type and non-empty query",
+        );
+      }
+    }
+  }
+  if (request.collections !== undefined) {
+    if (
+      !Array.isArray(request.collections) ||
+      request.collections.some(
+        (name) => typeof name !== "string" || !isValidCollectionName(name),
+      )
+    ) {
+      throw new WorkServiceError(
+        "malformed",
+        "collections must be an array of names",
+      );
+    }
+  }
+  validateOptionalNumber(request.limit, "limit", 1, MAX_SEARCH_LIMIT);
+  validateOptionalNumber(
+    request.candidateLimit,
+    "candidateLimit",
+    1,
+    MAX_CANDIDATE_LIMIT,
+  );
+  if (
+    request.minScore !== undefined &&
+    (!Number.isFinite(request.minScore) ||
+      request.minScore < 0 ||
+      request.minScore > 1)
+  ) {
+    throw new WorkServiceError(
+      "malformed",
+      "minScore must be between zero and one",
+    );
+  }
+  if (request.intent !== undefined && typeof request.intent !== "string") {
+    throw new WorkServiceError("malformed", "intent must be a string");
+  }
+  if (request.rerank !== undefined && typeof request.rerank !== "boolean") {
+    throw new WorkServiceError("malformed", "rerank must be a boolean");
+  }
+  if (request.explain !== undefined && typeof request.explain !== "boolean") {
+    throw new WorkServiceError("malformed", "explain must be a boolean");
+  }
+  if (
+    request.chunkStrategy !== undefined &&
+    request.chunkStrategy !== "auto" &&
+    request.chunkStrategy !== "regex"
+  ) {
+    throw new WorkServiceError("malformed", "chunkStrategy is not supported");
+  }
+}
+
+function isExplicitLexical(request: NormalizedSearchRequest): boolean {
+  return (
+    request.query === undefined &&
+    request.rerank === false &&
+    request.searches !== undefined &&
+    request.searches.length > 0 &&
+    request.searches.every((search) => search.type === "lex")
+  );
+}
+
+function updateScope(collections: readonly string[] | null | undefined): {
+  all: boolean;
+  collections: Set<string>;
+} {
+  if (collections == null) return { all: true, collections: new Set() };
+  return { all: false, collections: new Set(collections) };
+}
+
+function mergeUpdateScope(
+  target: { all: boolean; collections: Set<string> },
+  incoming: { all: boolean; collections: Set<string> },
+): void {
+  if (target.all || incoming.all) {
+    target.all = true;
+    target.collections.clear();
+    return;
+  }
+  for (const collection of incoming.collections)
+    target.collections.add(collection);
+}
+
+function validateEnsureRequest(
+  request: CollectionEnsureRequest,
+): CollectionEnsureRequest {
+  if (
+    typeof request !== "object" ||
+    request === null ||
+    Array.isArray(request)
+  ) {
+    throw new WorkServiceError("malformed", "request must be an object");
+  }
+  if (
+    (request.adds !== undefined && !Array.isArray(request.adds)) ||
+    (request.updates !== undefined && !Array.isArray(request.updates)) ||
+    (request.renames !== undefined && !Array.isArray(request.renames)) ||
+    (request.contexts !== undefined && !Array.isArray(request.contexts))
+  ) {
+    throw new WorkServiceError(
+      "malformed",
+      "adds, updates, renames, and contexts must be arrays when provided",
+    );
+  }
+  const adds = [...(request.adds ?? [])];
+  const updates = [...(request.updates ?? [])];
+  const renames = [...(request.renames ?? [])];
+  const contexts = [...(request.contexts ?? [])];
+  const names = new Set<string>();
+  const normalizeCollections = (
+    collections: CollectionEnsureItem[],
+  ): CollectionEnsureItem[] => {
+    return collections.map((collection) => {
+      if (
+        typeof collection !== "object" ||
+        collection === null ||
+        Array.isArray(collection)
+      )
+        throw new WorkServiceError(
+          "malformed",
+          "collection lists must contain objects",
+        );
+      if (
+        typeof collection.name !== "string" ||
+        !isValidCollectionName(collection.name)
+      ) {
+        throw new WorkServiceError(
+          "malformed",
+          "collection names may contain only letters, numbers, hyphens, and underscores",
+        );
+      }
+      if (names.has(collection.name))
+        throw new WorkServiceError("malformed", "duplicate collection name");
+      names.add(collection.name);
+      if (
+        typeof collection.path !== "string" ||
+        collection.path.trim().length === 0
+      ) {
+        throw new WorkServiceError(
+          "malformed",
+          "collection paths must be non-empty strings",
+        );
+      }
+      if (
+        collection.pattern !== undefined &&
+        (typeof collection.pattern !== "string" ||
+          collection.pattern.length === 0)
+      ) {
+        throw new WorkServiceError(
+          "malformed",
+          "collection patterns must be non-empty strings",
+        );
+      }
+      return {
+        name: collection.name,
+        path: collection.path,
+        ...(collection.pattern !== undefined
+          ? { pattern: collection.pattern }
+          : {}),
+      };
+    });
+  };
+  const normalizedAdds = normalizeCollections(adds);
+  const normalizedUpdates = normalizeCollections(updates);
+  const addNames = new Set(normalizedAdds.map((collection) => collection.name));
+  const updateNames = new Set(
+    normalizedUpdates.map((collection) => collection.name),
+  );
+  const renameSources = new Set<string>();
+  const renameTargets = new Set<string>();
+  const normalizedRenames = renames.map((rename) => {
+    if (
+      typeof rename !== "object" ||
+      rename === null ||
+      Array.isArray(rename) ||
+      typeof rename.from !== "string" ||
+      typeof rename.to !== "string" ||
+      !isValidCollectionName(rename.from) ||
+      !isValidCollectionName(rename.to) ||
+      rename.from === rename.to
+    ) {
+      throw new WorkServiceError(
+        "malformed",
+        "collection renames must use two different valid names",
+      );
+    }
+    if (renameSources.has(rename.from) || renameTargets.has(rename.to))
+      throw new WorkServiceError(
+        "malformed",
+        "collection renames are ambiguous",
+      );
+    renameSources.add(rename.from);
+    renameTargets.add(rename.to);
+    return { ...rename };
+  });
+  for (const source of renameSources) {
+    if (
+      renameTargets.has(source) ||
+      addNames.has(source) ||
+      updateNames.has(source)
+    )
+      throw new WorkServiceError("malformed", "collection mutations overlap");
+  }
+  for (const target of renameTargets) {
+    if (addNames.has(target))
+      throw new WorkServiceError("malformed", "collection mutations overlap");
+  }
+
+  const contextTargets = new Set<string>();
+  const normalizedContexts = contexts.map((context) => {
+    if (
+      typeof context !== "object" ||
+      context === null ||
+      Array.isArray(context) ||
+      typeof context.collection !== "string" ||
+      !isValidCollectionName(context.collection) ||
+      typeof context.path !== "string" ||
+      context.path.trim().length === 0 ||
+      typeof context.context !== "string"
+    ) {
+      throw new WorkServiceError(
+        "malformed",
+        "contexts must contain valid collection, path, and context strings",
+      );
+    }
+    const key = `${context.collection}\0${context.path}`;
+    if (contextTargets.has(key) || renameSources.has(context.collection))
+      throw new WorkServiceError(
+        "malformed",
+        "collection contexts are ambiguous",
+      );
+    contextTargets.add(key);
+    return { ...context };
+  });
+  if (
+    request.markDirty !== undefined &&
+    typeof request.markDirty !== "boolean"
+  ) {
+    throw new WorkServiceError("malformed", "markDirty must be a boolean");
+  }
+  return {
+    adds: normalizedAdds,
+    updates: normalizedUpdates,
+    renames: normalizedRenames,
+    contexts: normalizedContexts,
+    markDirty: request.markDirty ?? true,
+  };
+}
+
+export class QMDWorkService {
+  private readonly store: QMDStore;
+  private readonly modelConfigIdentity: string;
+  private readonly heavyQueue: HeavyJob[] = [];
+  private readonly heavyJobs = new Map<string, HeavyJob>();
+  private readonly fallbackJobs = new Map<
+    string,
+    Promise<DaemonSearchResponse>
+  >();
+  private readonly maintenanceQueue: MaintenanceJob[] = [];
+  private readonly maintenanceJobs = new Map<string, MaintenanceJob>();
+  private readonly operations = new Map<string, OperationStatus>();
+  private readonly activeWork = new Set<Promise<unknown>>();
+  private readonly metricsState: Omit<
+    AdmissionMetrics,
+    "queuedInteractive" | "queuedMaintenance"
+  > = {
+    activeHeavy: 0,
+    maintenanceActive: false,
+    deduplicated: 0,
+    queueFull: 0,
+    queueTimeout: 0,
+    degraded: 0,
+  };
+  private pendingUpdate: UpdateJob | undefined;
+  private activeMaintenanceJob: MaintenanceJob | undefined;
+  private activeFallbacks = 0;
+  private reservedMaintenanceSlots = 0;
+  private nextGeneration = 0;
+  private indexGeneration = 0;
+  private pumping = false;
+  private closed = false;
+  private closePromise: Promise<void> | undefined;
+
+  constructor(store: QMDStore, options: { modelConfigIdentity?: string } = {}) {
+    this.store = store;
+    this.modelConfigIdentity = options.modelConfigIdentity ?? "default";
+  }
+
+  get metrics(): AdmissionMetrics {
+    return {
+      ...this.metricsState,
+      queuedInteractive: this.heavyQueue.length,
+      queuedMaintenance: this.maintenanceQueue.length,
+    };
+  }
+
+  async health(): Promise<{
+    admission: AdmissionMetrics;
+    indexGeneration: number;
+  }> {
+    return { admission: this.metrics, indexGeneration: this.indexGeneration };
+  }
+
+  async search(
+    request: DaemonSearchRequest,
+    signal?: AbortSignal,
+  ): Promise<DaemonSearchResponse> {
+    if (this.closed)
+      throw new WorkServiceError("closed", "the QMD work service is closed");
+    if (isAbortSignalAborted(signal)) throw abortError();
+
+    let normalized: NormalizedSearchRequest;
+    try {
+      normalized = await this.normalizeSearchRequest(request);
+    } catch (error) {
+      if (error instanceof WorkServiceError) {
+        if (error.reason === "closed" || error.reason === "malformed")
+          throw error;
+        return this.unavailable(error.reason);
+      }
+      return this.unavailable("store_error");
+    }
+    if (isAbortSignalAborted(signal)) throw abortError();
+    this.assertOpen();
+
+    if (normalized.collections.length === 0) {
+      return {
+        status: "ok",
+        mode: normalized.resultMode,
+        authoritativeEmpty: true,
+        indexGeneration: this.indexGeneration,
+        results: [],
+      };
+    }
+    if (isExplicitLexical(normalized))
+      return this.runLexical(normalized, undefined, signal);
+    return this.enqueueHeavy(normalized, signal);
+  }
+
+  private read<T>(operation: () => Promise<T>): Promise<T> {
+    return this.trackStoreOperation(operation).catch((error: unknown) => {
+      if (error instanceof WorkServiceError) throw error;
+      throw new WorkServiceError("store_error", "QMD store unavailable");
+    });
+  }
+
+  get(pathOrDocid: string, options?: { includeBody?: boolean }) {
+    return this.read(() => this.store.get(pathOrDocid, options));
+  }
+
+  getDocumentBody(
+    pathOrDocid: string,
+    options?: { fromLine?: number; maxLines?: number },
+  ) {
+    return this.read(() => this.store.getDocumentBody(pathOrDocid, options));
+  }
+
+  multiGet(
+    pattern: string,
+    options?: { includeBody?: boolean; maxBytes?: number },
+  ) {
+    return this.read(() => this.store.multiGet(pattern, options));
+  }
+
+  getStatus(): Promise<IndexStatus> {
+    return this.read(() => this.store.getStatus());
+  }
+
+  getGlobalContext(): Promise<string | undefined> {
+    return this.read(() => this.store.getGlobalContext());
+  }
+
+  listCollections() {
+    return this.read(async () => {
+      const collections = await this.store.listCollections();
+      return collections.map((collection) => ({
+        name: collection.name,
+        path: collection.pwd,
+        pattern: collection.glob_pattern,
+        documents: collection.doc_count,
+        activeDocuments: collection.active_count,
+        lastModified: collection.last_modified,
+        includeByDefault: collection.includeByDefault,
+      }));
+    });
+  }
+
+  scheduleUpdate(scope: UpdateScope = {}): {
+    operationId: string;
+    state: OperationState;
+    generation: number;
+    coalesced: boolean;
+  } {
+    this.assertOpen();
+    if (
+      typeof scope !== "object" ||
+      scope === null ||
+      Array.isArray(scope) ||
+      (scope.collections !== undefined &&
+        scope.collections !== null &&
+        (!Array.isArray(scope.collections) ||
+          scope.collections.some(
+            (name) => typeof name !== "string" || !isValidCollectionName(name),
+          )))
+    )
+      throw new WorkServiceError(
+        "malformed",
+        "collections must be an array of names or null",
+      );
+    const incoming = updateScope(scope.collections);
+    if (this.pendingUpdate) {
+      mergeUpdateScope(this.pendingUpdate.scope, incoming);
+      return {
+        ...this.operationResponse(this.pendingUpdate.operation, true),
+        generation: this.pendingUpdate.operation.generation!,
+      };
+    }
+
+    this.assertMaintenanceCapacity();
+    const operation = this.createOperation("update", ++this.nextGeneration);
+    const job: UpdateJob = {
+      operation,
+      scope: incoming,
+      run: async () => {
+        const result = await this.store.update({
+          collections: job.scope.all ? undefined : [...job.scope.collections],
+        });
+        this.indexGeneration = Math.max(
+          this.indexGeneration,
+          operation.generation ?? 0,
+        );
+        return aggregateUpdateResult(result);
+      },
+    };
+    this.pendingUpdate = job;
+    this.enqueueMaintenance(job);
+    this.pump();
+    return {
+      ...this.operationResponse(operation, false),
+      generation: operation.generation!,
+    };
+  }
+
+  scheduleEmbed(request: DaemonEmbedRequest = {}): {
+    operationId: string;
+    state: OperationState;
+    coalesced: boolean;
+  } {
+    this.assertOpen();
+    validateEmbedRequest(request);
+    const key = embedJobKey(request);
+    const existing = this.maintenanceJobs.get(key);
+    if (
+      existing &&
+      !(existing === this.activeMaintenanceJob && this.maintenanceQueue.length > 0)
+    )
+      return this.operationResponse(existing.operation, true);
+    this.assertMaintenanceCapacity();
+    const operation = this.createOperation("embed");
+    const job: MaintenanceJob = {
+      operation,
+      key,
+      run: async () => {
+        const result = await this.store.embed({ ...request });
+        return aggregateEmbedResult(result);
+      },
+    };
+    this.enqueueMaintenance(job);
+    this.pump();
+    return this.operationResponse(operation, false);
+  }
+
+  scheduleEnsure(request: CollectionEnsureRequest): {
+    operationId: string;
+    state: OperationState;
+    coalesced: boolean;
+  } {
+    this.assertOpen();
+    const validated = validateEnsureRequest(request);
+    const key = ensureJobKey(validated);
+    const existing = this.maintenanceJobs.get(key);
+    if (existing) return this.operationResponse(existing.operation, true);
+    const hasMutations =
+      (validated.adds?.length ?? 0) +
+        (validated.updates?.length ?? 0) +
+        (validated.renames?.length ?? 0) +
+        (validated.contexts?.length ?? 0) >
+      0;
+    const reservedUpdate =
+      validated.markDirty !== false && hasMutations && !this.pendingUpdate;
+    this.assertMaintenanceCapacity(reservedUpdate ? 2 : 1);
+    const operation = this.createOperation("ensure");
+    const job: EnsureJob = {
+      operation,
+      key,
+      request: validated,
+      reservedUpdate,
+      run: () => this.runEnsure(job),
+    };
+    if (reservedUpdate) this.reservedMaintenanceSlots += 1;
+    this.enqueueMaintenance(job, true);
+    this.pump();
+    return this.operationResponse(operation, false);
+  }
+
+  getOperation(id: string): OperationStatus | undefined {
+    const operation = this.operations.get(id);
+    return operation ? cloneOperation(operation) : undefined;
+  }
+
+  async close(): Promise<void> {
+    if (this.closePromise) return this.closePromise;
+    this.closed = true;
+    this.rejectQueuedSearches(
+      new WorkServiceError("closed", "the QMD work service is closed"),
+    );
+    this.failQueuedOperations();
+    this.closePromise = (async () => {
+      await Promise.allSettled([...this.activeWork]);
+      await this.store.close();
+    })();
+    return this.closePromise;
+  }
+
+  private assertOpen(): void {
+    if (this.closed)
+      throw new WorkServiceError("closed", "the QMD work service is closed");
+  }
+
+  private async normalizeSearchRequest(
+    request: DaemonSearchRequest,
+  ): Promise<NormalizedSearchRequest> {
+    validateDaemonSearchRequest(request);
+    const collections =
+      request.collections === undefined
+        ? await this.read(() => this.store.getDefaultCollectionNames())
+        : [...request.collections];
+    const searches =
+      request.searches === undefined
+        ? undefined
+        : request.searches.map((search) => ({ ...search }));
+    const rerank = request.rerank ?? true;
+    return {
+      ...(request.query !== undefined ? { query: request.query } : {}),
+      ...(searches ? { searches } : {}),
+      collections,
+      limit: request.limit ?? DEFAULT_LIMIT,
+      minScore: request.minScore ?? DEFAULT_MIN_SCORE,
+      candidateLimit: request.candidateLimit ?? DEFAULT_CANDIDATE_LIMIT,
+      ...(request.intent !== undefined ? { intent: request.intent } : {}),
+      rerank,
+      explain: request.explain ?? false,
+      chunkStrategy: request.chunkStrategy ?? DEFAULT_CHUNK_STRATEGY,
+      resultMode:
+        searches &&
+        rerank === false &&
+        searches.every((search) => search.type === "lex")
+          ? "lexical"
+          : "semantic",
+      modelConfigIdentity: this.modelConfigIdentity,
+    };
+  }
+
+  private searchKey(request: NormalizedSearchRequest): string {
+    return JSON.stringify({
+      query: request.query ?? null,
+      searches:
+        request.searches?.map((search) => ({
+          type: search.type,
+          query: search.query,
+          line: search.line ?? null,
+        })) ?? null,
+      collections: request.collections,
+      limit: request.limit,
+      minScore: request.minScore,
+      candidateLimit: request.candidateLimit,
+      intent: request.intent ?? null,
+      rerank: request.rerank,
+      explain: request.explain,
+      chunkStrategy: request.chunkStrategy,
+      resultMode: request.resultMode,
+      modelConfigIdentity: request.modelConfigIdentity,
+    });
+  }
+
+  private enqueueHeavy(
+    request: NormalizedSearchRequest,
+    signal: AbortSignal | undefined,
+  ): Promise<DaemonSearchResponse> {
+    const key = this.searchKey(request);
+    const existing = this.heavyJobs.get(key);
+    if (existing) {
+      this.metricsState.deduplicated += 1;
+      return this.addWaiter(existing, signal);
+    }
+    const fallback = this.fallbackJobs.get(key);
+    if (fallback) {
+      this.metricsState.deduplicated += 1;
+      return raceAbort(fallback, signal);
+    }
+    if (this.heavyQueue.length >= INTERACTIVE_QUEUE_LIMIT) {
+      this.metricsState.queueFull += 1;
+      return this.degrade(request, "queue_full", signal);
+    }
+
+    const job: HeavyJob = { key, request, state: "queued", waiters: new Set() };
+    job.timer = setTimeout(
+      () => this.timeoutHeavyJob(job),
+      INTERACTIVE_QUEUE_TIMEOUT_MS,
+    );
+    job.timer.unref?.();
+    this.heavyJobs.set(key, job);
+    this.heavyQueue.push(job);
+    const waiter = this.addWaiter(job, signal);
+    this.pump();
+    return waiter;
+  }
+
+  private addWaiter(
+    job: HeavyJob,
+    signal: AbortSignal | undefined,
+  ): Promise<DaemonSearchResponse> {
+    if (isAbortSignalAborted(signal)) return Promise.reject(abortError());
+    return new Promise<DaemonSearchResponse>((resolve, reject) => {
+      const waiter: SearchWaiter = { resolve, reject, signal };
+      const onAbort = () => {
+        if (!job.waiters.delete(waiter)) return;
+        reject(abortError());
+        if (job.state === "queued" && job.waiters.size === 0)
+          this.removeQueuedJob(job);
+      };
+      waiter.onAbort = onAbort;
+      job.waiters.add(waiter);
+      signal?.addEventListener("abort", onAbort, { once: true });
+      if (signal?.aborted) onAbort();
+    });
+  }
+
+  private detachQueuedJob(job: HeavyJob): void {
+    const index = this.heavyQueue.indexOf(job);
+    if (index >= 0) this.heavyQueue.splice(index, 1);
+    if (job.timer) clearTimeout(job.timer);
+    this.heavyJobs.delete(job.key);
+  }
+
+  private removeQueuedJob(job: HeavyJob): void {
+    if (job.state !== "queued") return;
+    this.detachQueuedJob(job);
+    this.pump();
+  }
+
+  private timeoutHeavyJob(job: HeavyJob): void {
+    if (job.state !== "queued") return;
+    this.detachQueuedJob(job);
+    job.state = "fallback";
+    this.metricsState.queueTimeout += 1;
+    this.trackWork(this.degradeJob(job, "queue_timeout"));
+    this.pump();
+  }
+
+  private async degradeJob(
+    job: HeavyJob,
+    reason: SearchDegradationReason,
+  ): Promise<void> {
+    const response = await this.degrade(job.request, reason);
+    this.settleJob(job, response);
+  }
+
+  private async degrade(
+    request: NormalizedSearchRequest,
+    reason: SearchDegradationReason,
+    signal?: AbortSignal,
+  ): Promise<DaemonSearchResponse> {
+    this.metricsState.degraded += 1;
+    const key = this.searchKey(request);
+    const existing = this.fallbackJobs.get(key);
+    if (existing) {
+      this.metricsState.deduplicated += 1;
+      return raceAbort(existing, signal);
+    }
+    if (this.activeFallbacks >= LEXICAL_FALLBACK_CONCURRENCY_LIMIT) {
+      return this.unavailable(reason);
+    }
+
+    this.activeFallbacks += 1;
+    const work = this.runLexical(request, reason).finally(() => {
+      this.activeFallbacks -= 1;
+      if (this.fallbackJobs.get(key) === work) this.fallbackJobs.delete(key);
+    });
+    this.fallbackJobs.set(key, work);
+    return raceAbort(work, signal);
+  }
+
+  private async runLexical(
+    request: NormalizedSearchRequest,
+    degradedReason: SearchDegradationReason | undefined,
+    signal?: AbortSignal,
+  ): Promise<DaemonSearchResponse> {
+    const work = this.trackStoreOperation(async () => {
+      const results = await this.executeLexical(request);
+      return {
+        status: "ok" as const,
+        mode: "lexical" as const,
+        ...(degradedReason ? { reason: degradedReason } : {}),
+        authoritativeEmpty: degradedReason === undefined && results.length === 0,
+        indexGeneration: this.indexGeneration,
+        results,
+      };
+    });
+    try {
+      return await raceAbort(work, signal);
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") throw error;
+      return this.unavailable(
+        error instanceof WorkServiceError ? error.reason : "store_error",
+      );
+    }
+  }
+
+  private async executeLexical(
+    request: NormalizedSearchRequest,
+  ): Promise<SearchResult[]> {
+    const queries =
+      request.searches?.map((search) => search.query) ??
+      (request.query ? [request.query] : []);
+    if (queries.length === 0) throw new WorkServiceError("malformed");
+    const byFile = new Map<string, SearchResult>();
+    for (const query of queries) {
+      const results = await this.store.searchLex(query, {
+        limit: request.limit,
+        collection:
+          request.collections.length > 0 ? request.collections : undefined,
+      });
+      for (const result of results) {
+        if (result.score < request.minScore) continue;
+        const key = result.filepath || result.displayPath;
+        const previous = byFile.get(key);
+        if (!previous || result.score > previous.score) byFile.set(key, result);
+      }
+    }
+    return [...byFile.values()]
+      .sort((a, b) => b.score - a.score)
+      .slice(0, request.limit);
+  }
+
+  private async runHeavy(job: HeavyJob): Promise<void> {
+    this.metricsState.activeHeavy += 1;
+    try {
+      let response: DaemonSearchResponse;
+      try {
+        const results = await this.store.search({
+          ...(job.request.query !== undefined
+            ? { query: job.request.query }
+            : {}),
+          ...(job.request.searches !== undefined
+            ? { queries: job.request.searches }
+            : {}),
+          collections:
+            job.request.collections.length > 0
+              ? job.request.collections
+              : undefined,
+          limit: job.request.limit,
+          minScore: job.request.minScore,
+          candidateLimit: job.request.candidateLimit,
+          ...(job.request.intent !== undefined
+            ? { intent: job.request.intent }
+            : {}),
+          rerank: job.request.rerank,
+          explain: job.request.explain,
+          chunkStrategy: job.request.chunkStrategy,
+        });
+        if (!Array.isArray(results))
+          throw new Error("search returned a non-array result");
+        response = {
+          status: "ok",
+          mode: "semantic",
+          authoritativeEmpty: results.length === 0,
+          indexGeneration: this.indexGeneration,
+          results,
+        };
+      } catch {
+        response = await this.degrade(job.request, "semantic_error");
+      }
+      this.settleJob(job, response);
+    } catch (error) {
+      this.settleJob(
+        job,
+        this.unavailable(
+          error instanceof WorkServiceError ? error.reason : "store_error",
+        ),
+      );
+    } finally {
+      if (this.heavyJobs.get(job.key) === job) this.heavyJobs.delete(job.key);
+      this.metricsState.activeHeavy -= 1;
+    }
+  }
+
+  private settleJob(job: HeavyJob, response: DaemonSearchResponse): void {
+    for (const waiter of job.waiters) {
+      waiter.signal?.removeEventListener("abort", waiter.onAbort!);
+      waiter.resolve(response);
+    }
+    job.waiters.clear();
+  }
+
+  private unavailable(reason: SearchDegradationReason): DaemonSearchResponse {
+    return {
+      status: "unavailable",
+      reason,
+      authoritativeEmpty: false,
+      indexGeneration: this.indexGeneration,
+    };
+  }
+
+  private trackStoreOperation<T>(operation: () => Promise<T>): Promise<T> {
+    return this.trackWork(
+      (async () => {
+        if (this.closed)
+          throw new WorkServiceError(
+            "closed",
+            "the QMD work service is closed",
+          );
+        if (this.metricsState.maintenanceActive)
+          throw new WorkServiceError(
+            "maintenance_busy",
+            "maintenance is active",
+          );
+        this.activeStoreOperationStarted();
+        try {
+          return await operation();
+        } finally {
+          this.activeStoreOperationFinished();
+        }
+      })(),
+    );
+  }
+
+  private trackWork<T>(work: Promise<T>): Promise<T> {
+    this.activeWork.add(work);
+    void work.then(
+      () => this.finishTrackedWork(work),
+      () => this.finishTrackedWork(work),
+    );
+    return work;
+  }
+
+  private activeStoreOperationStarted(): void {
+    this.storeOperationCount += 1;
+  }
+
+  private activeStoreOperationFinished(): void {
+    this.storeOperationCount -= 1;
+    this.pump();
+  }
+
+  private storeOperationCount = 0;
+
+  private finishTrackedWork(work: Promise<unknown>): void {
+    this.activeWork.delete(work);
+    this.pump();
+  }
+
+  private pump(): void {
+    if (this.pumping || this.closed || this.metricsState.maintenanceActive)
+      return;
+    this.pumping = true;
+    try {
+      if (this.metricsState.activeHeavy === 0 && this.heavyQueue.length > 0) {
+        const job = this.heavyQueue.shift()!;
+        if (job.state === "queued") {
+          if (job.timer) clearTimeout(job.timer);
+          job.state = "running";
+          this.trackWork(this.runHeavy(job));
+        }
+        return;
+      }
+      if (
+        this.storeOperationCount === 0 &&
+        this.metricsState.activeHeavy === 0 &&
+        this.maintenanceQueue.length > 0
+      ) {
+        const job = this.maintenanceQueue.shift()!;
+        this.startMaintenance(job);
+      }
+    } finally {
+      this.pumping = false;
+    }
+  }
+
+  private startMaintenance(job: MaintenanceJob): void {
+    this.metricsState.maintenanceActive = true;
+    this.activeMaintenanceJob = job;
+    this.storeOperationCount += 1;
+    job.operation.state = "running";
+    job.operation.startedAt = new Date().toISOString();
+    if (
+      job.operation.kind === "update" &&
+      this.pendingUpdate?.operation.operationId === job.operation.operationId
+    )
+      this.pendingUpdate = undefined;
+    const work = (async () => {
+      try {
+        const result = await job.run();
+        job.operation.state = "completed";
+        job.operation.result = result;
+      } catch (error) {
+        job.operation.state = "failed";
+        job.operation.error = { reason: errorReason(error) };
+      } finally {
+        job.operation.completedAt = new Date().toISOString();
+        this.metricsState.maintenanceActive = false;
+        if (this.activeMaintenanceJob === job)
+          this.activeMaintenanceJob = undefined;
+        if (job.key && this.maintenanceJobs.get(job.key) === job)
+          this.maintenanceJobs.delete(job.key);
+        this.storeOperationCount -= 1;
+        this.pump();
+      }
+    })();
+    this.trackWork(work);
+  }
+
+  private createOperation(
+    kind: OperationKind,
+    generation?: number,
+  ): OperationStatus {
+    const operation: OperationStatus = {
+      operationId: `op_${randomUUID()}`,
+      kind,
+      state: "queued",
+      createdAt: new Date().toISOString(),
+      ...(generation !== undefined ? { generation } : {}),
+    };
+    this.operations.set(operation.operationId, operation);
+    if (this.operations.size > 128) {
+      for (const [id, candidate] of this.operations) {
+        if (candidate.state === "completed" || candidate.state === "failed") {
+          this.operations.delete(id);
+          break;
+        }
+      }
+    }
+    return operation;
+  }
+
+  private operationResponse(
+    operation: OperationStatus,
+    coalesced: boolean,
+  ): {
+    operationId: string;
+    state: OperationState;
+    generation?: number;
+    coalesced: boolean;
+  } {
+    return {
+      operationId: operation.operationId,
+      state: operation.state,
+      ...(operation.generation !== undefined
+        ? { generation: operation.generation }
+        : {}),
+      coalesced,
+    };
+  }
+
+  private assertMaintenanceCapacity(slots = 1): void {
+    if (
+      this.maintenanceQueue.length + this.reservedMaintenanceSlots + slots >
+      MAINTENANCE_QUEUE_LIMIT
+    ) {
+      throw new WorkServiceError(
+        "maintenance_busy",
+        "the maintenance queue is full",
+      );
+    }
+  }
+
+  private enqueueMaintenance(
+    job: MaintenanceJob,
+    beforePendingUpdate = false,
+  ): void {
+    this.assertMaintenanceCapacity();
+    if (job.key) this.maintenanceJobs.set(job.key, job);
+    if (beforePendingUpdate && this.pendingUpdate) {
+      const index = this.maintenanceQueue.indexOf(this.pendingUpdate);
+      this.maintenanceQueue.splice(Math.max(0, index), 0, job);
+      return;
+    }
+    this.insertInteractiveMaintenance(job);
+  }
+
+  private insertInteractiveMaintenance(job: MaintenanceJob): void {
+    const firstEmbed = this.maintenanceQueue.findIndex(
+      (queued) => queued.operation.kind === "embed",
+    );
+    if (firstEmbed >= 0) this.maintenanceQueue.splice(firstEmbed, 0, job);
+    else this.maintenanceQueue.push(job);
+  }
+
+  private async runEnsure(
+    job: EnsureJob,
+  ): Promise<Record<string, number | boolean | string>> {
+    const request = job.request;
+    const affected = new Set<string>();
+    try {
+      await this.preflightEnsure(request);
+      const mutations: CollectionMutation[] = [
+        ...(request.renames ?? []).map((rename) => ({
+          kind: "rename" as const,
+          from: rename.from,
+          to: rename.to,
+        })),
+        ...[...(request.adds ?? []), ...(request.updates ?? [])].map(
+          (collection) => ({
+            kind: "upsert" as const,
+            name: collection.name,
+            path: collection.path,
+            ...(collection.pattern !== undefined
+              ? { pattern: collection.pattern }
+              : {}),
+          }),
+        ),
+        ...(request.contexts ?? []).map((context) => ({
+          kind: "context" as const,
+          collection: context.collection,
+          path: context.path,
+          context: context.context,
+        })),
+      ];
+      await this.store.applyCollectionMutations(mutations);
+      for (const rename of request.renames ?? []) affected.add(rename.to);
+      for (const collection of [
+        ...(request.adds ?? []),
+        ...(request.updates ?? []),
+      ]) {
+        affected.add(collection.name);
+      }
+      for (const context of request.contexts ?? []) {
+        affected.add(context.collection);
+      }
+      let updateOperationId: string | undefined;
+      if (request.markDirty !== false && affected.size > 0) {
+        this.releaseEnsureUpdateReservation(job);
+        updateOperationId = this.scheduleUpdate({
+          collections: [...affected],
+        }).operationId;
+      }
+      return {
+        adds: (request.adds ?? []).length,
+        updates: (request.updates ?? []).length,
+        renames: (request.renames ?? []).length,
+        contexts: (request.contexts ?? []).length,
+        ...(updateOperationId ? { updateOperationId } : {}),
+      };
+    } finally {
+      this.releaseEnsureUpdateReservation(job);
+    }
+  }
+
+  private async preflightEnsure(
+    request: CollectionEnsureRequest,
+  ): Promise<void> {
+    const existing = new Set(
+      (await this.store.listCollections()).map((collection) => collection.name),
+    );
+    const finalNames = new Set(existing);
+    for (const rename of request.renames ?? []) {
+      if (!existing.has(rename.from) || existing.has(rename.to))
+        throw new Error("collection rename preflight failed");
+      finalNames.delete(rename.from);
+      finalNames.add(rename.to);
+    }
+    for (const collection of request.adds ?? []) {
+      if (finalNames.has(collection.name))
+        throw new Error("collection add preflight failed");
+      finalNames.add(collection.name);
+    }
+    for (const collection of request.updates ?? []) {
+      if (!finalNames.has(collection.name))
+        throw new Error("collection update preflight failed");
+    }
+    for (const context of request.contexts ?? []) {
+      if (!finalNames.has(context.collection))
+        throw new Error("collection context preflight failed");
+    }
+  }
+
+  private releaseEnsureUpdateReservation(job: EnsureJob): void {
+    if (!job.reservedUpdate) return;
+    job.reservedUpdate = false;
+    this.reservedMaintenanceSlots -= 1;
+  }
+
+  private rejectQueuedSearches(error: WorkServiceError): void {
+    for (const job of this.heavyQueue.splice(0)) {
+      this.detachQueuedJob(job);
+      for (const waiter of job.waiters) {
+        waiter.signal?.removeEventListener("abort", waiter.onAbort!);
+        waiter.reject(error);
+      }
+      job.waiters.clear();
+    }
+  }
+
+  private failQueuedOperations(): void {
+    for (const job of this.maintenanceQueue.splice(0)) {
+      if (job.key && this.maintenanceJobs.get(job.key) === job)
+        this.maintenanceJobs.delete(job.key);
+      if (job.operation.kind === "ensure")
+        this.releaseEnsureUpdateReservation(job as EnsureJob);
+      job.operation.state = "failed";
+      job.operation.error = { reason: "closed" };
+      job.operation.completedAt = new Date().toISOString();
+    }
+    this.pendingUpdate = undefined;
+  }
+}
+
+function aggregateUpdateResult(
+  result: UpdateResult,
+): Record<string, number | boolean | string> {
+  return {
+    collections: result.collections,
+    indexed: result.indexed,
+    updated: result.updated,
+    unchanged: result.unchanged,
+    removed: result.removed,
+    skipped: result.skipped,
+    needsEmbedding: result.needsEmbedding,
+  };
+}
+
+function aggregateEmbedResult(
+  result: EmbedResult,
+): Record<string, number | boolean | string> {
+  return {
+    docsProcessed: result.docsProcessed,
+    chunksEmbedded: result.chunksEmbedded,
+    errors: result.errors,
+    durationMs: result.durationMs,
+  };
+}
+
+function validateEmbedRequest(request: DaemonEmbedRequest): void {
+  if (typeof request !== "object" || request === null || Array.isArray(request))
+    throw new WorkServiceError("malformed", "request must be an object");
+  if (request.force !== undefined && typeof request.force !== "boolean")
+    throw new WorkServiceError("malformed", "force must be a boolean");
+  if (
+    request.model !== undefined &&
+    (typeof request.model !== "string" || request.model.length === 0)
+  )
+    throw new WorkServiceError("malformed", "model must be a non-empty string");
+  if (
+    request.collection !== undefined &&
+    (typeof request.collection !== "string" ||
+      !isValidCollectionName(request.collection))
+  )
+    throw new WorkServiceError(
+      "malformed",
+      "collection must be a non-empty string",
+    );
+  validateOptionalNumber(request.maxDocsPerBatch, "maxDocsPerBatch", 1);
+  validateOptionalNumber(request.maxBatchBytes, "maxBatchBytes", 1);
+  if (
+    request.chunkStrategy !== undefined &&
+    request.chunkStrategy !== "auto" &&
+    request.chunkStrategy !== "regex"
+  )
+    throw new WorkServiceError("malformed", "chunkStrategy is not supported");
+}
+
+function embedJobKey(request: DaemonEmbedRequest): string {
+  return JSON.stringify({
+    force: request.force ?? false,
+    model: request.model ?? null,
+    collection: request.collection ?? null,
+    maxDocsPerBatch:
+      request.maxDocsPerBatch ?? DEFAULT_EMBED_MAX_DOCS_PER_BATCH,
+    maxBatchBytes: request.maxBatchBytes ?? DEFAULT_EMBED_MAX_BATCH_BYTES,
+    chunkStrategy: request.chunkStrategy ?? "regex",
+  });
+}
+
+function ensureJobKey(request: CollectionEnsureRequest): string {
+  return JSON.stringify({
+    adds: request.adds ?? [],
+    updates: request.updates ?? [],
+    renames: request.renames ?? [],
+    contexts: request.contexts ?? [],
+    markDirty: request.markDirty !== false,
+  });
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -1145,7 +1145,7 @@ function initializeDatabase(db: Database): void {
     // sqlite-vec is optional — vector search won't work but FTS is fine
     _sqliteVecAvailable = false;
     _sqliteVecUnavailableReason = getErrorMessage(err);
-    console.warn(_sqliteVecUnavailableReason);
+    console.warn("sqlite-vec extension is unavailable; vector search is disabled.");
   }
   db.exec("PRAGMA foreign_keys = ON");
 
@@ -1336,14 +1336,19 @@ export function deleteStoreCollection(db: Database, name: string): boolean {
 }
 
 export function renameStoreCollection(db: Database, oldName: string, newName: string): boolean {
-  // Check target doesn't exist
-  const existing = db.prepare(`SELECT name FROM store_collections WHERE name = ?`).get(newName) as { name: string } | null | undefined;
-  if (existing != null) {
-    throw new Error(`Collection '${newName}' already exists`);
-  }
+  const rename = db.transaction(() => {
+    const existing = db.prepare(`SELECT name FROM store_collections WHERE name = ?`).get(newName) as { name: string } | null | undefined;
+    if (existing != null) {
+      throw new Error(`Collection '${newName}' already exists`);
+    }
 
-  const result = db.prepare(`UPDATE store_collections SET name = ? WHERE name = ?`).run(newName, oldName);
-  return result.changes > 0;
+    const result = db.prepare(`UPDATE store_collections SET name = ? WHERE name = ?`).run(newName, oldName);
+    if (result.changes > 0) {
+      db.prepare(`UPDATE documents SET collection = ? WHERE collection = ?`).run(newName, oldName);
+    }
+    return result.changes > 0;
+  });
+  return rename();
 }
 
 export function updateStoreContext(db: Database, collectionName: string, path: string, text: string): boolean {
@@ -3592,16 +3597,8 @@ export function removeCollection(db: Database, collectionName: string): { delete
   };
 }
 
-/**
- * Rename a collection.
- * Updates both YAML config and database documents table.
- */
+/** Rename a collection and its indexed documents. */
 export function renameCollection(db: Database, oldName: string, newName: string): void {
-  // Update all documents with the new collection name in database
-  db.prepare(`UPDATE documents SET collection = ? WHERE collection = ?`)
-    .run(newName, oldName);
-
-  // Rename in store_collections
   renameStoreCollection(db, oldName, newName);
 }
 

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -369,7 +369,9 @@ describe("native llama stdout containment", () => {
       expect(stdoutSpy).not.toHaveBeenCalled();
       expect(stderrSpy).toHaveBeenCalledWith("cmake build spam\n", undefined, undefined);
       expect(calls).toEqual(["cuda", false, false]);
-      expect(String(stderrSpy.mock.calls.map(call => call[0]).join(""))).toContain("skipping previously failed GPU init");
+      const stderr = String(stderrSpy.mock.calls.map(call => call[0]).join(""));
+      expect(stderr).toContain("skipping previously failed GPU init");
+      expect(stderr).not.toContain("CUDA unavailable");
     } finally {
       stdoutSpy.mockRestore();
       stderrSpy.mockRestore();
@@ -721,7 +723,7 @@ describe("LlamaCpp rerank deduping", () => {
 });
 
 describe("LlamaCpp ensureRerankContexts error reporting", () => {
-  test("warns with the underlying error and does not retry identical options", async () => {
+  test("uses a safe warning and does not retry identical options", async () => {
     const llm = new LlamaCpp({}) as any;
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
@@ -737,8 +739,9 @@ describe("LlamaCpp ensureRerankContexts error reporting", () => {
       expect(contexts).toEqual([]);
       expect(createRankingContext).toHaveBeenCalledTimes(1);
       expect(warn).toHaveBeenCalledWith(
-        expect.stringContaining("A context size of 40960 is too large for the available VRAM"),
+        "Reranker unavailable — skipping reranking. Use --no-rerank to silence this warning.",
       );
+      expect(warn.mock.calls.flat().join(" ")).not.toContain("40960");
     } finally {
       warn.mockRestore();
     }

--- a/test/mcp-http-v1.test.ts
+++ b/test/mcp-http-v1.test.ts
@@ -1,0 +1,274 @@
+/** Covers QMD API-v1 HTTP behavior and lifecycle boundaries. */
+import { request } from "node:http";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+  startMcpHttpServer,
+  type HttpServerHandle,
+} from "../src/mcp/server.js";
+import { _resetProductionModeForTesting } from "../src/store.js";
+
+const REQUIRED_FEATURES = [
+  "admission",
+  "operations",
+  "coalesced-update",
+  "daemon-embed",
+  "collection-ensure",
+];
+
+type OperationBody = {
+  operationId: string;
+  state: "queued" | "running" | "completed" | "failed";
+  error?: { reason: string };
+};
+
+describe("QMD daemon API v1", () => {
+  let handle: HttpServerHandle;
+  let baseUrl: string;
+  let root: string;
+  let docsPath: string;
+  let baselineSigtermListeners: number;
+  let baselineSigintListeners: number;
+  const originalIndexPath = process.env.INDEX_PATH;
+  const originalConfigDir = process.env.QMD_CONFIG_DIR;
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), "qmd-http-v1-"));
+    const configDir = join(root, "config");
+    docsPath = join(root, "docs");
+    await mkdir(configDir);
+    await mkdir(docsPath);
+    await writeFile(join(configDir, "index.yml"), "collections: {}\n");
+    process.env.INDEX_PATH = join(root, "index.sqlite");
+    process.env.QMD_CONFIG_DIR = configDir;
+    baselineSigtermListeners = process.listenerCount("SIGTERM");
+    baselineSigintListeners = process.listenerCount("SIGINT");
+    handle = await startMcpHttpServer(0, {
+      host: "127.0.0.1",
+      quiet: true,
+    });
+    baseUrl = `http://127.0.0.1:${handle.port}`;
+  });
+
+  afterAll(async () => {
+    await handle?.stop();
+    if (originalIndexPath === undefined) delete process.env.INDEX_PATH;
+    else process.env.INDEX_PATH = originalIndexPath;
+    if (originalConfigDir === undefined) delete process.env.QMD_CONFIG_DIR;
+    else process.env.QMD_CONFIG_DIR = originalConfigDir;
+    _resetProductionModeForTesting();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  async function waitForOperation(operationId: string): Promise<OperationBody> {
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      const response = await fetch(`${baseUrl}/v1/operations/${operationId}`);
+      expect(response.status).toBe(200);
+      const operation = (await response.json()) as OperationBody;
+      if (operation.state === "completed" || operation.state === "failed")
+        return operation;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    throw new Error("operation did not finish");
+  }
+
+  test("reports the exact API-v1 capability gate", async () => {
+    const response = await fetch(`${baseUrl}/health`);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      status: "ok",
+      apiVersion: 1,
+      features: REQUIRED_FEATURES,
+      indexGeneration: 0,
+      admission: {
+        activeHeavy: 0,
+        queuedInteractive: 0,
+        maintenanceActive: false,
+        queuedMaintenance: 0,
+      },
+    });
+    expect(typeof body.version).toBe("string");
+    expect(typeof body.uptime).toBe("number");
+  });
+
+  test("returns safe 400 responses for malformed and oversized bodies", async () => {
+    const malformed = await fetch(`${baseUrl}/v1/search`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{",
+    });
+    expect(malformed.status).toBe(400);
+    expect(await malformed.json()).toEqual({
+      status: "unavailable",
+      reason: "malformed",
+      authoritativeEmpty: false,
+    });
+
+    const oversized = await fetch(`${baseUrl}/v1/search`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "x".repeat(1_048_577),
+    });
+    expect(oversized.status).toBe(400);
+    expect(await oversized.json()).toEqual({
+      status: "unavailable",
+      reason: "malformed",
+      authoritativeEmpty: false,
+    });
+
+    const streamed = await new Promise<{ status: number; body: string }>(
+      (resolve, reject) => {
+        const req = request(
+          {
+            hostname: "127.0.0.1",
+            port: handle.port,
+            path: "/v1/search",
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+          },
+          (response) => {
+            let body = "";
+            response.setEncoding("utf8");
+            response.on("data", (chunk) => {
+              body += chunk;
+            });
+            response.on("end", () =>
+              resolve({ status: response.statusCode ?? 0, body }),
+            );
+          },
+        );
+        req.on("error", reject);
+        req.write("x".repeat(700_000));
+        req.end("x".repeat(400_000));
+      },
+    );
+    expect(streamed.status).toBe(400);
+    expect(JSON.parse(streamed.body)).toEqual({
+      status: "unavailable",
+      reason: "malformed",
+      authoritativeEmpty: false,
+    });
+
+    const excessiveLimit = await fetch(`${baseUrl}/v1/search`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "bounded", limit: 501 }),
+    });
+    expect(excessiveLimit.status).toBe(400);
+  });
+
+  test("returns authoritative empty lexical results without local inference", async () => {
+    const response = await fetch(`${baseUrl}/v1/search`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        searches: [{ type: "lex", query: "absent" }],
+        collections: [],
+        rerank: false,
+      }),
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      status: "ok",
+      mode: "lexical",
+      authoritativeEmpty: true,
+      results: [],
+    });
+  });
+
+  test("normalizes collections and exposes privacy-safe operation failures", async () => {
+    const accepted = await fetch(`${baseUrl}/v1/collections/ensure`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        adds: [{ name: "notes", path: docsPath, pattern: "**/*.md" }],
+        markDirty: false,
+      }),
+    });
+    expect(accepted.status).toBe(202);
+    const scheduled = (await accepted.json()) as OperationBody;
+    expect(scheduled.operationId).toMatch(/^op_/);
+    expect((await waitForOperation(scheduled.operationId)).state).toBe(
+      "completed",
+    );
+
+    const listed = await fetch(`${baseUrl}/v1/collections`);
+    expect(listed.status).toBe(200);
+    expect(await listed.json()).toEqual({
+      collections: [
+        {
+          name: "notes",
+          path: docsPath,
+          pattern: "**/*.md",
+          documents: 0,
+          activeDocuments: 0,
+          lastModified: null,
+          includeByDefault: true,
+        },
+      ],
+    });
+
+    const failing = await fetch(`${baseUrl}/v1/collections/ensure`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        updates: [{ name: "missing", path: "/private/path" }],
+        markDirty: false,
+      }),
+    });
+    expect(failing.status).toBe(202);
+    const failed = await waitForOperation(
+      ((await failing.json()) as OperationBody).operationId,
+    );
+    expect(failed).toMatchObject({
+      state: "failed",
+      error: { reason: "maintenance_failed" },
+    });
+    expect(JSON.stringify(failed)).not.toContain("/private/path");
+  });
+
+  test("cleans up disconnected requests", async () => {
+    await new Promise<void>((resolve) => {
+      const req = request({
+        hostname: "127.0.0.1",
+        port: handle.port,
+        path: "/v1/search",
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+      req.on("error", () => resolve());
+      req.write('{"searches":[');
+      req.destroy();
+      setTimeout(resolve, 50);
+    });
+    const response = await fetch(`${baseUrl}/health`);
+    expect(response.status).toBe(200);
+    await response.arrayBuffer();
+  });
+
+  test("stops partial requests and shares concurrent stop calls", async () => {
+    expect(process.listenerCount("SIGTERM")).toBe(baselineSigtermListeners + 1);
+    expect(process.listenerCount("SIGINT")).toBe(baselineSigintListeners + 1);
+    const partial = request({
+      hostname: "127.0.0.1",
+      port: handle.port,
+      path: "/v1/search",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+    partial.on("error", () => {});
+    partial.write('{"query":"partial');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const first = handle.stop();
+    const second = handle.stop();
+    expect(second).toBe(first);
+    await Promise.all([first, second]);
+    partial.destroy();
+    expect(process.listenerCount("SIGTERM")).toBe(baselineSigtermListeners);
+    expect(process.listenerCount("SIGINT")).toBe(baselineSigintListeners);
+  }, 2000);
+});

--- a/test/mcp-stdio-lifecycle.test.ts
+++ b/test/mcp-stdio-lifecycle.test.ts
@@ -112,7 +112,7 @@ describe("registerStdioEofShutdown", () => {
 
     expect(r.calls).toEqual(["idle-wait", "llm-dispose", "store-close"]);
     expect(r.warnings.join("")).toContain("server.close() failed during stdio shutdown");
-    expect(r.warnings.join("")).toContain("transport already gone");
+    expect(r.warnings.join("")).not.toContain("transport already gone");
     expect(r.exitCodes).toEqual([1]);
   });
 

--- a/test/mcp-work-service.test.ts
+++ b/test/mcp-work-service.test.ts
@@ -1,0 +1,782 @@
+/** Covers shared search admission, maintenance, and shutdown behavior. */
+import { describe, expect, test, vi } from "vitest";
+import type {
+  HybridQueryResult,
+  QMDStore,
+  SearchResult,
+} from "../src/index.js";
+import {
+  INTERACTIVE_QUEUE_LIMIT,
+  INTERACTIVE_QUEUE_TIMEOUT_MS,
+  LEXICAL_FALLBACK_CONCURRENCY_LIMIT,
+  MAINTENANCE_QUEUE_LIMIT,
+  QMDWorkService,
+} from "../src/mcp/work-service.js";
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function waitForCall(mock: {
+  mock: { calls: unknown[][] };
+}): Promise<void> {
+  for (let attempt = 0; attempt < 20 && mock.mock.calls.length === 0; attempt++)
+    await flush();
+  expect(mock.mock.calls.length).toBeGreaterThan(0);
+}
+
+function lexicalResult(score = 0.8): SearchResult {
+  return {
+    filepath: "/tmp/docs/one.md",
+    displayPath: "docs/one.md",
+    title: "One",
+    context: null,
+    hash: "abcdef123456",
+    docid: "abcdef",
+    collectionName: "docs",
+    modifiedAt: "2026-01-01T00:00:00.000Z",
+    bodyLength: 12,
+    score,
+    source: "fts",
+  };
+}
+
+function semanticResult(): HybridQueryResult {
+  return {
+    file: "qmd://docs/one.md",
+    displayPath: "docs/one.md",
+    title: "One",
+    body: "one document",
+    bestChunk: "one document",
+    bestChunkPos: 0,
+    score: 0.9,
+    context: null,
+    docid: "abcdef",
+  };
+}
+
+function createFakeStore() {
+  const search = vi.fn<
+    (options: Record<string, unknown>) => Promise<HybridQueryResult[]>
+  >(async () => [semanticResult()]);
+  const searchLex = vi.fn(async () => [lexicalResult()]);
+  const getDefaultCollectionNames = vi.fn(async () => ["docs"]);
+  const update = vi.fn(async () => ({
+    collections: 1,
+    indexed: 1,
+    updated: 0,
+    unchanged: 0,
+    removed: 0,
+    skipped: 0,
+    needsEmbedding: 1,
+  }));
+  const embed = vi.fn(async () => ({
+    docsProcessed: 1,
+    chunksEmbedded: 1,
+    errors: 0,
+    durationMs: 1,
+  }));
+  const applyCollectionMutations = vi.fn(async () => undefined);
+  const listCollections = vi.fn(async () => [{ name: "docs" }]);
+  const close = vi.fn(async () => undefined);
+  const store = {
+    search,
+    searchLex,
+    getDefaultCollectionNames,
+    update,
+    embed,
+    applyCollectionMutations,
+    listCollections,
+    close,
+  } as unknown as QMDStore;
+  return {
+    store,
+    search,
+    searchLex,
+    getDefaultCollectionNames,
+    update,
+    embed,
+    applyCollectionMutations,
+    listCollections,
+    close,
+  };
+}
+
+describe("QMDWorkService", () => {
+  test("deduplicates heavy searches and allows explicit lexical searches through", async () => {
+    const fake = createFakeStore();
+    const gate = deferred<HybridQueryResult[]>();
+    fake.search.mockReturnValue(gate.promise);
+    const service = new QMDWorkService(fake.store);
+
+    const first = service.search({ query: "same request" });
+    await waitForCall(fake.search);
+    const second = service.search({ query: "same request" });
+    await vi.waitFor(() => expect(service.metrics.deduplicated).toBe(1));
+
+    expect(service.metrics.activeHeavy).toBe(1);
+    gate.resolve([semanticResult()]);
+
+    await expect(first).resolves.toMatchObject({
+      status: "ok",
+      mode: "semantic",
+    });
+    await expect(second).resolves.toMatchObject({
+      status: "ok",
+      mode: "semantic",
+    });
+    expect(fake.search).toHaveBeenCalledTimes(1);
+
+    const lexical = await service.search({
+      searches: [{ type: "lex", query: "exact term" }],
+      rerank: false,
+    });
+    expect(lexical).toMatchObject({ status: "ok", mode: "lexical" });
+    expect(fake.searchLex).toHaveBeenCalledTimes(1);
+    expect(fake.search).toHaveBeenCalledTimes(1);
+
+    await service.close();
+  });
+
+  test("treats explicit and default empty collection scopes as authoritative", async () => {
+    const fake = createFakeStore();
+    const service = new QMDWorkService(fake.store);
+
+    await expect(
+      service.search({
+        searches: [{ type: "lex", query: "nothing" }],
+        collections: [],
+        rerank: false,
+      }),
+    ).resolves.toMatchObject({
+      status: "ok",
+      mode: "lexical",
+      authoritativeEmpty: true,
+      results: [],
+    });
+    fake.getDefaultCollectionNames.mockResolvedValue([]);
+    await expect(
+      service.search({
+        searches: [{ type: "lex", query: "nothing" }],
+        rerank: false,
+      }),
+    ).resolves.toMatchObject({
+      status: "ok",
+      mode: "lexical",
+      authoritativeEmpty: true,
+      results: [],
+    });
+    expect(fake.searchLex).not.toHaveBeenCalled();
+    expect(fake.search).not.toHaveBeenCalled();
+    await service.close();
+  });
+
+  test("bounds the heavy queue and degrades queued work after its timeout", async () => {
+    const fake = createFakeStore();
+    const activeGate = deferred<HybridQueryResult[]>();
+    fake.search.mockReturnValue(activeGate.promise);
+    const service = new QMDWorkService(fake.store);
+
+    const active = service.search({ query: "active" });
+    await waitForCall(fake.search);
+
+    const controllers = Array.from(
+      { length: INTERACTIVE_QUEUE_LIMIT },
+      () => new AbortController(),
+    );
+    const queued = controllers.map((controller, index) =>
+      service.search({ query: `queued-${index}` }, controller.signal),
+    );
+    await vi.waitFor(() =>
+      expect(service.metrics.queuedInteractive).toBe(INTERACTIVE_QUEUE_LIMIT),
+    );
+
+    const overflow = await service.search({ query: "overflow" });
+    expect(overflow).toMatchObject({
+      status: "ok",
+      mode: "lexical",
+      reason: "queue_full",
+      authoritativeEmpty: false,
+    });
+    expect(service.metrics.queueFull).toBe(1);
+
+    for (const controller of controllers) controller.abort();
+    await Promise.allSettled(queued);
+
+    activeGate.resolve([semanticResult()]);
+    await active;
+    await service.close();
+
+    const timeoutFake = createFakeStore();
+    const timeoutActiveGate = deferred<HybridQueryResult[]>();
+    timeoutFake.search.mockReturnValue(timeoutActiveGate.promise);
+    const timeoutService = new QMDWorkService(timeoutFake.store);
+    const timeoutActive = timeoutService.search({ query: "timeout-active" });
+    await waitForCall(timeoutFake.search);
+    const timedOut = timeoutService.search({ query: "timed-out" });
+
+    await new Promise((resolve) =>
+      setTimeout(resolve, INTERACTIVE_QUEUE_TIMEOUT_MS + 50),
+    );
+    await expect(timedOut).resolves.toMatchObject({
+      status: "ok",
+      mode: "lexical",
+      reason: "queue_timeout",
+      authoritativeEmpty: false,
+    });
+    expect(timeoutService.metrics.queueTimeout).toBe(1);
+
+    timeoutActiveGate.resolve([semanticResult()]);
+    await timeoutActive;
+    await timeoutService.close();
+  }, 10000);
+
+  test("bounds concurrent lexical degradation", async () => {
+    const fake = createFakeStore();
+    const activeGate = deferred<HybridQueryResult[]>();
+    fake.search.mockReturnValue(activeGate.promise);
+    const fallbackGates = Array.from(
+      { length: LEXICAL_FALLBACK_CONCURRENCY_LIMIT },
+      () => deferred<SearchResult[]>(),
+    );
+    let fallbackIndex = 0;
+    fake.searchLex.mockImplementation(
+      async () => fallbackGates[fallbackIndex++]!.promise,
+    );
+    const service = new QMDWorkService(fake.store);
+
+    const active = service.search({ query: "active" });
+    await waitForCall(fake.search);
+    const controllers = Array.from(
+      { length: INTERACTIVE_QUEUE_LIMIT },
+      () => new AbortController(),
+    );
+    const queued = controllers.map((controller, index) =>
+      service.search({ query: `queued-${index}` }, controller.signal),
+    );
+    await vi.waitFor(() =>
+      expect(service.metrics.queuedInteractive).toBe(INTERACTIVE_QUEUE_LIMIT),
+    );
+
+    const fallbacks = fallbackGates.map((_, index) =>
+      service.search({ query: `fallback-${index}` }),
+    );
+    await vi.waitFor(() =>
+      expect(fake.searchLex).toHaveBeenCalledTimes(
+        LEXICAL_FALLBACK_CONCURRENCY_LIMIT,
+      ),
+    );
+    await expect(
+      service.search({ query: "fallback-overflow" }),
+    ).resolves.toMatchObject({
+      status: "unavailable",
+      reason: "queue_full",
+    });
+
+    for (const gate of fallbackGates) gate.resolve([lexicalResult()]);
+    await Promise.all(fallbacks);
+    for (const controller of controllers) controller.abort();
+    await Promise.allSettled(queued);
+    activeGate.resolve([semanticResult()]);
+    await active;
+    await service.close();
+  });
+
+  test("prioritizes queued interactive work over maintenance", async () => {
+    const fake = createFakeStore();
+    const activeGate = deferred<HybridQueryResult[]>();
+    const queuedGate = deferred<HybridQueryResult[]>();
+    fake.search
+      .mockReturnValueOnce(activeGate.promise)
+      .mockReturnValueOnce(queuedGate.promise);
+    const service = new QMDWorkService(fake.store);
+
+    const active = service.search({ query: "active" });
+    await waitForCall(fake.search);
+    const update = service.scheduleUpdate({ collections: ["docs"] });
+    const queued = service.search({ query: "queued" });
+    await vi.waitFor(() => expect(service.metrics.queuedInteractive).toBe(1));
+
+    activeGate.resolve([semanticResult()]);
+    await vi.waitFor(() => expect(fake.search).toHaveBeenCalledTimes(2));
+    expect(fake.update).not.toHaveBeenCalled();
+
+    queuedGate.resolve([semanticResult()]);
+    await active;
+    await queued;
+    await vi.waitFor(() =>
+      expect(service.getOperation(update.operationId)?.state).toBe("completed"),
+    );
+    await service.close();
+  });
+
+  test("keeps maintenance exclusive and coalesces queued updates", async () => {
+    const fake = createFakeStore();
+    const firstEmbedGate = deferred<Awaited<ReturnType<typeof fake.embed>>>();
+    const updateGate = deferred<Awaited<ReturnType<typeof fake.update>>>();
+    const secondEmbedGate = deferred<Awaited<ReturnType<typeof fake.embed>>>();
+    fake.embed
+      .mockReturnValueOnce(firstEmbedGate.promise)
+      .mockReturnValueOnce(secondEmbedGate.promise);
+    fake.update.mockReturnValue(updateGate.promise);
+    const service = new QMDWorkService(fake.store);
+
+    const firstEmbed = service.scheduleEmbed();
+    await waitForCall(fake.embed);
+    const update = service.scheduleUpdate({ collections: ["one"] });
+    const coalesced = service.scheduleUpdate({ collections: ["two"] });
+    const secondEmbed = service.scheduleEmbed({ force: true });
+    expect(secondEmbed.state).toBe("queued");
+
+    expect(coalesced).toMatchObject({
+      operationId: update.operationId,
+      coalesced: true,
+    });
+    expect(service.metrics.maintenanceActive).toBe(true);
+    const blocked = await service.search({
+      searches: [{ type: "lex", query: "during maintenance" }],
+      rerank: false,
+    });
+    expect(blocked).toMatchObject({
+      status: "unavailable",
+      reason: "maintenance_busy",
+    });
+    expect(fake.searchLex).not.toHaveBeenCalled();
+
+    firstEmbedGate.resolve({
+      docsProcessed: 1,
+      chunksEmbedded: 1,
+      errors: 0,
+      durationMs: 1,
+    });
+    await vi.waitFor(() => expect(fake.update).toHaveBeenCalledTimes(1));
+    expect(fake.update).toHaveBeenCalledWith({
+      collections: ["one", "two"],
+    });
+
+    updateGate.resolve({
+      collections: 1,
+      indexed: 1,
+      updated: 0,
+      unchanged: 0,
+      removed: 0,
+      skipped: 0,
+      needsEmbedding: 0,
+    });
+    await vi.waitFor(() =>
+      expect(service.getOperation(update.operationId)?.state).toBe("completed"),
+    );
+    expect(service.getOperation(firstEmbed.operationId)?.state).toBe(
+      "completed",
+    );
+
+    await vi.waitFor(() => expect(fake.embed).toHaveBeenCalledTimes(2));
+    expect(service.getOperation(secondEmbed.operationId)?.state).toBe(
+      "running",
+    );
+    secondEmbedGate.resolve({
+      docsProcessed: 1,
+      chunksEmbedded: 1,
+      errors: 0,
+      durationMs: 1,
+    });
+    await vi.waitFor(() =>
+      expect(service.getOperation(secondEmbed.operationId)?.state).toBe(
+        "completed",
+      ),
+    );
+    expect(service.metrics.maintenanceActive).toBe(false);
+
+    const after = await service.search({
+      searches: [{ type: "lex", query: "after maintenance" }],
+      rerank: false,
+    });
+    expect(after).toMatchObject({ status: "ok", mode: "lexical" });
+    await service.close();
+  });
+
+  test("ensures collections through the exclusive service and closes after active work", async () => {
+    const fake = createFakeStore();
+    const service = new QMDWorkService(fake.store);
+
+    const ensure = service.scheduleEnsure({
+      adds: [
+        {
+          name: "notes",
+          path: "/tmp/notes",
+          pattern: "**/*.md",
+        },
+      ],
+      contexts: [
+        {
+          collection: "notes",
+          path: "README.md",
+          context: "Personal notes",
+        },
+      ],
+      markDirty: false,
+    });
+    await vi.waitFor(() =>
+      expect(service.getOperation(ensure.operationId)?.state).toBe("completed"),
+    );
+    expect(fake.applyCollectionMutations).toHaveBeenCalledWith([
+      {
+        kind: "upsert",
+        name: "notes",
+        path: "/tmp/notes",
+        pattern: "**/*.md",
+      },
+      {
+        kind: "context",
+        collection: "notes",
+        path: "README.md",
+        context: "Personal notes",
+      },
+    ]);
+    expect(fake.update).not.toHaveBeenCalled();
+
+    const gate = deferred<HybridQueryResult[]>();
+    fake.search.mockReturnValue(gate.promise);
+    const active = service.search({ query: "close waits" });
+    await waitForCall(fake.search);
+    const closing = service.close();
+    await flush();
+    expect(fake.close).not.toHaveBeenCalled();
+    await expect(
+      service.search({ query: "after close" }),
+    ).rejects.toMatchObject({
+      reason: "closed",
+    });
+    gate.resolve([semanticResult()]);
+    await active;
+    await closing;
+    expect(fake.close).toHaveBeenCalledTimes(1);
+  });
+
+  test("cancels queued and active searches without cancelling shared work", async () => {
+    const fake = createFakeStore();
+    const activeGate = deferred<HybridQueryResult[]>();
+    fake.search.mockReturnValue(activeGate.promise);
+    const service = new QMDWorkService(fake.store);
+
+    const activeController = new AbortController();
+    const active = service.search({ query: "active" }, activeController.signal);
+    await waitForCall(fake.search);
+    const queuedController = new AbortController();
+    const queued = service.search({ query: "queued" }, queuedController.signal);
+    await vi.waitFor(() => expect(service.metrics.queuedInteractive).toBe(1));
+
+    queuedController.abort();
+    await expect(queued).rejects.toMatchObject({ name: "AbortError" });
+    expect(service.metrics.queuedInteractive).toBe(0);
+    expect(fake.search).toHaveBeenCalledTimes(1);
+
+    activeController.abort();
+    await expect(active).rejects.toMatchObject({ name: "AbortError" });
+    activeGate.resolve([semanticResult()]);
+    await flush();
+    expect(fake.search).toHaveBeenCalledTimes(1);
+    await service.close();
+  });
+
+  test("coalesces identical maintenance and queues distinct work", async () => {
+    const fake = createFakeStore();
+    const embedGate = deferred<Awaited<ReturnType<typeof fake.embed>>>();
+    fake.embed.mockReturnValue(embedGate.promise);
+    const service = new QMDWorkService(fake.store);
+
+    const firstEmbed = service.scheduleEmbed();
+    await waitForCall(fake.embed);
+    expect(
+      service.scheduleEmbed({
+        force: false,
+        maxDocsPerBatch: 64,
+        maxBatchBytes: 64 * 1024 * 1024,
+        chunkStrategy: "regex",
+      }),
+    ).toMatchObject({
+      operationId: firstEmbed.operationId,
+      coalesced: true,
+    });
+    const distinct = service.scheduleEmbed({ force: true });
+    expect(distinct.operationId).not.toBe(firstEmbed.operationId);
+    expect(distinct.state).toBe("queued");
+
+    embedGate.resolve({
+      docsProcessed: 1,
+      chunksEmbedded: 1,
+      errors: 0,
+      durationMs: 1,
+    });
+    await vi.waitFor(() =>
+      expect(service.getOperation(firstEmbed.operationId)?.state).toBe(
+        "completed",
+      ),
+    );
+    await vi.waitFor(() =>
+      expect(service.getOperation(distinct.operationId)?.state).toBe(
+        "completed",
+      ),
+    );
+    expect(fake.embed).toHaveBeenCalledTimes(2);
+    await service.close();
+  });
+
+  test("queues an identical embed after intervening maintenance", async () => {
+    const fake = createFakeStore();
+    const firstEmbedGate = deferred<Awaited<ReturnType<typeof fake.embed>>>();
+    const updateGate = deferred<Awaited<ReturnType<typeof fake.update>>>();
+    const secondEmbedGate = deferred<Awaited<ReturnType<typeof fake.embed>>>();
+    fake.embed
+      .mockReturnValueOnce(firstEmbedGate.promise)
+      .mockReturnValueOnce(secondEmbedGate.promise);
+    fake.update.mockReturnValue(updateGate.promise);
+    const service = new QMDWorkService(fake.store);
+
+    const firstEmbed = service.scheduleEmbed();
+    await waitForCall(fake.embed);
+    service.scheduleUpdate({ collections: ["docs"] });
+    const secondEmbed = service.scheduleEmbed();
+    expect(secondEmbed).toMatchObject({ state: "queued", coalesced: false });
+    expect(secondEmbed.operationId).not.toBe(firstEmbed.operationId);
+
+    firstEmbedGate.resolve({
+      docsProcessed: 1,
+      chunksEmbedded: 1,
+      errors: 0,
+      durationMs: 1,
+    });
+    await waitForCall(fake.update);
+    updateGate.resolve({
+      collections: 1,
+      indexed: 1,
+      updated: 0,
+      unchanged: 0,
+      removed: 0,
+      skipped: 0,
+      needsEmbedding: 1,
+    });
+    await vi.waitFor(() => expect(fake.embed).toHaveBeenCalledTimes(2));
+    secondEmbedGate.resolve({
+      docsProcessed: 1,
+      chunksEmbedded: 1,
+      errors: 0,
+      durationMs: 1,
+    });
+    await vi.waitFor(() =>
+      expect(service.getOperation(secondEmbed.operationId)?.state).toBe(
+        "completed",
+      ),
+    );
+    await service.close();
+  });
+
+  test("coalesces identical collection ensures", async () => {
+    const fake = createFakeStore();
+    const applyGate =
+      deferred<Awaited<ReturnType<typeof fake.applyCollectionMutations>>>();
+    fake.applyCollectionMutations.mockReturnValue(applyGate.promise);
+    const service = new QMDWorkService(fake.store);
+    const request = {
+      adds: [{ name: "notes", path: "/tmp/notes" }],
+      markDirty: false,
+    };
+
+    const first = service.scheduleEnsure(request);
+    await waitForCall(fake.applyCollectionMutations);
+    expect(service.scheduleEnsure(request)).toMatchObject({
+      operationId: first.operationId,
+      coalesced: true,
+    });
+    const distinct = service.scheduleEnsure({
+      adds: [{ name: "other", path: "/tmp/other" }],
+      markDirty: false,
+    });
+    expect(distinct.operationId).not.toBe(first.operationId);
+    expect(distinct.state).toBe("queued");
+
+    applyGate.resolve(undefined);
+    await vi.waitFor(() =>
+      expect(service.getOperation(first.operationId)?.state).toBe("completed"),
+    );
+    await vi.waitFor(() =>
+      expect(service.getOperation(distinct.operationId)?.state).toBe(
+        "completed",
+      ),
+    );
+    expect(fake.applyCollectionMutations).toHaveBeenCalledTimes(2);
+    await service.close();
+  });
+
+  test("preflights collection mutations and removes empty contexts", async () => {
+    const fake = createFakeStore();
+    fake.listCollections.mockResolvedValue([
+      { name: "old" },
+      { name: "existing" },
+    ]);
+    const service = new QMDWorkService(fake.store);
+
+    const operation = service.scheduleEnsure({
+      adds: [{ name: "notes", path: "/tmp/notes" }],
+      updates: [{ name: "renamed", path: "/tmp/renamed" }],
+      renames: [{ from: "old", to: "renamed" }],
+      contexts: [{ collection: "renamed", path: "/", context: "" }],
+      markDirty: false,
+    });
+    await vi.waitFor(() =>
+      expect(service.getOperation(operation.operationId)?.state).toBe(
+        "completed",
+      ),
+    );
+    expect(fake.applyCollectionMutations).toHaveBeenCalledWith([
+      { kind: "rename", from: "old", to: "renamed" },
+      { kind: "upsert", name: "notes", path: "/tmp/notes" },
+      { kind: "upsert", name: "renamed", path: "/tmp/renamed" },
+      {
+        kind: "context",
+        collection: "renamed",
+        path: "/",
+        context: "",
+      },
+    ]);
+
+    expect(() =>
+      service.scheduleEnsure({
+        renames: [
+          { from: "a", to: "b" },
+          { from: "b", to: "c" },
+        ],
+      }),
+    ).toThrow(expect.objectContaining({ reason: "malformed" }));
+
+    fake.listCollections.mockResolvedValue([{ name: "docs" }]);
+    const collision = service.scheduleEnsure({
+      adds: [{ name: "docs", path: "/tmp/docs" }],
+      markDirty: false,
+    });
+    await vi.waitFor(() =>
+      expect(service.getOperation(collision.operationId)).toMatchObject({
+        state: "failed",
+        error: { reason: "maintenance_failed" },
+      }),
+    );
+    expect(fake.applyCollectionMutations).toHaveBeenCalledTimes(1);
+    await service.close();
+  });
+
+  test("schedules bounded dirty updates without blocking distinct maintenance", async () => {
+    const fake = createFakeStore();
+    const activeGate = deferred<Awaited<ReturnType<typeof fake.embed>>>();
+    fake.embed.mockReturnValue(activeGate.promise);
+    const service = new QMDWorkService(fake.store);
+
+    const active = service.scheduleEmbed({ model: "active" });
+    await waitForCall(fake.embed);
+    const update = service.scheduleUpdate({ collections: ["docs"] });
+    const ensure = service.scheduleEnsure({
+      adds: [{ name: "notes", path: "/tmp/notes" }],
+      markDirty: true,
+    });
+    const queuedEmbed = service.scheduleEmbed({ model: "queued" });
+    expect(service.metrics.queuedMaintenance).toBe(3);
+    expect(ensure.operationId).not.toBe(update.operationId);
+    expect(queuedEmbed.state).toBe("queued");
+
+    activeGate.resolve({
+      docsProcessed: 1,
+      chunksEmbedded: 1,
+      errors: 0,
+      durationMs: 1,
+    });
+    await vi.waitFor(() =>
+      expect(service.getOperation(active.operationId)?.state).toBe("completed"),
+    );
+    await vi.waitFor(() =>
+      expect(service.getOperation(ensure.operationId)?.state).toBe("completed"),
+    );
+    await vi.waitFor(() =>
+      expect(service.getOperation(queuedEmbed.operationId)?.state).toBe(
+        "completed",
+      ),
+    );
+    expect(fake.update).toHaveBeenCalledWith({
+      collections: ["docs", "notes"],
+    });
+    await service.close();
+  });
+
+  test("bounds distinct maintenance requests", async () => {
+    const fake = createFakeStore();
+    const gate = deferred<Awaited<ReturnType<typeof fake.embed>>>();
+    fake.embed.mockReturnValue(gate.promise);
+    const service = new QMDWorkService(fake.store);
+
+    service.scheduleEmbed({ model: "active" });
+    await waitForCall(fake.embed);
+    for (let index = 0; index < MAINTENANCE_QUEUE_LIMIT; index += 1)
+      service.scheduleEmbed({ model: `queued-${index}` });
+    expect(service.metrics.queuedMaintenance).toBe(MAINTENANCE_QUEUE_LIMIT);
+    expect(() => service.scheduleEmbed({ model: "overflow" })).toThrow(
+      expect.objectContaining({ reason: "maintenance_busy" }),
+    );
+
+    gate.resolve({
+      docsProcessed: 1,
+      chunksEmbedded: 1,
+      errors: 0,
+      durationMs: 1,
+    });
+    await service.close();
+  });
+
+  test("rejects malformed search requests instead of invoking the store", async () => {
+    const fake = createFakeStore();
+    const service = new QMDWorkService(fake.store);
+
+    await expect(service.search({ query: "" })).rejects.toMatchObject({
+      reason: "malformed",
+    });
+    await expect(
+      service.search({ query: "large", limit: 501 }),
+    ).rejects.toMatchObject({ reason: "malformed" });
+    await expect(
+      service.search({ query: "large", candidateLimit: 501 }),
+    ).rejects.toMatchObject({ reason: "malformed" });
+    expect(fake.getDefaultCollectionNames).not.toHaveBeenCalled();
+    await service.close();
+  });
+
+  test("reports lexical fallback as non-authoritative when the store fails", async () => {
+    const fake = createFakeStore();
+    fake.searchLex.mockRejectedValue(new Error("temporary store failure"));
+    const service = new QMDWorkService(fake.store);
+
+    const result = await service.search({
+      searches: [{ type: "lex", query: "missing" }],
+      rerank: false,
+    });
+    expect(result).toMatchObject({
+      status: "unavailable",
+      reason: "store_error",
+      authoritativeEmpty: false,
+    });
+    await service.close();
+  });
+});

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -195,14 +195,19 @@ describe("collection management", () => {
     expect(removed).toBe(false);
   });
 
-  test("renameCollection renames a collection", async () => {
+  test("renameCollection renames metadata and indexed documents", async () => {
     await store.addCollection("old-name", { path: docsDir, pattern: "**/*.md" });
+    await store.update({ collections: ["old-name"] });
     const renamed = await store.renameCollection("old-name", "new-name");
 
     expect(renamed).toBe(true);
     const names = (await store.listCollections()).map(c => c.name);
     expect(names).toContain("new-name");
     expect(names).not.toContain("old-name");
+    const indexed = store.internal.db
+      .prepare(`SELECT DISTINCT collection FROM documents`)
+      .all() as Array<{ collection: string }>;
+    expect(indexed).toEqual([{ collection: "new-name" }]);
   });
 
   test("renameCollection returns false for non-existent source", async () => {
@@ -386,6 +391,40 @@ describe("inline config isolation", () => {
     await store.close();
   });
 
+  test("collection batches update and restore the caller's inline config", async () => {
+    const config: CollectionConfig = {
+      collections: {
+        docs: { path: docsDir, pattern: "*.md" },
+      },
+    };
+    const store = await createStore({ dbPath: freshDbPath(), config });
+
+    await store.applyCollectionMutations([
+      { kind: "upsert", name: "docs", path: notesDir },
+    ]);
+    expect(config.collections.docs).toEqual({
+      path: notesDir,
+      pattern: "*.md",
+    });
+
+    await expect(
+      store.applyCollectionMutations([
+        { kind: "upsert", name: "docs", path: docsDir },
+        {
+          kind: "context",
+          collection: "missing",
+          path: "/",
+          context: "Missing",
+        },
+      ]),
+    ).rejects.toThrow("collection context update failed");
+    expect(config.collections.docs).toEqual({
+      path: notesDir,
+      pattern: "*.md",
+    });
+    await store.close();
+  });
+
   test("two stores with different inline configs are independent", async () => {
     const store1 = await createStore({
       dbPath: freshDbPath(),
@@ -452,6 +491,82 @@ describe("YAML config file mode", () => {
     const parsed = YAML.parse(raw) as CollectionConfig;
     expect(parsed.collections).toHaveProperty("newcol");
     expect(parsed.collections.newcol!.path).toBe(docsDir);
+  });
+
+  test("partial collection updates preserve existing settings", async () => {
+    const configPath = join(testDir, `config-preserve-${Date.now()}.yml`);
+    writeFileSync(
+      configPath,
+      YAML.stringify({
+        collections: {
+          docs: {
+            path: docsDir,
+            pattern: "*.md",
+            ignore: ["drafts/**"],
+            includeByDefault: false,
+            update: "git pull --ff-only",
+            context: { "/": "Documentation" },
+          },
+        },
+      }),
+    );
+
+    const store = await createStore({ dbPath: freshDbPath(), configPath });
+    await store.addCollection("docs", { path: notesDir });
+    const row = store.internal.db
+      .prepare(
+        `
+      SELECT path, pattern, ignore_patterns, include_by_default, update_command, context
+      FROM store_collections WHERE name = 'docs'
+    `,
+      )
+      .get();
+    expect(row).toEqual({
+      path: notesDir,
+      pattern: "*.md",
+      ignore_patterns: JSON.stringify(["drafts/**"]),
+      include_by_default: 0,
+      update_command: "git pull --ff-only",
+      context: JSON.stringify({ "/": "Documentation" }),
+    });
+    await store.close();
+
+    const parsed = YAML.parse(
+      readFileSync(configPath, "utf-8"),
+    ) as CollectionConfig;
+    expect(parsed.collections.docs).toEqual({
+      path: notesDir,
+      pattern: "*.md",
+      ignore: ["drafts/**"],
+      includeByDefault: false,
+      update: "git pull --ff-only",
+      context: { "/": "Documentation" },
+    });
+  });
+
+  test("collection mutation batches roll back on failure", async () => {
+    const configPath = join(testDir, `config-rollback-${Date.now()}.yml`);
+    writeFileSync(configPath, YAML.stringify({ collections: {} }));
+    const store = await createStore({ dbPath: freshDbPath(), configPath });
+
+    await expect(
+      store.applyCollectionMutations([
+        { kind: "upsert", name: "notes", path: notesDir },
+        {
+          kind: "context",
+          collection: "missing",
+          path: "/",
+          context: "Missing",
+        },
+      ]),
+    ).rejects.toThrow("collection context update failed");
+    expect(await store.listCollections()).toEqual([]);
+    await store.close();
+
+    const parsed = YAML.parse(
+      readFileSync(configPath, "utf-8"),
+    ) as CollectionConfig;
+    expect(parsed.collections).toEqual({});
   });
 
   test("context persists to YAML file", async () => {


### PR DESCRIPTION
**TLDR:** Add one loopback API-v1 daemon that bounds local inference and maintenance work across all clients.

### Situation / This PR / After Merging

- **Situation:** Separate QMD processes can load duplicate native model stacks and run heavy work without shared admission control.
- **This PR:** Adds a shared work service, versioned HTTP endpoints, bounded queues, request deduplication, cancellation, and coalesced maintenance.
- **After merging:** Clients can share one warm QMD process and receive typed degraded or unavailable outcomes under load.

### Behavior

- Semantic work uses one active slot and a bounded interactive queue. Bounded lexical fallback preserves search availability.
- Update, embed, and collection setup operations share one bounded maintenance queue and expose operation status.
- Collection setup applies one transactional database batch and restores configuration after failures.
- Existing MCP and unversioned HTTP routes remain available.

### Safety note

The daemon binds to loopback by default, validates collection scopes and request sizes, and omits queries, paths, prompts, bodies, and raw errors from logs. Empty degraded lexical results are non-authoritative, so clients can use their own fallback.

### Top-hatting

- `pnpm run test:types && pnpm run build && pnpm run test:node` — typecheck and build passed; 45 files and 1,245 tests passed.
- Started `dist/cli/qmd.js mcp --http --host 127.0.0.1` with temporary config and index paths. `/health` reported API v1, and an explicitly empty-scope `/v1/search` returned an authoritative empty result without local inference.
- Bun tests were not run locally because Bun is not installed in this environment.
