### PR TITLE
fix(store): tokenize embeddings with the store model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Embedding generation and legacy fingerprint adoption now tokenize documents
+  with the store-selected embedding model instead of the global default. This
+  keeps chunk boundaries aligned with the model that creates and verifies the
+  stored vectors without initializing an unrelated provider.
+
 ## [2.8.3] - 2026-08-16
 
 ### Security

--- a/src/store.ts
+++ b/src/store.ts
@@ -2083,7 +2083,8 @@ export async function generateEmbeddings(
         if (!doc.body.trim()) continue;
 
         const title = extractTitle(doc.body, doc.path);
-        const chunks = await chunkDocumentByTokens(
+        const chunks = await chunkDocumentByTokensWithLlm(
+          llm,
           doc.body,
           undefined, undefined, undefined,
           doc.path,
@@ -2587,7 +2588,16 @@ export async function maybeAdoptLegacyEmbeddingFingerprint(store: Store, model: 
   const llm = getLlm(store);
 
   return await withLLMSessionForLlm(llm, async (session) => {
-    const chunks = await chunkDocumentByTokens(sample.body, undefined, undefined, undefined, sample.path, undefined, session.signal);
+    const chunks = await chunkDocumentByTokensWithLlm(
+      llm,
+      sample.body,
+      undefined,
+      undefined,
+      undefined,
+      sample.path,
+      undefined,
+      session.signal,
+    );
     const chunk = chunks[sample.seq];
     if (!chunk) {
       return { checked: true, adopted: 0, reason: `sample chunk ${expectedHashSeq} no longer exists` };
@@ -3204,7 +3214,8 @@ function stripUnpairedSurrogates(text: string): string {
  * When filepath and chunkStrategy are provided, uses AST-aware break points
  * for supported code files.
  */
-export async function chunkDocumentByTokens(
+async function chunkDocumentByTokensWithLlm(
+  llm: LlamaCpp,
   content: string,
   maxTokens: number = CHUNK_SIZE_TOKENS,
   overlapTokens: number = CHUNK_OVERLAP_TOKENS,
@@ -3213,8 +3224,6 @@ export async function chunkDocumentByTokens(
   chunkStrategy: ChunkStrategy = "regex",
   signal?: AbortSignal
 ): Promise<{ text: string; pos: number; tokens: number }[]> {
-  const llm = getDefaultLlamaCpp();
-
   // Use moderate chars/token estimate (prose ~4, code ~2, mixed ~3)
   // If chunks exceed limit, they'll be re-split with actual ratio
   const avgCharsPerToken = 3;
@@ -3301,6 +3310,27 @@ export async function chunkDocumentByTokens(
   }
 
   return results;
+}
+
+export async function chunkDocumentByTokens(
+  content: string,
+  maxTokens: number = CHUNK_SIZE_TOKENS,
+  overlapTokens: number = CHUNK_OVERLAP_TOKENS,
+  windowTokens: number = CHUNK_WINDOW_TOKENS,
+  filepath?: string,
+  chunkStrategy: ChunkStrategy = "regex",
+  signal?: AbortSignal,
+): Promise<{ text: string; pos: number; tokens: number }[]> {
+  return await chunkDocumentByTokensWithLlm(
+    getDefaultLlamaCpp(),
+    content,
+    maxTokens,
+    overlapTokens,
+    windowTokens,
+    filepath,
+    chunkStrategy,
+    signal,
+  );
 }
 
 // =============================================================================

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -960,12 +960,16 @@ describe("embed", () => {
       async tokenize(text: string) {
         return new Array(Math.max(1, Math.ceil(text.length / 16))).fill(1);
       },
+      async detokenize(tokens: readonly number[]) {
+        return "x".repeat(tokens.length * 16);
+      },
     };
   }
 
   function createFakeEmbedLlm() {
     const embedBatchCalls: string[][] = [];
     return {
+      ...createFakeTokenizer(),
       embedBatchCalls,
       async embed(_text: string) {
         return { embedding: [0.1, 0.2, 0.3], model: "fake-embed" };

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -57,6 +57,7 @@ import {
   insertDocument,
   cleanupOrphanedVectors,
   generateEmbeddings,
+  maybeAdoptLegacyEmbeddingFingerprint,
   getHybridRrfWeights,
   _resetProductionModeForTesting,
   hybridQuery,
@@ -4084,10 +4085,19 @@ describe("Embedding batching", () => {
     const embedBatchCalls: string[][] = [];
     const embedCalls: { text: string; options?: { model?: string } }[] = [];
     const embedBatchModelCalls: ({ model?: string } | undefined)[] = [];
+    const tokenizeCalls: string[] = [];
     return {
       embedBatchCalls,
       embedCalls,
       embedBatchModelCalls,
+      tokenizeCalls,
+      async tokenize(text: string) {
+        tokenizeCalls.push(text);
+        return new Array(Math.max(1, Math.ceil(text.length / 16))).fill(1);
+      },
+      async detokenize(tokens: readonly number[]) {
+        return "x".repeat(tokens.length * 16);
+      },
       async embed(text: string, options?: { model?: string }) {
         embedCalls.push({ text, options });
         return { embedding: [0.1, 0.2, 0.3], model: "fake-embed" };
@@ -4102,6 +4112,82 @@ describe("Embedding batching", () => {
       },
     };
   }
+
+  test("generateEmbeddings tokenizes with the store-local LLM", async () => {
+    const store = await createTestStore();
+    const fakeLlm = createFakeEmbedLlm();
+    const globalTokenize = vi.fn(async () => {
+      throw new Error("global tokenizer must not run");
+    });
+
+    setDefaultLlamaCpp({
+      tokenize: globalTokenize,
+      detokenize: async () => "",
+    } as any);
+    store.llm = fakeLlm as any;
+
+    try {
+      await insertTestDocument(store.db, "docs", {
+        name: "store-local-tokenizer",
+        body: "# Store-local tokenizer\n\nVerified model bytes own document tokenization.",
+      });
+
+      const result = await generateEmbeddings(store);
+
+      expect(result.chunksEmbedded).toBe(1);
+      expect(fakeLlm.tokenizeCalls.length).toBeGreaterThan(0);
+      expect(globalTokenize).not.toHaveBeenCalled();
+    } finally {
+      setDefaultLlamaCpp(null);
+      await cleanupTestDb(store);
+    }
+  });
+
+  test("legacy fingerprint adoption tokenizes with the store-local LLM", async () => {
+    const store = await createTestStore();
+    const fakeLlm = createFakeEmbedLlm();
+    const globalTokenize = vi.fn(async () => {
+      throw new Error("global tokenizer must not run");
+    });
+    const model = "hf:test/store-local-fingerprint.gguf";
+    const body = "# Legacy fingerprint\n\nVerified model bytes own legacy tokenization.";
+    const hash = await hashContent(body);
+
+    setDefaultLlamaCpp({
+      tokenize: globalTokenize,
+      detokenize: async () => "",
+    } as any);
+    store.llm = fakeLlm as any;
+
+    try {
+      await insertTestDocument(store.db, "docs", {
+        name: "store-local-fingerprint",
+        body,
+        hash,
+      });
+      store.ensureVecTable(3);
+      store.insertEmbedding(
+        hash,
+        0,
+        0,
+        new Float32Array([0.1, 0.2, 0.3]),
+        model,
+        new Date(0).toISOString(),
+        1,
+        "",
+      );
+
+      const result = await maybeAdoptLegacyEmbeddingFingerprint(store, model);
+
+      expect(result.checked).toBe(true);
+      expect(result.adopted).toBe(1);
+      expect(fakeLlm.tokenizeCalls.length).toBeGreaterThan(0);
+      expect(globalTokenize).not.toHaveBeenCalled();
+    } finally {
+      setDefaultLlamaCpp(null);
+      await cleanupTestDb(store);
+    }
+  });
 
   test("generateEmbeddings flushes batches when maxDocsPerBatch is reached", async () => {
     const store = await createTestStore();

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -4224,6 +4224,7 @@ describe("Embedding batching", () => {
     // A slow embedder so the short session cap trips between document batches.
     const embedBatchCalls: string[][] = [];
     const slowLlm = {
+      ...createFakeTokenizer(),
       async embed() { return { embedding: [0.1, 0.2, 0.3], model: "fake-embed" }; },
       async embedBatch(texts: string[]) {
         embedBatchCalls.push([...texts]);
@@ -4344,6 +4345,7 @@ describe("Embedding batching", () => {
     const db = store.db;
     let embedCalls = 0;
     const fakeLlm = {
+      ...createFakeTokenizer(),
       async embed(_text: string, _options?: { model?: string }) {
         embedCalls++;
         return embedCalls === 1
@@ -4385,6 +4387,7 @@ describe("Embedding batching", () => {
     const store = await createTestStore();
     const db = store.db;
     const fakeLlm = {
+      ...createFakeTokenizer(),
       async embed(_text: string, _options?: { model?: string }) {
         return { embedding: [0.1, 0.2, 0.3], model: "fake-embed" };
       },
@@ -4450,6 +4453,7 @@ describe("Embedding batching", () => {
     // so vectors_vec is created as float[3].
     const storeModel = "hf:store/embeddinggemma-300M.gguf";
     const storeLlm = {
+      ...createFakeTokenizer(),
       embedModelName: storeModel,
       async embed(_text: string, _options?: { model?: string }) {
         return { embedding: [0.1, 0.2, 0.3], model: storeModel };


### PR DESCRIPTION
## Problem

`generateEmbeddings()` and `maybeAdoptLegacyEmbeddingFingerprint()` select the store-local LLM for embeddings, but their chunking path calls the public `chunkDocumentByTokens()` helper, which initializes and tokenizes with the global default LLM. When a store selects another embedding model, chunk boundaries and legacy fingerprint verification can therefore use a tokenizer unrelated to the model that creates the vectors. The extra global lookup can also initialize an unrelated provider.

## Change

- add a private chunking helper that accepts the selected `LlamaCpp` instance
- use the store-selected LLM for embedding generation and legacy fingerprint adoption
- preserve the public `chunkDocumentByTokens()` API and its global-default behavior for standalone callers
- add regression coverage for both store paths, including a sentinel global tokenizer that must never run

The two regression tests fail on `facd35e` (v2.8.3) with `global tokenizer must not run` and pass with this patch.

## Verification

- TypeScript build typecheck
- Node: 1,145 passed, 78 skipped
- Bun: 1,145 passed, 87 skipped
- package smoke: compiled Node/Bun CLI and AST grammar resolution