### PR TITLE
feat: add fail-closed shared Qwen embedding and reranking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixes
+
+- Doctor: distinguish bounded remote-embedding batch-shape numerical drift from stale or corrupt vectors, while retaining strict local checks and fail-closed handling for material remote mismatches.
+
 ### Security
 
 - `qmd update` no longer runs a project-local `.qmd/index.yml`'s `update:`

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -9,6 +9,7 @@ import { basename, dirname, join as pathJoin, relative as relativePath, resolve 
 import { parseArgs } from "util";
 import { readFileSync, readdirSync, realpathSync, statSync, existsSync, unlinkSync, writeFileSync, openSync, closeSync, mkdirSync, lstatSync, rmSync, symlinkSync, readlinkSync, copyFileSync } from "fs";
 import { createInterface } from "readline/promises";
+import { createHash } from "node:crypto";
 import {
   getPwd,
   getRealPath,
@@ -86,7 +87,7 @@ import {
   type ReindexResult,
   type ChunkStrategy,
 } from "../store.js";
-import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, setDefaultLlamaCpp, LlamaCpp, withLLMSession, pullModels, DEFAULT_MODEL_CACHE_DIR, resolveEmbedModel, resolveGenerateModel, resolveRerankModel, resolveModels, inspectGgufFile, isDarwinMetalMitigationActive } from "../llm.js";
+import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, setDefaultLlamaCpp, LlamaCpp, withLLMSession, withLLMSessionForLlm, pullModels, DEFAULT_MODEL_CACHE_DIR, resolveEmbedModel, resolveGenerateModel, resolveRerankModel, resolveModels, inspectGgufFile, isDarwinMetalMitigationActive } from "../llm.js";
 import {
   formatSearchResults,
   formatDocuments,
@@ -145,30 +146,55 @@ import {
 // =============================================================================
 
 let store: ReturnType<typeof createStore> | null = null;
+let doctorConfigLoadFailed = false;
 let storeDbPathOverride: string | undefined;
 let currentIndexName = "index";
 
-function getStore(): ReturnType<typeof createStore> {
+function getStore(options: { allowInvalidYamlForDoctor?: boolean } = {}): ReturnType<typeof createStore> {
   if (!store) {
+    doctorConfigLoadFailed = false;
     store = createStore(storeDbPathOverride);
-    // Sync YAML config into SQLite store_collections so store.ts reads from DB
+    // Sync YAML config into SQLite store_collections so store.ts reads from DB.
+    // loadConfig() handles an absent config; malformed structured remote model
+    // configuration must propagate so it cannot silently fall back to defaults.
+    let config: CollectionConfig;
     try {
-      const activeModels = ensureModelsConfiguredForCli();
-      const config = loadConfig();
-      syncConfigToDb(store.db, config);
-      // Untrusted project-local custom model URIs must not be loaded; status
-      // still displays the YAML values via resolveModelsForCli (#889).
-      const modelsForLlm = localConfigIsFullyTrusted() ? activeModels : resolveModels();
+      config = loadConfig();
+    } catch (error) {
+      if (!options.allowInvalidYamlForDoctor) throw error;
+      doctorConfigLoadFailed = true;
+      const defaults = resolveModels();
       const llm = new LlamaCpp({
-        embedModel: modelsForLlm.embed,
-        generateModel: modelsForLlm.generate,
-        rerankModel: modelsForLlm.rerank,
+        embedModel: defaults.embed,
+        generateModel: defaults.generate,
+        rerankModel: defaults.rerank,
       });
       setDefaultLlamaCpp(llm);
       store.llm = llm;
-    } catch {
-      // Config may not exist yet — that's fine, DB works without it
+      return store;
     }
+    const activeModels = ensureModelsConfiguredForCli();
+    syncConfigToDb(store.db, config);
+    // Validate configured structured models before trust gating. An untrusted
+    // malformed remote config must fail closed rather than being replaced by
+    // defaults before its endpoint/provider/model contract is checked.
+    const configuredLlm = new LlamaCpp({
+      embedModel: activeModels.embed,
+      generateModel: activeModels.generate,
+      rerankModel: activeModels.rerank,
+    });
+    // Untrusted project-local custom model URIs must not be loaded; status
+    // still displays the YAML values via resolveModelsForCli (#889).
+    const modelsForLlm = localConfigIsFullyTrusted() ? activeModels : resolveModels();
+    const llm = localConfigIsFullyTrusted()
+      ? configuredLlm
+      : new LlamaCpp({
+          embedModel: modelsForLlm.embed,
+          generateModel: modelsForLlm.generate,
+          rerankModel: modelsForLlm.rerank,
+        });
+    setDefaultLlamaCpp(llm);
+    store.llm = llm;
   }
   return store;
 }
@@ -350,8 +376,8 @@ function formatETA(seconds: number): string {
 
 
 // Check index health and print warnings/tips
-function checkIndexHealth(db: Database, model: string = resolveEmbedModelForCli()): void {
-  const { needsEmbedding, totalDocs, daysStale } = getIndexHealth(db, model);
+function checkIndexHealth(storeInstance: ReturnType<typeof createStore>, model?: string): void {
+  const { needsEmbedding, totalDocs, daysStale } = storeInstance.getIndexHealth(model);
 
   // Warn if many docs need embedding
   if (needsEmbedding > 0) {
@@ -513,7 +539,8 @@ function formatOrphanedVectorHint(orphaned: number, total: number): string {
 
 async function showStatus(): Promise<void> {
   const dbPath = getDbPath();
-  const db = getDb();
+  const storeInstance = getStore();
+  const db = storeInstance.db;
 
   // Collections are defined in YAML; no duplicate cleanup needed.
   // Collections are defined in YAML; no duplicate cleanup needed.
@@ -531,8 +558,7 @@ async function showStatus(): Promise<void> {
   // Overall stats
   const totalDocs = db.prepare(`SELECT COUNT(*) as count FROM documents WHERE active = 1`).get() as { count: number };
   const vectorCount = db.prepare(`SELECT COUNT(*) as count FROM content_vectors`).get() as { count: number };
-  const statusEmbedModel = resolveEmbedModelForCli();
-  const needsEmbedding = getHashesNeedingEmbedding(db, undefined, statusEmbedModel);
+  const needsEmbedding = storeInstance.getHashesNeedingEmbedding();
 
   // Most recent update across all collections
   const mostRecent = db.prepare(`SELECT MAX(modified_at) as latest FROM documents WHERE active = 1`).get() as { latest: string | null };
@@ -714,6 +740,16 @@ function builtinModels(): BuiltinModels {
   };
 }
 
+function safeRemoteEndpointTrustIdentity(endpoint: string): string {
+  const digest = createHash("sha256").update(endpoint).digest("hex").slice(0, 12);
+  try {
+    const url = new URL(endpoint);
+    return `${url.protocol}//${url.host || "invalid-host"}/[redacted]@sha256:${digest}`;
+  } catch {
+    return `[invalid-endpoint]@sha256:${digest}`;
+  }
+}
+
 /**
  * Gated surface of the active YAML: hooks, collection paths, models.
  * Read from the YAML rather than the synced SQLite copy so `qmd trust`
@@ -730,8 +766,16 @@ function collectSensitiveSnapshot(): SensitiveSnapshot {
       path: col.path,
     })),
     models: {
-      embed: config.models?.embed,
-      rerank: config.models?.rerank,
+      embed: typeof config.models?.embed === "string"
+        ? config.models.embed
+        : config.models?.embed
+          ? `${config.models.embed.provider}:${safeRemoteEndpointTrustIdentity(config.models.embed.endpoint)}#${config.models.embed.model}`
+          : undefined,
+      rerank: typeof config.models?.rerank === "string"
+        ? config.models.rerank
+        : config.models?.rerank
+          ? `${config.models.rerank.provider}:${safeRemoteEndpointTrustIdentity(config.models.rerank.endpoint)}#${config.models.rerank.model}`
+          : undefined,
       generate: config.models?.generate,
     },
   };
@@ -879,6 +923,7 @@ function manageTrust(subcommand?: string): void {
     return;
   }
 
+  ensureModelsConfiguredForCli();
   const snapshot = collectSensitiveSnapshot();
   const gated = localConfigGated(configPath, snapshot);
   if (!hasGatedItems(gated)) {
@@ -992,7 +1037,7 @@ async function updateCollections(): Promise<void> {
   }
 
   // Check if any documents need embedding (show once at end)
-  const needsEmbedding = getHashesNeedingEmbedding(db);
+  const needsEmbedding = getStore().getHashesNeedingEmbedding();
   const vectorTotal = (db.prepare(`SELECT COUNT(*) as count FROM content_vectors`).get() as { count: number }).count;
   const orphanedVectors = countOrphanedVectors(db);
   closeDb();
@@ -2038,7 +2083,7 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
   const orphanedContent = cleanupOrphanedContent(db);
 
   // Check if vector index needs updating
-  const needsEmbedding = getHashesNeedingEmbedding(db);
+  const needsEmbedding = getStore().getHashesNeedingEmbedding();
 
   progress.clear();
   console.log(`\nIndexed: ${indexed} new, ${updated} updated, ${unchanged} unchanged, ${removed} removed`);
@@ -2111,30 +2156,32 @@ function parseEmbedTimeoutOption(value: unknown): number | undefined {
   return minutes * 60 * 1000;
 }
 
-function ensureModelsConfiguredForCli(): { embed: string; generate: string; rerank: string } {
-  try {
-    const config = loadConfig();
-    const models = resolveModels(config.models);
-    const current = config.models ?? {};
-    if (current.embed !== models.embed || current.generate !== models.generate || current.rerank !== models.rerank) {
-      saveConfig({
-        ...config,
-        models: {
-          ...current,
-          embed: models.embed,
-          generate: models.generate,
-          rerank: models.rerank,
-        },
-      });
-    }
-    return models;
-  } catch {
-    return resolveModels();
+type ConfiguredModels = { embed: NonNullable<ModelsConfig["embed"]>; generate: string; rerank: NonNullable<ModelsConfig["rerank"]> };
+
+function ensureModelsConfiguredForCli(): ConfiguredModels {
+  const config = loadConfig();
+  const models = resolveModels(config.models);
+  // Validate every configured structured model before defaults are persisted,
+  // trust is recorded, or runtime trust gating can substitute local defaults.
+  resolveEmbedModel({ embed: models.embed });
+  resolveRerankModel({ rerank: models.rerank });
+  const current = config.models ?? {};
+  if (current.embed !== models.embed || current.generate !== models.generate || current.rerank !== models.rerank) {
+    saveConfig({
+      ...config,
+      models: {
+        ...current,
+        embed: models.embed,
+        generate: models.generate,
+        rerank: models.rerank,
+      },
+    });
   }
+  return models;
 }
 
 export function resolveEmbedModelForCli(): string {
-  return ensureModelsConfiguredForCli().embed;
+  return resolveEmbedModel({ embed: ensureModelsConfiguredForCli().embed });
 }
 
 export function resolveGenerateModelForCli(): string {
@@ -2142,16 +2189,21 @@ export function resolveGenerateModelForCli(): string {
 }
 
 export function resolveRerankModelForCli(): string {
-  return ensureModelsConfiguredForCli().rerank;
+  return resolveRerankModel({ rerank: ensureModelsConfiguredForCli().rerank });
 }
 
 function resolveModelsForCli(): { embed: string; generate: string; rerank: string } {
-  return ensureModelsConfiguredForCli();
+  const models = ensureModelsConfiguredForCli();
+  return {
+    ...models,
+    embed: resolveEmbedModel({ embed: models.embed }),
+    rerank: resolveRerankModel({ rerank: models.rerank }),
+  };
 }
 
 /** Models that may actually be loaded. Falls back to defaults/env when a
  *  project-local config's custom URIs are not trusted (#889). */
-function resolveModelsForRuntime(): { embed: string; generate: string; rerank: string } {
+function resolveModelsForRuntime(): ConfiguredModels {
   const configured = ensureModelsConfiguredForCli();
   if (localConfigIsFullyTrusted()) return configured;
   return resolveModels();
@@ -2179,7 +2231,7 @@ async function vectorIndex(
     }
 
     // Check if there's work to do before starting
-    const hashesToEmbed = getHashesNeedingEmbedding(db, batchOptions?.collection, model);
+    const hashesToEmbed = storeInstance.getHashesNeedingEmbedding(model, batchOptions?.collection);
     if (hashesToEmbed === 0 && !force) {
       console.log(`${c.green}✓ All content hashes already have embeddings.${c.reset}`);
       closeDb();
@@ -2849,7 +2901,7 @@ async function vectorSearch(query: string, opts: OutputOptions, _model: string =
   // Use default collections if none specified
   const collectionNames = resolveCollectionFilter(opts.collection, true);
 
-  checkIndexHealth(store.db);
+  checkIndexHealth(store);
 
   await withLLMSession(async () => {
     let results = await vectorSearchQuery(store, query, {
@@ -2891,7 +2943,7 @@ async function querySearch(query: string, opts: OutputOptions, _embedModel: stri
   // Use default collections if none specified
   const collectionNames = resolveCollectionFilter(opts.collection, true);
 
-  checkIndexHealth(store.db);
+  checkIndexHealth(store);
 
   // Check for structured query syntax (lex:/vec:/hyde:/intent: prefixes)
   const parsed = parseStructuredQuery(query);
@@ -3859,9 +3911,9 @@ function checkEnvironmentOverrides(activeModels: { embed: string; generate: stri
 
 function checkModelDefaults(activeModels: { embed: string; generate: string; rerank: string }, configModels: ModelsConfig = {}): void {
   const checks = [
-    { role: "embedding", key: "embed", active: activeModels.embed, configured: configModels.embed, defaultModel: DEFAULT_EMBED_MODEL, envName: "QMD_EMBED_MODEL", envValue: process.env.QMD_EMBED_MODEL },
+    { role: "embedding", key: "embed", active: activeModels.embed, configured: typeof configModels.embed === "string" ? configModels.embed : configModels.embed?.model, defaultModel: DEFAULT_EMBED_MODEL, envName: "QMD_EMBED_MODEL", envValue: process.env.QMD_EMBED_MODEL },
     { role: "generation", key: "generate", active: activeModels.generate, configured: configModels.generate, defaultModel: DEFAULT_QUERY_MODEL, envName: "QMD_GENERATE_MODEL", envValue: process.env.QMD_GENERATE_MODEL },
-    { role: "reranking", key: "rerank", active: activeModels.rerank, configured: configModels.rerank, defaultModel: DEFAULT_RERANK_MODEL, envName: "QMD_RERANK_MODEL", envValue: process.env.QMD_RERANK_MODEL },
+    { role: "reranking", key: "rerank", active: activeModels.rerank, configured: typeof configModels.rerank === "string" ? configModels.rerank : configModels.rerank?.model, defaultModel: DEFAULT_RERANK_MODEL, envName: "QMD_RERANK_MODEL", envValue: process.env.QMD_RERANK_MODEL },
   ] as const;
 
   const notes: string[] = [];
@@ -3884,11 +3936,11 @@ function checkModelDefaults(activeModels: { embed: string; generate: string; rer
   doctorCheck("model defaults", false, `non-default model configuration: ${notes.join("; ")}`);
 }
 
-function checkModelCache(activeModels: { embed: string; generate: string; rerank: string }, nextSteps: string[]): void {
+function checkModelCache(activeModels: { embed: string; generate: string; rerank: string }, nextSteps: string[], remoteEmbed: boolean = false, remoteRerank: boolean = false): void {
   const models = [
-    ["embedding", activeModels.embed],
+    ...(!remoteEmbed ? [["embedding", activeModels.embed] as const] : []),
     ["generation", activeModels.generate],
-    ["reranking", activeModels.rerank],
+    ...(!remoteRerank ? [["reranking", activeModels.rerank] as const] : []),
   ] as const;
   const unique = new Map<string, string[]>();
   for (const [role, model] of models) {
@@ -3928,7 +3980,7 @@ function checkModelCache(activeModels: { embed: string; generate: string; rerank
   }
 }
 
-async function checkEmbeddingVectorSamples(db: Database, model: string, fingerprint: string, sampleSize: number = 3): Promise<DoctorVectorSampleResult> {
+async function checkEmbeddingVectorSamples(db: Database, model: string, fingerprint: string, llm: LlamaCpp, sampleSize: number = 3): Promise<DoctorVectorSampleResult> {
   const activeDocs = (db.prepare(`SELECT COUNT(*) AS count FROM documents WHERE active = 1`).get() as { count: number }).count;
   if (activeDocs === 0) {
     return { ok: true, details: "no active documents indexed" };
@@ -3957,10 +4009,10 @@ async function checkEmbeddingVectorSamples(db: Database, model: string, fingerpr
   const threshold = 0.0001;
   const mismatches: string[] = [];
 
-  await withLLMSession(async (session) => {
+  await withLLMSessionForLlm(llm, async (session) => {
     for (const sample of samples) {
       const hashSeq = `${sample.hash}_${sample.seq}`;
-      const chunks = await chunkDocumentByTokens(sample.body, undefined, undefined, undefined, sample.path, undefined, session.signal);
+      const chunks = await chunkDocumentByTokens(sample.body, undefined, undefined, undefined, sample.path, undefined, session.signal, llm);
       const chunk = chunks[sample.seq];
       if (!chunk) {
         mismatches.push(`${shortHashSeq(hashSeq)}: chunk no longer exists`);
@@ -4133,12 +4185,23 @@ async function runDoctorDeviceChecks(nextSteps: string[]): Promise<void> {
 }
 
 async function showDoctor(): Promise<void> {
-  const storeInstance = getStore();
+  const storeInstance = getStore({ allowInvalidYamlForDoctor: true });
   const db = storeInstance.db;
   const pkg = readPackageJson();
-  const activeModels = resolveModelsForCli();
+  const activeModels = doctorConfigLoadFailed
+    ? (() => {
+        const defaults = resolveModels();
+        return {
+          ...defaults,
+          embed: resolveEmbedModel({ embed: defaults.embed }),
+          rerank: resolveRerankModel({ rerank: defaults.rerank }),
+        };
+      })()
+    : resolveModelsForCli();
   const embedModel = activeModels.embed;
-  const fingerprint = getEmbeddingFingerprint(embedModel);
+  const llm = storeInstance.llm ?? getDefaultLlamaCpp();
+  const remoteEmbed = llm.isRemoteEmbed();
+  const fingerprint = getEmbeddingFingerprint(remoteEmbed ? llm.embeddingFingerprintIdentity : embedModel);
   const nextSteps: string[] = [];
 
   console.log(`${c.bold}QMD Doctor${c.reset}\n`);
@@ -4166,12 +4229,14 @@ async function showDoctor(): Promise<void> {
   const configModels = configCheck.config?.models ?? {};
   checkEnvironmentOverrides(activeModels, configModels);
   checkModelDefaults(activeModels, configModels);
-  checkModelCache(activeModels, nextSteps);
+  checkModelCache(activeModels, nextSteps, remoteEmbed, llm.isRemoteRerank());
 
   await runDoctorDeviceChecks(nextSteps);
 
   try {
-    const adoption = await maybeAdoptLegacyEmbeddingFingerprint(storeInstance, embedModel);
+    const adoption = remoteEmbed
+      ? { checked: false, adopted: 0, reason: "legacy fingerprint adoption is disabled for remote embedding identities" }
+      : await maybeAdoptLegacyEmbeddingFingerprint(storeInstance, embedModel);
     if (adoption.checked || adoption.adopted > 0) {
       doctorCheck("legacy fingerprint adoption", adoption.adopted > 0, adoption.adopted > 0 ? `adopted ${adoption.adopted} legacy chunks; ${adoption.reason}` : adoption.reason);
     }
@@ -4180,7 +4245,7 @@ async function showDoctor(): Promise<void> {
   }
 
   try {
-    const pending = getHashesNeedingEmbedding(db, undefined, embedModel);
+    const pending = getHashesNeedingEmbedding(db, undefined, embedModel, fingerprint);
     doctorCheck("embedding freshness", pending === 0, pending === 0 ? "all active documents match current fingerprint" : `${formatCount(pending)} active documents need embeddings. Next: \`qmd embed\``);
     if (pending > 0) {
       nextSteps.push(`Run \`qmd embed\` to generate ${formatCount(pending)} missing/stale document embeddings.`);
@@ -4230,7 +4295,7 @@ async function showDoctor(): Promise<void> {
   }
 
   try {
-    const vectorSample = await checkEmbeddingVectorSamples(db, embedModel, fingerprint);
+    const vectorSample = await checkEmbeddingVectorSamples(db, embedModel, fingerprint, llm);
     doctorCheck("embedding vector sample", vectorSample.ok, vectorSample.details);
     if (!vectorSample.ok) {
       nextSteps.push("Run `qmd embed --force` to rebuild existing vectors that no longer reproduce under the current embedding pipeline.");
@@ -4330,6 +4395,7 @@ if (isMain) {
     process.exit(cli.values.help ? 0 : 1);
   }
 
+  let commandCompletedSuccessfully = true;
   switch (cli.command) {
     case "context": {
       const subcommand = cli.args[0];
@@ -4621,7 +4687,15 @@ if (isMain) {
       break;
 
     case "doctor":
-      await showDoctor();
+      try {
+        await showDoctor();
+      } catch (error) {
+        const message = error instanceof Error ? sanitizeDiagnosticMessage(error.message) : sanitizeDiagnosticMessage(String(error));
+        console.log(`${c.bold}QMD Doctor${c.reset}\n`);
+        doctorCheck("model configuration", false, message);
+        commandCompletedSuccessfully = false;
+        process.exitCode = 1;
+      }
       break;
 
     case "update":
@@ -4645,7 +4719,8 @@ if (isMain) {
         // embed operates on a single collection; only the first value is used.
         const embedValidatedCollections = resolveCollectionFilter(cli.opts.collection, false);
         const embedCollection = embedValidatedCollections[0];
-        await vectorIndex(resolveModelsForRuntime().embed, !!cli.values.force, {
+        const runtimeModels = resolveModelsForRuntime();
+        await vectorIndex(resolveEmbedModel({ embed: runtimeModels.embed }), !!cli.values.force, {
           maxDocsPerBatch,
           maxBatchBytes: maxBatchMb === undefined ? undefined : maxBatchMb * 1024 * 1024,
           chunkStrategy: embedChunkStrategy,
@@ -4662,9 +4737,9 @@ if (isMain) {
       const refresh = cli.values.refresh === undefined ? false : Boolean(cli.values.refresh);
       const activeModels = resolveModelsForRuntime();
       const models = [
-        activeModels.embed,
+        ...(typeof activeModels.embed === "string" ? [activeModels.embed] : []),
         activeModels.generate,
-        activeModels.rerank,
+        ...(typeof activeModels.rerank === "string" ? [activeModels.rerank] : []),
       ];
       console.log(`${c.bold}Pulling models${c.reset}`);
       const results = await pullModels(models, {
@@ -4953,7 +5028,7 @@ if (isMain) {
       process.exit(1);
   }
 
-  if (cli.command !== "mcp") {
+  if (cli.command !== "mcp" && commandCompletedSuccessfully) {
     await finishSuccessfulCliCommand({
       command: cli.command,
       format: cli.opts.format,

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -87,6 +87,11 @@ import {
   type ReindexResult,
   type ChunkStrategy,
 } from "../store.js";
+import {
+  buildDoctorVectorSampleResult,
+  classifyDoctorVectorDistance,
+  type DoctorVectorSampleResult,
+} from "../doctor-vector-repro.js";
 import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, setDefaultLlamaCpp, LlamaCpp, withLLMSession, withLLMSessionForLlm, pullModels, DEFAULT_MODEL_CACHE_DIR, resolveEmbedModel, resolveGenerateModel, resolveRerankModel, resolveModels, inspectGgufFile, isDarwinMetalMitigationActive } from "../llm.js";
 import {
   formatSearchResults,
@@ -3755,11 +3760,6 @@ function shortHashSeq(hashSeq: string): string {
   return `${hashSeq.slice(0, 12)}_${hashSeq.slice(idx + 1)}`;
 }
 
-type DoctorVectorSampleResult = {
-  ok: boolean;
-  details: string;
-};
-
 function decodeStoredEmbedding(bytes: Uint8Array): Float32Array {
   return new Float32Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
 }
@@ -3983,12 +3983,12 @@ function checkModelCache(activeModels: { embed: string; generate: string; rerank
 async function checkEmbeddingVectorSamples(db: Database, model: string, fingerprint: string, llm: LlamaCpp, sampleSize: number = 3): Promise<DoctorVectorSampleResult> {
   const activeDocs = (db.prepare(`SELECT COUNT(*) AS count FROM documents WHERE active = 1`).get() as { count: number }).count;
   if (activeDocs === 0) {
-    return { ok: true, details: "no active documents indexed" };
+    return { ok: true, details: "no active documents indexed", forceRebuild: false };
   }
 
   const vecTableExists = db.prepare(`SELECT 1 FROM sqlite_master WHERE type='table' AND name='vectors_vec'`).get();
   if (!vecTableExists) {
-    return { ok: false, details: "no vector table to test; please run qmd embed again" };
+    return { ok: false, details: "no vector table to test; please run qmd embed again", forceRebuild: true };
   }
 
   const samples = db.prepare(`
@@ -4003,11 +4003,12 @@ async function checkEmbeddingVectorSamples(db: Database, model: string, fingerpr
   `).all(model, fingerprint, sampleSize) as { hash: string; seq: number; body: string; path: string }[];
 
   if (samples.length === 0) {
-    return { ok: false, details: "no current embedded chunks to test; please run qmd embed again" };
+    return { ok: false, details: "no current embedded chunks to test; please run qmd embed again", forceRebuild: true };
   }
 
-  const threshold = 0.0001;
   const mismatches: string[] = [];
+  const remoteDrifts: string[] = [];
+  const remoteEmbedding = llm.isRemoteEmbed();
 
   await withLLMSessionForLlm(llm, async (session) => {
     for (const sample of samples) {
@@ -4033,23 +4034,16 @@ async function checkEmbeddingVectorSamples(db: Database, model: string, fingerpr
       }
 
       const distance = cosineDistance(result.embedding, decodeStoredEmbedding(stored.embedding));
-      if (distance > threshold) {
+      const classification = classifyDoctorVectorDistance(distance, remoteEmbedding);
+      if (classification === "mismatch") {
         mismatches.push(`${shortHashSeq(hashSeq)}: stored vector distance ${distance.toFixed(6)}`);
+      } else if (classification === "remote-drift") {
+        remoteDrifts.push(`${shortHashSeq(hashSeq)}: stored vector distance ${distance.toFixed(6)}`);
       }
     }
   }, { maxDuration: 10 * 60 * 1000, name: "doctorEmbeddingVectorSample" });
 
-  if (mismatches.length > 0) {
-    return {
-      ok: false,
-      details: `${mismatches.length}/${samples.length} sampled chunks differ from stored vectors (${mismatches[0]}). Rebuild with \`qmd embed --force\``,
-    };
-  }
-
-  return {
-    ok: true,
-    details: `${samples.length} sampled ${samples.length === 1 ? "chunk" : "chunks"} reproduce stored vectors`,
-  };
+  return buildDoctorVectorSampleResult(samples.length, mismatches, remoteDrifts);
 }
 
 function hasLibraryInDirs(libraryBaseName: string, dirs: string[]): boolean {
@@ -4297,7 +4291,7 @@ async function showDoctor(): Promise<void> {
   try {
     const vectorSample = await checkEmbeddingVectorSamples(db, embedModel, fingerprint, llm);
     doctorCheck("embedding vector sample", vectorSample.ok, vectorSample.details);
-    if (!vectorSample.ok) {
+    if (vectorSample.forceRebuild) {
       nextSteps.push("Run `qmd embed --force` to rebuild existing vectors that no longer reproduce under the current embedding pipeline.");
     }
   } catch (error) {

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -9,6 +9,8 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join, dirname, resolve } from "path";
 import { qmdHomedir } from "./paths.js";
 import YAML from "yaml";
+import type { EmbeddingConfig } from "./remote-embed.js";
+import type { RerankConfig } from "./remote-rerank.js";
 
 // ============================================================================
 // Types
@@ -37,8 +39,8 @@ export interface Collection {
  * Model configuration for embedding, reranking, and generation
  */
 export interface ModelsConfig {
-  embed?: string;
-  rerank?: string;
+  embed?: EmbeddingConfig;
+  rerank?: RerankConfig;
   generate?: string;
 }
 

--- a/src/doctor-vector-repro.ts
+++ b/src/doctor-vector-repro.ts
@@ -1,0 +1,53 @@
+export const DOCTOR_VECTOR_REPRO_THRESHOLD = 0.0001;
+// A 100-chunk full-corpus sample from the shared llama.cpp/ROCm service
+// produced singleton-vs-stored cosine distances up to 0.000691 (p99 0.000635)
+// for the same fingerprint and vector semantics. Keep this remote-only ceiling
+// below the materially-different test case while leaving local reproducibility
+// at the original strict threshold.
+export const DOCTOR_REMOTE_BATCH_DRIFT_THRESHOLD = 0.001;
+
+export type DoctorVectorDistanceClassification = "match" | "remote-drift" | "mismatch";
+
+export type DoctorVectorSampleResult = {
+  ok: boolean;
+  details: string;
+  forceRebuild: boolean;
+};
+
+export function classifyDoctorVectorDistance(
+  distance: number,
+  remoteEmbedding: boolean,
+): DoctorVectorDistanceClassification {
+  if (!Number.isFinite(distance)) return "mismatch";
+  if (distance <= DOCTOR_VECTOR_REPRO_THRESHOLD) return "match";
+  if (remoteEmbedding && distance <= DOCTOR_REMOTE_BATCH_DRIFT_THRESHOLD) return "remote-drift";
+  return "mismatch";
+}
+
+export function buildDoctorVectorSampleResult(
+  sampleCount: number,
+  mismatches: string[],
+  remoteDrifts: string[],
+): DoctorVectorSampleResult {
+  if (mismatches.length > 0) {
+    return {
+      ok: false,
+      details: `${mismatches.length}/${sampleCount} sampled chunks differ from stored vectors (${mismatches[0]}). Rebuild with \`qmd embed --force\``,
+      forceRebuild: true,
+    };
+  }
+
+  if (remoteDrifts.length > 0) {
+    return {
+      ok: true,
+      details: `${remoteDrifts.length}/${sampleCount} sampled remote chunks show bounded batch-shape drift (${remoteDrifts[0]}); fingerprint and vector semantics match, so no rebuild is needed`,
+      forceRebuild: false,
+    };
+  }
+
+  return {
+    ok: true,
+    details: `${sampleCount} sampled ${sampleCount === 1 ? "chunk" : "chunks"} reproduce stored vectors`,
+    forceRebuild: false,
+  };
+}

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -78,6 +78,8 @@ import { homedir } from "os";
 import { dirname, join } from "path";
 import { accessSync, constants, existsSync, mkdirSync, statSync, unlinkSync, readdirSync, readFileSync, writeFileSync, openSync, readSync, closeSync } from "fs";
 import { createRequire } from "node:module";
+import { OpenAIEmbeddingClient, RemoteEmbeddingProtocolError, resolveEmbeddingConfig, type EmbeddingConfig, type ResolvedEmbeddingConfig } from "./remote-embed.js";
+import { OpenAIRerankClient, getRerankCacheIdentity, resolveRerankConfig, type RerankConfig, type ResolvedRerankConfig } from "./remote-rerank.js";
 
 // =============================================================================
 // Embedding Formatting Functions
@@ -295,13 +297,13 @@ export const DEFAULT_RERANK_MODEL_URI = DEFAULT_RERANK_MODEL;
 export const DEFAULT_GENERATE_MODEL_URI = DEFAULT_GENERATE_MODEL;
 
 export type ModelResolutionConfig = {
-  embed?: string;
+  embed?: EmbeddingConfig;
   generate?: string;
-  rerank?: string;
+  rerank?: RerankConfig;
 };
 
 export function resolveEmbedModel(config?: ModelResolutionConfig): string {
-  return config?.embed || process.env.QMD_EMBED_MODEL || DEFAULT_EMBED_MODEL;
+  return resolveEmbeddingConfig(config?.embed || process.env.QMD_EMBED_MODEL || DEFAULT_EMBED_MODEL).model;
 }
 
 export function resolveGenerateModel(config?: ModelResolutionConfig): string {
@@ -309,14 +311,14 @@ export function resolveGenerateModel(config?: ModelResolutionConfig): string {
 }
 
 export function resolveRerankModel(config?: ModelResolutionConfig): string {
-  return config?.rerank || process.env.QMD_RERANK_MODEL || DEFAULT_RERANK_MODEL;
+  return resolveRerankConfig(config?.rerank || process.env.QMD_RERANK_MODEL || DEFAULT_RERANK_MODEL).model;
 }
 
-export function resolveModels(config?: ModelResolutionConfig): Required<ModelResolutionConfig> {
+export function resolveModels(config?: ModelResolutionConfig): { embed: EmbeddingConfig; generate: string; rerank: RerankConfig } {
   return {
-    embed: resolveEmbedModel(config),
+    embed: config?.embed || process.env.QMD_EMBED_MODEL || DEFAULT_EMBED_MODEL,
     generate: resolveGenerateModel(config),
-    rerank: resolveRerankModel(config),
+    rerank: config?.rerank || process.env.QMD_RERANK_MODEL || DEFAULT_RERANK_MODEL,
   };
 }
 
@@ -598,9 +600,9 @@ export interface LLM {
 // =============================================================================
 
 export type LlamaCppConfig = {
-  embedModel?: string;
+  embedModel?: EmbeddingConfig;
   generateModel?: string;
-  rerankModel?: string;
+  rerankModel?: RerankConfig;
   modelCacheDir?: string;
   /**
    * Context size used for query expansion generation contexts.
@@ -811,8 +813,12 @@ export class LlamaCpp implements LLM {
   private rerankContexts: Awaited<ReturnType<LlamaModel["createRankingContext"]>>[] = [];
 
   private embedModelUri: string;
+  private readonly embedConfig: ResolvedEmbeddingConfig;
+  private remoteEmbedder: OpenAIEmbeddingClient | null = null;
   private generateModelUri: string;
   private rerankModelUri: string;
+  private readonly rerankConfig: ResolvedRerankConfig;
+  private remoteReranker: OpenAIRerankClient | null = null;
   private modelCacheDir: string;
   private expandContextSize: number;
 
@@ -844,9 +850,11 @@ export class LlamaCpp implements LLM {
     // See isDarwinMetalMitigationActive() for the runtime check exposed to
     // diagnostics. No constructor-time guard installation is needed.
 
-    this.embedModelUri = resolveEmbedModel({ embed: config.embedModel });
+    this.embedConfig = resolveEmbeddingConfig(config.embedModel || process.env.QMD_EMBED_MODEL || DEFAULT_EMBED_MODEL);
+    this.embedModelUri = this.embedConfig.model;
     this.generateModelUri = resolveGenerateModel({ generate: config.generateModel });
-    this.rerankModelUri = resolveRerankModel({ rerank: config.rerankModel });
+    this.rerankConfig = resolveRerankConfig(config.rerankModel || process.env.QMD_RERANK_MODEL || DEFAULT_RERANK_MODEL);
+    this.rerankModelUri = this.rerankConfig.model;
     this.modelCacheDir = config.modelCacheDir || MODEL_CACHE_DIR;
     this.expandContextSize = resolveExpandContextSize(config.expandContextSize);
     this.inactivityTimeoutMs = config.inactivityTimeoutMs ?? DEFAULT_INACTIVITY_TIMEOUT_MS;
@@ -857,12 +865,42 @@ export class LlamaCpp implements LLM {
     return this.embedModelUri;
   }
 
+  get embeddingFingerprintIdentity(): string | Exclude<ResolvedEmbeddingConfig, { kind: "local" }> {
+    return this.embedConfig.kind === "remote" ? this.embedConfig : this.embedModelUri;
+  }
+
+  isRemoteEmbed(): boolean { return this.embedConfig.kind === "remote"; }
+
+  private getRemoteEmbedder(): OpenAIEmbeddingClient {
+    if (this.embedConfig.kind !== "remote") throw new Error("remote embedding is not configured");
+    this.remoteEmbedder ??= new OpenAIEmbeddingClient({ ...this.embedConfig, provider: "openai" });
+    return this.remoteEmbedder;
+  }
+
+  private assertRemoteEmbeddingModel(model?: string): void {
+    if (model && model !== this.embedModelUri) {
+      throw new RemoteEmbeddingProtocolError("remote embedding model override does not match configured model identity");
+    }
+  }
+
   get generateModelName(): string {
     return this.generateModelUri;
   }
 
   get rerankModelName(): string {
     return this.rerankModelUri;
+  }
+
+  get rerankCacheIdentity(): string {
+    return getRerankCacheIdentity(this.rerankConfig);
+  }
+
+  isRemoteRerank(): boolean { return this.rerankConfig.kind === "remote"; }
+
+  private getRemoteReranker(): OpenAIRerankClient {
+    if (this.rerankConfig.kind !== "remote") throw new Error("remote reranking is not configured");
+    this.remoteReranker ??= new OpenAIRerankClient({ ...this.rerankConfig, provider: "openai" });
+    return this.remoteReranker;
   }
 
   /**
@@ -1443,6 +1481,11 @@ export class LlamaCpp implements LLM {
   }
 
   async embed(text: string, options: EmbedOptions = {}): Promise<EmbeddingResult | null> {
+    if (this.isRemoteEmbed()) {
+      this.assertRemoteEmbeddingModel(options.model);
+      const embedding = await this.getRemoteEmbedder().embed(text);
+      return { embedding, model: options.model ?? this.embedModelUri };
+    }
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();
 
@@ -1472,6 +1515,11 @@ export class LlamaCpp implements LLM {
    * Uses Promise.all for parallel embedding - node-llama-cpp handles batching internally
    */
   async embedBatch(texts: string[], options: EmbedOptions = {}): Promise<(EmbeddingResult | null)[]> {
+    if (this.isRemoteEmbed()) {
+      this.assertRemoteEmbeddingModel(options.model);
+      const embeddings = await this.getRemoteEmbedder().embedBatch(texts);
+      return embeddings.map(embedding => ({ embedding, model: options.model ?? this.embedModelUri }));
+    }
     if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();
@@ -1707,6 +1755,7 @@ export class LlamaCpp implements LLM {
     documents: RerankDocument[],
     options: RerankOptions = {}
   ): Promise<RerankResult> {
+    if (this.rerankConfig.kind === "remote") return this.getRemoteReranker().rerank(query, documents);
     if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
     // Ping activity at start to keep models alive during this operation
     this.touchActivity();
@@ -1714,7 +1763,7 @@ export class LlamaCpp implements LLM {
     const contexts = await this.ensureRerankContexts();
     if (contexts.length === 0) {
       return {
-        results: documents.map((d) => ({ ...d, score: 0.5, index: 0 })),
+        results: documents.map((d, index) => ({ ...d, score: 0.5, index })),
         model: "fallback",
       };
     }

--- a/src/remote-embed.ts
+++ b/src/remote-embed.ts
@@ -1,0 +1,190 @@
+/** Strict OpenAI-compatible remote embedding transport. */
+
+export const REMOTE_EMBEDDING_NATIVE_DIMENSIONS = 2560;
+export const REMOTE_EMBEDDING_OUTPUT_DIMENSIONS = 1024;
+export const REMOTE_EMBEDDING_REDUCTION = "mrl-prefix" as const;
+export const REMOTE_EMBEDDING_FORMAT_VERSION = "qmd-remote-embedding-v1";
+
+export type RemoteEmbeddingNormalization = "l2";
+export type RemoteEmbeddingReduction = typeof REMOTE_EMBEDDING_REDUCTION;
+
+export interface OpenAIEmbeddingConfig {
+  provider: "openai";
+  endpoint: string;
+  model: string;
+  nativeDimensions: number;
+  dimensions: number;
+  reduction: RemoteEmbeddingReduction;
+  apiKey?: string;
+  modelAliases?: string[];
+  normalization: RemoteEmbeddingNormalization;
+  formatVersion?: string;
+  timeoutMs?: number;
+}
+
+export type EmbeddingConfig = string | OpenAIEmbeddingConfig;
+export type ResolvedEmbeddingConfig =
+  | { kind: "local"; model: string }
+  | ({ kind: "remote" } & Omit<OpenAIEmbeddingConfig, "provider"> & { provider: "openai"; formatVersion: string });
+
+export class RemoteEmbeddingError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = new.target.name;
+  }
+}
+export class RemoteEmbeddingTransportError extends RemoteEmbeddingError {}
+export class RemoteEmbeddingProtocolError extends RemoteEmbeddingError {}
+
+function embeddingsEndpoint(endpoint: string): string {
+  let url: URL;
+  try {
+    url = new URL(endpoint);
+  } catch {
+    throw new RemoteEmbeddingProtocolError("remote embedding endpoint must be a valid HTTP(S) /v1 URL");
+  }
+  if ((url.protocol !== "http:" && url.protocol !== "https:") || url.username || url.password || url.search || url.hash) {
+    throw new RemoteEmbeddingProtocolError("remote embedding endpoint must be a credential-free HTTP(S) /v1 URL");
+  }
+  const pathname = url.pathname.replace(/\/+$/, "");
+  if (pathname === "/v1") url.pathname = "/v1/embeddings";
+  else if (pathname === "/v1/embeddings") url.pathname = pathname;
+  else throw new RemoteEmbeddingProtocolError("remote embedding endpoint path must be /v1 or /v1/embeddings");
+  return url.toString();
+}
+
+export function resolveEmbeddingConfig(config: EmbeddingConfig): ResolvedEmbeddingConfig {
+  if (typeof config === "string") return { kind: "local", model: config };
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    throw new RemoteEmbeddingProtocolError("remote embedding configuration must be an object");
+  }
+  if (config.provider !== "openai") throw new RemoteEmbeddingProtocolError("unsupported remote embedding provider");
+  if (typeof config.endpoint !== "string" || !config.endpoint.trim() || typeof config.model !== "string" || !config.model.trim()) {
+    throw new RemoteEmbeddingProtocolError("remote embedding endpoint and model must be non-empty strings");
+  }
+  if (config.nativeDimensions !== REMOTE_EMBEDDING_NATIVE_DIMENSIONS) {
+    throw new RemoteEmbeddingProtocolError(`remote embedding nativeDimensions must be exactly ${REMOTE_EMBEDDING_NATIVE_DIMENSIONS}`);
+  }
+  if (config.dimensions !== REMOTE_EMBEDDING_OUTPUT_DIMENSIONS || config.dimensions >= config.nativeDimensions) {
+    throw new RemoteEmbeddingProtocolError(`remote embedding dimensions must be exactly ${REMOTE_EMBEDDING_OUTPUT_DIMENSIONS} and less than nativeDimensions`);
+  }
+  if (config.reduction !== REMOTE_EMBEDDING_REDUCTION) {
+    throw new RemoteEmbeddingProtocolError(`remote embedding reduction must be ${REMOTE_EMBEDDING_REDUCTION}`);
+  }
+  if (config.normalization !== "l2") {
+    throw new RemoteEmbeddingProtocolError("remote embedding normalization must be l2");
+  }
+  if (config.formatVersion !== undefined && (typeof config.formatVersion !== "string" || !config.formatVersion.trim())) {
+    throw new RemoteEmbeddingProtocolError("remote embedding formatVersion must be a non-empty string");
+  }
+  if (config.timeoutMs !== undefined && (!Number.isInteger(config.timeoutMs) || config.timeoutMs <= 0)) {
+    throw new RemoteEmbeddingProtocolError("remote embedding timeoutMs must be a positive integer");
+  }
+  if (config.apiKey !== undefined && (typeof config.apiKey !== "string" || config.apiKey.length === 0)) {
+    throw new RemoteEmbeddingProtocolError("remote embedding apiKey must be a non-empty string");
+  }
+  if (config.modelAliases !== undefined) {
+    if (!Array.isArray(config.modelAliases) || config.modelAliases.some(alias => typeof alias !== "string" || !alias.trim())) {
+      throw new RemoteEmbeddingProtocolError("remote embedding modelAliases must contain only non-empty strings");
+    }
+    if (new Set(config.modelAliases).size !== config.modelAliases.length) {
+      throw new RemoteEmbeddingProtocolError("remote embedding modelAliases must be unique");
+    }
+  }
+  return {
+    kind: "remote",
+    ...config,
+    endpoint: embeddingsEndpoint(config.endpoint),
+    formatVersion: config.formatVersion ?? REMOTE_EMBEDDING_FORMAT_VERSION,
+  };
+}
+
+function normalize(vector: number[]): number[] {
+  const norm = Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0));
+  if (!Number.isFinite(norm) || norm === 0) throw new RemoteEmbeddingProtocolError("remote embedding vector has zero or invalid norm");
+  const normalized = vector.map(value => value / norm);
+  if (!normalized.every(value => Number.isFinite(value) && Number.isFinite(Math.fround(value)))) {
+    throw new RemoteEmbeddingProtocolError("remote embedding normalized vector must contain only finite Float32 values");
+  }
+  return normalized;
+}
+
+export class OpenAIEmbeddingClient {
+  private readonly config: ReturnType<typeof resolveEmbeddingConfig> & { kind: "remote" };
+
+  constructor(config: OpenAIEmbeddingConfig) {
+    const resolved = resolveEmbeddingConfig(config);
+    if (resolved.kind !== "remote") throw new RemoteEmbeddingProtocolError("remote embedding configuration required");
+    this.config = resolved;
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return [];
+    let response: Response;
+    try {
+      response = await fetch(this.config.endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(this.config.apiKey ? { Authorization: `Bearer ${this.config.apiKey}` } : {}),
+        },
+        body: JSON.stringify({ model: this.config.model, input: texts }),
+        signal: AbortSignal.timeout(this.config.timeoutMs ?? 30_000),
+      });
+    } catch {
+      throw new RemoteEmbeddingTransportError("remote embedding request failed");
+    }
+    if (!response.ok) {
+      throw new RemoteEmbeddingTransportError(`remote embedding request returned HTTP ${response.status}`);
+    }
+
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      throw new RemoteEmbeddingProtocolError("remote embedding response was not valid JSON");
+    }
+    return this.validate(body, texts.length);
+  }
+
+  async embed(text: string): Promise<number[]> {
+    return (await this.embedBatch([text]))[0]!;
+  }
+
+  private validate(body: unknown, count: number): number[][] {
+    if (!body || typeof body !== "object") throw new RemoteEmbeddingProtocolError("remote embedding response must be an object");
+    const record = body as Record<string, unknown>;
+    const allowed = new Set([this.config.model, ...(this.config.modelAliases ?? [])]);
+    if (typeof record.model !== "string" || !allowed.has(record.model)) {
+      throw new RemoteEmbeddingProtocolError("remote embedding response model does not match configured model identity");
+    }
+    if (!Array.isArray(record.data) || record.data.length !== count) {
+      throw new RemoteEmbeddingProtocolError("remote embedding response cardinality does not match input");
+    }
+
+    const output: number[][] = new Array(count);
+    const seen = new Set<number>();
+    for (const rawItem of record.data) {
+      if (!rawItem || typeof rawItem !== "object") throw new RemoteEmbeddingProtocolError("remote embedding item must be an object");
+      const item = rawItem as Record<string, unknown>;
+      const index = item.index;
+      if (!Number.isInteger(index) || (index as number) < 0 || (index as number) >= count || seen.has(index as number)) {
+        throw new RemoteEmbeddingProtocolError("remote embedding response has invalid index coverage");
+      }
+      const embedding = item.embedding;
+      if (!Array.isArray(embedding) || embedding.length === 0 || embedding.length !== this.config.nativeDimensions) {
+        throw new RemoteEmbeddingProtocolError("remote embedding vector has invalid dimensions");
+      }
+      if (!embedding.every(value => typeof value === "number" && Number.isFinite(value) && Number.isFinite(Math.fround(value)))) {
+        throw new RemoteEmbeddingProtocolError("remote embedding vector must contain only finite Float32 values");
+      }
+      seen.add(index as number);
+      const prefix = (embedding as number[]).slice(0, this.config.dimensions);
+      output[index as number] = normalize(prefix);
+    }
+    if (seen.size !== count || output.some(value => value === undefined)) {
+      throw new RemoteEmbeddingProtocolError("remote embedding response does not cover every input index exactly once");
+    }
+    return output;
+  }
+}

--- a/src/remote-rerank.ts
+++ b/src/remote-rerank.ts
@@ -1,0 +1,141 @@
+import type { RerankDocument, RerankResult } from "./llm.js";
+
+export interface OpenAIRerankConfig {
+  provider: "openai";
+  endpoint: string;
+  model: string;
+  apiKey?: string;
+  modelAliases?: string[];
+  timeoutMs?: number;
+  failurePolicy?: "fail-closed";
+}
+
+export type RerankConfig = string | OpenAIRerankConfig;
+export type ResolvedRerankConfig =
+  | { kind: "local"; model: string }
+  | ({ kind: "remote" } & OpenAIRerankConfig);
+
+export class RemoteRerankError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = new.target.name;
+  }
+}
+export class RemoteRerankTransportError extends RemoteRerankError {}
+export class RemoteRerankProtocolError extends RemoteRerankError {}
+
+function rerankEndpoint(endpoint: string): string {
+  if (typeof endpoint !== "string" || endpoint.length === 0) throw new RemoteRerankProtocolError("remote rerank endpoint must be a non-empty string");
+  let url: URL;
+  try {
+    url = new URL(endpoint);
+  } catch {
+    throw new RemoteRerankProtocolError("remote rerank endpoint must be a valid URL");
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") throw new RemoteRerankProtocolError("remote rerank endpoint must use HTTP or HTTPS");
+  if (url.username || url.password || url.search || url.hash) throw new RemoteRerankProtocolError("remote rerank endpoint must not contain credentials, query, or fragment");
+  const pathname = url.pathname.replace(/\/+$/, "");
+  if (pathname === "/v1") url.pathname = "/v1/rerank";
+  else if (pathname !== "/v1/rerank") throw new RemoteRerankProtocolError("remote rerank endpoint path must be /v1 or /v1/rerank");
+  return url.toString();
+}
+
+export function resolveRerankConfig(config: RerankConfig): ResolvedRerankConfig {
+  if (typeof config === "string") return { kind: "local", model: config };
+  if (!config || typeof config !== "object" || Array.isArray(config)) throw new RemoteRerankProtocolError("remote rerank configuration must be an object");
+  const raw = config as unknown as Record<string, unknown>;
+  if (raw.provider !== "openai") throw new RemoteRerankProtocolError("unsupported remote rerank provider");
+  if (typeof raw.model !== "string" || raw.model.trim().length === 0 || raw.model !== raw.model.trim()) throw new RemoteRerankProtocolError("remote rerank model must be a canonical non-empty string");
+  if (raw.apiKey !== undefined && (typeof raw.apiKey !== "string" || raw.apiKey.trim().length === 0 || raw.apiKey !== raw.apiKey.trim())) throw new RemoteRerankProtocolError("remote rerank apiKey must be a canonical non-empty string");
+  if (raw.timeoutMs !== undefined && (typeof raw.timeoutMs !== "number" || !Number.isFinite(raw.timeoutMs) || !Number.isInteger(raw.timeoutMs) || raw.timeoutMs <= 0)) {
+    throw new RemoteRerankProtocolError("remote rerank timeoutMs must be a positive integer");
+  }
+  if (raw.modelAliases !== undefined) {
+    if (!Array.isArray(raw.modelAliases) || raw.modelAliases.some(alias => typeof alias !== "string")) {
+      throw new RemoteRerankProtocolError("remote rerank modelAliases must contain only canonical non-empty strings");
+    }
+    const aliases = raw.modelAliases as string[];
+    const trimmed = aliases.map(alias => alias.trim());
+    if (aliases.some((alias, index) => trimmed[index]!.length === 0 || alias !== trimmed[index]) || new Set(trimmed).size !== trimmed.length || trimmed.includes(raw.model as string)) {
+      throw new RemoteRerankProtocolError("remote rerank modelAliases must be unique canonical aliases distinct from the primary model");
+    }
+  }
+  if (raw.failurePolicy !== undefined && raw.failurePolicy !== "fail-closed") {
+    throw new RemoteRerankProtocolError("remote rerank failurePolicy must be fail-closed");
+  }
+  return { ...config, kind: "remote", endpoint: rerankEndpoint(config.endpoint) };
+}
+
+export function getRerankCacheIdentity(config: ResolvedRerankConfig): string {
+  if (config.kind === "local") return config.model;
+  return JSON.stringify({
+    provider: config.provider,
+    endpoint: config.endpoint,
+    model: config.model,
+    modelAliases: [...(config.modelAliases ?? [])].sort(),
+    scoreContract: "normalized-relevance-score-v1",
+    failurePolicy: config.failurePolicy ?? "fail-closed",
+  });
+}
+
+export class OpenAIRerankClient {
+  readonly failurePolicy = "fail-closed" as const;
+  private readonly config: OpenAIRerankConfig & { endpoint: string };
+
+  constructor(config: OpenAIRerankConfig) {
+    const resolved = resolveRerankConfig(config);
+    if (resolved.kind !== "remote") throw new RemoteRerankProtocolError("remote rerank configuration required");
+    this.config = resolved;
+  }
+
+  async rerank(query: string, documents: RerankDocument[]): Promise<RerankResult> {
+    if (documents.length === 0) return { model: this.config.model, results: [] };
+    let response: Response;
+    try {
+      response = await fetch(this.config.endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(this.config.apiKey ? { Authorization: `Bearer ${this.config.apiKey}` } : {}),
+        },
+        body: JSON.stringify({ model: this.config.model, query, documents: documents.map(document => document.text) }),
+        signal: AbortSignal.timeout(this.config.timeoutMs ?? 60_000),
+      });
+    } catch {
+      throw new RemoteRerankTransportError("remote rerank transport failed");
+    }
+    if (!response.ok) throw new RemoteRerankTransportError(`remote rerank request returned HTTP ${response.status}`);
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      throw new RemoteRerankProtocolError("remote rerank response was not valid JSON");
+    }
+    if (!body || typeof body !== "object") throw new RemoteRerankProtocolError("remote rerank response must be an object");
+    const record = body as Record<string, unknown>;
+    const allowedModels = new Set([this.config.model, ...(this.config.modelAliases ?? [])]);
+    if (typeof record.model !== "string" || !allowedModels.has(record.model)) {
+      throw new RemoteRerankProtocolError("remote rerank response model does not match configured model identity");
+    }
+    if (!Array.isArray(record.results) || record.results.length !== documents.length) {
+      throw new RemoteRerankProtocolError("remote rerank response cardinality does not match documents");
+    }
+    const seen = new Set<number>();
+    const results = record.results.map((rawResult) => {
+      if (!rawResult || typeof rawResult !== "object") throw new RemoteRerankProtocolError("remote rerank result must be an object");
+      const result = rawResult as Record<string, unknown>;
+      const index = result.index;
+      if (!Number.isInteger(index) || (index as number) < 0 || (index as number) >= documents.length || seen.has(index as number)) {
+        throw new RemoteRerankProtocolError("remote rerank response has invalid index coverage");
+      }
+      const score = result.relevance_score;
+      if (typeof score !== "number" || !Number.isFinite(score) || score < 0 || score > 1) {
+        throw new RemoteRerankProtocolError("remote rerank relevance_score must be finite and normalized to [0,1]");
+      }
+      seen.add(index as number);
+      return { file: documents[index as number]!.file, index: index as number, score };
+    });
+    if (seen.size !== documents.length) throw new RemoteRerankProtocolError("remote rerank response does not cover every document exactly once");
+    return { model: record.model, results };
+  }
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -111,8 +111,29 @@ export const CHUNK_OVERLAP_CHARS = CHUNK_OVERLAP_TOKENS * 4;  // 540 chars
 export const CHUNK_WINDOW_TOKENS = 200;
 export const CHUNK_WINDOW_CHARS = CHUNK_WINDOW_TOKENS * 4;  // 800 chars
 
-export function getEmbeddingFingerprint(model: string = DEFAULT_EMBED_MODEL): string {
+export type EmbeddingFingerprintIdentity = string | {
+  provider: string;
+  model: string;
+  nativeDimensions: number;
+  dimensions: number;
+  reduction: string;
+  normalization: string;
+  formatVersion: string;
+  endpoint?: string;
+  apiKey?: string;
+};
+
+export function getEmbeddingFingerprint(identity: EmbeddingFingerprintIdentity = DEFAULT_EMBED_MODEL): string {
+  const model = typeof identity === "string" ? identity : identity.model;
   const significant = [
+    ...(typeof identity === "string" ? [] : [
+      `provider:${identity.provider}`,
+      `native_dimensions:${identity.nativeDimensions}`,
+      `output_dimensions:${identity.dimensions}`,
+      `reduction:${identity.reduction}`,
+      `normalization:${identity.normalization}`,
+      `format_version:${identity.formatVersion}`,
+    ]),
     `model:${model}`,
     `query:${formatQueryForEmbedding(EMBED_FINGERPRINT_PROBE_QUERY, model)}`,
     `doc:${formatDocForEmbedding(EMBED_FINGERPRINT_PROBE_DOC, EMBED_FINGERPRINT_PROBE_TITLE, model)}`,
@@ -129,6 +150,17 @@ export function getEmbeddingFingerprint(model: string = DEFAULT_EMBED_MODEL): st
 function getLlm(store: Store): LlamaCpp {
   return store.llm ?? getDefaultLlamaCpp();
 }
+
+function getStoreEmbeddingIdentity(store: Store, model?: string): { model: string; fingerprint: string } {
+  const activeModel = model ?? store.llm?.embedModelName ?? DEFAULT_EMBED_MODEL;
+  const llm = store.llm;
+  const identity = llm && typeof llm.isRemoteEmbed === "function" && llm.isRemoteEmbed() && activeModel === llm.embedModelName
+    ? llm.embeddingFingerprintIdentity
+    : activeModel;
+  return { model: activeModel, fingerprint: getEmbeddingFingerprint(identity) };
+}
+
+const activeRemoteEmbeddingDatabases = new WeakSet<object>();
 
 // =============================================================================
 // Smart Chunking - Break Point Detection
@@ -1460,7 +1492,7 @@ export type Store = {
   ensureVecTable: (dimensions: number) => void;
 
   // Index health
-  getHashesNeedingEmbedding: (model?: string) => number;
+  getHashesNeedingEmbedding: (model?: string, collection?: string) => number;
   getIndexHealth: (model?: string) => IndexHealthInfo;
   getStatus: (model?: string) => IndexStatus;
 
@@ -1844,9 +1876,15 @@ function withLazyContentVectorMigration<T>(db: Database, operation: () => T): T 
   }
 }
 
-function getPendingEmbeddingDocs(db: Database, collection?: string, model: string = DEFAULT_EMBED_MODEL): PendingEmbeddingDoc[] {
+function getPendingEmbeddingDocs(
+  db: Database,
+  collection?: string,
+  model: string = DEFAULT_EMBED_MODEL,
+  fingerprint: string = getEmbeddingFingerprint(model),
+  force: boolean = false,
+): PendingEmbeddingDoc[] {
   const collectionFilter = collection ? `AND d.collection = ?` : ``;
-  const fingerprint = getEmbeddingFingerprint(model);
+  const pendingFilter = force ? `` : `AND (v.hash IS NULL OR v.chunk_count < v.expected_chunks)`;
   return withLazyContentVectorMigration(db, () => {
     const stmt = db.prepare(`
       SELECT d.hash, MIN(d.path) as path, length(CAST(c.doc AS BLOB)) as bytes
@@ -1859,7 +1897,7 @@ function getPendingEmbeddingDocs(db: Database, collection?: string, model: strin
         GROUP BY hash, model, embed_fingerprint
       ) v ON d.hash = v.hash
       WHERE d.active = 1
-        AND (v.hash IS NULL OR v.chunk_count < v.expected_chunks)
+        ${pendingFilter}
         ${collectionFilter}
       GROUP BY d.hash
       ORDER BY MIN(d.path)
@@ -1927,24 +1965,68 @@ export async function generateEmbeddings(
 ): Promise<EmbedResult> {
   const db = store.db;
   const llm = getLlm(store);
-  const model = options?.model ?? llm.embedModelName ?? DEFAULT_EMBED_MODEL;
-  const fingerprint = getEmbeddingFingerprint(model);
+  const remoteEmbed = typeof llm.isRemoteEmbed === "function" && llm.isRemoteEmbed();
+  const activeModel = llm.embedModelName ?? DEFAULT_EMBED_MODEL;
+  if (remoteEmbed && options?.model && options.model !== activeModel) {
+    throw new Error("Remote embedding model override does not match the configured semantic identity");
+  }
+  const model = remoteEmbed ? activeModel : options?.model ?? activeModel;
+  const fingerprint = getEmbeddingFingerprint(remoteEmbed ? llm.embeddingFingerprintIdentity : model);
   const now = new Date().toISOString();
   const { maxDocsPerBatch, maxBatchBytes } = resolveEmbedOptions(options);
   const encoder = new TextEncoder();
+  const remoteFailClosed = remoteEmbed;
+  const remoteSavepoint = "qmd_remote_embedding_invocation";
+  let ownsRemoteInvocation = false;
+  const stagedRemoteEmbeddings: Array<{ chunk: ChunkItem; embedding: Float32Array }> = [];
+  let remoteDimensions: number | undefined;
 
-  if (options?.force) {
-    clearAllEmbeddings(db, options?.collection);
-  }
+  const commitRemoteEmbeddings = (): void => {
+    if (!remoteFailClosed) return;
+    db.exec(`SAVEPOINT ${remoteSavepoint}`);
+    try {
+      if (options?.force) clearAllEmbeddings(db, options.collection);
+      if (stagedRemoteEmbeddings.length > 0) {
+        if (!remoteDimensions) throw new Error("Remote embedding dimensions were not established");
+        store.ensureVecTable(remoteDimensions);
+        for (const { chunk, embedding } of stagedRemoteEmbeddings) {
+          insertEmbedding(db, chunk.hash, chunk.seq, chunk.pos, embedding, model, now, chunk.expectedTotalChunks, fingerprint);
+        }
+      }
+      db.exec(`RELEASE ${remoteSavepoint}`);
+    } catch (error) {
+      db.exec(`ROLLBACK TO ${remoteSavepoint}`);
+      db.exec(`RELEASE ${remoteSavepoint}`);
+      throw error;
+    }
+  };
 
-  const docsToEmbed = getPendingEmbeddingDocs(db, options?.collection, model);
+  try {
+    if (remoteFailClosed) {
+      if (activeRemoteEmbeddingDatabases.has(db)) {
+        throw new Error("A remote embedding invocation is already active for this database");
+      }
+      activeRemoteEmbeddingDatabases.add(db);
+      ownsRemoteInvocation = true;
+    }
 
-  if (docsToEmbed.length === 0) {
-    return { docsProcessed: 0, chunksEmbedded: 0, errors: 0, durationMs: 0 };
-  }
-  const totalBytes = docsToEmbed.reduce((sum, doc) => sum + Math.max(0, doc.bytes), 0);
-  const totalDocs = docsToEmbed.length;
-  const startTime = Date.now();
+    if (options?.force && !remoteFailClosed) {
+      clearAllEmbeddings(db, options?.collection);
+    }
+
+    const docsToEmbed = getPendingEmbeddingDocs(db, options?.collection, model, fingerprint, remoteFailClosed && !!options?.force);
+
+    if (docsToEmbed.length === 0) {
+      commitRemoteEmbeddings();
+      if (ownsRemoteInvocation) {
+        activeRemoteEmbeddingDatabases.delete(db);
+        ownsRemoteInvocation = false;
+      }
+      return { docsProcessed: 0, chunksEmbedded: 0, errors: 0, durationMs: 0 };
+    }
+    const totalBytes = docsToEmbed.reduce((sum, doc) => sum + Math.max(0, doc.bytes), 0);
+    const totalDocs = docsToEmbed.length;
+    const startTime = Date.now();
 
   // Use store's LlamaCpp or global singleton, wrapped in a session
   const embedModelUri = model;
@@ -1994,7 +2076,9 @@ export async function generateEmbeddings(
           recordFailure(chunk, "embedding returned no vector");
           return false;
         }
-        insertEmbedding(db, chunk.hash, chunk.seq, chunk.pos, new Float32Array(result.embedding), model, now, chunk.expectedTotalChunks, fingerprint);
+        const embedding = new Float32Array(result.embedding);
+        if (remoteFailClosed) stagedRemoteEmbeddings.push({ chunk, embedding });
+        else insertEmbedding(db, chunk.hash, chunk.seq, chunk.pos, embedding, model, now, chunk.expectedTotalChunks, fingerprint);
         chunksEmbedded++;
         successesSinceRetry++;
         clearFailure(chunk);
@@ -2051,6 +2135,7 @@ export async function generateEmbeddings(
           doc.path,
           options?.chunkStrategy,
           session.signal,
+          llm,
         );
 
         for (let seq = 0; seq < chunks.length; seq++) {
@@ -2084,7 +2169,8 @@ export async function generateEmbeddings(
         if (!firstResult) {
           throw new Error("Failed to get embedding dimensions from first chunk");
         }
-        store.ensureVecTable(firstResult.embedding.length);
+        if (remoteFailClosed) remoteDimensions = firstResult.embedding.length;
+        else store.ensureVecTable(firstResult.embedding.length);
         vectorTableInitialized = true;
       }
 
@@ -2119,7 +2205,9 @@ export async function generateEmbeddings(
             const chunk = chunkBatch[i]!;
             const embedding = embeddings[i];
             if (embedding) {
-              insertEmbedding(db, chunk.hash, chunk.seq, chunk.pos, new Float32Array(embedding.embedding), model, now, chunk.expectedTotalChunks, fingerprint);
+              const vector = new Float32Array(embedding.embedding);
+              if (remoteFailClosed) stagedRemoteEmbeddings.push({ chunk, embedding: vector });
+              else insertEmbedding(db, chunk.hash, chunk.seq, chunk.pos, vector, model, now, chunk.expectedTotalChunks, fingerprint);
               chunksEmbedded++;
               successesSinceRetry++;
               clearFailure(chunk);
@@ -2161,7 +2249,7 @@ export async function generateEmbeddings(
 
       await retryFailedChunks(true);
 
-      const removedPartialChunks = removeIncompleteEmbeddings(db, expectedChunksByHash, model);
+      const removedPartialChunks = remoteFailClosed ? 0 : removeIncompleteEmbeddings(db, expectedChunksByHash, model);
       if (removedPartialChunks > 0) {
         chunksEmbedded = Math.max(0, chunksEmbedded - removedPartialChunks);
       }
@@ -2173,13 +2261,31 @@ export async function generateEmbeddings(
     return { chunksEmbedded, errors: activeErrorCount(), failures: failureList() };
   }, { maxDuration: options?.maxDurationMs ?? DEFAULT_EMBED_MAX_DURATION_MS, name: 'generateEmbeddings' });
 
-  return {
-    docsProcessed: totalDocs,
-    chunksEmbedded: result.chunksEmbedded,
-    errors: result.errors,
-    failures: result.failures,
-    durationMs: Date.now() - startTime,
-  };
+    if (remoteFailClosed && result.errors > 0) {
+      throw new Error(`Remote embedding failed closed with ${result.errors} unresolved chunk error(s)`);
+    }
+
+    commitRemoteEmbeddings();
+
+    const output = {
+      docsProcessed: totalDocs,
+      chunksEmbedded: result.chunksEmbedded,
+      errors: result.errors,
+      failures: result.failures,
+      durationMs: Date.now() - startTime,
+    };
+    if (ownsRemoteInvocation) {
+      activeRemoteEmbeddingDatabases.delete(db);
+      ownsRemoteInvocation = false;
+    }
+    return output;
+  } catch (error) {
+    if (ownsRemoteInvocation) {
+      activeRemoteEmbeddingDatabases.delete(db);
+      ownsRemoteInvocation = false;
+    }
+    throw error;
+  }
 }
 
 /**
@@ -2201,9 +2307,18 @@ export function createStore(dbPath?: string): Store {
     ensureVecTable: (dimensions: number) => ensureVecTableInternal(db, dimensions),
 
     // Index health
-    getHashesNeedingEmbedding: (model?: string) => getHashesNeedingEmbedding(db, undefined, model ?? store.llm?.embedModelName ?? DEFAULT_EMBED_MODEL),
-    getIndexHealth: (model?: string) => getIndexHealth(db, model ?? store.llm?.embedModelName ?? DEFAULT_EMBED_MODEL),
-    getStatus: (model?: string) => getStatus(db, model ?? store.llm?.embedModelName ?? DEFAULT_EMBED_MODEL),
+    getHashesNeedingEmbedding: (model?: string, collection?: string) => {
+      const identity = getStoreEmbeddingIdentity(store, model);
+      return getHashesNeedingEmbedding(db, collection, identity.model, identity.fingerprint);
+    },
+    getIndexHealth: (model?: string) => {
+      const identity = getStoreEmbeddingIdentity(store, model);
+      return getIndexHealth(db, identity.model, identity.fingerprint);
+    },
+    getStatus: (model?: string) => {
+      const identity = getStoreEmbeddingIdentity(store, model);
+      return getStatus(db, identity.model, identity.fingerprint);
+    },
 
     // Caching
     getCacheKey,
@@ -2479,9 +2594,13 @@ export type IndexStatus = {
 // Index health
 // =============================================================================
 
-export function getHashesNeedingEmbedding(db: Database, collection?: string, model: string = DEFAULT_EMBED_MODEL): number {
+export function getHashesNeedingEmbedding(
+  db: Database,
+  collection?: string,
+  model: string = DEFAULT_EMBED_MODEL,
+  fingerprint: string = getEmbeddingFingerprint(model),
+): number {
   const collectionFilter = collection ? `AND d.collection = ?` : ``;
-  const fingerprint = getEmbeddingFingerprint(model);
   return withLazyContentVectorMigration(db, () => {
     const stmt = db.prepare(`
       SELECT COUNT(DISTINCT d.hash) as count
@@ -2549,7 +2668,7 @@ export async function maybeAdoptLegacyEmbeddingFingerprint(store: Store, model: 
   const llm = getLlm(store);
 
   return await withLLMSessionForLlm(llm, async (session) => {
-    const chunks = await chunkDocumentByTokens(sample.body, undefined, undefined, undefined, sample.path, undefined, session.signal);
+    const chunks = await chunkDocumentByTokens(sample.body, undefined, undefined, undefined, sample.path, undefined, session.signal, llm);
     const chunk = chunks[sample.seq];
     if (!chunk) {
       return { checked: true, adopted: 0, reason: `sample chunk ${expectedHashSeq} no longer exists` };
@@ -2580,8 +2699,8 @@ export async function maybeAdoptLegacyEmbeddingFingerprint(store: Store, model: 
   });
 }
 
-export function getIndexHealth(db: Database, model: string = DEFAULT_EMBED_MODEL): IndexHealthInfo {
-  const needsEmbedding = getHashesNeedingEmbedding(db, undefined, model);
+export function getIndexHealth(db: Database, model: string = DEFAULT_EMBED_MODEL, fingerprint: string = getEmbeddingFingerprint(model)): IndexHealthInfo {
+  const needsEmbedding = getHashesNeedingEmbedding(db, undefined, model, fingerprint);
   const totalDocs = (db.prepare(`SELECT COUNT(*) as count FROM documents WHERE active = 1`).get() as { count: number }).count;
 
   const mostRecent = db.prepare(`SELECT MAX(modified_at) as latest FROM documents WHERE active = 1`).get() as { latest: string | null };
@@ -3173,10 +3292,9 @@ export async function chunkDocumentByTokens(
   windowTokens: number = CHUNK_WINDOW_TOKENS,
   filepath?: string,
   chunkStrategy: ChunkStrategy = "regex",
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  llmOverride?: LlamaCpp,
 ): Promise<{ text: string; pos: number; tokens: number }[]> {
-  const llm = getDefaultLlamaCpp();
-
   // Use moderate chars/token estimate (prose ~4, code ~2, mixed ~3)
   // If chunks exceed limit, they'll be re-split with actual ratio
   const avgCharsPerToken = 3;
@@ -3187,6 +3305,13 @@ export async function chunkDocumentByTokens(
   // Chunk in character space with conservative estimate
   // Use AST-aware chunking for the first pass when filepath/strategy provided
   let charChunks = await chunkDocumentAsync(content, maxChars, overlapChars, windowChars, filepath, chunkStrategy);
+
+  const activeLlm = llmOverride ?? getDefaultLlamaCpp();
+  if (typeof activeLlm.isRemoteEmbed === "function" && activeLlm.isRemoteEmbed()) {
+    return charChunks.map(chunk => ({ text: chunk.text, pos: chunk.pos, tokens: Math.ceil(chunk.text.length / avgCharsPerToken) }));
+  }
+
+  const llm = typeof activeLlm.tokenize === "function" ? activeLlm : getDefaultLlamaCpp();
 
   // Tokenize and split any chunks that still exceed limit
   const results: { text: string; pos: number; tokens: number }[] = [];
@@ -4491,7 +4616,7 @@ export async function rerank(query: string, documents: { file: string; text: str
   const llm = llmOverride ?? getDefaultLlamaCpp();
   // Prefer the LLM instance's resolved URI so a models.rerank swap cannot
   // reuse another model's cache entries (#764).
-  const cacheModel = llm.rerankModelName ?? model;
+  const cacheModel = llm.rerankCacheIdentity ?? llm.rerankModelName ?? model;
 
   const cachedResults: Map<string, number> = new Map();
   const uncachedDocsByChunk: Map<string, RerankDocument> = new Map();
@@ -4517,10 +4642,13 @@ export async function rerank(query: string, documents: { file: string; text: str
     const uncachedDocs = [...uncachedDocsByChunk.values()];
     const rerankResult = await llm.rerank(rerankQuery, uncachedDocs, { model: cacheModel });
 
-    // Cache results by chunk text so identical chunks across files are scored once.
-    const textByFile = new Map(uncachedDocs.map(d => [d.file, d.text]));
+    // Cache by the returned document index. File paths are not unique here: one
+    // source file commonly contributes several candidate chunks.
     for (const result of rerankResult.results) {
-      const chunk = textByFile.get(result.file) || "";
+      if (!Number.isInteger(result.index) || result.index < 0 || result.index >= uncachedDocs.length) {
+        throw new Error("Reranker returned an invalid document index");
+      }
+      const chunk = uncachedDocs[result.index]!.text;
       const cacheKey = getCacheKey("rerank", { query: rerankQuery, model: cacheModel, chunk });
       setCachedResult(db, cacheKey, result.score.toString());
       cachedResults.set(chunk, result.score);
@@ -5119,7 +5247,7 @@ export function findDocuments(
 // Status
 // =============================================================================
 
-export function getStatus(db: Database, model: string = DEFAULT_EMBED_MODEL): IndexStatus {
+export function getStatus(db: Database, model: string = DEFAULT_EMBED_MODEL, fingerprint: string = getEmbeddingFingerprint(model)): IndexStatus {
   // DB is source of truth for collections — config provides supplementary metadata
   const dbCollections = db.prepare(`
     SELECT
@@ -5154,7 +5282,7 @@ export function getStatus(db: Database, model: string = DEFAULT_EMBED_MODEL): In
   });
 
   const totalDocs = (db.prepare(`SELECT COUNT(*) as c FROM documents WHERE active = 1`).get() as { c: number }).c;
-  const needsEmbedding = getHashesNeedingEmbedding(db, undefined, model);
+  const needsEmbedding = getHashesNeedingEmbedding(db, undefined, model, fingerprint);
   const hasVectors = !!db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'`).get();
 
   return {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -766,6 +766,132 @@ describe("CLI Status Command", () => {
     expect(stdout).toContain("qmd pull");
   }, 20000);
 
+  test("qmd doctor does not treat remote embedding as a missing local GGUF", async () => {
+    const env = await createIsolatedTestEnv("doctor-remote-embed");
+    await writeFile(join(env.configDir, "index.yml"), [
+      "collections: {}",
+      "models:",
+      "  embed:",
+      "    provider: openai",
+      "    endpoint: http://127.0.0.1:8086/v1",
+      "    model: Qwen3-Embedding-4B-Q8_0.gguf",
+      "    nativeDimensions: 2560",
+      "    dimensions: 1024",
+      "    reduction: mrl-prefix",
+      "    normalization: l2",
+      "    formatVersion: qwen3-query-document-v1",
+      `  generate: ${DEFAULT_GENERATE_MODEL_URI}`,
+      `  rerank: ${DEFAULT_RERANK_MODEL_URI}`,
+      "",
+    ].join("\n"));
+
+    const { stdout, exitCode } = await runQmd(["doctor"], {
+      dbPath: env.dbPath,
+      configDir: env.configDir,
+      env: { QMD_DOCTOR_DEVICE_PROBE: "0" },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stdout).not.toContain("embedding: Qwen3-Embedding-4B-Q8_0.gguf");
+    expect(stdout).not.toContain("[object Object]");
+    expect(stdout).toContain("current fingerprint 6618ed");
+  }, 20000);
+
+  test.each(["status", "doctor", "update", "embed"])(
+    "qmd %s rejects an incompatible remote embedding identity during preflight",
+    async (command) => {
+      const env = await createIsolatedTestEnv(`invalid-remote-embed-${command}`);
+      await writeFile(join(env.configDir, "index.yml"), [
+        "collections: {}",
+        "models:",
+        "  embed:",
+        "    provider: openai",
+        "    endpoint: http://127.0.0.1:8086/v1",
+        "    model: Qwen3-Embedding-4B-Q8_0.gguf",
+        "    nativeDimensions: 2560",
+        "    dimensions: 2560",
+        "    reduction: mrl-prefix",
+        "    normalization: l2",
+        `  generate: ${DEFAULT_GENERATE_MODEL_URI}`,
+        `  rerank: ${DEFAULT_RERANK_MODEL_URI}`,
+        "",
+      ].join("\n"));
+
+      const result = await runQmd([command], { dbPath: env.dbPath, configDir: env.configDir });
+      expect(result.exitCode).toBe(1);
+      expect(`${result.stdout}\n${result.stderr}`).toContain("dimensions must be exactly 1024");
+      expect(`${result.stdout}\n${result.stderr}`).not.toContain("[object Object]");
+    },
+    20000,
+  );
+
+  test("qmd doctor does not treat remote reranking as a missing local GGUF", async () => {
+    const env = await createIsolatedTestEnv("doctor-remote-rerank");
+    await writeFile(join(env.configDir, "index.yml"), [
+      "collections: {}",
+      "models:",
+      `  embed: ${DEFAULT_EMBED_MODEL_URI}`,
+      `  generate: ${DEFAULT_GENERATE_MODEL_URI}`,
+      "  rerank:",
+      "    provider: openai",
+      "    endpoint: http://127.0.0.1:8088/v1",
+      "    model: Qwen3-Reranker-0.6B-Q4_K_M.gguf",
+      "",
+    ].join("\n"));
+
+    const { stdout, exitCode } = await runQmd(["doctor"], {
+      dbPath: env.dbPath,
+      configDir: env.configDir,
+      env: { QMD_DOCTOR_DEVICE_PROBE: "0" },
+    });
+
+    expect(exitCode, stdout).toBe(0);
+    expect(stdout).not.toContain("reranking: Qwen3-Reranker-0.6B-Q4_K_M.gguf");
+    expect(stdout).not.toContain("[object Object]");
+  }, 20000);
+
+  test("qmd status fails closed on malformed structured remote rerank config", async () => {
+    const env = await createIsolatedTestEnv("status-invalid-remote-rerank");
+    await writeFile(join(env.configDir, "index.yml"), [
+      "collections: {}",
+      "models:",
+      `  embed: ${DEFAULT_EMBED_MODEL_URI}`,
+      `  generate: ${DEFAULT_GENERATE_MODEL_URI}`,
+      "  rerank:",
+      "    provider: openai",
+      "    endpoint: file:///tmp/v1",
+      "    model: Qwen3-Reranker-0.6B-Q4_K_M.gguf",
+      "",
+    ].join("\n"));
+
+    const result = await runQmd(["status"], { dbPath: env.dbPath, configDir: env.configDir });
+    expect(result.exitCode).toBe(1);
+    expect(`${result.stdout}\n${result.stderr}`).toContain("remote rerank endpoint must use HTTP or HTTPS");
+    expect(`${result.stdout}\n${result.stderr}`).not.toContain("[object Object]");
+  }, 20000);
+
+  test("qmd doctor reports malformed remote rerank config without fallback", async () => {
+    const env = await createIsolatedTestEnv("doctor-invalid-remote-rerank");
+    await writeFile(join(env.configDir, "index.yml"), [
+      "collections: {}",
+      "models:",
+      `  embed: ${DEFAULT_EMBED_MODEL_URI}`,
+      `  generate: ${DEFAULT_GENERATE_MODEL_URI}`,
+      "  rerank:",
+      "    provider: openai",
+      "    endpoint: file:///tmp/v1",
+      "    model: Qwen3-Reranker-0.6B-Q4_K_M.gguf",
+      "",
+    ].join("\n"));
+
+    const result = await runQmd(["doctor"], { dbPath: env.dbPath, configDir: env.configDir });
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain("QMD Doctor");
+    expect(result.stdout).toContain("model configuration");
+    expect(result.stdout).toContain("remote rerank endpoint must use HTTP or HTTPS");
+    expect(`${result.stdout}\n${result.stderr}`).not.toContain("[object Object]");
+  }, 20000);
+
   test("qmd doctor identifies cached non-GGUF model files", async () => {
     const env = await createIsolatedTestEnv("doctor-invalid-model-cache");
     const model = "hf:example/custom-model/custom.gguf";
@@ -919,6 +1045,45 @@ describe("CLI Status Command", () => {
     expect(stdout).toContain("embedding fingerprints");
     expect(stdout).toContain("mixed named embedding fingerprints");
     expect(stdout).toContain("stale1");
+  }, 20000);
+
+  test("status treats remote semantic fingerprints as current", async () => {
+    const env = await createIsolatedTestEnv("status-remote-embed");
+    await writeFile(join(env.configDir, "index.yml"), [
+      "collections:",
+      "  docs:",
+      `    path: ${JSON.stringify(fixturesDir)}`,
+      '    pattern: "**/*.md"',
+      "models:",
+      "  embed:",
+      "    provider: openai",
+      "    endpoint: http://127.0.0.1:8086/v1",
+      "    model: Qwen3-Embedding-4B-Q8_0.gguf",
+      "    nativeDimensions: 2560",
+      "    dimensions: 1024",
+      "    reduction: mrl-prefix",
+      "    normalization: l2",
+      "    formatVersion: qwen3-query-document-v1",
+      `  generate: ${DEFAULT_GENERATE_MODEL_URI}`,
+      `  rerank: ${DEFAULT_RERANK_MODEL_URI}`,
+      "",
+    ].join("\n"));
+    await runQmd(["update"], { dbPath: env.dbPath, configDir: env.configDir });
+
+    const db = openDatabase(env.dbPath);
+    const now = new Date().toISOString();
+    const hashes = db.prepare(`SELECT DISTINCT hash FROM documents WHERE active = 1`).all() as { hash: string }[];
+    for (const { hash } of hashes) {
+      db.prepare(`
+        INSERT INTO content_vectors (hash, seq, pos, model, embed_fingerprint, total_chunks, embedded_at)
+        VALUES (?, 0, 0, 'Qwen3-Embedding-4B-Q8_0.gguf', '6618ed', 1, ?)
+      `).run(hash, now);
+    }
+    db.close();
+
+    const { stdout, exitCode } = await runQmd(["status"], { dbPath: env.dbPath, configDir: env.configDir });
+    expect(exitCode).toBe(0);
+    expect(stdout).not.toContain("Pending:");
   }, 20000);
 
   test("shows index status", async () => {

--- a/test/doctor-vector-repro.test.ts
+++ b/test/doctor-vector-repro.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildDoctorVectorSampleResult,
+  classifyDoctorVectorDistance,
+} from "../src/doctor-vector-repro.js";
+
+describe("doctor vector reproducibility classification", () => {
+  test("keeps the strict threshold for local embeddings", () => {
+    expect(classifyDoctorVectorDistance(0.000228, false)).toBe("mismatch");
+  });
+
+  test("classifies calibrated remote batch-shape variance as drift", () => {
+    expect(classifyDoctorVectorDistance(0.000691, true)).toBe("remote-drift");
+  });
+
+  test("still rejects materially different remote vectors", () => {
+    expect(classifyDoctorVectorDistance(0.002, true)).toBe("mismatch");
+  });
+
+  test("accepts vectors within the strict reproducibility threshold", () => {
+    expect(classifyDoctorVectorDistance(0.00005, false)).toBe("match");
+    expect(classifyDoctorVectorDistance(0.00005, true)).toBe("match");
+  });
+
+  test("rejects invalid distances for every backend", () => {
+    expect(classifyDoctorVectorDistance(Number.NaN, false)).toBe("mismatch");
+    expect(classifyDoctorVectorDistance(Number.POSITIVE_INFINITY, true)).toBe("mismatch");
+  });
+
+  test("bounded remote drift is healthy and does not recommend a rebuild", () => {
+    const result = buildDoctorVectorSampleResult(3, [], ["abc123_1: stored vector distance 0.000691"]);
+    expect(result.ok).toBe(true);
+    expect(result.forceRebuild).toBe(false);
+    expect(result.details).toContain("bounded batch-shape drift");
+    expect(result.details).toContain("no rebuild is needed");
+    expect(result.details).not.toContain("embed --force");
+  });
+
+  test("material mismatch fails and recommends a forced rebuild", () => {
+    const result = buildDoctorVectorSampleResult(3, ["abc123_1: stored vector distance 0.002000"], []);
+    expect(result.ok).toBe(false);
+    expect(result.forceRebuild).toBe(true);
+    expect(result.details).toContain("qmd embed --force");
+  });
+});

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -721,6 +721,17 @@ describe("LlamaCpp rerank deduping", () => {
 });
 
 describe("LlamaCpp ensureRerankContexts error reporting", () => {
+  test("unavailable-reranker fallback preserves each document index", async () => {
+    const llm = new LlamaCpp({}) as any;
+    llm.ensureRerankContexts = vi.fn().mockResolvedValue([]);
+    const result = await llm.rerank("query", [
+      { file: "a.md", text: "a" },
+      { file: "b.md", text: "b" },
+    ]);
+    expect(result.results.map((item: { index: number }) => item.index)).toEqual([0, 1]);
+    expect(result.results.map((item: { score: number }) => item.score)).toEqual([0.5, 0.5]);
+  });
+
   test("warns with the underlying error and does not retry identical options", async () => {
     const llm = new LlamaCpp({}) as any;
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/test/local-config-trust-cli.test.ts
+++ b/test/local-config-trust-cli.test.ts
@@ -129,6 +129,128 @@ describe("qmd update with a checked-in collection path outside the project", () 
 });
 
 describe("qmd update with a checked-in custom model URI", () => {
+  test("malformed untrusted structured rerank config fails closed before trust fallback", async () => {
+    writeLocalConfig([
+      "collections:",
+      "  docs:",
+      "    path: ./docs",
+      '    pattern: "**/*.md"',
+      "models:",
+      "  rerank:",
+      "    provider: openai",
+      "    endpoint: file:///tmp/v1",
+      "    model: Qwen3-Reranker-0.6B-Q4_K_M.gguf",
+      "",
+    ].join("\n"));
+
+    const result = await runQmd(["update"]);
+    expect(result.exitCode).toBe(1);
+    expect(`${result.stdout}\n${result.stderr}`).toContain("remote rerank endpoint must use HTTP or HTTPS");
+    expect(result.stdout).not.toContain("Indexed: 1 new");
+  }, 120_000);
+
+  test("trusted malformed structured rerank config also fails closed", async () => {
+    writeLocalConfig([
+      "collections:",
+      "  docs:",
+      "    path: ./docs",
+      '    pattern: "**/*.md"',
+      "models:",
+      "  rerank:",
+      "    provider: openai",
+      "    endpoint: file:///tmp/v1",
+      "    model: Qwen3-Reranker-0.6B-Q4_K_M.gguf",
+      "",
+    ].join("\n"));
+
+    const result = await runQmd(["update"], { QMD_TRUST_LOCAL_CONFIG: "1" });
+    expect(result.exitCode).toBe(1);
+    expect(`${result.stdout}\n${result.stderr}`).toContain("remote rerank endpoint must use HTTP or HTTPS");
+    expect(result.stdout).not.toContain("Indexed: 1 new");
+  }, 120_000);
+
+  test("trust refuses malformed structured rerank config before recording approval", async () => {
+    writeLocalConfig([
+      "collections:",
+      "  docs:",
+      "    path: ./docs",
+      '    pattern: "**/*.md"',
+      "models:",
+      "  rerank:",
+      "    provider: openai",
+      "    endpoint: file:///tmp/v1",
+      "    model: Qwen3-Reranker-0.6B-Q4_K_M.gguf",
+      "",
+    ].join("\n"));
+
+    const result = await runQmd(["trust"]);
+    expect(result.exitCode).toBe(1);
+    expect(`${result.stdout}\n${result.stderr}`).toContain("remote rerank endpoint must use HTTP or HTTPS");
+    expect(result.stdout).not.toContain("✓ Trusted");
+  }, 120_000);
+
+  test("pull refuses malformed structured rerank config before model downloads", async () => {
+    writeLocalConfig([
+      "collections:",
+      "  docs:",
+      "    path: ./docs",
+      '    pattern: "**/*.md"',
+      "models:",
+      "  rerank:",
+      "    provider: openai",
+      "    endpoint: file:///tmp/v1",
+      "    model: Qwen3-Reranker-0.6B-Q4_K_M.gguf",
+      "",
+    ].join("\n"));
+
+    const result = await runQmd(["pull"]);
+    expect(result.exitCode).toBe(1);
+    expect(`${result.stdout}\n${result.stderr}`).toContain("remote rerank endpoint must use HTTP or HTTPS");
+    expect(result.stdout).not.toContain("Pulling");
+  }, 120_000);
+
+  test("never prints credentials embedded in a remote endpoint trust snapshot", async () => {
+    writeLocalConfig([
+      "collections:",
+      "  docs:",
+      "    path: ./docs",
+      '    pattern: "**/*.md"',
+      "models:",
+      "  embed:",
+      "    provider: openai",
+      "    endpoint: http://user:secret-token@127.0.0.1:8086/v1?api_key=query-secret",
+      "    model: Qwen3-Embedding-4B-Q8_0.gguf",
+      "    nativeDimensions: 2560",
+      "    dimensions: 1024",
+      "    reduction: mrl-prefix",
+      "    normalization: l2",
+      "",
+    ].join("\n"));
+
+    const result = await runQmd(["update"]);
+    expect(`${result.stdout}\n${result.stderr}`).not.toContain("secret-token");
+    expect(`${result.stdout}\n${result.stderr}`).not.toContain("query-secret");
+  }, 120_000);
+
+  test("never prints credentials embedded in a remote rerank endpoint trust snapshot", async () => {
+    writeLocalConfig([
+      "collections:",
+      "  docs:",
+      "    path: ./docs",
+      '    pattern: "**/*.md"',
+      "models:",
+      "  rerank:",
+      "    provider: openai",
+      "    endpoint: http://user:rerank-secret@127.0.0.1:8088/v1?api_key=rerank-query-secret",
+      "    model: Qwen3-Reranker-0.6B-Q4_K_M.gguf",
+      "",
+    ].join("\n"));
+
+    const result = await runQmd(["update"]);
+    expect(`${result.stdout}\n${result.stderr}`).not.toContain("rerank-secret");
+    expect(`${result.stdout}\n${result.stderr}`).not.toContain("rerank-query-secret");
+  }, 120_000);
+
   test("does not treat the custom model as trusted, but still indexes the project", async () => {
     writeLocalConfig([
       "collections:",

--- a/test/remote-embed.test.ts
+++ b/test/remote-embed.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  RemoteEmbeddingProtocolError,
+  RemoteEmbeddingTransportError,
+  OpenAIEmbeddingClient,
+  resolveEmbeddingConfig,
+} from "../src/remote-embed.js";
+
+const NATIVE_DIM = 2560;
+const OUTPUT_DIM = 1024;
+const vector = (seed = 1) => Array.from({ length: NATIVE_DIM }, (_, i) => seed + i / 10000);
+const response = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status });
+const directJsonResponse = (body: unknown) => ({
+  ok: true,
+  status: 200,
+  json: async () => body,
+}) as Response;
+const indexed = (items: Array<{ index: number; embedding: unknown }>, model = "Qwen3-Embedding-4B-Q8_0.gguf") => ({
+  object: "list", model, data: items.map(item => ({ object: "embedding", ...item })),
+});
+const client = (overrides: Partial<ConstructorParameters<typeof OpenAIEmbeddingClient>[0]> = {}) => new OpenAIEmbeddingClient({
+  provider: "openai",
+  endpoint: "http://127.0.0.1:8086/v1/embeddings",
+  model: "Qwen3-Embedding-4B-Q8_0.gguf",
+  nativeDimensions: NATIVE_DIM,
+  dimensions: OUTPUT_DIM,
+  reduction: "mrl-prefix",
+  normalization: "l2",
+  formatVersion: "qwen3-v1",
+  ...overrides,
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("OpenAIEmbeddingClient", () => {
+  test("posts untruncated input and restores reordered data by index", async () => {
+    const a = vector(1), b = vector(2);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(response(indexed([
+      { index: 1, embedding: b }, { index: 0, embedding: a },
+    ])));
+    const embeddings = await client().embedBatch(["a".repeat(13000), "b"]);
+    expect(embeddings).toHaveLength(2);
+    expect(embeddings[0]).toHaveLength(OUTPUT_DIM);
+    expect(embeddings[1]).toHaveLength(OUTPUT_DIM);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("http://127.0.0.1:8086/v1/embeddings");
+    expect(JSON.parse(String(init?.body))).toEqual({ model: "Qwen3-Embedding-4B-Q8_0.gguf", input: ["a".repeat(13000), "b"] });
+  });
+
+  test("selects the exact leading 1024 components and L2-normalizes only that prefix", async () => {
+    const native = Array(NATIVE_DIM).fill(0);
+    native[0] = 3;
+    native[1] = 4;
+    native[OUTPUT_DIM] = 12;
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response(indexed([{ index: 0, embedding: native }])));
+
+    const embedding = await client().embed("query or document");
+
+    expect(embedding).toHaveLength(OUTPUT_DIM);
+    expect(embedding[0]).toBeCloseTo(0.6, 7);
+    expect(embedding[1]).toBeCloseTo(0.8, 7);
+    expect(embedding.slice(2)).toEqual(Array(OUTPUT_DIM - 2).fill(0));
+  });
+
+  test("validates the full native vector before truncating the tail", async () => {
+    const native = vector();
+    native[OUTPUT_DIM + 100] = Number.POSITIVE_INFINITY;
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(directJsonResponse(indexed([{ index: 0, embedding: native }])));
+
+    await expect(client().embed("a")).rejects.toThrow("finite Float32");
+  });
+
+  test("rejects a zero prefix even when the discarded tail is nonzero", async () => {
+    const native = Array(NATIVE_DIM).fill(0);
+    native[OUTPUT_DIM] = 1;
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response(indexed([{ index: 0, embedding: native }])));
+
+    await expect(client().embed("a")).rejects.toThrow("zero or invalid norm");
+  });
+
+  test("rejects an underflowed prefix norm and never returns invalid normalized Float32 output", async () => {
+    const native = Array(NATIVE_DIM).fill(0);
+    native[0] = Number.MIN_VALUE;
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response(indexed([{ index: 0, embedding: native }])));
+
+    await expect(client().embed("a")).rejects.toThrow("zero or invalid norm");
+  });
+
+  test.each([
+    ["wrong cardinality", indexed([{ index: 0, embedding: vector() }])],
+    ["missing index", indexed([{ index: 0, embedding: vector() }, { index: 2, embedding: vector(2) }])],
+    ["duplicate index", indexed([{ index: 0, embedding: vector() }, { index: 0, embedding: vector(2) }])],
+    ["negative index", indexed([{ index: -1, embedding: vector() }, { index: 1, embedding: vector(2) }])],
+    ["non-integer index", indexed([{ index: 0.5, embedding: vector() }, { index: 1, embedding: vector(2) }])],
+    ["out of range index", indexed([{ index: 0, embedding: vector() }, { index: 2, embedding: vector(2) }])],
+    ["missing data", { model: "Qwen3-Embedding-4B-Q8_0.gguf" }],
+    ["empty vector", indexed([{ index: 0, embedding: [] }, { index: 1, embedding: vector() }])],
+    ["malformed vector", indexed([{ index: 0, embedding: "bad" }, { index: 1, embedding: vector() }])],
+    ["non numeric vector", indexed([{ index: 0, embedding: [...vector().slice(0, -1), "x"] }, { index: 1, embedding: vector() }])],
+    ["non-finite vector", indexed([{ index: 0, embedding: [...vector().slice(0, -1), Infinity] }, { index: 1, embedding: vector() }])],
+    ["Float32-overflow vector", indexed([{ index: 0, embedding: [...vector().slice(0, -1), 1e300] }, { index: 1, embedding: vector() }])],
+    ["wrong dimension", indexed([{ index: 0, embedding: [1, 2] }, { index: 1, embedding: [3, 4] }])],
+    ["inconsistent dimension", indexed([{ index: 0, embedding: vector() }, { index: 1, embedding: vector().slice(1) }])],
+    ["missing response model", { data: [{ index: 0, embedding: vector() }, { index: 1, embedding: vector(2) }] }],
+    ["wrong response model", indexed([{ index: 0, embedding: vector() }, { index: 1, embedding: vector(2) }], "other-model")],
+  ])("rejects %s as a typed protocol error", async (_name, body) => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response(body));
+    await expect(client().embedBatch(["a", "b"])).rejects.toBeInstanceOf(RemoteEmbeddingProtocolError);
+  });
+
+  test("accepts an explicitly configured response model alias", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response(indexed([{ index: 0, embedding: vector() }], "server-alias")));
+    expect(await client({ modelAliases: ["server-alias"] }).embedBatch(["a"])).toHaveLength(1);
+  });
+
+  test.each([
+    ["HTTP failure", async () => response({ error: { message: "no" } }, 503)],
+    ["invalid JSON", async () => new Response("not-json", { status: 200 })],
+    ["network failure", async () => { throw new Error("connect secret-token"); }],
+    ["timeout", async () => { throw new DOMException("timed out", "TimeoutError"); }],
+    ["abort", async () => { throw new DOMException("aborted", "AbortError"); }],
+  ])("turns %s into a typed safe error", async (_name, implementation) => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(implementation as typeof fetch);
+    const error = await client({ apiKey: "secret-token" }).embedBatch(["a"]).catch(e => e);
+    expect(error).toBeInstanceOf(_name === "invalid JSON" ? RemoteEmbeddingProtocolError : RemoteEmbeddingTransportError);
+    expect(String(error)).not.toContain("secret-token");
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+  });
+
+  test("sends an optional bearer key without exposing it in identity", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(response(indexed([{ index: 0, embedding: vector() }])));
+    await client({ apiKey: "secret-token" }).embedBatch(["a"]);
+    expect((fetchMock.mock.calls[0]![1]!.headers as Record<string, string>).Authorization).toBe("Bearer secret-token");
+  });
+});
+
+describe("embedding configuration compatibility", () => {
+  test("resolves explicit native and stored dimensions with required MRL semantics", () => {
+    expect(resolveEmbeddingConfig({
+      provider: "openai",
+      endpoint: "http://host/v1/embeddings",
+      model: "qwen",
+      nativeDimensions: 2560,
+      dimensions: 1024,
+      reduction: "mrl-prefix",
+      normalization: "l2",
+      apiKey: "key",
+    })).toMatchObject({
+      kind: "remote",
+      endpoint: "http://host/v1/embeddings",
+      model: "qwen",
+      nativeDimensions: 2560,
+      dimensions: 1024,
+      reduction: "mrl-prefix",
+      normalization: "l2",
+      apiKey: "key",
+    });
+  });
+  test.each([
+    ["non-string model", { model: 42 }],
+    ["missing native dimensions", { nativeDimensions: undefined }],
+    ["wrong native dimensions", { nativeDimensions: 1024 }],
+    ["fractional native dimensions", { nativeDimensions: 2559.5 }],
+    ["negative native dimensions", { nativeDimensions: -2560 }],
+    ["missing output dimensions", { dimensions: undefined }],
+    ["wrong output dimensions", { dimensions: 768 }],
+    ["output dimensions equal native dimensions", { dimensions: 2560 }],
+    ["output dimensions greater than native dimensions", { dimensions: 4096 }],
+    ["fractional output dimensions", { dimensions: 1023.5 }],
+    ["negative output dimensions", { dimensions: -1024 }],
+    ["missing reduction", { reduction: undefined }],
+    ["wrong reduction", { reduction: "mean-pool" }],
+    ["missing normalization", { normalization: undefined }],
+    ["wrong normalization", { normalization: "none" }],
+    ["invalid normalization", { normalization: "cosine" }],
+    ["empty formatVersion", { formatVersion: "" }],
+    ["non-string formatVersion", { formatVersion: 7 }],
+    ["zero timeoutMs", { timeoutMs: 0 }],
+    ["fractional timeoutMs", { timeoutMs: 1.5 }],
+    ["non-array modelAliases", { modelAliases: "alias" }],
+    ["non-string model alias", { modelAliases: [7] }],
+    ["empty model alias", { modelAliases: [""] }],
+    ["non-string apiKey", { apiKey: 7 }],
+    ["empty apiKey", { apiKey: "" }],
+  ])("rejects %s at runtime", (_name, override) => {
+    expect(() => resolveEmbeddingConfig({
+      provider: "openai",
+      endpoint: "http://127.0.0.1:8086/v1",
+      model: "qwen",
+      nativeDimensions: 2560,
+      dimensions: 1024,
+      reduction: "mrl-prefix",
+      normalization: "l2",
+      ...override,
+    } as any)).toThrow(RemoteEmbeddingProtocolError);
+  });
+
+  test.each([
+    ["not a URL", "not-a-url"],
+    ["wrong scheme", "ftp://127.0.0.1/v1"],
+    ["wrong path", "http://127.0.0.1:8086/api"],
+    ["embedded credentials", "http://user:secret-token@127.0.0.1:8086/v1"],
+    ["query credentials", "http://127.0.0.1:8086/v1?api_key=secret-token"],
+  ])("rejects %s with a typed safe endpoint error", (_name, endpoint) => {
+    let error: unknown;
+    try {
+      resolveEmbeddingConfig({
+        provider: "openai",
+        endpoint,
+        model: "qwen",
+        nativeDimensions: 2560,
+        dimensions: 1024,
+        reduction: "mrl-prefix",
+        normalization: "l2",
+      });
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(RemoteEmbeddingProtocolError);
+    expect(String(error)).not.toContain("secret-token");
+  });
+
+  test("keeps every string model URI local, including HTTP GGUF URLs", () => {
+    expect(resolveEmbeddingConfig("hf:org/repo/model.gguf")).toEqual({ kind: "local", model: "hf:org/repo/model.gguf" });
+    expect(resolveEmbeddingConfig("https://models.example/qwen.gguf")).toEqual({
+      kind: "local",
+      model: "https://models.example/qwen.gguf",
+    });
+  });
+});

--- a/test/remote-embedding-routing.test.ts
+++ b/test/remote-embedding-routing.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { LlamaCpp, setDefaultLlamaCpp, setNodeLlamaCppModuleForTest } from "../src/llm.js";
+import { chunkDocumentByTokens, getEmbeddingFingerprint } from "../src/store.js";
+
+const remote = (endpoint = "http://127.0.0.1:8086/v1/embeddings", apiKey = "secret") => ({
+  provider: "openai" as const,
+  endpoint,
+  model: "Qwen3-Embedding-4B-Q8_0.gguf",
+  nativeDimensions: 2560,
+  dimensions: 1024,
+  apiKey,
+  reduction: "mrl-prefix" as const,
+  normalization: "l2" as const,
+  formatVersion: "qwen3-query-document-v1",
+});
+const vector = () => Array.from({ length: 2560 }, (_, i) => i / 2560);
+const ok = (count: number) => new Response(JSON.stringify({
+  model: "Qwen3-Embedding-4B-Q8_0.gguf",
+  data: Array.from({ length: count }, (_, index) => ({ index, embedding: vector() })),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setDefaultLlamaCpp(null);
+  setNodeLlamaCppModuleForTest(null);
+});
+
+describe("remote embedding routing", () => {
+  test("embeds remotely without resolving, initializing, or downloading local embedding GGUF", async () => {
+    const getLlama = vi.fn();
+    const resolveModelFile = vi.fn();
+    setNodeLlamaCppModuleForTest({ getLlama, resolveModelFile, LlamaChatSession: vi.fn() as any, LlamaLogLevel: { error: 0 } });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(ok(1));
+    const llm = new LlamaCpp({ embedModel: remote() });
+
+    const result = await llm.embed("untruncated remote input");
+
+    expect(result?.embedding).toHaveLength(1024);
+    expect(result?.model).toBe("Qwen3-Embedding-4B-Q8_0.gguf");
+    expect(getLlama).not.toHaveBeenCalled();
+    expect(resolveModelFile).not.toHaveBeenCalled();
+  });
+
+  test("applies the same 1024-dimensional transformation to single, query, and batch paths", async () => {
+    const native = Array(2560).fill(0);
+    native[0] = 3;
+    native[1] = 4;
+    native[1024] = 12;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      const count = (JSON.parse(String(init?.body)).input as string[]).length;
+      return new Response(JSON.stringify({
+        model: "Qwen3-Embedding-4B-Q8_0.gguf",
+        data: Array.from({ length: count }, (_, index) => ({ index, embedding: native })),
+      }));
+    });
+    const llm = new LlamaCpp({ embedModel: remote() });
+
+    const single = await llm.embed("single");
+    const query = await llm.embed("query", { isQuery: true });
+    const batch = await llm.embedBatch(["document one", "document two"]);
+
+    for (const result of [single, query, ...batch]) {
+      expect(result?.embedding).toHaveLength(1024);
+      expect(result?.embedding[0]).toBeCloseTo(0.6, 7);
+      expect(result?.embedding[1]).toBeCloseTo(0.8, 7);
+      expect(result?.embedding.slice(2)).toEqual(Array(1022).fill(0));
+    }
+  });
+
+  test("fails closed with the typed remote error and never falls back locally", async () => {
+    const getLlama = vi.fn();
+    const resolveModelFile = vi.fn();
+    setNodeLlamaCppModuleForTest({ getLlama, resolveModelFile, LlamaChatSession: vi.fn() as any, LlamaLogLevel: { error: 0 } });
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
+    const llm = new LlamaCpp({ embedModel: remote() });
+
+    await expect(llm.embedBatch(["a", "b"])).rejects.toMatchObject({ name: "RemoteEmbeddingTransportError" });
+    expect(getLlama).not.toHaveBeenCalled();
+    expect(resolveModelFile).not.toHaveBeenCalled();
+  });
+
+  test("rejects a conflicting explicit model before calling the remote endpoint", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(ok(1));
+    const llm = new LlamaCpp({ embedModel: remote() });
+
+    await expect(llm.embed("text", { model: "other-model" })).rejects.toThrow("does not match");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("default remote token chunking never initializes a local embedding context", async () => {
+    const getLlama = vi.fn();
+    const resolveModelFile = vi.fn();
+    setNodeLlamaCppModuleForTest({ getLlama, resolveModelFile, LlamaChatSession: vi.fn() as any, LlamaLogLevel: { error: 0 } });
+    setDefaultLlamaCpp(new LlamaCpp({ embedModel: remote() }));
+
+    const chunks = await chunkDocumentByTokens("remote chunking must not load a local model");
+
+    expect(chunks).toHaveLength(1);
+    expect(getLlama).not.toHaveBeenCalled();
+    expect(resolveModelFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("remote embedding fingerprint", () => {
+  test("preserves the upstream local fingerprint for backward compatibility", () => {
+    expect(getEmbeddingFingerprint()).toBe("c37385");
+  });
+
+  test("includes semantic fields but excludes endpoint and secrets", () => {
+    const a = getEmbeddingFingerprint(remote("http://a/v1/embeddings", "key-a"));
+    const b = getEmbeddingFingerprint(remote("http://b/v1/embeddings", "key-b"));
+    expect(a).toBe(b);
+    expect(a).toBe("6618ed");
+    expect(getEmbeddingFingerprint({ ...remote(), nativeDimensions: 2048 })).not.toBe(a);
+    expect(getEmbeddingFingerprint({ ...remote(), dimensions: 768 })).not.toBe(a);
+    expect(getEmbeddingFingerprint({ ...remote(), model: "other" })).not.toBe(a);
+    expect(getEmbeddingFingerprint({ ...remote(), reduction: "other" })).not.toBe(a);
+    expect(getEmbeddingFingerprint({ ...remote(), normalization: "none" })).not.toBe(a);
+    expect(getEmbeddingFingerprint({ ...remote(), formatVersion: "v2" })).not.toBe(a);
+    expect(getEmbeddingFingerprint({ ...remote(), provider: "openai-compatible" as any })).not.toBe(a);
+  });
+});

--- a/test/remote-rerank-routing.test.ts
+++ b/test/remote-rerank-routing.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { LlamaCpp, setNodeLlamaCppModuleForTest } from "../src/llm.js";
+
+const remote = {
+  provider: "openai" as const,
+  endpoint: "http://127.0.0.1:8088/v1",
+  model: "Qwen3-Reranker-0.6B-Q4_K_M.gguf",
+};
+
+const ok = () => new Response(JSON.stringify({
+  model: remote.model,
+  results: [
+    { index: 1, relevance_score: 0.9 },
+    { index: 0, relevance_score: 0.1 },
+  ],
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setNodeLlamaCppModuleForTest(null);
+});
+
+describe("remote rerank routing", () => {
+  test("reranks remotely without initializing or resolving a local GGUF", async () => {
+    const getLlama = vi.fn();
+    const resolveModelFile = vi.fn();
+    setNodeLlamaCppModuleForTest({ getLlama, resolveModelFile, LlamaChatSession: vi.fn() as never, LlamaLogLevel: { error: 0 } });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(ok());
+    const llm = new LlamaCpp({ rerankModel: remote });
+
+    const result = await llm.rerank("query", [
+      { file: "a.md", text: "a" },
+      { file: "b.md", text: "b" },
+    ]);
+
+    expect(result.results.map(item => item.index)).toEqual([1, 0]);
+    expect(result.results.map(item => item.score)).toEqual([0.9, 0.1]);
+    expect(getLlama).not.toHaveBeenCalled();
+    expect(resolveModelFile).not.toHaveBeenCalled();
+  });
+
+  test("fails closed and never falls back to a local reranker", async () => {
+    const getLlama = vi.fn();
+    const resolveModelFile = vi.fn();
+    setNodeLlamaCppModuleForTest({ getLlama, resolveModelFile, LlamaChatSession: vi.fn() as never, LlamaLogLevel: { error: 0 } });
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
+    const llm = new LlamaCpp({ rerankModel: remote });
+
+    await expect(llm.rerank("query", [{ file: "a.md", text: "a" }]))
+      .rejects.toMatchObject({ name: "RemoteRerankTransportError" });
+    expect(getLlama).not.toHaveBeenCalled();
+    expect(resolveModelFile).not.toHaveBeenCalled();
+  });
+});

--- a/test/remote-rerank.test.ts
+++ b/test/remote-rerank.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  OpenAIRerankClient,
+  RemoteRerankProtocolError,
+  RemoteRerankTransportError,
+  getRerankCacheIdentity,
+  resolveRerankConfig,
+} from "../src/remote-rerank.js";
+
+const config = {
+  provider: "openai" as const,
+  endpoint: "http://127.0.0.1:8088/v1",
+  model: "Qwen3-Reranker-0.6B-Q4_K_M.gguf",
+};
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("OpenAIRerankClient", () => {
+  test("maps ranked out-of-order indexes and preserves normalized relevance_score", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      model: "Qwen3-Reranker-0.6B-Q4_K_M.gguf",
+      results: [
+        { index: 2, relevance_score: 0.97 },
+        { index: 0, relevance_score: 0.61 },
+        { index: 1, relevance_score: 0.02 },
+      ],
+    }), { status: 200, headers: { "Content-Type": "application/json" } }));
+
+    const documents = [
+      { file: "a.md", text: "alpha" },
+      { file: "b.md", text: "beta" },
+      { file: "c.md", text: "gamma" },
+    ];
+    const result = await new OpenAIRerankClient(config).rerank("query", documents);
+
+    expect(result).toEqual({
+      model: config.model,
+      results: [
+        { file: "c.md", index: 2, score: 0.97 },
+        { file: "a.md", index: 0, score: 0.61 },
+        { file: "b.md", index: 1, score: 0.02 },
+      ],
+    });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("http://127.0.0.1:8088/v1/rerank");
+    expect(JSON.parse(String(init?.body))).toEqual({
+      model: config.model,
+      query: "query",
+      documents: ["alpha", "beta", "gamma"],
+    });
+  });
+
+  test.each([
+    ["missing results", { model: config.model }],
+    ["wrong cardinality", { model: config.model, results: [{ index: 0, relevance_score: 0.5 }] }],
+    ["duplicate index", { model: config.model, results: [{ index: 0, relevance_score: 0.5 }, { index: 0, relevance_score: 0.4 }] }],
+    ["negative index", { model: config.model, results: [{ index: -1, relevance_score: 0.5 }, { index: 1, relevance_score: 0.4 }] }],
+    ["fractional index", { model: config.model, results: [{ index: 0.5, relevance_score: 0.5 }, { index: 1, relevance_score: 0.4 }] }],
+    ["out-of-range index", { model: config.model, results: [{ index: 0, relevance_score: 0.5 }, { index: 2, relevance_score: 0.4 }] }],
+    ["NaN score", { model: config.model, results: [{ index: 0, relevance_score: Number.NaN }, { index: 1, relevance_score: 0.4 }] }],
+    ["infinite score", { model: config.model, results: [{ index: 0, relevance_score: Infinity }, { index: 1, relevance_score: 0.4 }] }],
+    ["score below zero", { model: config.model, results: [{ index: 0, relevance_score: -0.1 }, { index: 1, relevance_score: 0.4 }] }],
+    ["score above one", { model: config.model, results: [{ index: 0, relevance_score: 1.1 }, { index: 1, relevance_score: 0.4 }] }],
+    ["missing response model", { results: [{ index: 0, relevance_score: 0.5 }, { index: 1, relevance_score: 0.4 }] }],
+    ["wrong response model", { model: "other", results: [{ index: 0, relevance_score: 0.5 }, { index: 1, relevance_score: 0.4 }] }],
+  ])("rejects %s", async (_name, body) => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify(body), { status: 200 }));
+    await expect(new OpenAIRerankClient(config).rerank("q", [
+      { file: "a.md", text: "a" },
+      { file: "b.md", text: "b" },
+    ])).rejects.toBeInstanceOf(RemoteRerankProtocolError);
+  });
+
+  test.each([
+    ["malformed URL", { endpoint: "not a URL" }],
+    ["unsupported scheme", { endpoint: "file:///tmp/v1" }],
+    ["wrong path", { endpoint: "http://127.0.0.1:8088/api" }],
+    ["URL credentials", { endpoint: "http://user:pass@127.0.0.1:8088/v1" }],
+    ["URL query", { endpoint: "http://127.0.0.1:8088/v1?token=secret" }],
+    ["URL fragment", { endpoint: "http://127.0.0.1:8088/v1#secret" }],
+    ["non-string model", { model: 42 }],
+    ["empty model", { model: "" }],
+    ["whitespace model", { model: "   " }],
+    ["padded model", { model: " model " }],
+    ["non-string key", { apiKey: 7 }],
+    ["empty key", { apiKey: "" }],
+    ["whitespace key", { apiKey: "   " }],
+    ["padded key", { apiKey: " key " }],
+    ["zero timeout", { timeoutMs: 0 }],
+    ["fractional timeout", { timeoutMs: 1.5 }],
+    ["non-array aliases", { modelAliases: "alias" }],
+    ["invalid alias", { modelAliases: [""] }],
+    ["whitespace alias", { modelAliases: ["   "] }],
+    ["padded alias", { modelAliases: [" alias "] }],
+    ["duplicate aliases", { modelAliases: ["alias", "alias"] }],
+    ["trim-equivalent aliases", { modelAliases: ["alias", " alias"] }],
+    ["primary model as alias", { modelAliases: [config.model] }],
+  ])("rejects invalid config: %s", (_name, override) => {
+    expect(() => resolveRerankConfig({ ...config, ...override } as never)).toThrow(RemoteRerankProtocolError);
+  });
+
+  test("plain string reranker configurations remain local", () => {
+    expect(resolveRerankConfig("http://models.example/reranker.gguf")).toEqual({
+      kind: "local", model: "http://models.example/reranker.gguf",
+    });
+  });
+
+  test("cache identity includes endpoint semantics but excludes API keys", () => {
+    const a = resolveRerankConfig({ ...config, endpoint: "http://host-a/v1", apiKey: "key-a" });
+    const b = resolveRerankConfig({ ...config, endpoint: "http://host-a/v1", apiKey: "key-b" });
+    const c = resolveRerankConfig({ ...config, endpoint: "http://host-b/v1", apiKey: "key-a" });
+    expect(getRerankCacheIdentity(a)).toBe(getRerankCacheIdentity(b));
+    expect(getRerankCacheIdentity(c)).not.toBe(getRerankCacheIdentity(a));
+    expect(getRerankCacheIdentity(a)).not.toContain("key-a");
+  });
+
+  test("exposes the only supported endpoint failure policy as fail-closed", () => {
+    expect(new OpenAIRerankClient(config).failurePolicy).toBe("fail-closed");
+    expect(() => resolveRerankConfig({ ...config, failurePolicy: "fallback-local" } as never))
+      .toThrow(RemoteRerankProtocolError);
+  });
+
+  test.each([
+    ["HTTP error", async () => new Response("secret response", { status: 503 })],
+    ["network error", async () => { throw new Error("connect secret-token"); }],
+  ])("fails closed with safe typed transport error for %s", async (_name, implementation) => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(implementation as typeof fetch);
+    const error = await new OpenAIRerankClient({ ...config, apiKey: "secret-token" })
+      .rerank("q", [{ file: "a.md", text: "a" }]).catch((value: unknown) => value);
+    expect(error).toBeInstanceOf(RemoteRerankTransportError);
+    expect(String(error)).not.toContain("secret-token");
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+  });
+});

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1306,6 +1306,62 @@ describe("Caching", () => {
       await cleanupTestDb(store);
     }
   });
+
+  test("rerank caches same-file chunks by returned index rather than ambiguous file path", async () => {
+    const store = await createTestStore();
+    const docs = [
+      { file: "same.md", text: "first chunk" },
+      { file: "same.md", text: "second chunk" },
+    ];
+    const rerankSpy = vi.fn(async () => ({
+      model: "remote-reranker",
+      results: [
+        { file: "same.md", index: 1, score: 0.9 },
+        { file: "same.md", index: 0, score: 0.1 },
+      ],
+    }));
+    store.llm = { rerank: rerankSpy, rerankModelName: "remote-reranker" } as any;
+
+    try {
+      expect(await store.rerank("query", docs)).toEqual([
+        { file: "same.md", score: 0.9 },
+        { file: "same.md", score: 0.1 },
+      ]);
+      expect(rerankSpy).toHaveBeenCalledTimes(1);
+      expect(await store.rerank("query", docs)).toEqual([
+        { file: "same.md", score: 0.9 },
+        { file: "same.md", score: 0.1 },
+      ]);
+      expect(rerankSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      await cleanupTestDb(store);
+    }
+  });
+
+  test("rerank cache identity separates remote backends with the same model name", async () => {
+    const store = await createTestStore();
+    const docs = [{ file: "doc.md", text: "same chunk" }];
+    const makeRemoteMock = (identity: string, score: number) => {
+      const spy = vi.fn(async () => ({
+        model: "same-model",
+        results: [{ file: "doc.md", index: 0, score }],
+      }));
+      return { spy, llm: { rerank: spy, rerankModelName: "same-model", rerankCacheIdentity: identity } };
+    };
+    const first = makeRemoteMock("remote:endpoint-a", 0.2);
+    const second = makeRemoteMock("remote:endpoint-b", 0.8);
+    store.llm = first.llm as any;
+
+    try {
+      expect((await store.rerank("query", docs))[0]!.score).toBe(0.2);
+      store.llm = second.llm as any;
+      expect((await store.rerank("query", docs))[0]!.score).toBe(0.8);
+      expect(first.spy).toHaveBeenCalledTimes(1);
+      expect(second.spy).toHaveBeenCalledTimes(1);
+    } finally {
+      await cleanupTestDb(store);
+    }
+  });
 });
 
 describe("Query expansion cache (#818)", () => {
@@ -4102,6 +4158,188 @@ describe("Embedding batching", () => {
       },
     };
   }
+
+  function remoteOutputVector(): number[] {
+    const embedding = Array(1024).fill(0);
+    embedding[0] = 0.1;
+    embedding[1] = 0.2;
+    embedding[2] = 0.3;
+    return embedding;
+  }
+
+  test("remote Qwen MRL output creates and stores only float[1024] vectors", async () => {
+    const store = await createTestStore();
+    const db = store.db;
+    const native = Array(2560).fill(0);
+    native[0] = 3;
+    native[1] = 4;
+    native[1024] = 12;
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      const count = (JSON.parse(String(init?.body)).input as string[]).length;
+      return new Response(JSON.stringify({
+        model: "Qwen3-Embedding-4B-Q8_0.gguf",
+        data: Array.from({ length: count }, (_, index) => ({ index, embedding: native })),
+      }));
+    });
+    const getLlama = vi.fn();
+    const resolveModelFile = vi.fn();
+    llmModule.setNodeLlamaCppModuleForTest({
+      getLlama,
+      resolveModelFile,
+      LlamaChatSession: vi.fn() as any,
+      LlamaLogLevel: { error: 0 },
+    });
+    store.llm = new llmModule.LlamaCpp({
+      embedModel: {
+        provider: "openai",
+        endpoint: "http://127.0.0.1:8086/v1",
+        model: "Qwen3-Embedding-4B-Q8_0.gguf",
+        nativeDimensions: 2560,
+        dimensions: 1024,
+        reduction: "mrl-prefix",
+        normalization: "l2",
+        formatVersion: "qwen3-query-document-v1",
+      },
+    });
+
+    try {
+      await insertTestDocument(db, "docs", { name: "one", body: "# One\n\nAlpha" });
+      await expect(generateEmbeddings(store)).resolves.toMatchObject({ errors: 0, chunksEmbedded: 1 });
+
+      const table = db.prepare(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'vectors_vec'`).get() as { sql: string };
+      expect(table.sql).toContain("embedding float[1024]");
+      expect(db.prepare(`SELECT COUNT(*) AS count FROM vectors_vec`).get()).toEqual({ count: 1 });
+      expect(fetchMock).toHaveBeenCalled();
+      expect(getLlama).not.toHaveBeenCalled();
+      expect(resolveModelFile).not.toHaveBeenCalled();
+    } finally {
+      await cleanupTestDb(store);
+    }
+  });
+
+  test("rejects a concurrent remote embedding invocation on the same database", async () => {
+    const store = await createTestStore();
+    const db = store.db;
+    let releaseFirstBatch!: () => void;
+    let markFirstBatchStarted!: () => void;
+    const firstBatchStarted = new Promise<void>(resolve => { markFirstBatchStarted = resolve; });
+    const firstBatchGate = new Promise<void>(resolve => { releaseFirstBatch = resolve; });
+    let batchCalls = 0;
+    const identity = {
+      provider: "openai", model: "Qwen3-Embedding-4B-Q8_0.gguf",
+      nativeDimensions: 2560, dimensions: 1024, reduction: "mrl-prefix",
+      normalization: "l2", formatVersion: "qwen3-query-document-v1",
+    };
+    store.llm = {
+      embedModelName: identity.model,
+      embeddingFingerprintIdentity: identity,
+      isRemoteEmbed: () => true,
+      async embed() { return { embedding: remoteOutputVector(), model: identity.model }; },
+      async embedBatch(texts: string[]) {
+        batchCalls++;
+        if (batchCalls === 1) {
+          markFirstBatchStarted();
+          await firstBatchGate;
+        }
+        return texts.map(() => ({ embedding: remoteOutputVector(), model: identity.model }));
+      },
+    } as any;
+
+    try {
+      await insertTestDocument(db, "docs", { name: "one", body: "# One\n\nAlpha" });
+      const first = generateEmbeddings(store);
+      await firstBatchStarted;
+      await expect(generateEmbeddings(store)).rejects.toThrow("already active");
+      releaseFirstBatch();
+      await expect(first).resolves.toMatchObject({ errors: 0 });
+    } finally {
+      releaseFirstBatch?.();
+      await cleanupTestDb(store);
+    }
+  });
+
+  test("remote embedding keeps its semantic fingerprint when the CLI passes the matching model explicitly", async () => {
+    const store = await createTestStore();
+    const db = store.db;
+    const identity = {
+      provider: "openai",
+      model: "Qwen3-Embedding-4B-Q8_0.gguf",
+      nativeDimensions: 2560,
+      dimensions: 1024,
+      reduction: "mrl-prefix",
+      normalization: "l2",
+      formatVersion: "qwen3-query-document-v1",
+    };
+    store.llm = {
+      embedModelName: identity.model,
+      embeddingFingerprintIdentity: identity,
+      isRemoteEmbed: () => true,
+      async embed() { return { embedding: remoteOutputVector(), model: identity.model }; },
+      async embedBatch(texts: string[]) {
+        return texts.map(() => ({ embedding: remoteOutputVector(), model: identity.model }));
+      },
+    } as any;
+
+    try {
+      await insertTestDocument(db, "docs", { name: "one", body: "# One\n\nAlpha" });
+      const result = await generateEmbeddings(store, { model: identity.model });
+      expect(result.errors).toBe(0);
+      expect(db.prepare(`SELECT DISTINCT embed_fingerprint FROM content_vectors`).all()).toEqual([
+        { embed_fingerprint: getEmbeddingFingerprint(identity) },
+      ]);
+      expect(store.getHashesNeedingEmbedding()).toBe(0);
+      expect(store.getStatus().needsEmbedding).toBe(0);
+    } finally {
+      await cleanupTestDb(store);
+    }
+  });
+
+  test("remote embedding failure rolls back every vector written by the invocation", async () => {
+    const store = await createTestStore();
+    const db = store.db;
+    let batchCalls = 0;
+    const remoteLlm = {
+      embedModelName: "Qwen3-Embedding-4B-Q8_0.gguf",
+      embeddingFingerprintIdentity: {
+        provider: "openai",
+        model: "Qwen3-Embedding-4B-Q8_0.gguf",
+        nativeDimensions: 2560,
+        dimensions: 1024,
+        reduction: "mrl-prefix",
+        normalization: "l2",
+        formatVersion: "qwen3-query-document-v1",
+      },
+      isRemoteEmbed: () => true,
+      async embed() {
+        if (batchCalls > 0) throw new Error("remote embedding unavailable");
+        return { embedding: remoteOutputVector(), model: "Qwen3-Embedding-4B-Q8_0.gguf" };
+      },
+      async embedBatch(texts: string[]) {
+        batchCalls++;
+        if (batchCalls > 1) throw new Error("remote embedding unavailable");
+        db.prepare(`INSERT INTO llm_cache (hash, result, created_at) VALUES (?, ?, ?)`).run("unrelated-write", "must-survive", new Date().toISOString());
+        return texts.map(() => ({ embedding: remoteOutputVector(), model: "Qwen3-Embedding-4B-Q8_0.gguf" }));
+      },
+    };
+    store.llm = remoteLlm as any;
+
+    try {
+      await insertTestDocument(db, "docs", { name: "one", body: "# One\n\nAlpha" });
+      await insertTestDocument(db, "docs", { name: "two", body: "# Two\n\nBeta" });
+
+      await expect(generateEmbeddings(store, {
+        maxDocsPerBatch: 1,
+        maxBatchBytes: 1024 * 1024,
+      })).rejects.toThrow("Remote embedding failed closed");
+
+      expect(db.prepare(`SELECT COUNT(*) as count FROM content_vectors`).get()).toEqual({ count: 0 });
+      const vectorTable = db.prepare(`SELECT name FROM sqlite_master WHERE name = 'vectors_vec'`).get();
+      expect(vectorTable).toBeUndefined();
+      expect(db.prepare(`SELECT result FROM llm_cache WHERE hash = ?`).get("unrelated-write")).toEqual({ result: "must-survive" });
+    } finally {
+      await cleanupTestDb(store);
+    }
+  });
 
   test("generateEmbeddings flushes batches when maxDocsPerBatch is reached", async () => {
     const store = await createTestStore();


### PR DESCRIPTION
## Summary

Adds strict, fail-closed HTTP backends for shared embedding and reranking services while preserving QMD's existing local model-string behavior.

This draft is intentionally narrower than the complete generation + embedding + reranking backend requested in #620. It contributes a hardened embedding/reranking path for a concrete Qwen3 deployment:

- OpenAI-compatible `POST /v1/embeddings`
- llama.cpp-compatible `POST /v1/rerank`
- native Qwen3 2,560-dimensional validation
- first-1,024 Matryoshka prefix reduction
- L2 normalization after truncation
- no local model initialization or fallback in remote mode

## Motivation

Multiple QMD clients should be able to reuse one embedding model and one reranking model without each process loading duplicate GGUF models.

The important correctness boundary is stronger than transport compatibility: vectors from different producers, preprocessing paths, dimensions, or normalization pipelines must never be silently mixed under one identity. Remote failure therefore fails closed rather than falling back to a local GGUF model.

## Configuration

```yaml
models:
  embed:
    provider: openai
    endpoint: http://127.0.0.1:8086/v1
    model: Qwen3-Embedding-4B-Q8_0.gguf
    nativeDimensions: 2560
    dimensions: 1024
    reduction: mrl-prefix
    normalization: l2
    formatVersion: qwen3-query-document-v1
  rerank:
    provider: openai
    endpoint: http://127.0.0.1:8088/v1
    model: Qwen3-Reranker-0.6B-Q4_K_M.gguf
    failurePolicy: fail-closed
```

Plain model strings remain local configurations, including strings that happen to look like HTTP URLs. Remote mode requires the explicit structured form.

## Embedding safety contract

- Supports single and batched input.
- Maps entries using each returned `index`, never response position.
- Rejects missing, duplicate, fractional, negative, and out-of-range indexes.
- Requires exactly 2,560 native values for this Qwen3 configuration.
- Validates every native value before truncation, including the discarded tail.
- Rejects non-finite values and finite JS doubles that overflow Float32.
- Takes exactly the first 1,024 dimensions, then L2-normalizes the prefix.
- Rejects zero/invalid prefix norms and invalid normalized Float32 values.
- Applies the identical transformation to document and query embeddings.
- Requires response model identity, with only explicit canonical aliases accepted.
- Uses a semantic fingerprint covering provider, model, native/output dimensions, reduction, normalization order, and formatting version; endpoint and credentials are excluded.
- Never initializes `node-llama-cpp` or silently falls back locally in remote mode.
- Stages remote results in memory before a bounded SQLite write, avoiding network awaits inside transactions/savepoints.
- Prevents overlapping remote embedding invocations against the same store.

## Reranking safety contract

- Sends chunks as `documents` and maps results by returned document index.
- Validates cardinality, unique/in-range integer indexes, finite normalized scores, and response model identity.
- Uses normalized `relevance_score` directly without applying a second sigmoid.
- Caches by returned document index rather than file path.
- Separates cache identity for different remote backends without including credentials.
- Uses explicit `failurePolicy: fail-closed` and never initializes/falls back to a local reranker in remote mode.

## CLI and configuration behavior

Structured configuration is validated before status, doctor, pull, trust, update, embed preflight, and runtime use. Malformed remote configuration does not degrade into a local path. Diagnostics redact API keys, URL credentials/query secrets, response bodies, and raw transport causes.

## Relation to existing work

This draft overlaps with and is informed by:

- #620 — broader OpenAI-compatible generation/embedding/reranking goal
- #705 — RemoteLLM/HybridLLM architecture
- #761 — remote OpenAI-compatible embedding backend
- #769 — remote inference for low-power clients

It specifically addresses correctness concerns raised during review of those PRs:

- fail closed rather than mix local/remote vector producers;
- validate response cardinality and complete returned-index coverage;
- reject malformed dimensions and non-finite values;
- fingerprint the actual semantic transform;
- separate reranking cache identities;
- add focused routing/config/store/CLI tests;
- avoid duplicate local model initialization.

This is submitted as a draft because the Qwen3 2,560→1,024 MRL contract is intentionally explicit and opinionated. Maintainer guidance is welcome on whether to retain this strict profile, generalize the structured transform fields, or extract parts into the broader #620 implementation.

## Verification

Focused local test lanes:

- embedding/reranking/routing/LLM/store: **452 passed, 0 failed**
- CLI/config/SDK/trust/update-hook: **318 passed, 0 failed**
- TypeScript check: passed
- build: passed
- `git diff --check`: passed

Full Vitest run:

- **1,351 passed**
- **1 failed**: `MCP HTTP Transport > POST /mcp initialize still works for 2025-era clients (no session id)`

That MCP failure was reproduced on the untouched base commit and is unrelated to this change; this PR does not claim a completely green full suite.

Additional isolated endpoint verification against llama.cpp services confirmed:

- adapter output length: 1,024
- post-prefix norm: approximately 1.0
- manual native-prefix transform cosine: approximately 1.0
- retrieval fixture: Recall@3 1.00, MRR 0.85
- bounded four-worker load: 20/20 requests successful
- live TCP traffic to both embedding and reranking endpoints
- no additional embedding or reranking model process loaded

No production database, generated index, credential, benchmark artifact, or deployment configuration is included in this PR.
