### PR TITLE
fix(cli): bound doctor embedding sample query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `qmd doctor` now chooses embedding sample identifiers before joining full
+  document bodies. This prevents its random sample query from materializing
+  and sorting the indexed corpus, which could exhaust memory on large indexes.
+
 ## [2.8.3] - 2026-08-16
 
 ### Security

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -3708,6 +3708,13 @@ type DoctorVectorSampleResult = {
   details: string;
 };
 
+type DoctorEmbeddingVectorSample = {
+  hash: string;
+  seq: number;
+  body: string;
+  path: string;
+};
+
 function decodeStoredEmbedding(bytes: Uint8Array): Float32Array {
   return new Float32Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
 }
@@ -3928,6 +3935,41 @@ function checkModelCache(activeModels: { embed: string; generate: string; rerank
   }
 }
 
+export function selectDoctorEmbeddingVectorSamples(
+  db: Database,
+  model: string,
+  fingerprint: string,
+  sampleSize: number = 3,
+): DoctorEmbeddingVectorSample[] {
+  // Keep full document bodies out of SQLite's random sort. On large indexes,
+  // joining content before LIMIT can materialize the corpus in a temp B-tree.
+  return db.prepare(`
+    WITH sampled AS MATERIALIZED (
+      SELECT cv.hash, cv.seq
+      FROM content_vectors cv
+      WHERE cv.model = ?
+        AND cv.embed_fingerprint = ?
+        AND EXISTS (
+          SELECT 1
+          FROM documents d
+          WHERE d.hash = cv.hash AND d.active = 1
+        )
+      ORDER BY random()
+      LIMIT ?
+    )
+    SELECT sampled.hash,
+           sampled.seq,
+           c.doc AS body,
+           (
+             SELECT MIN(d.path)
+             FROM documents d
+             WHERE d.hash = sampled.hash AND d.active = 1
+           ) AS path
+    FROM sampled
+    JOIN content c ON c.hash = sampled.hash
+  `).all(model, fingerprint, sampleSize) as DoctorEmbeddingVectorSample[];
+}
+
 async function checkEmbeddingVectorSamples(db: Database, model: string, fingerprint: string, sampleSize: number = 3): Promise<DoctorVectorSampleResult> {
   const activeDocs = (db.prepare(`SELECT COUNT(*) AS count FROM documents WHERE active = 1`).get() as { count: number }).count;
   if (activeDocs === 0) {
@@ -3939,16 +3981,7 @@ async function checkEmbeddingVectorSamples(db: Database, model: string, fingerpr
     return { ok: false, details: "no vector table to test; please run qmd embed again" };
   }
 
-  const samples = db.prepare(`
-    SELECT cv.hash, cv.seq, c.doc AS body, MIN(d.path) AS path
-    FROM content_vectors cv
-    JOIN documents d ON d.hash = cv.hash AND d.active = 1
-    JOIN content c ON c.hash = cv.hash
-    WHERE cv.model = ? AND cv.embed_fingerprint = ?
-    GROUP BY cv.hash, cv.seq, c.doc
-    ORDER BY random()
-    LIMIT ?
-  `).all(model, fingerprint, sampleSize) as { hash: string; seq: number; body: string; path: string }[];
+  const samples = selectDoctorEmbeddingVectorSamples(db, model, fingerprint, sampleSize);
 
   if (samples.length === 0) {
     return { ok: false, details: "no current embedded chunks to test; please run qmd embed again" };

--- a/test/doctor-vector-sample.test.ts
+++ b/test/doctor-vector-sample.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "vitest";
+
+import { selectDoctorEmbeddingVectorSamples } from "../src/cli/qmd.ts";
+import { openDatabase, type Database } from "../src/db.ts";
+
+const MODEL = "test-embed-model";
+const FINGERPRINT = "test-fingerprint";
+const isBunRuntime = typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
+
+function createSamplingSchema(db: Database, contentTableSql: string = `
+  CREATE TABLE content (
+    hash TEXT PRIMARY KEY,
+    doc TEXT NOT NULL
+  );
+`): void {
+  db.exec(`
+    ${contentTableSql}
+    CREATE TABLE documents (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      hash TEXT NOT NULL,
+      path TEXT NOT NULL,
+      active INTEGER NOT NULL DEFAULT 1
+    );
+    CREATE INDEX idx_documents_hash ON documents(hash);
+    CREATE TABLE content_vectors (
+      hash TEXT NOT NULL,
+      seq INTEGER NOT NULL,
+      model TEXT NOT NULL,
+      embed_fingerprint TEXT NOT NULL,
+      PRIMARY KEY (hash, seq)
+    );
+    CREATE INDEX idx_content_vectors_model_fingerprint
+      ON content_vectors(model, embed_fingerprint, hash);
+  `);
+}
+
+function insertSample(
+  db: Database,
+  {
+    hash,
+    seq = 0,
+    body,
+    path,
+    active = 1,
+    model = MODEL,
+    fingerprint = FINGERPRINT,
+  }: {
+    hash: string;
+    seq?: number;
+    body: string;
+    path: string;
+    active?: number;
+    model?: string;
+    fingerprint?: string;
+  },
+  contentTable: string = "content",
+): void {
+  db.prepare(`INSERT INTO ${contentTable} (hash, doc) VALUES (?, ?)`).run(hash, body);
+  db.prepare(`INSERT INTO documents (hash, path, active) VALUES (?, ?, ?)`).run(hash, path, active);
+  db.prepare(`
+    INSERT INTO content_vectors (hash, seq, model, embed_fingerprint)
+    VALUES (?, ?, ?, ?)
+  `).run(hash, seq, model, fingerprint);
+}
+
+describe("doctor embedding vector sampling", () => {
+  test("preserves active-document, model, fingerprint, and minimum-path selection", () => {
+    const db = openDatabase(":memory:");
+    try {
+      createSamplingSchema(db);
+      insertSample(db, { hash: "active-a", body: "body a", path: "z.md" });
+      db.prepare(`INSERT INTO documents (hash, path, active) VALUES (?, ?, 1)`).run("active-a", "a.md");
+      insertSample(db, { hash: "active-b", seq: 1, body: "body b", path: "b.md" });
+      insertSample(db, { hash: "inactive", body: "inactive body", path: "inactive.md", active: 0 });
+      insertSample(db, { hash: "wrong-model", body: "wrong model", path: "wrong-model.md", model: "other-model" });
+      insertSample(db, { hash: "wrong-fingerprint", body: "wrong fingerprint", path: "wrong-fingerprint.md", fingerprint: "other-fingerprint" });
+
+      const samples = selectDoctorEmbeddingVectorSamples(db, MODEL, FINGERPRINT, 10)
+        .sort((a, b) => a.hash.localeCompare(b.hash));
+
+      expect(samples).toEqual([
+        { hash: "active-a", seq: 0, body: "body a", path: "a.md" },
+        { hash: "active-b", seq: 1, body: "body b", path: "b.md" },
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+
+  test.skipIf(isBunRuntime)("reads document bodies only after limiting sample identifiers", () => {
+    const db = openDatabase(":memory:") as Database & {
+      function(name: string, fn: (value: string) => string): void;
+    };
+    let bodyReads = 0;
+    db.function("observe_body", (value: string) => {
+      bodyReads += 1;
+      return value;
+    });
+
+    try {
+      createSamplingSchema(db, `
+        CREATE TABLE raw_content (
+          hash TEXT PRIMARY KEY,
+          doc TEXT NOT NULL
+        );
+        CREATE VIEW content AS
+          SELECT hash, observe_body(doc) AS doc
+          FROM raw_content;
+      `);
+      for (let index = 0; index < 40; index += 1) {
+        insertSample(db, {
+          hash: `hash-${index.toString().padStart(2, "0")}`,
+          body: `body-${index}`,
+          path: `doc-${index}.md`,
+        }, "raw_content");
+      }
+
+      const samples = selectDoctorEmbeddingVectorSamples(db, MODEL, FINGERPRINT, 3);
+
+      expect(samples).toHaveLength(3);
+      expect(bodyReads).toBe(samples.length);
+    } finally {
+      db.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

On large indexes, `qmd doctor` consumes excessive memory because its embedding health check joins full document bodies before applying `ORDER BY random() LIMIT 3`. SQLite can therefore materialize and sort the indexed corpus just to select three samples.

This changes the query to:

1. Select three `(hash, seq)` identifiers first.
2. Join document bodies only for those selected samples.

Active-document filtering and minimum-path selection remain unchanged.

## Reproduction

Reproduced on a multi-gigabyte local index with tens of thousands of documents:

- Before: process memory grew into the tens of gigabytes and the command did not complete.
- After: `qmd doctor` completes in a few seconds.

## Validation

- Added cross-runtime coverage for the existing selection semantics.
- Added a regression test proving document-body reads are bounded to the requested sample size.
- `bun run test:unit`
- `bun run test:types`
- `bun run build`
- `bun run test:package`
