### PR TITLE
fix(embed): report actual completion and session expiry (additive)

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -2241,7 +2241,11 @@ async function vectorIndex(
       console.log(`${c.green}✓ No non-empty documents to embed.${c.reset}`);
     } else {
       console.log(`\r${c.green}${renderProgressBar(100)}${c.reset} ${c.bold}100%${c.reset}                                    `);
-      console.log(`\n${c.green}✓ Done!${c.reset} Embedded ${c.bold}${result.chunksEmbedded}${c.reset} chunks from ${c.bold}${result.docsProcessed}${c.reset} documents in ${c.bold}${formatETA(totalTimeSec)}${c.reset}`);
+      console.log(`\n${c.green}✓ Done!${c.reset} Embedded ${c.bold}${result.chunksEmbedded}${c.reset} chunks from ${c.bold}${result.docsCompleted}${c.reset} documents in ${c.bold}${formatETA(totalTimeSec)}${c.reset}`);
+      if (result.remainingDocs > 0) {
+        const stopReason = result.sessionExpired ? "session expired at the duration cap" : "run stopped early";
+        console.log(`${c.yellow}⚠ ${formatCount(result.remainingDocs)} documents remaining (${stopReason}) — re-run \`qmd embed\` to continue${c.reset}`);
+      }
       if (result.errors > 0) {
         console.log(`${c.yellow}⚠ ${formatCount(result.errors)} chunks still failed after retries${c.reset}`);
         for (const failure of (result.failures ?? []).slice(0, 8)) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1705,7 +1705,18 @@ export type EmbedProgress = {
 };
 
 export type EmbedResult = {
+  /**
+   * Number of pending documents selected at run start. Kept for backward
+   * compatibility; use {@link EmbedResult.docsCompleted} for the number of
+   * documents actually completed before the run ended.
+   */
   docsProcessed: number;
+  /** Number of documents whose chunks were fully embedded before the run ended. */
+  docsCompleted: number;
+  /** Number of selected documents that remain pending (docsProcessed - docsCompleted). */
+  remainingDocs: number;
+  /** True when the run stopped because the session duration cap was reached. */
+  sessionExpired: boolean;
   chunksEmbedded: number;
   /** Active failed chunks that did not recover after retries. */
   errors: number;
@@ -1940,11 +1951,12 @@ export async function generateEmbeddings(
   const docsToEmbed = getPendingEmbeddingDocs(db, options?.collection, model);
 
   if (docsToEmbed.length === 0) {
-    return { docsProcessed: 0, chunksEmbedded: 0, errors: 0, durationMs: 0 };
+    return { docsProcessed: 0, docsCompleted: 0, remainingDocs: 0, sessionExpired: false, chunksEmbedded: 0, errors: 0, durationMs: 0 };
   }
   const totalBytes = docsToEmbed.reduce((sum, doc) => sum + Math.max(0, doc.bytes), 0);
   const totalDocs = docsToEmbed.length;
   const startTime = Date.now();
+  let docsCompleted = 0;
 
   // Use store's LlamaCpp or global singleton, wrapped in a session
   const embedModelUri = model;
@@ -2166,15 +2178,25 @@ export async function generateEmbeddings(
         chunksEmbedded = Math.max(0, chunksEmbedded - removedPartialChunks);
       }
 
+      const countChunksStmt = db.prepare(`SELECT COUNT(*) as count FROM content_vectors WHERE hash = ? AND model = ?`);
+      for (const [hash, expectedChunks] of expectedChunksByHash) {
+        if (expectedChunks === 0) continue;
+        const row = countChunksStmt.get(hash, model) as { count: number };
+        if (row.count === expectedChunks) docsCompleted++;
+      }
+
       bytesProcessed += batchBytes;
       options?.onProgress?.({ chunksEmbedded, totalChunks, bytesProcessed, totalBytes, errors: activeErrorCount(), failures: failureList() });
     }
 
-    return { chunksEmbedded, errors: activeErrorCount(), failures: failureList() };
+    return { chunksEmbedded, errors: activeErrorCount(), failures: failureList(), sessionExpired: !session.isValid };
   }, { maxDuration: options?.maxDurationMs ?? DEFAULT_EMBED_MAX_DURATION_MS, name: 'generateEmbeddings' });
 
   return {
     docsProcessed: totalDocs,
+    docsCompleted,
+    remainingDocs: totalDocs - docsCompleted,
+    sessionExpired: result.sessionExpired,
     chunksEmbedded: result.chunksEmbedded,
     errors: result.errors,
     failures: result.failures,

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -4124,6 +4124,9 @@ describe("Embedding batching", () => {
       expect(fakeLlm.embedBatchCalls).toHaveLength(3);
       expect(fakeLlm.embedBatchCalls.map(call => call.length)).toEqual([1, 1, 1]);
       expect(result.docsProcessed).toBe(3);
+      expect(result.docsCompleted).toBe(3);
+      expect(result.remainingDocs).toBe(0);
+      expect(result.sessionExpired).toBe(false);
       expect(result.chunksEmbedded).toBe(3);
       expect(db.prepare(`SELECT COUNT(*) as count FROM content_vectors`).get()).toEqual({ count: 3 });
     } finally {
@@ -4164,6 +4167,10 @@ describe("Embedding batching", () => {
       expect(embedBatchCalls.length).toBeGreaterThanOrEqual(1);
       expect(embedBatchCalls.length).toBeLessThan(3);
       expect(result.chunksEmbedded).toBeLessThan(3);
+      expect(result.docsProcessed).toBe(3);
+      expect(result.docsCompleted + result.remainingDocs).toBe(3);
+      expect(result.remainingDocs).toBeGreaterThan(0);
+      expect(result.sessionExpired).toBe(true);
     } finally {
       setDefaultLlamaCpp(null);
       await cleanupTestDb(store);


### PR DESCRIPTION
## What

Additive, non-breaking reporting fix for the embed failure mode described in #724. `EmbedResult` now distinguishes between documents **selected** at run start (`docsProcessed`, kept for compatibility) and documents actually **completed** before the run ended (`docsCompleted`, `remainingDocs`, `sessionExpired`).

## Why

`generateEmbeddings()` returned `docsProcessed: totalDocs` — the pending selection at run start, not the number of documents completed before session expiry. The CLI printed `✓ Done! Embedded X chunks from Y documents` with Y = that selection and exited 0. A run stopped at the session cap can therefore look like a completed run to automation even though `qmd status` still shows pending documents.

The on-disk partial-state problem from #637 is already handled (keep-partial fix); this is specifically about **result semantics / operator visibility**.

## Changes

- `EmbedResult`: adds `docsCompleted`, `remainingDocs`, `sessionExpired`; `docsProcessed` retained and documented as "pending selection at run start".
- CLI summary: prints completed documents; when `remainingDocs > 0`, adds `⚠ N documents remaining (session expired at the duration cap | run stopped early) — re-run qmd embed to continue`. Exit code unchanged.
- Tests: extended the existing `maxDurationMs` expiry test and the full-run test to assert the new fields.

## Testing

- `npm run test:types` passes.
- vitest "Embedding batching" (`test/store.test.ts`): 14/14 pass, including the two extended tests.
