### PR TITLE
fix(store): serialize concurrent FTS table create on cold open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,15 @@
 
 ### Fixed
 
+- Concurrent first-open of a cold index no longer fails with
+  `table documents_fts already exists` on Bun/macOS. FTS5
+  `CREATE VIRTUAL TABLE IF NOT EXISTS` is not atomic across WAL
+  connections: two processes can both see a missing table on their
+  schema snapshot and the loser throws. Table create and legacy-schema
+  repair now use the same `BEGIN IMMEDIATE` + double-check as the FTS
+  sync triggers, and treat a concurrent "already exists" as success
+  when the table is present.
+
 - Nix flake `qmd-node-modules` FOD hashes updated for x86_64-linux and
   aarch64-darwin after the MCP SDK 2.0 bump. `nix build` / Nix GHA was
   failing with a fixed-output hash mismatch.

--- a/src/store.ts
+++ b/src/store.ts
@@ -1001,28 +1001,71 @@ function documentsFtsSchemaIsCurrent(db: Database): boolean {
   return names.has("filepath") && names.has("title") && names.has("body") && !names.has("name");
 }
 
+function isAlreadyExistsError(err: unknown): boolean {
+  return /already exists/i.test(getErrorMessage(err));
+}
+
+function documentsFtsExists(db: Database): boolean {
+  const row = db.prepare(
+    `SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'documents_fts'`
+  ).get() as { name?: string } | undefined | null;
+  return Boolean(row?.name);
+}
+
+// FTS5 CREATE VIRTUAL TABLE IF NOT EXISTS is not atomic across WAL connections.
+// Two first-open processes can both observe a missing table on their schema
+// snapshot; the loser then throws `table documents_fts already exists`
+// (Bun/macOS CI). IF NOT EXISTS still helps the uncontended path, and a
+// concurrent "already exists" is treated as success when the table is present.
+const DOCUMENTS_FTS_DDL = `
+  CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(
+    filepath, title, body,
+    tokenize='porter unicode61'
+  )
+`;
+
+function createDocumentsFtsTable(db: Database): void {
+  try {
+    db.exec(DOCUMENTS_FTS_DDL);
+  } catch (err) {
+    if (!isAlreadyExistsError(err) || !documentsFtsExists(db)) throw err;
+  }
+}
+
 function recreateDocumentsFts(db: Database): void {
   db.exec(`DROP TRIGGER IF EXISTS documents_ai`);
   db.exec(`DROP TRIGGER IF EXISTS documents_ad`);
   db.exec(`DROP TRIGGER IF EXISTS documents_au`);
   db.exec(`DROP TABLE IF EXISTS documents_fts`);
-  db.exec(`
-    CREATE VIRTUAL TABLE documents_fts USING fts5(
-      filepath, title, body,
-      tokenize='porter unicode61'
-    )
-  `);
+  createDocumentsFtsTable(db);
   db.exec(`DELETE FROM store_config WHERE key = 'fts_cjk_normalized_version'`);
 }
 
+// Missing-table create and legacy-schema repair share one IMMEDIATE
+// transaction with a double-checked read, matching applyFtsSyncTriggers:
+// the DROP+CREATE (or first CREATE) is atomic across connections, and
+// losers skip once any process has published the current table.
 function ensureDocumentsFtsSchema(db: Database): void {
   if (documentsFtsSchemaIsCurrent(db)) return;
-  recreateDocumentsFts(db);
-  // recreateDocumentsFts dropped the sync triggers. applyFtsSyncTriggers
-  // only reinstalls them when user_version is stale, so a DB that already
-  // has the current user_version would otherwise be left untriggered.
-  if (getUserVersion(db) >= STORE_SCHEMA_VERSION) {
-    installFtsSyncTriggers(db);
+  db.exec(`BEGIN IMMEDIATE`);
+  try {
+    if (!documentsFtsSchemaIsCurrent(db)) {
+      if (documentsFtsExists(db)) {
+        recreateDocumentsFts(db);
+        // recreateDocumentsFts dropped the sync triggers. applyFtsSyncTriggers
+        // only reinstalls them when user_version is stale, so a DB that already
+        // has the current user_version would otherwise be left untriggered.
+        if (getUserVersion(db) >= STORE_SCHEMA_VERSION) {
+          installFtsSyncTriggers(db);
+        }
+      } else {
+        createDocumentsFtsTable(db);
+      }
+    }
+    db.exec(`COMMIT`);
+  } catch (err) {
+    db.exec(`ROLLBACK`);
+    throw err;
   }
 }
 
@@ -1230,14 +1273,9 @@ function initializeDatabase(db: Database): void {
     )
   `);
 
-  // FTS - index filepath (collection/path), title, and content
-  db.exec(`
-    CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(
-      filepath, title, body,
-      tokenize='porter unicode61'
-    )
-  `);
-
+  // FTS - index filepath (collection/path), title, and content.
+  // Do not CREATE VIRTUAL TABLE here as an autocommit statement: FTS5
+  // IF NOT EXISTS races under WAL (see createDocumentsFtsTable).
   ensureDocumentsFtsSchema(db);
   applyFtsSyncTriggers(db);
 

--- a/test/store-concurrency.test.ts
+++ b/test/store-concurrency.test.ts
@@ -2,9 +2,11 @@
  * store-concurrency.test.ts - concurrent schema-init safety
  *
  * Reproduces cross-process races in cold store initialization: WAL migration,
+ * FTS virtual-table CREATE (`table documents_fts already exists` on Bun/macOS),
  * FTS sync trigger rebuild, and CJK FTS normalization shadow-table rebuild.
  */
 import { describe, test, expect } from "vitest";
+import { readFileSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
@@ -19,6 +21,9 @@ const tsxCli = join(projectRoot, "node_modules", "tsx", "dist", "cli.mjs");
 const isBunRuntime = typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
 
 const WORKERS = isBunRuntime ? (process.platform === "darwin" ? 16 : 12) : 6;
+// A single unlucky schedule can miss the FTS CREATE race that Bun/macOS CI
+// hits. Two cold trials keep the test tight without blowing the 60s budget.
+const COLD_TRIALS = 2;
 
 type WorkerResult = { code: number | null; stderr: string };
 
@@ -41,8 +46,10 @@ async function openConcurrently(dbPath: string, n: number): Promise<WorkerResult
 
 function expectAllSucceeded(results: WorkerResult[]): void {
   const failed = results.filter(r => r.code !== 0);
+  const joined = failed.map(r => r.stderr.trim()).join("\n---\n");
   // On failure the joined worker stderr is surfaced by the assertion below.
-  expect(failed.map(r => r.stderr.trim()).join("\n---\n")).toBe("");
+  expect(joined).toBe("");
+  expect(joined).not.toMatch(/already exists/i);
   expect(failed).toHaveLength(0);
 }
 
@@ -79,15 +86,49 @@ function expectSchemaIntact(dbPath: string): void {
 }
 
 describe("concurrent store initialization", () => {
+  test("FTS table create is serialized (IF NOT EXISTS + BEGIN IMMEDIATE)", () => {
+    const storeSrc = readFileSync(join(projectRoot, "src", "store.ts"), "utf8");
+    const startIdx = storeSrc.indexOf("const DOCUMENTS_FTS_DDL");
+    const ensureIdx = storeSrc.indexOf("function ensureDocumentsFtsSchema(");
+    const endIdx = storeSrc.indexOf("function cjkRebuildVersion(", ensureIdx);
+    expect(startIdx).toBeGreaterThan(-1);
+    expect(ensureIdx).toBeGreaterThan(startIdx);
+    expect(endIdx).toBeGreaterThan(ensureIdx);
+
+    const createBody = storeSrc.slice(startIdx, ensureIdx)
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .split("\n")
+      .map(line => line.replace(/\/\/.*$/, ""))
+      .join("\n");
+    const ensureBody = storeSrc.slice(ensureIdx, endIdx)
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .split("\n")
+      .map(line => line.replace(/\/\/.*$/, ""))
+      .join("\n");
+
+    expect(createBody).toMatch(/CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts/);
+    expect(createBody).toContain("isAlreadyExistsError");
+    expect(ensureBody).toContain("BEGIN IMMEDIATE");
+    expect(ensureBody).toContain("createDocumentsFtsTable");
+    // initializeDatabase must not autocommit-create the FTS table outside the lock.
+    const initStart = storeSrc.indexOf("function initializeDatabase(");
+    const initEnd = storeSrc.indexOf("function rowToNamedCollection(", initStart);
+    const initBody = storeSrc.slice(initStart, initEnd);
+    expect(initBody).not.toMatch(/CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts/);
+    expect(initBody).toContain("ensureDocumentsFtsSchema");
+  });
+
   test("cold database: N processes initialize without colliding on FTS setup", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "qmd-store-concurrency-"));
-    const dbPath = join(dir, "index.sqlite");
-    try {
-      const results = await openConcurrently(dbPath, WORKERS);
-      expectAllSucceeded(results);
-      expectSchemaIntact(dbPath);
-    } finally {
-      await rm(dir, { recursive: true, force: true });
+    for (let trial = 0; trial < COLD_TRIALS; trial++) {
+      const dir = await mkdtemp(join(tmpdir(), "qmd-store-concurrency-"));
+      const dbPath = join(dir, "index.sqlite");
+      try {
+        const results = await openConcurrently(dbPath, WORKERS);
+        expectAllSucceeded(results);
+        expectSchemaIntact(dbPath);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
     }
   }, 60_000);
 


### PR DESCRIPTION
Fixes the Bun/macOS CI failure on main: `table documents_fts already exists` from `concurrent store initialization > cold database` in `test/store-concurrency.test.ts` ([run 31734426108](https://github.com/tobi/qmd/actions/runs/31734426108)).

## What was wrong

Trigger rebuild and CJK publish were already serialized with `BEGIN IMMEDIATE` + a double-checked read. The remaining hole was the FTS **table** itself.

`CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts` ran as an autocommit statement in `initializeDatabase`. FTS5's `IF NOT EXISTS` is not atomic across WAL connections: two first-open processes can both observe a missing table on their schema snapshot, and the loser throws `table documents_fts already exists`. `recreateDocumentsFts` had the same check-then-`CREATE` window without `IF NOT EXISTS`. Bun/macOS SQLite locking makes that window show up in CI; Node and Linux usually miss it.

## The fix

- Move first-create and legacy-schema repair into `ensureDocumentsFtsSchema`, under the same `BEGIN IMMEDIATE` + double-check as the sync triggers.
- Keep `CREATE VIRTUAL TABLE IF NOT EXISTS` for the uncontended path.
- Treat a concurrent `already exists` as success when `documents_fts` is present.
- Stop autocommit-creating the FTS table in `initializeDatabase`.

## Tests

- Structural assertion that FTS DDL is `IF NOT EXISTS`, create/repair is inside `BEGIN IMMEDIATE`, and `initializeDatabase` no longer autocommit-creates the table.
- Cold-open multi-process test now runs two trials (the single-schedule flake that misses the race).
- Local: bun `test/store-concurrency.test.ts` + `test/store-cjk-fts.test.ts` + store slice + `test/store.test.ts` green. Node 22 vitest concurrency + CJK + store slice green. No release. `flake.nix` / `flake.lock` untouched.