### PR TITLE
Add metadata support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added Oxlint lint fence.
+- Document metadata and metadata filtering. Markdown documents can opt into typed metadata through a namespaced frontmatter block (`qmd.metadata` with strings, numbers, booleans, or flat homogeneous arrays), and every search surface — CLI `search`/`vsearch`/`query` via `--filter <json>`, the SDK's `filter` option on `search()`/`searchLex()`/`searchVector()`, the MCP `query` tool, and HTTP `POST /query` and `/search` — accepts one shared recursive filter AST discriminated by `operator`: `and`/`or`/`not` logical groups, `eq`/`ne`/`gt`/`gte`/`lt`/`lte` comparisons, `in`/`nin`/`all` membership, and `exists` presence. Every returned result satisfies the filter (applied before RRF fusion and reranking); like collection filtering, highly selective filters remain best-effort for top-K completeness. Frontmatter stays ordinary searchable content — no chunking, embedding, snippet, or line-number changes — and documents without `qmd.metadata` behave exactly as before. JSON/SDK/MCP/HTTP results now include each document's indexed metadata, and `qmd status` reports how many documents still need metadata extraction (a normal `qmd update` backfills existing indexes).
 
 ## [2.8.3] - 2026-08-16
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ runs in a container and a liveness probe connects from a non-loopback address.
 
 The HTTP server exposes two endpoints:
 - `POST /mcp` — MCP Streamable HTTP (JSON responses, stateless)
-- `POST /query` (alias `/search`) — structured search without the MCP protocol
+- `POST /query` (alias `/search`) — structured search without the MCP protocol. Accepts the same optional `filter` object as the `query` tool (invalid filters return `400`); see [Metadata Filtering](#metadata-filtering)
 - `GET /health` — liveness check with uptime
 
 
@@ -187,6 +187,7 @@ Point any MCP client at `http://localhost:8181/mcp` to connect.
 |------|-----------|------|-------|
 | `query` | `searches` | array | Typed sub-queries (`lex`/`vec`/`hyde`), 1–10. **Required.** First gets 2x weight. |
 | `query` | `collections` | string[] | Filter by collection names (OR). **Array only** — singular `collection` is silently ignored. |
+| `query` | `filter` | object | Metadata filter (recursive `operator`-discriminated JSON AST; see [Metadata Filtering](#metadata-filtering)) |
 | `query` | `intent` | string | Disambiguation context (does not search on its own) |
 | `query` | `limit` | number | Max results (default 10) |
 | `query` | `minScore` | number | Minimum relevance 0–1 (default 0) |
@@ -292,6 +293,20 @@ const results3 = await store.search({
 
 // Skip reranking for faster results
 const fast = await store.search({ query: "auth", rerank: false })
+
+// Metadata filter — every returned result satisfies it (also available on
+// searchLex() and searchVector()); results expose indexed metadata via
+// r.metadata. See "Metadata Filtering" for the full grammar.
+const published = await store.search({
+  query: "authentication flow",
+  filter: {
+    operator: "and",
+    operands: [
+      { key: "topics", operator: "all", value: ["typescript"] },
+      { key: "status", operator: "ne", value: "draft" },
+    ],
+  },
+})
 ```
 
 For direct backend access:
@@ -860,6 +875,7 @@ and `deep-search` (→ `query`).
 --full             # Show full document content
 --line-numbers     # Add line numbers to output
 --explain          # Include retrieval score traces (query, JSON/CLI output)
+--filter <json>    # Metadata filter (recursive JSON AST; see Metadata Filtering)
 --index <name>     # Use named index
 --intent "<text>"  # Disambiguation context (e.g. "web page load times")
 --no-rerank        # Skip LLM reranking (RRF scores only; faster on CPU)
@@ -902,6 +918,72 @@ explicitly with `-c`.
 > **Note:** With multiple `-c` flags, results come from a global top-K pool and are
 > then filtered. If one collection dominates the rankings, matches from smaller
 > collections may not appear at the default limit — raise `-n` or use `--all`.
+
+### Metadata Filtering
+
+Documents can opt into typed metadata through a namespaced frontmatter block. A document without `qmd.metadata` behaves exactly as before, and the frontmatter stays ordinary searchable content (no chunking, embedding, or line-number changes):
+
+```markdown
+---
+qmd:
+  metadata:
+    topics:
+      - typescript
+      - programming
+    status: published
+    priority: 3
+    reviewed: true
+---
+
+# Document body starts here
+```
+
+Supported values are strings, numbers, booleans, and flat homogeneous arrays of one of those. Nested objects, nulls, empty arrays, and mixed-type arrays are rejected (the document still indexes; it is excluded from filtered search until corrected). Metadata keys are user-defined data — `tags`, `topics`, and `labels` are all ordinary keys with no special semantics.
+
+Every search surface (CLI, SDK, MCP, HTTP) accepts the same recursive filter, a JSON AST discriminated by `operator`:
+
+```sh
+# One condition
+qmd search "authentication" \
+  --filter '{"key":"status","operator":"eq","value":"published"}'
+
+# Composed conditions — works with search, vsearch, and query
+qmd query "dependency injection" --filter '{
+  "operator": "and",
+  "operands": [
+    { "key": "topics", "operator": "all", "value": ["typescript", "programming"] },
+    { "key": "status", "operator": "nin", "value": ["draft", "archived"] },
+    { "operator": "or", "operands": [
+      { "key": "priority", "operator": "gte", "value": 3 },
+      { "key": "reviewed", "operator": "eq", "value": true }
+    ] },
+    { "operator": "not", "operand": { "key": "audience", "operator": "eq", "value": "internal" } }
+  ]
+}'
+```
+
+| Node | Shape |
+|------|-------|
+| Logical group | `{ "operator": "and" \| "or", "operands": […] }` |
+| Negation | `{ "operator": "not", "operand": {…} }` |
+| Comparison | `{ "key", "operator": "eq" \| "ne" \| "gt" \| "gte" \| "lt" \| "lte", "value" }` |
+| Membership | `{ "key", "operator": "in" \| "nin" \| "all", "value": […] }` |
+| Presence | `{ "key", "operator": "exists", "value": true \| false }` |
+
+Semantics:
+
+- Matching is typed and exact — no string/number/boolean coercion, and a type mismatch never matches (including `ne` and `nin`).
+- Array-valued metadata is a set: a condition matches when any element satisfies it, `all` requires every filter value to be present.
+- Missing keys do not match `ne`/`nin`; combine with `{ "operator": "exists", "value": false }` in an `or` group to include them.
+- Multiple conditions require an explicit `and` group — there is no implicit AND, and no `$`-prefixed shorthand.
+
+Guarantees and limits:
+
+- Every returned result satisfies the filter, before RRF fusion and reranking.
+- Like collection filtering, highly selective filters are best-effort for top-K completeness: backends over-fetch and post-filter, so a very selective filter can return fewer than `limit` results.
+- Filtered search only considers documents whose metadata has been extracted (run `qmd update` after upgrading; `qmd status` shows the pending count).
+
+JSON output (`--format json`), the SDK, MCP structured results, and the HTTP endpoints include each result's indexed metadata.
 
 ### Output Format
 

--- a/skills/qmd/SKILL.md
+++ b/skills/qmd/SKILL.md
@@ -199,6 +199,17 @@ qmd query "merchant support product reality" -c concepts -c sources -n 10
 
 Omit `-c` to search everything.
 
+## Filter by metadata
+
+Documents can carry typed metadata in a `qmd.metadata` frontmatter block (strings, numbers, booleans, or flat arrays). `search`, `vsearch`, and `query` accept `--filter` with a recursive JSON AST; every returned result satisfies it:
+
+```bash
+qmd search "authentication" --filter '{"key":"status","operator":"eq","value":"published"}'
+qmd query "dependency injection" --filter '{"operator":"and","operands":[{"key":"topics","operator":"all","value":["typescript"]},{"key":"status","operator":"nin","value":["draft","archived"]}]}'
+```
+
+Nodes are discriminated by `operator`: groups `and`/`or` take `operands`, `not` takes one `operand`, and conditions take `key` + `value` with operators `eq`/`ne`/`gt`/`gte`/`lt`/`lte` (comparison), `in`/`nin`/`all` (membership), or `exists` (presence). Matching is typed and exact; missing keys do not match `ne`/`nin` (add an `exists: false` branch in an `or` group to include them). The MCP `query` tool accepts the same AST as a `filter` object. JSON output includes each result's `metadata`.
+
 ## MCP Tool: `query`
 
 When using the MCP server, prefer structured searches:

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -86,6 +86,7 @@ import {
   type ReindexResult,
   type ChunkStrategy,
 } from "../store.js";
+import { syncDocumentMetadata, countDocumentsPendingMetadata } from "../metadata-store.js";
 import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, setDefaultLlamaCpp, LlamaCpp, withLLMSession, pullModels, DEFAULT_MODEL_CACHE_DIR, resolveEmbedModel, resolveGenerateModel, resolveRerankModel, resolveModels, inspectGgufFile, isDarwinMetalMitigationActive } from "../llm.js";
 import {
   formatSearchResults,
@@ -566,6 +567,10 @@ async function showStatus(): Promise<void> {
   if (needsEmbedding > 0) {
     console.log(`  ${c.yellow}Pending:  ${needsEmbedding} need embedding${c.reset} (run 'qmd embed')`);
   }
+  const pendingMetadata = countDocumentsPendingMetadata(db);
+  if (pendingMetadata > 0) {
+    console.log(`  ${c.yellow}Metadata: ${pendingMetadata} need extraction${c.reset} (run 'qmd update'; excluded from --filter searches)`);
+  }
   if (mostRecent.latest) {
     const lastUpdate = new Date(mostRecent.latest);
     console.log(`  Updated:  ${formatTimeAgo(lastUpdate)}`);
@@ -985,6 +990,7 @@ async function updateCollections(): Promise<void> {
     progress.clear();
     console.log(`\nIndexed: ${result.indexed} new, ${result.updated} updated, ${result.unchanged} unchanged, ${result.removed} removed`);
     reportSkippedReads(result.skippedFiles);
+    reportMetadataErrors(result.metadataErrors);
     if (result.orphanedCleaned > 0) {
       console.log(`Cleaned up ${result.orphanedCleaned} orphaned content hash(es)`);
     }
@@ -1945,7 +1951,7 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
     // Continue so the deactivation pass can mark previously indexed docs as inactive.
   }
 
-  let indexed = 0, updated = 0, unchanged = 0, processed = 0;
+  let indexed = 0, updated = 0, unchanged = 0, processed = 0, metadataErrors = 0;
   const skippedFiles: { file: string; code: string }[] = [];
   const seenPaths = new Set<string>();
   // Literal paths of every file in this scan. Passed to the legacy-path
@@ -1988,8 +1994,13 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
     // Check if document exists (also migrates legacy lowercase paths)
     const existing = findOrMigrateLegacyDocument(db, collectionName, path, livePaths);
 
+    let documentId: number;
+    let contentChanged = true;
+
     if (existing) {
+      documentId = existing.id;
       if (existing.hash === hash) {
+        contentChanged = false;
         // Hash unchanged, but check if title needs updating
         if (existing.title !== title) {
           updateDocumentTitle(db, existing.id, title, now);
@@ -2010,10 +2021,15 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
       indexed++;
       insertContent(db, hash, content, now);
       const stat = statSync(filepath);
-      insertDocument(db, collectionName, path, title, hash,
+      documentId = insertDocument(db, collectionName, path, title, hash,
         stat ? new Date(stat.birthtime).toISOString() : now,
         stat ? new Date(stat.mtime).toISOString() : now);
     }
+
+    // Unchanged content still backfills missing or stale extraction state.
+    const extraction = syncDocumentMetadata(db, documentId, content, path,
+      contentChanged ? undefined : { onlyIfStale: true });
+    if (extraction?.error) metadataErrors++;
 
     processed++;
     progress.set((processed / total) * 100);
@@ -2043,6 +2059,7 @@ async function indexFiles(pwd?: string, globPattern: string = DEFAULT_GLOB, coll
   progress.clear();
   console.log(`\nIndexed: ${indexed} new, ${updated} updated, ${unchanged} unchanged, ${removed} removed`);
   reportSkippedReads(skippedFiles);
+  reportMetadataErrors(metadataErrors);
   if (orphanedContent > 0) {
     console.log(`Cleaned up ${orphanedContent} orphaned content hash(es)`);
   }
@@ -2060,6 +2077,11 @@ function fsErrorCode(err: unknown): string {
     if (typeof code === "string" && code.length > 0) return code;
   }
   return "ERROR";
+}
+
+function reportMetadataErrors(metadataErrors: number): void {
+  if (metadataErrors === 0) return;
+  console.warn(`⚠ ${metadataErrors} file(s) have invalid qmd.metadata frontmatter and are excluded from filtered search`);
 }
 
 function reportSkippedReads(skippedFiles: { file: string; code: string }[]): void {

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -87,6 +87,8 @@ import {
   type ChunkStrategy,
 } from "../store.js";
 import { syncDocumentMetadata, countDocumentsPendingMetadata } from "../metadata-store.js";
+import type { DocumentMetadata } from "../metadata.js";
+import { parseMetadataFilter, type MetadataFilter } from "../metadata-filter.js";
 import { disposeDefaultLlamaCpp, getDefaultLlamaCpp, setDefaultLlamaCpp, LlamaCpp, withLLMSession, pullModels, DEFAULT_MODEL_CACHE_DIR, resolveEmbedModel, resolveGenerateModel, resolveRerankModel, resolveModels, inspectGgufFile, isDarwinMetalMitigationActive } from "../llm.js";
 import {
   formatSearchResults,
@@ -2338,6 +2340,7 @@ type OutputOptions = {
   skipRerank?: boolean;  // Skip LLM reranking, use RRF scores only
   chunkStrategy?: ChunkStrategy;  // "auto" (default) or "regex"
   fullPath?: boolean;    // Show realpath instead of qmd:// URI (relative to $PWD when subpath)
+  filter?: MetadataFilter;  // Metadata filter (--filter JSON)
 };
 
 // Highlight query terms in text (skip short words < 3 chars)
@@ -2412,6 +2415,7 @@ type OutputRow = {
   chunkLen?: number;
   hash?: string;
   docid?: string;
+  metadata?: DocumentMetadata;
   explain?: HybridQueryExplain;
 };
 
@@ -2536,6 +2540,7 @@ function outputResults(results: OutputRow[], query: string, opts: OutputOptions)
         line: snippetInfo.line,
         title: row.title,
         ...(row.context && { context: row.context }),
+        ...(row.metadata && Object.keys(row.metadata).length > 0 && { metadata: row.metadata }),
         ...(body && { body }),
         ...(snippet && { snippet }),
         ...(opts.explain && row.explain && { explain: row.explain }),
@@ -2812,6 +2817,36 @@ function parseStructuredQuery(query: string): ParsedStructuredQuery | null {
   return typed.length > 0 ? { searches: typed, intent } : null;
 }
 
+// Parse and validate a --filter JSON string; exits with an actionable
+// message on malformed JSON or an invalid filter AST.
+function parseCliMetadataFilter(rawFilter: unknown): MetadataFilter | undefined {
+  if (rawFilter === undefined) return undefined;
+
+  let filterJson: unknown;
+  try {
+    filterJson = JSON.parse(String(rawFilter));
+  } catch (err) {
+    console.error(`Invalid --filter JSON: ${err instanceof Error ? err.message : String(err)}`);
+    console.error(`Example: --filter '{"key":"status","operator":"eq","value":"published"}'`);
+    process.exit(1);
+  }
+
+  try {
+    return parseMetadataFilter(filterJson);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}
+
+// Filtered search excludes documents without current metadata extraction;
+// tell the user when that makes results incomplete.
+function warnPendingMetadata(db: Database): void {
+  const pendingMetadata = countDocumentsPendingMetadata(db);
+  if (pendingMetadata === 0) return;
+  process.stderr.write(`${c.yellow}Warning: ${pendingMetadata} document(s) lack current metadata extraction and are excluded from filtered results. Run 'qmd update'.${c.reset}\n`);
+}
+
 function search(query: string, opts: OutputOptions): void {
   const db = getDb();
 
@@ -2819,9 +2854,11 @@ function search(query: string, opts: OutputOptions): void {
   // Use default collections if none specified
   const collectionNames = resolveCollectionFilter(opts.collection, true);
 
+  if (opts.filter) warnPendingMetadata(db);
+
   // Use large limit for --all, otherwise fetch more than needed and let outputResults filter
   const fetchLimit = opts.all ? 100000 : Math.max(50, opts.limit * 2);
-  const results = searchFTS(db, query, fetchLimit, collectionSearchFilter(collectionNames));
+  const results = searchFTS(db, query, fetchLimit, collectionSearchFilter(collectionNames), opts.filter);
 
   // Add context to results
   const resultsWithContext = results.map(r => ({
@@ -2833,6 +2870,7 @@ function search(query: string, opts: OutputOptions): void {
     context: getContextForFile(db, r.filepath),
     hash: r.hash,
     docid: r.docid,
+    metadata: r.metadata,
   }));
 
   closeDb();
@@ -2867,10 +2905,12 @@ async function vectorSearch(query: string, opts: OutputOptions, _model: string =
   const collectionNames = resolveCollectionFilter(opts.collection, true);
 
   checkIndexHealth(store.db);
+  if (opts.filter) warnPendingMetadata(store.db);
 
   await withLLMSession(async () => {
     let results = await vectorSearchQuery(store, query, {
       collection: collectionSearchFilter(collectionNames),
+      filter: opts.filter,
       limit: opts.all ? 500 : (opts.limit || 10),
       minScore: opts.minScore || 0.3,
       intent: opts.intent,
@@ -2897,6 +2937,7 @@ async function vectorSearch(query: string, opts: OutputOptions, _model: string =
       score: r.score,
       context: r.context,
       docid: r.docid,
+      metadata: r.metadata,
     })), query, { ...opts, limit: results.length });
   }, { maxDuration: 10 * 60 * 1000, name: 'vectorSearch' });
 }
@@ -2909,6 +2950,7 @@ async function querySearch(query: string, opts: OutputOptions, _embedModel: stri
   const collectionNames = resolveCollectionFilter(opts.collection, true);
 
   checkIndexHealth(store.db);
+  if (opts.filter) warnPendingMetadata(store.db);
 
   // Check for structured query syntax (lex:/vec:/hyde:/intent: prefixes)
   const parsed = parseStructuredQuery(query);
@@ -2937,6 +2979,7 @@ async function querySearch(query: string, opts: OutputOptions, _embedModel: stri
 
       results = await structuredSearch(store, structuredQueries, {
         collections: collectionNames.length > 0 ? collectionNames : undefined,
+        filter: opts.filter,
         limit: opts.all ? 500 : (opts.limit || 10),
         minScore: opts.minScore || 0,
         candidateLimit: opts.candidateLimit,
@@ -2965,6 +3008,7 @@ async function querySearch(query: string, opts: OutputOptions, _embedModel: stri
       // Standard hybrid query with automatic expansion
       results = await hybridQuery(store, query, {
         collection: collectionSearchFilter(collectionNames),
+        filter: opts.filter,
         limit: opts.all ? 500 : (opts.limit || 10),
         minScore: opts.minScore || 0,
         candidateLimit: opts.candidateLimit,
@@ -3025,6 +3069,7 @@ async function querySearch(query: string, opts: OutputOptions, _embedModel: stri
       score: r.score,
       context: r.context,
       docid: r.docid,
+      metadata: r.metadata,
       explain: r.explain,
     })), displayQuery, { ...opts, limit: results.length });
   }, { maxDuration: 10 * 60 * 1000, name: 'querySearch' });
@@ -3062,6 +3107,7 @@ function parseCLI() {
       json: { type: "boolean" },
       explain: { type: "boolean" },
       collection: { type: "string", short: "c", multiple: true },  // Filter by collection(s)
+      filter: { type: "string" },  // Metadata filter (JSON AST) for search/vsearch/query
       // Collection options
       name: { type: "string" },  // collection name
       mask: { type: "string" },  // glob pattern
@@ -3678,6 +3724,8 @@ function showHelp(): void {
   console.log("  --explain                  - Include retrieval score traces (query, CLI/--format json)");
   console.log("  --format <kind>            - Output format: cli (default) | json | csv | md | xml | files");
   console.log("  -c, --collection <name>    - Filter by one or more collections");
+  console.log("  --filter <json>            - Metadata filter (recursive JSON AST; search/vsearch/query)");
+  console.log("                                e.g. '{\"key\":\"status\",\"operator\":\"eq\",\"value\":\"published\"}'");
   console.log("");
   console.log("Embed/query options:");
   console.log("  --chunk-strategy <auto|regex> - Chunking mode (default: regex; auto uses AST for code files)");
@@ -4702,6 +4750,7 @@ if (isMain) {
         console.error("Usage: qmd search [options] <query>");
         process.exit(1);
       }
+      cli.opts.filter = parseCliMetadataFilter(cli.values.filter);
       search(cli.query, cli.opts);
       break;
 
@@ -4715,6 +4764,7 @@ if (isMain) {
       if (!cli.values["min-score"]) {
         cli.opts.minScore = 0.3;
       }
+      cli.opts.filter = parseCliMetadataFilter(cli.values.filter);
       await resolveLocalConfigTrust();
       await vectorSearch(cli.query, cli.opts);
       break;
@@ -4725,6 +4775,7 @@ if (isMain) {
         console.error("Usage: qmd query [options] <query>");
         process.exit(1);
       }
+      cli.opts.filter = parseCliMetadataFilter(cli.values.filter);
       await resolveLocalConfigTrust();
       await querySearch(cli.query, cli.opts);
       break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,20 @@ import {
 import {
   LlamaCpp,
 } from "./llm.js";
+import type {
+  DocumentMetadata,
+  MetadataScalar,
+  MetadataScalarArray,
+  MetadataValue,
+} from "./metadata.js";
+import {
+  parseMetadataFilter,
+  MetadataFilterError,
+  type MetadataFilter,
+  type MetadataFilterGroup,
+  type MetadataFilterNegation,
+  type MetadataCondition,
+} from "./metadata-filter.js";
 import {
   setConfigSource,
   loadConfig,
@@ -108,6 +122,19 @@ export type {
   NamedCollection,
   ContextMap,
 };
+
+// Re-export metadata and metadata-filter types shared by every search surface
+export type {
+  DocumentMetadata,
+  MetadataScalar,
+  MetadataScalarArray,
+  MetadataValue,
+  MetadataFilter,
+  MetadataFilterGroup,
+  MetadataFilterNegation,
+  MetadataCondition,
+};
+export { parseMetadataFilter, MetadataFilterError };
 
 // Re-export the internal Store type for advanced consumers
 export type { InternalStore };
@@ -161,6 +188,8 @@ export interface SearchOptions {
   collection?: string;
   /** Filter to specific collections */
   collections?: string[];
+  /** Metadata filter — every returned result satisfies it */
+  filter?: MetadataFilter;
   /** Max results (default: 10) */
   limit?: number;
   /** Max candidates to rerank (default: 40) */
@@ -179,6 +208,8 @@ export interface SearchOptions {
 export interface LexSearchOptions {
   limit?: number;
   collection?: string | string[];
+  /** Metadata filter — every returned result satisfies it */
+  filter?: MetadataFilter;
 }
 
 /**
@@ -187,6 +218,8 @@ export interface LexSearchOptions {
 export interface VectorSearchOptions {
   limit?: number;
   collection?: string | string[];
+  /** Metadata filter — every returned result satisfies it */
+  filter?: MetadataFilter;
 }
 
 /**
@@ -410,6 +443,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
         // Pre-expanded queries — use structuredSearch
         return structuredSearch(internal, opts.queries, {
           collections: collections.length > 0 ? collections : undefined,
+          filter: opts.filter,
           limit: opts.limit,
           minScore: opts.minScore,
           explain: opts.explain,
@@ -423,6 +457,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
       // Simple query string — use hybridQuery (expand + search + rerank)
       return hybridQuery(internal, opts.query!, {
         collection: collections.length > 0 ? collections : undefined,
+        filter: opts.filter,
         limit: opts.limit,
         minScore: opts.minScore,
         explain: opts.explain,
@@ -432,8 +467,8 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
         chunkStrategy: opts.chunkStrategy,
       });
     },
-    searchLex: async (q, opts) => internal.searchFTS(q, opts?.limit, opts?.collection),
-    searchVector: async (q, opts) => internal.searchVec(q, llm.embedModelName, opts?.limit, opts?.collection),
+    searchLex: async (q, opts) => internal.searchFTS(q, opts?.limit, opts?.collection, opts?.filter),
+    searchVector: async (q, opts) => internal.searchVec(q, llm.embedModelName, opts?.limit, opts?.collection, undefined, undefined, opts?.filter),
     expandQuery: async (q) => internal.expandQuery(q),
     get: async (pathOrDocid, opts) => internal.findDocument(pathOrDocid, opts),
     getDocumentBody: async (pathOrDocid, opts) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -438,12 +438,16 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
         ...(opts.collections ?? []),
       ];
       const skipRerank = opts.rerank === false;
+      // The SDK is also a JavaScript boundary: TypeScript declarations do not
+      // protect plain-JS callers or deserialized input. Apply the same bounded,
+      // strict validation used by CLI, MCP, and HTTP before compiling SQL.
+      const filter = opts.filter === undefined ? undefined : parseMetadataFilter(opts.filter);
 
       if (opts.queries) {
         // Pre-expanded queries — use structuredSearch
         return structuredSearch(internal, opts.queries, {
           collections: collections.length > 0 ? collections : undefined,
-          filter: opts.filter,
+          filter,
           limit: opts.limit,
           minScore: opts.minScore,
           explain: opts.explain,
@@ -457,7 +461,7 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
       // Simple query string — use hybridQuery (expand + search + rerank)
       return hybridQuery(internal, opts.query!, {
         collection: collections.length > 0 ? collections : undefined,
-        filter: opts.filter,
+        filter,
         limit: opts.limit,
         minScore: opts.minScore,
         explain: opts.explain,
@@ -467,8 +471,14 @@ export async function createStore(options: StoreOptions): Promise<QMDStore> {
         chunkStrategy: opts.chunkStrategy,
       });
     },
-    searchLex: async (q, opts) => internal.searchFTS(q, opts?.limit, opts?.collection, opts?.filter),
-    searchVector: async (q, opts) => internal.searchVec(q, llm.embedModelName, opts?.limit, opts?.collection, undefined, undefined, opts?.filter),
+    searchLex: async (q, opts) => {
+      const filter = opts?.filter === undefined ? undefined : parseMetadataFilter(opts.filter);
+      return internal.searchFTS(q, opts?.limit, opts?.collection, filter);
+    },
+    searchVector: async (q, opts) => {
+      const filter = opts?.filter === undefined ? undefined : parseMetadataFilter(opts.filter);
+      return internal.searchVec(q, llm.embedModelName, opts?.limit, opts?.collection, undefined, undefined, filter);
+    },
     expandQuery: async (q) => internal.expandQuery(q),
     get: async (pathOrDocid, opts) => internal.findDocument(pathOrDocid, opts),
     getDocumentBody: async (pathOrDocid, opts) => {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -22,9 +22,12 @@ import {
   addLineNumbers,
   getDefaultDbPath,
   DEFAULT_MULTI_GET_MAX_BYTES,
+  parseMetadataFilter,
   type QMDStore,
   type ExpandedQuery,
   type IndexStatus,
+  type DocumentMetadata,
+  type MetadataFilter,
 } from "../index.js";
 import { getConfigPath } from "../collections.js";
 import { enableProductionMode } from "../store.js";
@@ -40,9 +43,23 @@ type SearchResultItem = {
   title: string;
   score: number;
   context: string | null;
+  metadata?: DocumentMetadata;  // Indexed qmd.metadata (present when non-empty)
   line: number;   // Absolute line in source markdown
   snippet: string;
 };
+
+/**
+ * Validate an untrusted `filter` argument through the shared runtime
+ * validator. Returns the parse error message when invalid.
+ */
+function validateFilterArgument(filter: unknown): { filter?: MetadataFilter; error?: string } {
+  if (filter === undefined) return {};
+  try {
+    return { filter: parseMetadataFilter(filter) };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+}
 
 type StatusResult = {
   totalDocuments: number;
@@ -328,6 +345,15 @@ Intent-aware lex (C++ performance, not sports):
           "Maximum candidates to rerank (default: 40, lower = faster but may miss results)"
         ),
         collections: z.array(z.string()).optional().describe("Filter to collections (OR match)"),
+        filter: z.record(z.string(), z.unknown()).optional().describe(
+          "Metadata filter (recursive JSON AST). Every returned result satisfies it. " +
+          "Nodes are operator-discriminated: logical groups {operator:'and'|'or', operands:[...]}, " +
+          "negation {operator:'not', operand:{...}}, and conditions {key, operator, value} with " +
+          "operators eq/ne/gt/gte/lt/lte (comparison), in/nin/all (membership), exists (presence). " +
+          "Values are typed exactly (no coercion); missing keys do not match ne/nin. " +
+          "Example: {\"operator\":\"and\",\"operands\":[{\"key\":\"topics\",\"operator\":\"all\",\"value\":[\"typescript\"]}," +
+          "{\"key\":\"status\",\"operator\":\"ne\",\"value\":\"draft\"}]}"
+        ),
         intent: z.string().optional().describe(
           "Background context to disambiguate the query. Example: query='performance', intent='web page load times and Core Web Vitals'. Does not search on its own."
         ),
@@ -336,7 +362,7 @@ Intent-aware lex (C++ performance, not sports):
         ),
       }),
     },
-    track(async ({ query, searches, limit, minScore, candidateLimit, collections, intent, rerank }) => {
+    track(async ({ query, searches, limit, minScore, candidateLimit, collections, filter, intent, rerank }) => {
       // Require exactly one of `query` (plain text, auto-expanded) or `searches` (typed sub-queries).
       if (!query && (!searches || searches.length === 0)) {
         return {
@@ -347,6 +373,14 @@ Intent-aware lex (C++ performance, not sports):
       if (query && searches && searches.length > 0) {
         return {
           content: [{ type: "text" as const, text: "Error: 'query' and 'searches' are mutually exclusive; provide only one" }],
+          isError: true,
+        };
+      }
+
+      const filterValidation = validateFilterArgument(filter);
+      if (filterValidation.error) {
+        return {
+          content: [{ type: "text" as const, text: `Error: ${filterValidation.error}` }],
           isError: true,
         };
       }
@@ -363,6 +397,7 @@ Intent-aware lex (C++ performance, not sports):
       const results = await store.search({
         ...searchOptions,
         collections: effectiveCollections.length > 0 ? effectiveCollections : undefined,
+        filter: filterValidation.filter,
         limit,
         minScore,
         candidateLimit,
@@ -385,6 +420,7 @@ Intent-aware lex (C++ performance, not sports):
           title: r.title,
           score: Math.round(r.score * 100) / 100,
           context: r.context,
+          ...(Object.keys(r.metadata).length > 0 ? { metadata: r.metadata } : {}),
           line,
           snippet: addLineNumbers(snippet, line),
         };
@@ -998,12 +1034,30 @@ export async function startMcpHttpServer(
           query: String(s.query || ""),
         }));
 
+        // Optional metadata filter — must be an object and a valid filter AST
+        let restFilter: MetadataFilter | undefined;
+        if (params.filter !== undefined) {
+          if (typeof params.filter !== "object" || params.filter === null || Array.isArray(params.filter)) {
+            nodeRes.writeHead(400, { "Content-Type": "application/json" });
+            nodeRes.end(JSON.stringify({ error: "Invalid field: filter (must be an object)" }));
+            return;
+          }
+          const filterValidation = validateFilterArgument(params.filter);
+          if (filterValidation.error) {
+            nodeRes.writeHead(400, { "Content-Type": "application/json" });
+            nodeRes.end(JSON.stringify({ error: filterValidation.error }));
+            return;
+          }
+          restFilter = filterValidation.filter;
+        }
+
         // Use default collections if none specified
         const effectiveCollections = Array.isArray(params.collections) ? params.collections.map(String) : defaultCollectionNames;
 
         const results = await store.search({
           queries,
           collections: effectiveCollections.length > 0 ? effectiveCollections : undefined,
+          filter: restFilter,
           limit: typeof params.limit === "number" ? params.limit : 10,
           minScore: typeof params.minScore === "number" ? params.minScore : 0,
           candidateLimit: typeof params.candidateLimit === "number" ? params.candidateLimit : undefined,
@@ -1024,6 +1078,7 @@ export async function startMcpHttpServer(
             title: r.title,
             score: Math.round(r.score * 100) / 100,
             context: r.context,
+            ...(Object.keys(r.metadata).length > 0 ? { metadata: r.metadata } : {}),
             line,
             snippet: addLineNumbers(snippet, line),
           };

--- a/src/metadata-filter.ts
+++ b/src/metadata-filter.ts
@@ -1,0 +1,370 @@
+/**
+ * QMD Metadata Filter - Recursive filter AST, strict runtime validation, and
+ * parameterized SQL compilation.
+ *
+ * The filter has one canonical, `operator`-discriminated recursive shape shared
+ * by every public search surface (CLI, SDK, MCP, HTTP):
+ *
+ *   { "operator": "and", "operands": [ ... ] }
+ *   { "operator": "not", "operand": { ... } }
+ *   { "key": "status", "operator": "eq", "value": "published" }
+ *
+ * Compilation emits correlated EXISTS/NOT EXISTS subqueries over
+ * `document_metadata_values` with every user value bound as a parameter —
+ * metadata keys and values are data, never SQL.
+ */
+
+import type { MetadataScalar, MetadataScalarArray } from "./metadata.js";
+import { METADATA_LIMITS } from "./metadata.js";
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+export type MetadataFilter =
+  | MetadataFilterGroup
+  | MetadataFilterNegation
+  | MetadataCondition;
+
+export interface MetadataFilterGroup {
+  operator: "and" | "or";
+  operands: readonly MetadataFilter[];
+}
+
+export interface MetadataFilterNegation {
+  operator: "not";
+  operand: MetadataFilter;
+}
+
+export type MetadataCondition =
+  | { key: string; operator: "eq" | "ne"; value: MetadataScalar }
+  | { key: string; operator: "gt" | "gte" | "lt" | "lte"; value: string | number }
+  | { key: string; operator: "in" | "nin" | "all"; value: MetadataScalarArray }
+  | { key: string; operator: "exists"; value: boolean };
+
+export interface CompiledMetadataFilter {
+  sql: string;
+  params: (string | number)[];
+}
+
+/** Raised by parseMetadataFilter with the JSON path of the failing node. */
+export class MetadataFilterError extends Error {
+  readonly path: string;
+
+  constructor(path: string, message: string) {
+    super(`Invalid metadata filter at ${path}: ${message}`);
+    this.name = "MetadataFilterError";
+    this.path = path;
+  }
+}
+
+// =============================================================================
+// Limits
+// =============================================================================
+
+/** Defensive limits for recursive filters from untrusted callers. */
+export const METADATA_FILTER_LIMITS = {
+  maxDepth: 16,
+  maxNodes: 256,
+  maxGroupOperands: 32,
+  maxMembershipValues: 64,
+  maxKeyBytes: METADATA_LIMITS.maxKeyBytes,
+  maxStringLength: METADATA_LIMITS.maxStringLength,
+} as const;
+
+const GROUP_OPERATORS = new Set(["and", "or"]);
+const COMPARISON_OPERATORS = new Set(["eq", "ne", "gt", "gte", "lt", "lte"]);
+const ORDERED_OPERATORS = new Set(["gt", "gte", "lt", "lte"]);
+const MEMBERSHIP_OPERATORS = new Set(["in", "nin", "all"]);
+const CONDITION_OPERATORS = new Set([...COMPARISON_OPERATORS, ...MEMBERSHIP_OPERATORS, "exists"]);
+const ALL_OPERATORS = [...GROUP_OPERATORS, "not", ...CONDITION_OPERATORS];
+
+// =============================================================================
+// Validation
+// =============================================================================
+
+type FilterParseState = { nodes: number };
+
+/**
+ * Strictly validate an untrusted value as a MetadataFilter.
+ * Rejects unknown operators, unknown properties, operator-incompatible values,
+ * and inputs exceeding METADATA_FILTER_LIMITS. Canonicalizes membership value
+ * arrays by de-duplicating while preserving order.
+ */
+export function parseMetadataFilter(input: unknown): MetadataFilter {
+  const state: FilterParseState = { nodes: 0 };
+  return parseFilterNode(input, "$", 1, state);
+}
+
+function parseFilterNode(input: unknown, path: string, depth: number, state: FilterParseState): MetadataFilter {
+  if (depth > METADATA_FILTER_LIMITS.maxDepth) {
+    throw new MetadataFilterError(path, `exceeds maximum nesting depth of ${METADATA_FILTER_LIMITS.maxDepth}`);
+  }
+
+  state.nodes += 1;
+  if (state.nodes > METADATA_FILTER_LIMITS.maxNodes) {
+    throw new MetadataFilterError(path, `exceeds maximum of ${METADATA_FILTER_LIMITS.maxNodes} nodes`);
+  }
+
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    throw new MetadataFilterError(path, "each filter node must be an object");
+  }
+
+  const node = input as Record<string, unknown>;
+  const operator = node["operator"];
+  if (typeof operator !== "string") {
+    throw new MetadataFilterError(path, "missing 'operator' property");
+  }
+
+  if (GROUP_OPERATORS.has(operator)) {
+    return parseFilterGroup(node, operator as "and" | "or", path, depth, state);
+  }
+  if (operator === "not") {
+    return parseFilterNegation(node, path, depth, state);
+  }
+  if (CONDITION_OPERATORS.has(operator)) {
+    return parseFilterCondition(node, operator, path);
+  }
+
+  throw new MetadataFilterError(path, `unknown operator '${operator}' — expected one of: ${ALL_OPERATORS.join(", ")}`);
+}
+
+function parseFilterGroup(
+  node: Record<string, unknown>,
+  operator: "and" | "or",
+  path: string,
+  depth: number,
+  state: FilterParseState,
+): MetadataFilterGroup {
+  rejectUnknownProperties(node, ["operator", "operands"], path);
+
+  const operands = node["operands"];
+  if (!Array.isArray(operands)) {
+    throw new MetadataFilterError(path, `'${operator}' requires an 'operands' array`);
+  }
+  if (operands.length === 0) {
+    throw new MetadataFilterError(path, `'${operator}' requires a non-empty 'operands' array`);
+  }
+  if (operands.length > METADATA_FILTER_LIMITS.maxGroupOperands) {
+    throw new MetadataFilterError(path, `'${operator}' exceeds maximum of ${METADATA_FILTER_LIMITS.maxGroupOperands} operands`);
+  }
+
+  return {
+    operator,
+    operands: operands.map((operand, index) =>
+      parseFilterNode(operand, `${path}.operands[${index}]`, depth + 1, state)),
+  };
+}
+
+function parseFilterNegation(
+  node: Record<string, unknown>,
+  path: string,
+  depth: number,
+  state: FilterParseState,
+): MetadataFilterNegation {
+  rejectUnknownProperties(node, ["operator", "operand"], path);
+
+  if (!("operand" in node)) {
+    throw new MetadataFilterError(path, "'not' requires exactly one 'operand'");
+  }
+
+  return {
+    operator: "not",
+    operand: parseFilterNode(node["operand"], `${path}.operand`, depth + 1, state),
+  };
+}
+
+function parseFilterCondition(node: Record<string, unknown>, operator: string, path: string): MetadataCondition {
+  rejectUnknownProperties(node, ["key", "operator", "value"], path);
+
+  const key = node["key"];
+  if (typeof key !== "string" || key.length === 0) {
+    throw new MetadataFilterError(path, `'${operator}' requires a non-empty string 'key'`);
+  }
+  if (Buffer.byteLength(key, "utf-8") > METADATA_FILTER_LIMITS.maxKeyBytes) {
+    throw new MetadataFilterError(path, `'key' exceeds ${METADATA_FILTER_LIMITS.maxKeyBytes} bytes`);
+  }
+
+  if (!("value" in node)) {
+    throw new MetadataFilterError(path, `'${operator}' requires a 'value'`);
+  }
+  const value = node["value"];
+
+  if (operator === "exists") {
+    if (typeof value !== "boolean") {
+      throw new MetadataFilterError(`${path}.value`, "'exists' requires a boolean value");
+    }
+    return { key, operator, value };
+  }
+
+  if (MEMBERSHIP_OPERATORS.has(operator)) {
+    return {
+      key,
+      operator: operator as "in" | "nin" | "all",
+      value: parseMembershipValues(value, operator, path),
+    };
+  }
+
+  // Comparison operators: eq, ne, gt, gte, lt, lte.
+  const scalar = parseScalarValue(value, `${path}.value`);
+  if (ORDERED_OPERATORS.has(operator) && typeof scalar === "boolean") {
+    throw new MetadataFilterError(`${path}.value`, `'${operator}' requires a string or number value`);
+  }
+  return { key, operator, value: scalar } as MetadataCondition;
+}
+
+function parseMembershipValues(value: unknown, operator: string, path: string): MetadataScalarArray {
+  if (!Array.isArray(value)) {
+    throw new MetadataFilterError(`${path}.value`, `'${operator}' requires an array value`);
+  }
+  if (value.length === 0) {
+    throw new MetadataFilterError(`${path}.value`, `'${operator}' requires a non-empty array value`);
+  }
+  if (value.length > METADATA_FILTER_LIMITS.maxMembershipValues) {
+    throw new MetadataFilterError(`${path}.value`, `'${operator}' exceeds maximum of ${METADATA_FILTER_LIMITS.maxMembershipValues} values`);
+  }
+
+  const scalars = value.map((element, index) => parseScalarValue(element, `${path}.value[${index}]`));
+
+  const elementType = typeof scalars[0];
+  if (scalars.some(scalar => typeof scalar !== elementType)) {
+    throw new MetadataFilterError(`${path}.value`, `'${operator}' requires a homogeneous array of one scalar type`);
+  }
+
+  // Canonicalize: de-duplicate while preserving first-seen order.
+  return Array.from(new Set(scalars)) as unknown as MetadataScalarArray;
+}
+
+function parseScalarValue(value: unknown, path: string): MetadataScalar {
+  if (typeof value === "string") {
+    if (value.length > METADATA_FILTER_LIMITS.maxStringLength) {
+      throw new MetadataFilterError(path, `string exceeds ${METADATA_FILTER_LIMITS.maxStringLength} characters`);
+    }
+    return value;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new MetadataFilterError(path, "numbers must be finite");
+    }
+    return value;
+  }
+  if (typeof value === "boolean") return value;
+  throw new MetadataFilterError(path, "expected a string, number, or boolean");
+}
+
+function rejectUnknownProperties(node: Record<string, unknown>, allowed: string[], path: string): void {
+  for (const property of Object.keys(node)) {
+    if (!allowed.includes(property)) {
+      throw new MetadataFilterError(path, `unknown property '${property}' — allowed: ${allowed.join(", ")}`);
+    }
+  }
+}
+
+// =============================================================================
+// SQL compilation
+// =============================================================================
+
+/**
+ * Compile a validated filter into one parameterized SQL predicate correlated
+ * against a documents-table alias (e.g. `d`). All keys and values are bound
+ * parameters. The caller is responsible for restricting the surrounding query
+ * to active documents with current, error-free metadata extraction.
+ */
+export function compileMetadataFilter(filter: MetadataFilter, documentsAlias: string): CompiledMetadataFilter {
+  const params: (string | number)[] = [];
+  const sql = compileFilterNode(filter, documentsAlias, params);
+  return { sql, params };
+}
+
+function compileFilterNode(filter: MetadataFilter, alias: string, params: (string | number)[]): string {
+  switch (filter.operator) {
+    case "and":
+    case "or": {
+      const joiner = filter.operator === "and" ? " AND " : " OR ";
+      return `(${filter.operands.map(operand => compileFilterNode(operand, alias, params)).join(joiner)})`;
+    }
+
+    case "not":
+      return `NOT ${compileFilterNode(filter.operand, alias, params)}`;
+
+    case "exists":
+      params.push(filter.key);
+      return filter.value
+        ? buildValueExistsSql(alias, "mv.key = ?")
+        : `NOT ${buildValueExistsSql(alias, "mv.key = ?")}`;
+
+    case "eq":
+    case "gt":
+    case "gte":
+    case "lt":
+    case "lte": {
+      const sqlOperator = { eq: "=", gt: ">", gte: ">=", lt: "<", lte: "<=" }[filter.operator];
+      params.push(filter.key, bindScalar(filter.value));
+      return buildValueExistsSql(
+        alias,
+        `mv.key = ? AND mv.value_type = '${valueTypeOf(filter.value)}' AND mv.${valueColumnOf(filter.value)} ${sqlOperator} ?`,
+      );
+    }
+
+    case "ne": {
+      // Key must have at least one same-type value, and no same-type value
+      // may equal the operand. Missing keys and type mismatches do not match.
+      const valueType = valueTypeOf(filter.value);
+      params.push(filter.key);
+      const presentSql = buildValueExistsSql(alias, `mv.key = ? AND mv.value_type = '${valueType}'`);
+      params.push(filter.key, bindScalar(filter.value));
+      const equalSql = buildValueExistsSql(
+        alias,
+        `mv.key = ? AND mv.value_type = '${valueType}' AND mv.${valueColumnOf(filter.value)} = ?`,
+      );
+      return `(${presentSql} AND NOT ${equalSql})`;
+    }
+
+    case "in":
+    case "nin": {
+      const valueType = valueTypeOf(filter.value[0]!);
+      const column = valueColumnOf(filter.value[0]!);
+      const placeholders = filter.value.map(() => "?").join(", ");
+
+      if (filter.operator === "in") {
+        params.push(filter.key, ...filter.value.map(bindScalar));
+        return buildValueExistsSql(alias, `mv.key = ? AND mv.value_type = '${valueType}' AND mv.${column} IN (${placeholders})`);
+      }
+
+      params.push(filter.key);
+      const presentSql = buildValueExistsSql(alias, `mv.key = ? AND mv.value_type = '${valueType}'`);
+      params.push(filter.key, ...filter.value.map(bindScalar));
+      const memberSql = buildValueExistsSql(alias, `mv.key = ? AND mv.value_type = '${valueType}' AND mv.${column} IN (${placeholders})`);
+      return `(${presentSql} AND NOT ${memberSql})`;
+    }
+
+    case "all": {
+      const valueType = valueTypeOf(filter.value[0]!);
+      const column = valueColumnOf(filter.value[0]!);
+      const memberSqls = filter.value.map(element => {
+        params.push(filter.key, bindScalar(element));
+        return buildValueExistsSql(alias, `mv.key = ? AND mv.value_type = '${valueType}' AND mv.${column} = ?`);
+      });
+      return `(${memberSqls.join(" AND ")})`;
+    }
+  }
+}
+
+function buildValueExistsSql(alias: string, conditionSql: string): string {
+  return `EXISTS (SELECT 1 FROM document_metadata_values mv WHERE mv.document_id = ${alias}.id AND ${conditionSql})`;
+}
+
+function valueTypeOf(scalar: MetadataScalar): "string" | "number" | "boolean" {
+  return typeof scalar as "string" | "number" | "boolean";
+}
+
+function valueColumnOf(scalar: MetadataScalar): "text_value" | "number_value" | "boolean_value" {
+  if (typeof scalar === "string") return "text_value";
+  if (typeof scalar === "number") return "number_value";
+  return "boolean_value";
+}
+
+function bindScalar(scalar: MetadataScalar): string | number {
+  if (typeof scalar === "boolean") return scalar ? 1 : 0;
+  return scalar;
+}

--- a/src/metadata-filter.ts
+++ b/src/metadata-filter.ts
@@ -226,13 +226,18 @@ function parseMembershipValues(value: unknown, operator: string, path: string): 
 
   const scalars = value.map((element, index) => parseScalarValue(element, `${path}.value[${index}]`));
 
-  const elementType = typeof scalars[0];
-  if (scalars.some(scalar => typeof scalar !== elementType)) {
-    throw new MetadataFilterError(`${path}.value`, `'${operator}' requires a homogeneous array of one scalar type`);
+  // Narrow each homogeneous case explicitly so the public array union remains
+  // precise without discarding type evidence through chained assertions.
+  if (scalars.every((scalar): scalar is string => typeof scalar === "string")) {
+    return Array.from(new Set(scalars));
   }
-
-  // Canonicalize: de-duplicate while preserving first-seen order.
-  return Array.from(new Set(scalars)) as unknown as MetadataScalarArray;
+  if (scalars.every((scalar): scalar is number => typeof scalar === "number")) {
+    return Array.from(new Set(scalars));
+  }
+  if (scalars.every((scalar): scalar is boolean => typeof scalar === "boolean")) {
+    return Array.from(new Set(scalars));
+  }
+  throw new MetadataFilterError(`${path}.value`, `'${operator}' requires a homogeneous array of one scalar type`);
 }
 
 function parseScalarValue(value: unknown, path: string): MetadataScalar {

--- a/src/metadata-store.ts
+++ b/src/metadata-store.ts
@@ -1,0 +1,212 @@
+/**
+ * QMD Metadata Store - Schema, persistence, and batch loading for document
+ * metadata.
+ *
+ * Metadata attaches to document identity (`documents.id`), not content
+ * identity: two paths can share one content hash while carrying different
+ * metadata. SQLite stays a derived index — metadata is rebuilt from source
+ * documents on `qmd update`, never mutated in place.
+ *
+ * `document_metadata` records extraction state per document (including
+ * successful-but-empty extraction), so filtered search can distinguish
+ * "extracted with no metadata" from "not yet extracted" and "extraction
+ * failed". `document_metadata_values` holds one indexed row per scalar value
+ * for filtering.
+ */
+
+import type { Database } from "./db.js";
+import {
+  extractDocumentMetadata,
+  METADATA_EXTRACTION_VERSION,
+  type DocumentMetadata,
+  type MetadataExtractionResult,
+} from "./metadata.js";
+
+// =============================================================================
+// Schema
+// =============================================================================
+
+export function initializeMetadataSchema(db: Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS document_metadata (
+      document_id INTEGER PRIMARY KEY,
+      metadata_json TEXT NOT NULL DEFAULT '{}',
+      extraction_version INTEGER NOT NULL,
+      extraction_error TEXT,
+      extracted_at TEXT NOT NULL,
+      FOREIGN KEY (document_id) REFERENCES documents(id) ON DELETE CASCADE
+    )
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS document_metadata_values (
+      document_id INTEGER NOT NULL,
+      key TEXT NOT NULL,
+      ordinal INTEGER NOT NULL,
+      value_type TEXT NOT NULL,
+      text_value TEXT,
+      number_value REAL,
+      boolean_value INTEGER,
+      PRIMARY KEY (document_id, key, ordinal),
+      FOREIGN KEY (document_id)
+        REFERENCES document_metadata(document_id)
+        ON DELETE CASCADE,
+      CHECK (value_type IN ('string', 'number', 'boolean')),
+      CHECK (
+        (value_type = 'string' AND text_value IS NOT NULL AND number_value IS NULL AND boolean_value IS NULL)
+        OR (value_type = 'number' AND number_value IS NOT NULL AND text_value IS NULL AND boolean_value IS NULL)
+        OR (value_type = 'boolean' AND boolean_value IN (0, 1) AND text_value IS NULL AND number_value IS NULL)
+      )
+    )
+  `);
+
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_metadata_text_lookup
+    ON document_metadata_values(key, text_value, document_id)
+    WHERE value_type = 'string'
+  `);
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_metadata_number_lookup
+    ON document_metadata_values(key, number_value, document_id)
+    WHERE value_type = 'number'
+  `);
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_metadata_boolean_lookup
+    ON document_metadata_values(key, boolean_value, document_id)
+    WHERE value_type = 'boolean'
+  `);
+}
+
+// =============================================================================
+// Persistence
+// =============================================================================
+
+/**
+ * Extract and persist metadata for one document, replacing any prior rows.
+ *
+ * With `onlyIfStale`, extraction is skipped when the document already has a
+ * current-version extraction row — the cheap path for unchanged documents
+ * during re-index. Returns the extraction result, or null when skipped.
+ */
+export function syncDocumentMetadata(
+  db: Database,
+  documentId: number,
+  content: string,
+  path: string,
+  options?: { onlyIfStale?: boolean },
+): MetadataExtractionResult | null {
+  if (options?.onlyIfStale && isDocumentMetadataCurrent(db, documentId)) return null;
+
+  const extraction = extractDocumentMetadata(content, path);
+  replaceDocumentMetadata(db, documentId, extraction);
+  return extraction;
+}
+
+/**
+ * Replace a document's metadata rows atomically. A failed extraction persists
+ * empty metadata plus the error, so stale metadata never survives a bad edit.
+ */
+export function replaceDocumentMetadata(db: Database, documentId: number, extraction: MetadataExtractionResult): void {
+  const replace = db.transaction(() => {
+    db.prepare(`
+      INSERT INTO document_metadata (document_id, metadata_json, extraction_version, extraction_error, extracted_at)
+      VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT(document_id) DO UPDATE SET
+        metadata_json = excluded.metadata_json,
+        extraction_version = excluded.extraction_version,
+        extraction_error = excluded.extraction_error,
+        extracted_at = excluded.extracted_at
+    `).run(
+      documentId,
+      JSON.stringify(extraction.metadata),
+      extraction.extractionVersion,
+      extraction.error ?? null,
+      new Date().toISOString(),
+    );
+
+    db.prepare(`DELETE FROM document_metadata_values WHERE document_id = ?`).run(documentId);
+
+    const insertValue = db.prepare(`
+      INSERT INTO document_metadata_values (document_id, key, ordinal, value_type, text_value, number_value, boolean_value)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    for (const [key, value] of Object.entries(extraction.metadata)) {
+      const scalars = Array.isArray(value) ? value : [value];
+      scalars.forEach((scalar, ordinal) => {
+        insertValue.run(
+          documentId,
+          key,
+          ordinal,
+          typeof scalar,
+          typeof scalar === "string" ? scalar : null,
+          typeof scalar === "number" ? scalar : null,
+          typeof scalar === "boolean" ? (scalar ? 1 : 0) : null,
+        );
+      });
+    }
+  });
+
+  replace();
+}
+
+function isDocumentMetadataCurrent(db: Database, documentId: number): boolean {
+  const row = db.prepare(`SELECT extraction_version FROM document_metadata WHERE document_id = ?`)
+    .get(documentId) as { extraction_version: number } | undefined;
+  return row?.extraction_version === METADATA_EXTRACTION_VERSION;
+}
+
+// =============================================================================
+// Queries
+// =============================================================================
+
+/**
+ * Count active documents without a current, error-free metadata extraction.
+ * These documents are excluded from filtered search until `qmd update` runs.
+ */
+export function countDocumentsPendingMetadata(db: Database): number {
+  const row = db.prepare(`
+    SELECT COUNT(*) as c FROM documents d
+    WHERE d.active = 1
+      AND NOT EXISTS (
+        SELECT 1 FROM document_metadata dm
+        WHERE dm.document_id = d.id
+          AND dm.extraction_version = ?
+          AND dm.extraction_error IS NULL
+      )
+  `).get(METADATA_EXTRACTION_VERSION) as { c: number };
+  return row.c;
+}
+
+/**
+ * Batch-load canonical metadata for a set of result filepaths
+ * (`qmd://collection/path`). One query — never per-result lookups.
+ */
+export function getMetadataByFilepath(db: Database, filepaths: readonly string[]): Map<string, DocumentMetadata> {
+  const metadataByFilepath = new Map<string, DocumentMetadata>();
+  if (filepaths.length === 0) return metadataByFilepath;
+
+  const placeholders = filepaths.map(() => "?").join(", ");
+  const rows = db.prepare(`
+    SELECT 'qmd://' || d.collection || '/' || d.path AS filepath, dm.metadata_json
+    FROM documents d
+    JOIN document_metadata dm ON dm.document_id = d.id
+    WHERE d.active = 1
+      AND 'qmd://' || d.collection || '/' || d.path IN (${placeholders})
+  `).all(...filepaths) as { filepath: string; metadata_json: string }[];
+
+  for (const row of rows) {
+    metadataByFilepath.set(row.filepath, parseMetadataJson(row.metadata_json));
+  }
+  return metadataByFilepath;
+}
+
+/** Parse a stored `metadata_json` column value, tolerating absent rows. */
+export function parseMetadataJson(metadataJson: string | null | undefined): DocumentMetadata {
+  if (!metadataJson) return {};
+  try {
+    return JSON.parse(metadataJson) as DocumentMetadata;
+  } catch {
+    return {};
+  }
+}

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,0 +1,256 @@
+/**
+ * QMD Metadata - Public metadata types and frontmatter extraction.
+ *
+ * Documents opt into metadata through a namespaced Markdown frontmatter block:
+ *
+ *   ---
+ *   qmd:
+ *     metadata:
+ *       topics:
+ *         - typescript
+ *         - programming
+ *       status: published
+ *   ---
+ *
+ * Extraction is source-agnostic at the persistence boundary: this module
+ * produces a canonical `MetadataExtractionResult`, and future non-frontmatter
+ * sources can produce the same shape without touching storage or filtering.
+ *
+ * The raw document is never modified — frontmatter stays part of the stored,
+ * indexed, chunked, and embedded content.
+ */
+
+import YAML from "yaml";
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+export type MetadataScalar = string | number | boolean;
+
+export type MetadataScalarArray =
+  | readonly string[]
+  | readonly number[]
+  | readonly boolean[];
+
+export type MetadataValue = MetadataScalar | MetadataScalarArray;
+
+export type DocumentMetadata = Record<string, MetadataValue>;
+
+/**
+ * Result of extracting metadata from one document.
+ *
+ * `error` is set when the document opted into `qmd.metadata` but the value was
+ * invalid — the document still indexes normally, but it is excluded from
+ * filtered search until the metadata is corrected and re-indexed.
+ */
+export interface MetadataExtractionResult {
+  metadata: DocumentMetadata;
+  error?: string;
+  extractionVersion: number;
+}
+
+// =============================================================================
+// Limits
+// =============================================================================
+
+/**
+ * Bump when extraction or normalization semantics change so existing rows are
+ * re-extracted on the next `qmd update`.
+ */
+export const METADATA_EXTRACTION_VERSION = 1;
+
+/** Defensive limits for metadata from untrusted repositories. */
+export const METADATA_LIMITS = {
+  maxFrontmatterBytes: 64 * 1024,
+  maxKeys: 64,
+  maxKeyBytes: 128,
+  maxStringLength: 1024,
+  maxArrayLength: 128,
+  maxYamlAliasCount: 100,
+  maxErrorLength: 200,
+} as const;
+
+/** File extensions parsed for frontmatter metadata. */
+const FRONTMATTER_FILE_EXTENSIONS = new Set([".md", ".markdown", ".mdx"]);
+
+// =============================================================================
+// Extraction
+// =============================================================================
+
+/**
+ * Extract `qmd.metadata` from a document's leading YAML frontmatter.
+ *
+ * Never throws. A document without frontmatter, without a `qmd` namespace, or
+ * with a non-frontmatter extension yields empty metadata with no error.
+ * Invalid frontmatter or invalid metadata yields empty metadata plus a bounded
+ * extraction error.
+ */
+export function extractDocumentMetadata(content: string, path: string): MetadataExtractionResult {
+  const success = (metadata: DocumentMetadata): MetadataExtractionResult =>
+    ({ metadata, extractionVersion: METADATA_EXTRACTION_VERSION });
+
+  const failure = (message: string): MetadataExtractionResult => ({
+    metadata: {},
+    error: truncateErrorMessage(message),
+    extractionVersion: METADATA_EXTRACTION_VERSION,
+  });
+
+  if (!hasFrontmatterFileExtension(path)) return success({});
+
+  const frontmatterYaml = getFrontmatterYaml(content);
+  if (frontmatterYaml === null) return success({});
+
+  if (Buffer.byteLength(frontmatterYaml, "utf-8") > METADATA_LIMITS.maxFrontmatterBytes) {
+    return failure(`frontmatter exceeds ${METADATA_LIMITS.maxFrontmatterBytes} bytes`);
+  }
+
+  let frontmatter: unknown;
+  try {
+    frontmatter = YAML.parse(frontmatterYaml, { maxAliasCount: METADATA_LIMITS.maxYamlAliasCount });
+  } catch (err) {
+    return failure(`invalid frontmatter YAML: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  if (!isPlainObject(frontmatter)) return success({});
+
+  const qmdNamespace = frontmatter["qmd"];
+  if (qmdNamespace === undefined) return success({});
+  if (!isPlainObject(qmdNamespace)) {
+    return failure("frontmatter 'qmd' must be a mapping");
+  }
+
+  const rawMetadata = qmdNamespace["metadata"];
+  if (rawMetadata === undefined) return success({});
+  if (!isPlainObject(rawMetadata)) {
+    return failure("frontmatter 'qmd.metadata' must be a mapping");
+  }
+
+  try {
+    return success(normalizeMetadata(rawMetadata));
+  } catch (err) {
+    return failure(err instanceof Error ? err.message : String(err));
+  }
+}
+
+function hasFrontmatterFileExtension(path: string): boolean {
+  const dotIndex = path.lastIndexOf(".");
+  if (dotIndex < 0) return false;
+  return FRONTMATTER_FILE_EXTENSIONS.has(path.slice(dotIndex).toLowerCase());
+}
+
+/**
+ * Slice the YAML between a leading `---` line and a closing `---` or `...`
+ * line. Tolerates a UTF-8 BOM and CRLF line endings. Returns null when the
+ * document has no complete leading frontmatter block.
+ */
+function getFrontmatterYaml(content: string): string | null {
+  const body = content.charCodeAt(0) === 0xfeff ? content.slice(1) : content;
+
+  const openMatch = body.match(/^---[ \t]*\r?\n/);
+  if (!openMatch) return null;
+
+  const yamlStart = openMatch[0].length;
+  const closePattern = /^(?:---|\.\.\.)[ \t]*(?:\r?\n|$)/m;
+  const closeMatch = body.slice(yamlStart).match(closePattern);
+  if (!closeMatch || closeMatch.index === undefined) return null;
+
+  return body.slice(yamlStart, yamlStart + closeMatch.index);
+}
+
+// =============================================================================
+// Normalization
+// =============================================================================
+
+/**
+ * Normalize raw `qmd.metadata` into canonical `DocumentMetadata`.
+ * Throws on any unsupported key or value — extraction is all-or-nothing per
+ * document so stale partial metadata can never persist.
+ */
+function normalizeMetadata(rawMetadata: Record<string, unknown>): DocumentMetadata {
+  const keys = Object.keys(rawMetadata);
+  if (keys.length > METADATA_LIMITS.maxKeys) {
+    throw new Error(`metadata has ${keys.length} keys (max ${METADATA_LIMITS.maxKeys})`);
+  }
+
+  const metadata: DocumentMetadata = {};
+  for (const key of keys) {
+    validateMetadataKey(key);
+    metadata[key] = normalizeMetadataValue(key, rawMetadata[key]);
+  }
+  return metadata;
+}
+
+function validateMetadataKey(key: string): void {
+  if (key.length === 0) {
+    throw new Error("metadata keys must be non-empty strings");
+  }
+  if (Buffer.byteLength(key, "utf-8") > METADATA_LIMITS.maxKeyBytes) {
+    throw new Error(`metadata key exceeds ${METADATA_LIMITS.maxKeyBytes} bytes`);
+  }
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u001f\u007f]/.test(key)) {
+    throw new Error("metadata keys must not contain control characters");
+  }
+}
+
+function normalizeMetadataValue(key: string, rawValue: unknown): MetadataValue {
+  if (Array.isArray(rawValue)) {
+    return normalizeMetadataArray(key, rawValue);
+  }
+  return normalizeMetadataScalar(key, rawValue);
+}
+
+function normalizeMetadataScalar(key: string, rawValue: unknown): MetadataScalar {
+  if (typeof rawValue === "string") {
+    if (rawValue.length > METADATA_LIMITS.maxStringLength) {
+      throw new Error(`metadata key "${key}": string exceeds ${METADATA_LIMITS.maxStringLength} characters`);
+    }
+    return rawValue;
+  }
+  if (typeof rawValue === "number") {
+    if (!Number.isFinite(rawValue)) {
+      throw new Error(`metadata key "${key}": numbers must be finite`);
+    }
+    return rawValue;
+  }
+  if (typeof rawValue === "boolean") return rawValue;
+  if (rawValue === null) {
+    throw new Error(`metadata key "${key}": null is not supported — omit the key instead`);
+  }
+  throw new Error(`metadata key "${key}": unsupported value type — use strings, numbers, booleans, or flat arrays of one of those`);
+}
+
+function normalizeMetadataArray(key: string, rawValues: unknown[]): MetadataScalarArray {
+  if (rawValues.length === 0) {
+    throw new Error(`metadata key "${key}": empty arrays are not supported — omit the key instead`);
+  }
+  if (rawValues.length > METADATA_LIMITS.maxArrayLength) {
+    throw new Error(`metadata key "${key}": array exceeds ${METADATA_LIMITS.maxArrayLength} values`);
+  }
+
+  const scalars = rawValues.map(rawValue => {
+    if (Array.isArray(rawValue)) {
+      throw new Error(`metadata key "${key}": nested arrays are not supported`);
+    }
+    return normalizeMetadataScalar(key, rawValue);
+  });
+
+  const elementType = typeof scalars[0];
+  if (scalars.some(scalar => typeof scalar !== elementType)) {
+    throw new Error(`metadata key "${key}": mixed-type arrays are not supported`);
+  }
+
+  // De-duplicate while preserving first-seen order.
+  return Array.from(new Set(scalars)) as unknown as MetadataScalarArray;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function truncateErrorMessage(message: string): string {
+  const singleLine = message.replace(/\s+/g, " ").trim();
+  if (singleLine.length <= METADATA_LIMITS.maxErrorLength) return singleLine;
+  return singleLine.slice(0, METADATA_LIMITS.maxErrorLength - 3) + "...";
+}

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -173,12 +173,15 @@ function normalizeMetadata(rawMetadata: Record<string, unknown>): DocumentMetada
     throw new Error(`metadata has ${keys.length} keys (max ${METADATA_LIMITS.maxKeys})`);
   }
 
-  const metadata: DocumentMetadata = {};
+  const entries: [string, MetadataValue][] = [];
   for (const key of keys) {
     validateMetadataKey(key);
-    metadata[key] = normalizeMetadataValue(key, rawMetadata[key]);
+    entries.push([key, normalizeMetadataValue(key, rawMetadata[key])]);
   }
-  return metadata;
+  // Object.fromEntries defines "__proto__" as ordinary data instead of
+  // invoking Object.prototype's legacy setter. Metadata keys are unrestricted
+  // user data, so prototype-shaped names must round-trip like every other key.
+  return Object.fromEntries(entries);
 }
 
 function validateMetadataKey(key: string): void {
@@ -236,13 +239,18 @@ function normalizeMetadataArray(key: string, rawValues: unknown[]): MetadataScal
     return normalizeMetadataScalar(key, rawValue);
   });
 
-  const elementType = typeof scalars[0];
-  if (scalars.some(scalar => typeof scalar !== elementType)) {
-    throw new Error(`metadata key "${key}": mixed-type arrays are not supported`);
+  // Narrow each homogeneous case explicitly so the public array union remains
+  // precise without discarding type evidence through chained assertions.
+  if (scalars.every((scalar): scalar is string => typeof scalar === "string")) {
+    return Array.from(new Set(scalars));
   }
-
-  // De-duplicate while preserving first-seen order.
-  return Array.from(new Set(scalars)) as unknown as MetadataScalarArray;
+  if (scalars.every((scalar): scalar is number => typeof scalar === "number")) {
+    return Array.from(new Set(scalars));
+  }
+  if (scalars.every((scalar): scalar is boolean => typeof scalar === "boolean")) {
+    return Array.from(new Set(scalars));
+  }
+  throw new Error(`metadata key "${key}": mixed-type arrays are not supported`);
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/src/store.ts
+++ b/src/store.ts
@@ -37,6 +37,11 @@ import type {
   CollectionConfig,
   ContextMap,
 } from "./collections.js";
+import {
+  initializeMetadataSchema,
+  syncDocumentMetadata,
+  countDocumentsPendingMetadata,
+} from "./metadata-store.js";
 
 // =============================================================================
 // Configuration
@@ -1252,6 +1257,10 @@ function initializeDatabase(db: Database): void {
 
   ensureContentVectorsStatusIndex(db);
 
+  // Document metadata — extraction state plus normalized value rows for
+  // metadata filtering. Keyed by document identity, not content hash.
+  initializeMetadataSchema(db);
+
   // Store collections — makes the DB self-contained (no external config needed)
   db.exec(`
     CREATE TABLE IF NOT EXISTS store_collections (
@@ -1551,7 +1560,7 @@ export type Store = {
 
   // Document indexing operations
   insertContent: (hash: string, content: string, createdAt: string) => void;
-  insertDocument: (collectionName: string, path: string, title: string, hash: string, createdAt: string, modifiedAt: string) => void;
+  insertDocument: (collectionName: string, path: string, title: string, hash: string, createdAt: string, modifiedAt: string) => number;
   findActiveDocument: (collectionName: string, path: string) => { id: number; hash: string; title: string } | null;
   findOrMigrateLegacyDocument: (collectionName: string, path: string) => { id: number; hash: string; title: string } | null;
   updateDocumentTitle: (documentId: number, title: string, modifiedAt: string) => void;
@@ -1596,6 +1605,8 @@ export type ReindexResult = {
   orphanedCleaned: number;
   skipped: number;
   skippedFiles: ReindexSkippedFile[];
+  /** Documents whose qmd.metadata frontmatter failed extraction this pass. */
+  metadataErrors: number;
 };
 
 /**
@@ -1634,7 +1645,7 @@ export async function reindexCollection(
   });
 
   const total = files.length;
-  let indexed = 0, updated = 0, unchanged = 0, processed = 0;
+  let indexed = 0, updated = 0, unchanged = 0, processed = 0, metadataErrors = 0;
   const skippedFiles: ReindexSkippedFile[] = [];
   const seenPaths = new Set<string>();
   // Literal paths of every file in this scan. Passed to the legacy-path
@@ -1681,8 +1692,13 @@ export async function reindexCollection(
 
     const existing = findOrMigrateLegacyDocument(db, collectionName, path, livePaths);
 
+    let documentId: number;
+    let contentChanged = true;
+
     if (existing) {
+      documentId = existing.id;
       if (existing.hash === hash) {
+        contentChanged = false;
         if (existing.title !== title) {
           updateDocumentTitle(db, existing.id, title, now);
           updated++;
@@ -1700,10 +1716,15 @@ export async function reindexCollection(
       indexed++;
       insertContent(db, hash, content, now);
       const stat = statSync(filepath);
-      insertDocument(db, collectionName, path, title, hash,
+      documentId = insertDocument(db, collectionName, path, title, hash,
         stat ? new Date(stat.birthtime).toISOString() : now,
         stat ? new Date(stat.mtime).toISOString() : now);
     }
+
+    // Unchanged content still backfills missing or stale extraction state.
+    const extraction = syncDocumentMetadata(db, documentId, content, path,
+      contentChanged ? undefined : { onlyIfStale: true });
+    if (extraction?.error) metadataErrors++;
 
     processed++;
     options?.onProgress?.({ file: relativeFile, current: processed, total });
@@ -1721,7 +1742,7 @@ export async function reindexCollection(
 
   const orphanedCleaned = cleanupOrphanedContent(db);
 
-  return { indexed, updated, unchanged, removed, orphanedCleaned, skipped: skippedFiles.length, skippedFiles };
+  return { indexed, updated, unchanged, removed, orphanedCleaned, skipped: skippedFiles.length, skippedFiles, metadataErrors };
 }
 
 export type EmbedFailure = {
@@ -2510,6 +2531,8 @@ export type IndexStatus = {
   totalDocuments: number;
   needsEmbedding: number;
   hasVectorIndex: boolean;
+  /** Active documents without current, error-free metadata extraction. */
+  pendingMetadata: number;
   collections: CollectionInfo[];
 };
 
@@ -2939,6 +2962,7 @@ function rebuildDocumentFTS(db: Database, documentId: number): void {
 
 /**
  * Insert a new document into the documents table.
+ * Returns the document's id so callers can attach document-scoped state.
  */
 export function insertDocument(
   db: Database,
@@ -2948,7 +2972,7 @@ export function insertDocument(
   hash: string,
   createdAt: string,
   modifiedAt: string
-): void {
+): number {
   db.prepare(`
     INSERT INTO documents (collection, path, title, hash, created_at, modified_at, active)
     VALUES (?, ?, ?, ?, ?, ?, 1)
@@ -2960,7 +2984,10 @@ export function insertDocument(
   `).run(collectionName, path, title, hash, createdAt, modifiedAt);
 
   const row = db.prepare(`SELECT id FROM documents WHERE collection = ? AND path = ?`).get(collectionName, path) as { id: number } | undefined;
-  if (row) rebuildDocumentFTS(db, row.id);
+  if (!row) throw new Error(`Document row missing after insert: ${collectionName}/${path}`);
+
+  rebuildDocumentFTS(db, row.id);
+  return row.id;
 }
 
 /**
@@ -5206,6 +5233,7 @@ export function getStatus(db: Database, model: string = DEFAULT_EMBED_MODEL): In
     totalDocuments: totalDocs,
     needsEmbedding,
     hasVectorIndex: hasVectors,
+    pendingMetadata: countDocumentsPendingMetadata(db),
     collections,
   };
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -37,10 +37,14 @@ import type {
   CollectionConfig,
   ContextMap,
 } from "./collections.js";
+import { METADATA_EXTRACTION_VERSION, type DocumentMetadata } from "./metadata.js";
+import { compileMetadataFilter, type MetadataFilter } from "./metadata-filter.js";
 import {
   initializeMetadataSchema,
   syncDocumentMetadata,
   countDocumentsPendingMetadata,
+  getMetadataByFilepath,
+  parseMetadataJson,
 } from "./metadata-store.js";
 
 // =============================================================================
@@ -1539,8 +1543,8 @@ export type Store = {
   toVirtualPath: (absolutePath: string) => string | null;
 
   // Search
-  searchFTS: (query: string, limit?: number, collectionName?: string | readonly string[]) => SearchResult[];
-  searchVec: (query: string, model: string, limit?: number, collectionName?: string | readonly string[], session?: ILLMSession, precomputedEmbedding?: number[]) => Promise<SearchResult[]>;
+  searchFTS: (query: string, limit?: number, collectionName?: string | readonly string[], filter?: MetadataFilter) => SearchResult[];
+  searchVec: (query: string, model: string, limit?: number, collectionName?: string | readonly string[], session?: ILLMSession, precomputedEmbedding?: number[], filter?: MetadataFilter) => Promise<SearchResult[]>;
 
   // Query expansion & reranking
   expandQuery: (query: string, model?: string) => Promise<ExpandedQuery[]>;
@@ -2292,8 +2296,8 @@ export function createStore(dbPath?: string): Store {
     toVirtualPath: (absolutePath: string) => toVirtualPath(db, absolutePath),
 
     // Search
-    searchFTS: (query: string, limit?: number, collectionName?: string | readonly string[]) => searchFTS(db, query, limit, collectionName),
-    searchVec: (query: string, model: string, limit?: number, collectionName?: string | readonly string[], session?: ILLMSession, precomputedEmbedding?: number[]) => searchVec(db, query, model, limit, collectionName, session, precomputedEmbedding, getLlm(store)),
+    searchFTS: (query: string, limit?: number, collectionName?: string | readonly string[], filter?: MetadataFilter) => searchFTS(db, query, limit, collectionName, filter),
+    searchVec: (query: string, model: string, limit?: number, collectionName?: string | readonly string[], session?: ILLMSession, precomputedEmbedding?: number[], filter?: MetadataFilter) => searchVec(db, query, model, limit, collectionName, session, precomputedEmbedding, getLlm(store), filter),
 
     // Query expansion & reranking
     expandQuery: (query: string, model?: string) => expandQuery(query, model ?? store.llm?.generateModelName ?? DEFAULT_QUERY_MODEL, db, store.llm),
@@ -2437,6 +2441,7 @@ export function handelize(path: string): string {
  * Search result extends DocumentResult with score and source info
  */
 export type SearchResult = DocumentResult & {
+  metadata: DocumentMetadata;
   score: number;              // Relevance score (0-1)
   source: "fts" | "vec";      // Search source (full-text or vector)
   chunkPos?: number;          // Character position of matching chunk (for vector search)
@@ -4077,12 +4082,12 @@ function mergeSearchResultsByScore(lists: SearchResult[][], limit: number): Sear
     .slice(0, limit);
 }
 
-export function searchFTS(db: Database, query: string, limit: number = 20, collectionName?: string | readonly string[]): SearchResult[] {
+export function searchFTS(db: Database, query: string, limit: number = 20, collectionName?: string | readonly string[], filter?: MetadataFilter): SearchResult[] {
   const names = scopedCollectionNames(collectionName);
   // Search each requested collection before merging/truncating so a large
   // unrelated collection cannot occupy global top-k and starve the rest (#775).
   if (names && names.length > 1) {
-    return mergeSearchResultsByScore(names.map(name => searchFTS(db, query, limit, name)), limit);
+    return mergeSearchResultsByScore(names.map(name => searchFTS(db, query, limit, name, filter)), limit);
   }
   const collectionFilter = names?.[0];
 
@@ -4096,10 +4101,12 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
   // query into a 17-second query on large collections.
   const params: (string | number)[] = [ftsQuery];
 
-  // When filtering by collection, fetch extra candidates from the FTS index
-  // since some will be filtered out. Without a collection filter we can
-  // fetch exactly the requested limit.
-  const ftsLimit = collectionFilter ? limit * 10 : limit;
+  // When filtering by collection or metadata, fetch extra candidates from the
+  // FTS index since some will be filtered out. Without a filter we can fetch
+  // exactly the requested limit. Selective filters remain best-effort: an
+  // eligible document outside this candidate window is missed (same
+  // completeness contract as collection filtering).
+  const ftsLimit = (collectionFilter || filter) ? limit * 10 : limit;
 
   let sql = `
     WITH fts_matches AS (
@@ -4115,10 +4122,12 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
       d.title,
       content.doc as body,
       d.hash,
-      fm.bm25_score
+      fm.bm25_score,
+      dm.metadata_json
     FROM fts_matches fm
     JOIN documents d ON d.id = fm.rowid
     JOIN content ON content.hash = d.hash
+    LEFT JOIN document_metadata dm ON dm.document_id = d.id
     WHERE d.active = 1
   `;
 
@@ -4127,11 +4136,19 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
     params.push(String(collectionFilter));
   }
 
+  if (filter) {
+    // Only documents with current, error-free extraction can match — an
+    // unprocessed document must not accidentally satisfy `exists: false`.
+    const compiledFilter = compileMetadataFilter(filter, "d");
+    sql += ` AND dm.extraction_version = ${METADATA_EXTRACTION_VERSION} AND dm.extraction_error IS NULL AND ${compiledFilter.sql}`;
+    params.push(...compiledFilter.params);
+  }
+
   // bm25 lower is better; sort ascending.
   sql += ` ORDER BY fm.bm25_score ASC LIMIT ?`;
   params.push(limit);
 
-  const rows = db.prepare(sql).all(...params) as { filepath: string; display_path: string; title: string; body: string; hash: string; bm25_score: number }[];
+  const rows = db.prepare(sql).all(...params) as { filepath: string; display_path: string; title: string; body: string; hash: string; bm25_score: number; metadata_json: string | null }[];
   return rows.map(row => {
     const collectionName = row.filepath.split('//')[1]?.split('/')[0] || "";
     // Convert bm25 (negative, lower is better) into a stable [0..1) score where higher is better.
@@ -4150,6 +4167,7 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
       bodyLength: row.body.length,
       body: row.body,
       context: getContextForFile(db, row.filepath),
+      metadata: parseMetadataJson(row.metadata_json),
       score,
       source: "fts" as const,
     };
@@ -4164,12 +4182,13 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
 const SQLITE_VEC_MAX_K = 4096;
 
 /**
- * Max collection-scoped vectors for an exact cosine scan. Above this we fall
+ * Max filter-eligible vectors for an exact cosine scan. Above this we fall
  * back to global ANN with a capped over-fetch. Exact scan avoids the
- * post-filter starvation of small collections (#791, #803); ANN remains for
- * very large collections where a full scan would be expensive.
+ * post-filter starvation of small eligible sets — originally small
+ * collections (#791, #803), now also selective metadata filters; ANN remains
+ * for very large eligible sets where a full scan would be expensive.
  */
-const COLLECTION_VEC_EXACT_SCAN_MAX = 20_000;
+const FILTERED_VEC_EXACT_SCAN_MAX = 20_000;
 
 const VEC_HASH_SEQ_IN_CHUNK = 400;
 
@@ -4218,7 +4237,7 @@ function annVecScan(
   `).all(new Float32Array(embedding), vecK) as { hash_seq: string; distance: number }[];
 }
 
-export async function searchVec(db: Database, query: string, model: string, limit: number = 20, collectionName?: string | readonly string[], session?: ILLMSession, precomputedEmbedding?: number[], llm?: LlamaCpp): Promise<SearchResult[]> {
+export async function searchVec(db: Database, query: string, model: string, limit: number = 20, collectionName?: string | readonly string[], session?: ILLMSession, precomputedEmbedding?: number[], llm?: LlamaCpp, filter?: MetadataFilter): Promise<SearchResult[]> {
   const tableExists = db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'`).get();
   if (!tableExists) return [];
 
@@ -4228,7 +4247,7 @@ export async function searchVec(db: Database, query: string, model: string, limi
   const names = scopedCollectionNames(collectionName);
   if (names && names.length > 1) {
     const lists = await Promise.all(
-      names.map(name => searchVec(db, query, model, limit, name, session, embedding, llm)),
+      names.map(name => searchVec(db, query, model, limit, name, session, embedding, llm, filter)),
     );
     return mergeSearchResultsByScore(lists, limit);
   }
@@ -4241,30 +4260,49 @@ export async function searchVec(db: Database, query: string, model: string, limi
 
   // Step 1: Get vector matches from sqlite-vec (no JOINs allowed).
   //
-  // Collection filter cannot be pushed into MATCH (sqlite-vec has no join-safe
-  // predicate here). Global ANN + post-filter starves small collections: they
-  // never enter the top-k (#791, #803). Multiplier over-fetch alone is not
-  // enough either — sqlite-vec caps k at 4096. For a collection filter we
-  // therefore exact-scan that collection's vectors when the set is small
+  // Collection and metadata filters cannot be pushed into MATCH (sqlite-vec
+  // has no join-safe predicate here). Global ANN + post-filter starves small
+  // eligible sets: they never enter the top-k (#791, #803). Multiplier
+  // over-fetch alone is not enough either — sqlite-vec caps k at 4096. For a
+  // filter we therefore exact-scan the eligible vectors when the set is small
   // enough, and only then fall back to capped ANN + post-filter.
   let vecResults: { hash_seq: string; distance: number }[];
 
-  if (collectionFilter) {
-    const collectionHashSeqs = withLazyContentVectorMigration(db, () =>
-      db.prepare(`
-        SELECT cv.hash || '_' || cv.seq AS hash_seq
-        FROM content_vectors cv
-        JOIN documents d ON d.hash = cv.hash AND d.active = 1
-        WHERE d.collection = ?
-      `).all(collectionFilter) as { hash_seq: string }[],
+  if (collectionFilter || filter) {
+    let eligibleSql = `
+      SELECT DISTINCT cv.hash || '_' || cv.seq AS hash_seq
+      FROM content_vectors cv
+      JOIN documents d ON d.hash = cv.hash AND d.active = 1
+    `;
+    const eligibleConditions: string[] = [];
+    const eligibleParams: (string | number)[] = [];
+
+    if (collectionFilter) {
+      eligibleConditions.push(`d.collection = ?`);
+      eligibleParams.push(collectionFilter);
+    }
+
+    if (filter) {
+      const compiledFilter = compileMetadataFilter(filter, "d");
+      eligibleSql += ` JOIN document_metadata dm ON dm.document_id = d.id`;
+      eligibleConditions.push(`dm.extraction_version = ${METADATA_EXTRACTION_VERSION}`);
+      eligibleConditions.push(`dm.extraction_error IS NULL`);
+      eligibleConditions.push(compiledFilter.sql);
+      eligibleParams.push(...compiledFilter.params);
+    }
+
+    eligibleSql += ` WHERE ${eligibleConditions.join(" AND ")}`;
+
+    const eligibleHashSeqs = withLazyContentVectorMigration(db, () =>
+      db.prepare(eligibleSql).all(...eligibleParams) as { hash_seq: string }[],
     ).map((r) => r.hash_seq);
 
-    if (collectionHashSeqs.length === 0) return [];
+    if (eligibleHashSeqs.length === 0) return [];
 
-    if (collectionHashSeqs.length <= COLLECTION_VEC_EXACT_SCAN_MAX) {
-      vecResults = exactVecScanByHashSeq(db, embedding, collectionHashSeqs, limit);
+    if (eligibleHashSeqs.length <= FILTERED_VEC_EXACT_SCAN_MAX) {
+      vecResults = exactVecScanByHashSeq(db, embedding, eligibleHashSeqs, limit);
     } else {
-      // Large collection: ANN with over-fetch, hard-capped at sqlite-vec's max k.
+      // Large eligible set: ANN with over-fetch, hard-capped at sqlite-vec's max k.
       vecResults = annVecScan(db, embedding, Math.max(limit * 30, limit * 3));
     }
   } else {
@@ -4287,22 +4325,32 @@ export async function searchVec(db: Database, query: string, model: string, limi
       'qmd://' || d.collection || '/' || d.path as filepath,
       d.collection || '/' || d.path as display_path,
       d.title,
-      content.doc as body
+      content.doc as body,
+      dm.metadata_json
     FROM content_vectors cv
     JOIN documents d ON d.hash = cv.hash AND d.active = 1
     JOIN content ON content.hash = d.hash
+    LEFT JOIN document_metadata dm ON dm.document_id = d.id
     WHERE cv.hash || '_' || cv.seq IN (${placeholders})
   `;
-  const params: string[] = [...hashSeqs];
+  const params: (string | number)[] = [...hashSeqs];
 
   if (collectionFilter) {
     docSql += ` AND d.collection = ?`;
     params.push(collectionFilter);
   }
 
+  if (filter) {
+    // Re-apply the filter on the document join: vectors are content-scoped,
+    // so one hash can belong to both matching and non-matching documents.
+    const compiledFilter = compileMetadataFilter(filter, "d");
+    docSql += ` AND dm.extraction_version = ${METADATA_EXTRACTION_VERSION} AND dm.extraction_error IS NULL AND ${compiledFilter.sql}`;
+    params.push(...compiledFilter.params);
+  }
+
   const docRows = withLazyContentVectorMigration(db, () => db.prepare(docSql).all(...params) as {
     hash_seq: string; hash: string; pos: number; filepath: string;
-    display_path: string; title: string; body: string;
+    display_path: string; title: string; body: string; metadata_json: string | null;
   }[]);
 
   // Combine with distances and dedupe by filepath
@@ -4331,6 +4379,7 @@ export async function searchVec(db: Database, query: string, model: string, limi
         bodyLength: row.body.length,
         body: row.body,
         context: getContextForFile(db, row.filepath),
+        metadata: parseMetadataJson(row.metadata_json),
         score: 1 - bestDist,  // Cosine similarity = 1 - cosine distance
         source: "vec" as const,
         chunkPos: row.pos,
@@ -5418,6 +5467,7 @@ export interface SearchHooks {
 
 export interface HybridQueryOptions {
   collection?: string | readonly string[];
+  filter?: MetadataFilter;  // metadata filter applied to every retrieval call
   limit?: number;           // default 10
   minScore?: number;        // default 0
   candidateLimit?: number;  // default RERANK_CANDIDATE_LIMIT
@@ -5438,7 +5488,21 @@ export interface HybridQueryResult {
   score: number;            // blended score (full precision)
   context: string | null;   // user-set context
   docid: string;            // content hash prefix (6 chars)
+  metadata: DocumentMetadata; // indexed qmd.metadata for the document
   explain?: HybridQueryExplain;
+}
+
+/**
+ * Attach canonical metadata to final search results with one batch query.
+ * Runs after RRF/reranking so metadata is never duplicated through the
+ * intermediate ranked lists.
+ */
+function attachResultMetadata<T extends { file: string }>(
+  db: Database,
+  results: T[],
+): (T & { metadata: DocumentMetadata })[] {
+  const metadataByFilepath = getMetadataByFilepath(db, results.map(r => r.file));
+  return results.map(r => ({ ...r, metadata: metadataByFilepath.get(r.file) ?? {} }));
 }
 
 export type RankedListMeta = {
@@ -5484,6 +5548,7 @@ export async function hybridQuery(
   const minScore = options?.minScore ?? 0;
   const candidateLimit = options?.candidateLimit ?? RERANK_CANDIDATE_LIMIT;
   const collection = options?.collection;
+  const filter = options?.filter;
   const explain = options?.explain ?? false;
   const intent = options?.intent;
   const skipRerank = options?.skipRerank ?? false;
@@ -5500,8 +5565,10 @@ export async function hybridQuery(
   // When intent is provided, disable strong-signal bypass — the obvious BM25
   // match may not be what the caller wants (e.g. "performance" with intent
   // "web page load times" should NOT shortcut to a sports-performance doc).
-  // Pass collection directly into FTS query (filter at SQL level, not post-hoc)
-  const initialFts = store.searchFTS(query, 20, collection);
+  // Pass collection and metadata filter directly into FTS query (filter at
+  // SQL level, not post-hoc) — the strong-signal decision must be based only
+  // on eligible documents.
+  const initialFts = store.searchFTS(query, 20, collection, filter);
   const topScore = initialFts[0]?.score ?? 0;
   const secondScore = initialFts[1]?.score ?? 0;
   const hasStrongSignal = !intent && initialFts.length > 0
@@ -5538,7 +5605,7 @@ export async function hybridQuery(
   // 3a: Run FTS for all lex expansions right away (no LLM needed)
   for (const q of expanded) {
     if (q.type === 'lex') {
-      const ftsResults = store.searchFTS(q.query, 20, collection);
+      const ftsResults = store.searchFTS(q.query, 20, collection, filter);
       if (ftsResults.length > 0) {
         for (const r of ftsResults) docidMap.set(r.filepath, r.docid);
         rankedLists.push(ftsResults.map(r => ({
@@ -5577,7 +5644,7 @@ export async function hybridQuery(
 
       const vecResults = await store.searchVec(
         vecQueries[i]!.text, embedModel, 20, collection,
-        undefined, embedding
+        undefined, embedding, filter
       );
       if (vecResults.length > 0) {
         for (const r of vecResults) docidMap.set(r.filepath, r.docid);
@@ -5646,7 +5713,7 @@ export async function hybridQuery(
   if (skipRerank) {
     // Skip LLM reranking — return candidates scored by RRF only
     const seenFiles = new Set<string>();
-    return candidates
+    const rrfResults = candidates
       .map((cand, i) => {
         const chunkInfo = docChunkMap.get(cand.file);
         const bestIdx = chunkInfo?.bestIdx ?? 0;
@@ -5691,6 +5758,7 @@ export async function hybridQuery(
       })
       .filter(r => r.score >= minScore)
       .slice(0, limit);
+    return attachResultMetadata(store.db, rrfResults);
   }
 
   // Step 6: Rerank chunks (NOT full bodies)
@@ -5761,7 +5829,7 @@ export async function hybridQuery(
 
   // Step 8: Dedup by file (safety net — prevents duplicate output)
   const seenFiles = new Set<string>();
-  return blended
+  const finalResults = blended
     .filter(r => {
       if (seenFiles.has(r.file)) return false;
       seenFiles.add(r.file);
@@ -5769,10 +5837,12 @@ export async function hybridQuery(
     })
     .filter(r => r.score >= minScore)
     .slice(0, limit);
+  return attachResultMetadata(store.db, finalResults);
 }
 
 export interface VectorSearchOptions {
   collection?: string | readonly string[];
+  filter?: MetadataFilter;  // metadata filter applied to every retrieval call
   limit?: number;           // default 10
   minScore?: number;        // default 0.3
   intent?: string;          // domain intent hint for disambiguation
@@ -5787,6 +5857,7 @@ export interface VectorSearchResult {
   score: number;
   context: string | null;
   docid: string;
+  metadata: DocumentMetadata;
 }
 
 /**
@@ -5806,6 +5877,7 @@ export async function vectorSearchQuery(
   const limit = options?.limit ?? 10;
   const minScore = options?.minScore ?? 0.3;
   const collection = options?.collection;
+  const filter = options?.filter;
   const intent = options?.intent;
 
   const hasVectors = !!store.db.prepare(
@@ -5824,7 +5896,7 @@ export async function vectorSearchQuery(
   const queryTexts = [query, ...vecExpanded.map(q => q.query)];
   const allResults = new Map<string, VectorSearchResult>();
   for (const q of queryTexts) {
-    const vecResults = await store.searchVec(q, embedModel, limit, collection);
+    const vecResults = await store.searchVec(q, embedModel, limit, collection, undefined, undefined, filter);
     for (const r of vecResults) {
       const existing = allResults.get(r.filepath);
       if (!existing || r.score > existing.score) {
@@ -5836,6 +5908,7 @@ export async function vectorSearchQuery(
           score: r.score,
           context: store.getContextForFile(r.filepath),
           docid: r.docid,
+          metadata: r.metadata,
         });
       }
     }
@@ -5857,6 +5930,7 @@ export async function vectorSearchQuery(
  */
 export interface StructuredSearchOptions {
   collections?: string[];   // Filter to specific collections (OR match)
+  filter?: MetadataFilter;  // metadata filter applied to every retrieval call
   limit?: number;           // default 10
   minScore?: number;        // default 0
   candidateLimit?: number;  // default RERANK_CANDIDATE_LIMIT
@@ -5901,6 +5975,7 @@ export async function structuredSearch(
   const hooks = options?.hooks;
 
   const collections = options?.collections;
+  const filter = options?.filter;
 
   if (searches.length === 0) return [];
 
@@ -5937,7 +6012,7 @@ export async function structuredSearch(
   for (const search of searches) {
     if (search.type === 'lex') {
       for (const coll of collectionList) {
-        const ftsResults = store.searchFTS(search.query, 20, coll);
+        const ftsResults = store.searchFTS(search.query, 20, coll, filter);
         if (ftsResults.length > 0) {
           for (const r of ftsResults) docidMap.set(r.filepath, r.docid);
           rankedLists.push(ftsResults.map(r => ({
@@ -5976,7 +6051,7 @@ export async function structuredSearch(
         for (const coll of collectionList) {
           const vecResults = await store.searchVec(
             vecSearches[i]!.query, embedModel, 20, coll,
-            undefined, embedding
+            undefined, embedding, filter
           );
           if (vecResults.length > 0) {
             for (const r of vecResults) docidMap.set(r.filepath, r.docid);
@@ -6040,7 +6115,7 @@ export async function structuredSearch(
   if (skipRerank) {
     // Skip LLM reranking — return candidates scored by RRF only
     const seenFiles = new Set<string>();
-    return candidates
+    const rrfResults = candidates
       .map((cand, i) => {
         const chunkInfo = docChunkMap.get(cand.file);
         const bestIdx = chunkInfo?.bestIdx ?? 0;
@@ -6085,6 +6160,7 @@ export async function structuredSearch(
       })
       .filter(r => r.score >= minScore)
       .slice(0, limit);
+    return attachResultMetadata(store.db, rrfResults);
   }
 
   // Step 5: Rerank chunks
@@ -6154,7 +6230,7 @@ export async function structuredSearch(
 
   // Step 7: Dedup by file
   const seenFiles = new Set<string>();
-  return blended
+  const finalResults = blended
     .filter(r => {
       if (seenFiles.has(r.file)) return false;
       seenFiles.add(r.file);
@@ -6162,4 +6238,5 @@ export async function structuredSearch(
     })
     .filter(r => r.score >= minScore)
     .slice(0, limit);
+  return attachResultMetadata(store.db, finalResults);
 }

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -17,6 +17,7 @@ import YAML from "yaml";
 import type { CollectionConfig } from "../src/collections";
 import { setConfigIndexName } from "../src/collections";
 import { syncConfigToDb } from "../src/store";
+import { initializeMetadataSchema } from "../src/metadata-store";
 
 // =============================================================================
 // Test Database Setup
@@ -124,6 +125,9 @@ function initTestDatabase(db: Database): void {
       value TEXT
     )
   `);
+
+  // Document metadata tables — searchFTS/searchVec join them for result metadata
+  initializeMetadataSchema(db);
 }
 
 function seedTestData(db: Database): void {

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1088,9 +1088,19 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
       }),
     });
     expect(res.status).toBe(200);
-    expect(res.headers.get("content-type")).toContain("application/json");
+    const contentType = res.headers.get("content-type") ?? "";
+    expect(contentType).toMatch(/application\/json|text\/event-stream/);
     expect(res.headers.get("mcp-session-id")).toBeNull();
-    const json = await res.json() as any;
+
+    // Streamable HTTP permits either a direct JSON response or one SSE
+    // message when the client advertises both. The MCP SDK currently chooses
+    // SSE for legacy initialize even when responseMode is "json".
+    const responseText = await res.text();
+    const payload = contentType.includes("text/event-stream")
+      ? responseText.split(/\r?\n/).find(line => line.startsWith("data: "))?.slice(6)
+      : responseText;
+    expect(payload).toBeDefined();
+    const json = JSON.parse(payload!) as any;
     expect(json.jsonrpc).toBe("2.0");
     expect(json.id).toBe(1);
     expect(json.result.serverInfo.name).toBe("qmd");

--- a/test/metadata-cli.test.ts
+++ b/test/metadata-cli.test.ts
@@ -1,0 +1,161 @@
+/**
+ * metadata-cli.test.ts - CLI --filter integration: parsing, propagation,
+ * JSON output metadata, and error behavior. Spawns real qmd processes.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+
+const thisDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(thisDir, "..");
+const qmdScript = join(projectRoot, "src", "cli", "qmd.ts");
+const isBunRuntime = typeof (globalThis as { Bun?: unknown }).Bun !== "undefined";
+const tsxCli = join(projectRoot, "node_modules", "tsx", "dist", "cli.mjs");
+const qmdCommand = isBunRuntime
+  ? { command: process.execPath, args: [qmdScript] }
+  : { command: process.execPath, args: [tsxCli, qmdScript] };
+
+let testDir: string;
+let fixturesDir: string;
+let dbPath: string;
+let configDir: string;
+
+async function runQmd(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = spawn(qmdCommand.command, [...qmdCommand.args, ...args], {
+    cwd: fixturesDir,
+    env: {
+      ...process.env,
+      INDEX_PATH: dbPath,
+      QMD_CONFIG_DIR: configDir,
+      PWD: fixturesDir,
+    },
+  });
+
+  let stdout = "";
+  let stderr = "";
+  proc.stdout.on("data", chunk => { stdout += chunk; });
+  proc.stderr.on("data", chunk => { stderr += chunk; });
+
+  const exitCode = await new Promise<number>(resolve => {
+    proc.on("close", code => resolve(code ?? -1));
+  });
+  return { stdout, stderr, exitCode };
+}
+
+beforeAll(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "qmd-metadata-cli-"));
+  fixturesDir = join(testDir, "fixtures");
+  configDir = join(testDir, "config");
+  dbPath = join(testDir, "index.sqlite");
+  await mkdir(fixturesDir, { recursive: true });
+  await mkdir(configDir, { recursive: true });
+
+  await writeFile(join(fixturesDir, "published.md"), [
+    "---",
+    "qmd:",
+    "  metadata:",
+    "    status: published",
+    "    topics: [typescript, programming]",
+    "---",
+    "",
+    "# Published doc",
+    "",
+    "cli filter keyword body",
+    "",
+  ].join("\n"));
+  await writeFile(join(fixturesDir, "draft.md"), [
+    "---",
+    "qmd:",
+    "  metadata:",
+    "    status: draft",
+    "---",
+    "",
+    "# Draft doc",
+    "",
+    "cli filter keyword body",
+    "",
+  ].join("\n"));
+
+  const addResult = await runQmd(["collection", "add", ".", "--name", "notes"]);
+  expect(addResult.exitCode).toBe(0);
+}, 60000);
+
+afterAll(async () => {
+  await rm(testDir, { recursive: true, force: true });
+});
+
+describe("qmd search --filter", () => {
+  test("returns only matching documents and includes metadata in JSON output", async () => {
+    const { stdout, exitCode } = await runQmd([
+      "search", "cli filter keyword",
+      "--format", "json",
+      "--filter", '{"key":"status","operator":"eq","value":"published"}',
+    ]);
+    expect(exitCode).toBe(0);
+
+    const results = JSON.parse(stdout);
+    expect(results.length).toBe(1);
+    expect(results[0].file).toBe("qmd://notes/published.md");
+    expect(results[0].metadata).toEqual({ status: "published", topics: ["typescript", "programming"] });
+  }, 30000);
+
+  test("supports nested filters", async () => {
+    const filter = JSON.stringify({
+      operator: "and",
+      operands: [
+        { key: "topics", operator: "all", value: ["typescript", "programming"] },
+        { operator: "not", operand: { key: "status", operator: "eq", value: "draft" } },
+      ],
+    });
+    const { stdout, exitCode } = await runQmd([
+      "search", "cli filter keyword", "--format", "json", "--filter", filter,
+    ]);
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout).map((r: { file: string }) => r.file)).toEqual(["qmd://notes/published.md"]);
+  }, 30000);
+
+  test("returns format-safe empty output when nothing matches", async () => {
+    const { stdout, exitCode } = await runQmd([
+      "search", "cli filter keyword",
+      "--format", "json",
+      "--filter", '{"key":"status","operator":"eq","value":"missing"}',
+    ]);
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toEqual([]);
+  }, 30000);
+
+  test("omits metadata from JSON output when a document has none", async () => {
+    await writeFile(join(fixturesDir, "plain.md"), "# Plain doc\n\ncli filter keyword body\n");
+    const updateResult = await runQmd(["update"]);
+    expect(updateResult.exitCode).toBe(0);
+
+    const { stdout, exitCode } = await runQmd(["search", "cli filter keyword", "--format", "json"]);
+    expect(exitCode).toBe(0);
+
+    const results = JSON.parse(stdout);
+    const plainResult = results.find((r: { file: string }) => r.file === "qmd://notes/plain.md");
+    expect(plainResult).toBeDefined();
+    expect(plainResult.metadata).toBeUndefined();
+  }, 60000);
+
+  test("rejects malformed --filter JSON with a non-zero exit", async () => {
+    const { stderr, exitCode } = await runQmd([
+      "search", "cli filter keyword", "--filter", "{not json",
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/Invalid --filter JSON/);
+  }, 30000);
+
+  test("rejects valid JSON with an invalid filter AST", async () => {
+    const { stderr, exitCode } = await runQmd([
+      "search", "cli filter keyword", "--filter", '{"key":"status","operator":"equal","value":"x"}',
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/Invalid metadata filter at \$/);
+    expect(stderr).toMatch(/unknown operator 'equal'/);
+  }, 30000);
+});

--- a/test/metadata-filter.test.ts
+++ b/test/metadata-filter.test.ts
@@ -1,0 +1,299 @@
+/**
+ * metadata-filter.test.ts - Filter AST validation and parameterized SQL
+ * compilation, including end-to-end predicate semantics against SQLite.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { openDatabase } from "../src/db.js";
+import type { Database } from "../src/db.js";
+import {
+  parseMetadataFilter,
+  compileMetadataFilter,
+  MetadataFilterError,
+  METADATA_FILTER_LIMITS,
+  type MetadataFilter,
+} from "../src/metadata-filter.js";
+import { initializeMetadataSchema, replaceDocumentMetadata } from "../src/metadata-store.js";
+import { METADATA_EXTRACTION_VERSION, type DocumentMetadata } from "../src/metadata.js";
+
+// =============================================================================
+// Validation
+// =============================================================================
+
+describe("parseMetadataFilter", () => {
+  test("accepts every condition operator shape", () => {
+    const conditions: unknown[] = [
+      { key: "status", operator: "eq", value: "published" },
+      { key: "status", operator: "ne", value: "draft" },
+      { key: "priority", operator: "gt", value: 3 },
+      { key: "priority", operator: "gte", value: 3 },
+      { key: "priority", operator: "lt", value: 10 },
+      { key: "name", operator: "lte", value: "m" },
+      { key: "topics", operator: "in", value: ["a", "b"] },
+      { key: "topics", operator: "nin", value: [1, 2] },
+      { key: "flags", operator: "all", value: [true, false] },
+      { key: "status", operator: "exists", value: false },
+    ];
+    for (const condition of conditions) {
+      expect(parseMetadataFilter(condition)).toEqual(condition);
+    }
+  });
+
+  test("accepts nested groups and negation", () => {
+    const filter = {
+      operator: "and",
+      operands: [
+        { key: "topics", operator: "all", value: ["typescript", "programming"] },
+        {
+          operator: "or",
+          operands: [
+            { key: "status", operator: "eq", value: "published" },
+            { operator: "not", operand: { key: "audience", operator: "eq", value: "internal" } },
+          ],
+        },
+      ],
+    };
+    expect(parseMetadataFilter(filter)).toEqual(filter);
+  });
+
+  test("canonicalizes membership arrays by de-duplicating", () => {
+    const parsed = parseMetadataFilter({ key: "topics", operator: "in", value: ["a", "b", "a"] });
+    expect(parsed).toEqual({ key: "topics", operator: "in", value: ["a", "b"] });
+  });
+
+  test("rejects invalid node shapes with the failing JSON path", () => {
+    const cases: [unknown, RegExp][] = [
+      ["not-an-object", /at \$:.*must be an object/],
+      [{ key: "a", value: 1 }, /at \$:.*missing 'operator'/],
+      [{ operator: "equal", key: "a", value: 1 }, /unknown operator 'equal'/],
+      [{ operator: "and", operands: [] }, /non-empty 'operands'/],
+      [{ operator: "and", operands: "nope" }, /'operands' array/],
+      [{ operator: "not", operands: [{ key: "a", operator: "eq", value: 1 }] }, /unknown property 'operands'/],
+      [{ operator: "not" }, /exactly one 'operand'/],
+      [{ operator: "and", operands: [{ operator: "eq" }] }, /at \$\.operands\[0\]/],
+      [{ operator: "eq", value: 1 }, /non-empty string 'key'/],
+      [{ operator: "eq", key: "a" }, /requires a 'value'/],
+      [{ operator: "eq", key: "a", value: 1, extra: true }, /unknown property 'extra'/],
+      [{ operator: "and", operands: [{ key: "a", operator: "eq", value: 1 }], key: "a" }, /unknown property 'key'/],
+      [{ operator: "gt", key: "a", value: true }, /string or number value/],
+      [{ operator: "eq", key: "a", value: NaN }, /finite/],
+      [{ operator: "eq", key: "a", value: { nested: 1 } }, /string, number, or boolean/],
+      [{ operator: "in", key: "a", value: "x" }, /array value/],
+      [{ operator: "in", key: "a", value: [] }, /non-empty array/],
+      [{ operator: "in", key: "a", value: [1, "two"] }, /homogeneous array/],
+      [{ operator: "exists", key: "a", value: "yes" }, /boolean value/],
+    ];
+
+    for (const [input, expected] of cases) {
+      expect(() => parseMetadataFilter(input)).toThrow(expected);
+      expect(() => parseMetadataFilter(input)).toThrow(MetadataFilterError);
+    }
+  });
+
+  test("rejects excessive depth, node count, and operand count", () => {
+    let deepFilter: unknown = { key: "a", operator: "eq", value: 1 };
+    for (let i = 0; i <= METADATA_FILTER_LIMITS.maxDepth; i++) {
+      deepFilter = { operator: "not", operand: deepFilter };
+    }
+    expect(() => parseMetadataFilter(deepFilter)).toThrow(/nesting depth/);
+
+    const condition = { key: "a", operator: "eq", value: 1 };
+    const wideGroup = {
+      operator: "or",
+      operands: Array.from({ length: METADATA_FILTER_LIMITS.maxGroupOperands + 1 }, () => condition),
+    };
+    expect(() => parseMetadataFilter(wideGroup)).toThrow(/operands/);
+
+    const manyNodes = {
+      operator: "and",
+      operands: Array.from({ length: METADATA_FILTER_LIMITS.maxGroupOperands }, () => ({
+        operator: "and",
+        operands: Array.from({ length: METADATA_FILTER_LIMITS.maxGroupOperands }, () => condition),
+      })),
+    };
+    expect(() => parseMetadataFilter(manyNodes)).toThrow(/nodes/);
+
+    const manyValues = {
+      key: "a",
+      operator: "in",
+      value: Array.from({ length: METADATA_FILTER_LIMITS.maxMembershipValues + 1 }, (_, i) => i),
+    };
+    expect(() => parseMetadataFilter(manyValues)).toThrow(/values/);
+  });
+});
+
+// =============================================================================
+// SQL compilation and semantics
+// =============================================================================
+
+describe("compileMetadataFilter semantics", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = openDatabase(":memory:");
+    db.exec(`
+      CREATE TABLE documents (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        path TEXT NOT NULL,
+        active INTEGER NOT NULL DEFAULT 1
+      )
+    `);
+    initializeMetadataSchema(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function insertDoc(path: string, metadata: DocumentMetadata): number {
+    const result = db.prepare(`INSERT INTO documents (path) VALUES (?)`).run(path);
+    const documentId = Number(result.lastInsertRowid);
+    replaceDocumentMetadata(db, documentId, { metadata, extractionVersion: METADATA_EXTRACTION_VERSION });
+    return documentId;
+  }
+
+  function matchPaths(filter: MetadataFilter): string[] {
+    const compiled = compileMetadataFilter(parseMetadataFilter(filter), "d");
+    const rows = db.prepare(`
+      SELECT d.path FROM documents d
+      JOIN document_metadata dm ON dm.document_id = d.id
+        AND dm.extraction_version = ${METADATA_EXTRACTION_VERSION}
+        AND dm.extraction_error IS NULL
+      WHERE d.active = 1 AND ${compiled.sql}
+      ORDER BY d.path
+    `).all(...compiled.params) as { path: string }[];
+    return rows.map(row => row.path);
+  }
+
+  test("eq matches each scalar type exactly, without coercion", () => {
+    insertDoc("str.md", { status: "published" });
+    insertDoc("num.md", { status: 1 });
+    insertDoc("bool.md", { status: true });
+
+    expect(matchPaths({ key: "status", operator: "eq", value: "published" })).toEqual(["str.md"]);
+    expect(matchPaths({ key: "status", operator: "eq", value: 1 })).toEqual(["num.md"]);
+    expect(matchPaths({ key: "status", operator: "eq", value: true })).toEqual(["bool.md"]);
+    expect(matchPaths({ key: "status", operator: "eq", value: "1" })).toEqual([]);
+  });
+
+  test("ne requires key presence and matching type", () => {
+    insertDoc("draft.md", { status: "draft" });
+    insertDoc("published.md", { status: "published" });
+    insertDoc("missing.md", { other: "x" });
+    insertDoc("typed.md", { status: 1 });
+
+    expect(matchPaths({ key: "status", operator: "ne", value: "draft" })).toEqual(["published.md"]);
+  });
+
+  test("ordered comparisons match numbers and binary-ordered strings", () => {
+    insertDoc("low.md", { priority: 1 });
+    insertDoc("mid.md", { priority: 3 });
+    insertDoc("high.md", { priority: 7 });
+    insertDoc("alpha.md", { name: "alpha" });
+    insertDoc("zulu.md", { name: "zulu" });
+
+    expect(matchPaths({ key: "priority", operator: "gte", value: 3 })).toEqual(["high.md", "mid.md"]);
+    expect(matchPaths({ key: "priority", operator: "lt", value: 3 })).toEqual(["low.md"]);
+    expect(matchPaths({ key: "name", operator: "gt", value: "alpha" })).toEqual(["zulu.md"]);
+    // Type mismatch: no string 'priority' values exist.
+    expect(matchPaths({ key: "priority", operator: "gte", value: "3" })).toEqual([]);
+  });
+
+  test("in, nin, and all evaluate membership over value sets", () => {
+    insertDoc("ts.md", { topics: ["typescript", "programming"] });
+    insertDoc("go.md", { topics: ["go"] });
+    insertDoc("none.md", { other: "x" });
+
+    expect(matchPaths({ key: "topics", operator: "in", value: ["typescript", "rust"] })).toEqual(["ts.md"]);
+    expect(matchPaths({ key: "topics", operator: "nin", value: ["typescript", "rust"] })).toEqual(["go.md"]);
+    expect(matchPaths({ key: "topics", operator: "all", value: ["typescript", "programming"] })).toEqual(["ts.md"]);
+    expect(matchPaths({ key: "topics", operator: "all", value: ["typescript", "rust"] })).toEqual([]);
+  });
+
+  test("exists matches presence and absence", () => {
+    insertDoc("has.md", { status: "ok" });
+    insertDoc("hasnt.md", { other: "x" });
+
+    expect(matchPaths({ key: "status", operator: "exists", value: true })).toEqual(["has.md"]);
+    expect(matchPaths({ key: "status", operator: "exists", value: false })).toEqual(["hasnt.md"]);
+  });
+
+  test("and, or, and not compose recursively", () => {
+    insertDoc("a.md", { status: "published", priority: 5 });
+    insertDoc("b.md", { status: "published", priority: 1 });
+    insertDoc("c.md", { status: "draft", priority: 9 });
+
+    expect(matchPaths({
+      operator: "and",
+      operands: [
+        { key: "status", operator: "eq", value: "published" },
+        { key: "priority", operator: "gte", value: 3 },
+      ],
+    })).toEqual(["a.md"]);
+
+    expect(matchPaths({
+      operator: "or",
+      operands: [
+        { key: "priority", operator: "gte", value: 9 },
+        { key: "priority", operator: "lte", value: 1 },
+      ],
+    })).toEqual(["b.md", "c.md"]);
+
+    expect(matchPaths({
+      operator: "not",
+      operand: { key: "status", operator: "eq", value: "draft" },
+    })).toEqual(["a.md", "b.md"]);
+  });
+
+  test("independent conditions on one array key match different elements", () => {
+    insertDoc("wide.md", { priority: [1, 20] });
+    insertDoc("narrow.md", { priority: [5] });
+
+    const rangeFilter: MetadataFilter = {
+      operator: "and",
+      operands: [
+        { key: "priority", operator: "gte", value: 3 },
+        { key: "priority", operator: "lt", value: 10 },
+      ],
+    };
+    // Document-level semantics: [1, 20] satisfies both conditions via
+    // different elements — no implicit same-element fusion.
+    expect(matchPaths(rangeFilter)).toEqual(["narrow.md", "wide.md"]);
+  });
+
+  test("boolean values round-trip through membership operators", () => {
+    insertDoc("flagged.md", { reviewed: true });
+    insertDoc("unflagged.md", { reviewed: false });
+
+    expect(matchPaths({ key: "reviewed", operator: "in", value: [true] })).toEqual(["flagged.md"]);
+    expect(matchPaths({ key: "reviewed", operator: "nin", value: [true] })).toEqual(["unflagged.md"]);
+  });
+
+  test("SQL injection payloads in keys and values stay data", () => {
+    insertDoc("safe.md", { "key'; DROP TABLE documents; --": "v'; DROP TABLE documents; --" });
+
+    expect(matchPaths({
+      key: "key'; DROP TABLE documents; --",
+      operator: "eq",
+      value: "v'; DROP TABLE documents; --",
+    })).toEqual(["safe.md"]);
+
+    // Table survived.
+    expect((db.prepare(`SELECT COUNT(*) as c FROM documents`).get() as { c: number }).c).toBe(1);
+  });
+
+  test("compiled SQL never interpolates user keys or values", () => {
+    const filter = parseMetadataFilter({
+      operator: "and",
+      operands: [
+        { key: "key'; --", operator: "eq", value: "value'; --" },
+        { key: "topics", operator: "in", value: ["a'; --"] },
+      ],
+    });
+    const compiled = compileMetadataFilter(filter, "d");
+    expect(compiled.sql).not.toContain("'; --");
+    expect(compiled.params).toContain("key'; --");
+    expect(compiled.params).toContain("value'; --");
+    expect(compiled.params).toContain("a'; --");
+  });
+});

--- a/test/metadata-search.test.ts
+++ b/test/metadata-search.test.ts
@@ -1,0 +1,272 @@
+/**
+ * metadata-search.test.ts - Metadata filtering across FTS, vector, and
+ * structured search. Vector tests use precomputed embeddings so no models
+ * are downloaded.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createStore,
+  searchFTS,
+  searchVec,
+  structuredSearch,
+  insertContent,
+  insertDocument,
+  insertEmbedding,
+  hashContent,
+  DEFAULT_EMBED_MODEL,
+  type Store,
+} from "../src/store.js";
+import { replaceDocumentMetadata, syncDocumentMetadata } from "../src/metadata-store.js";
+import { METADATA_EXTRACTION_VERSION, type DocumentMetadata } from "../src/metadata.js";
+import type { MetadataFilter } from "../src/metadata-filter.js";
+
+let testDir: string;
+let store: Store;
+
+beforeAll(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "qmd-metadata-search-"));
+});
+
+afterAll(async () => {
+  await rm(testDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  const dbPath = join(testDir, `test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+  store = createStore(dbPath);
+});
+
+afterEach(() => {
+  store.close();
+});
+
+async function insertDoc(
+  collection: string,
+  path: string,
+  body: string,
+  metadata?: DocumentMetadata,
+): Promise<{ documentId: number; hash: string }> {
+  const now = new Date().toISOString();
+  const hash = await hashContent(body);
+  insertContent(store.db, hash, body, now);
+  const documentId = insertDocument(store.db, collection, path, path, hash, now, now);
+
+  if (metadata !== undefined) {
+    replaceDocumentMetadata(store.db, documentId, { metadata, extractionVersion: METADATA_EXTRACTION_VERSION });
+  }
+  return { documentId, hash };
+}
+
+describe("searchFTS with metadata filter", () => {
+  test("returns only documents matching the filter, with metadata attached", async () => {
+    await insertDoc("notes", "published.md", "# Auth\n\nauthentication flow details", { status: "published" });
+    await insertDoc("notes", "draft.md", "# Auth draft\n\nauthentication flow draft", { status: "draft" });
+    await insertDoc("notes", "plain.md", "# Auth notes\n\nauthentication flow notes", {});
+
+    const unfiltered = searchFTS(store.db, "authentication", 10);
+    expect(unfiltered.length).toBe(3);
+
+    const filtered = searchFTS(store.db, "authentication", 10, undefined, {
+      key: "status", operator: "eq", value: "published",
+    });
+    expect(filtered.map(r => r.displayPath)).toEqual(["notes/published.md"]);
+    expect(filtered[0]!.metadata).toEqual({ status: "published" });
+  });
+
+  test("excludes pending, stale, and errored documents from filtered search", async () => {
+    const { documentId: erroredId } = await insertDoc("notes", "errored.md", "# One\n\ncommon term");
+    await insertDoc("notes", "pending.md", "# Two\n\ncommon term");
+    const { documentId: staleId } = await insertDoc("notes", "stale.md", "# Three\n\ncommon term");
+    await insertDoc("notes", "extracted.md", "# Four\n\ncommon term", {});
+
+    replaceDocumentMetadata(store.db, erroredId, {
+      metadata: {},
+      error: "boom",
+      extractionVersion: METADATA_EXTRACTION_VERSION,
+    });
+    replaceDocumentMetadata(store.db, staleId, {
+      metadata: {},
+      extractionVersion: METADATA_EXTRACTION_VERSION - 1,
+    });
+
+    // An unprocessed document must not satisfy `exists: false`.
+    const filtered = searchFTS(store.db, "common", 10, undefined, {
+      key: "status", operator: "exists", value: false,
+    });
+    expect(filtered.map(r => r.displayPath)).toEqual(["notes/extracted.md"]);
+
+    // Unfiltered search still sees every document.
+    expect(searchFTS(store.db, "common", 10).length).toBe(4);
+  });
+
+  test("composes multi-collection scope with one metadata filter", async () => {
+    await insertDoc("notes", "a.md", "# A\n\nshared topic", { status: "published" });
+    await insertDoc("docs", "b.md", "# B\n\nshared topic", { status: "published" });
+    await insertDoc("docs", "c.md", "# C\n\nshared topic", { status: "draft" });
+    await insertDoc("other", "d.md", "# D\n\nshared topic", { status: "published" });
+
+    const filtered = searchFTS(store.db, "shared", 10, ["notes", "docs"], {
+      key: "status", operator: "eq", value: "published",
+    });
+    expect(filtered.map(r => r.displayPath).sort()).toEqual(["docs/b.md", "notes/a.md"]);
+  });
+
+  test("nested filters apply through FTS", async () => {
+    await insertDoc("notes", "match.md", "# M\n\nfilter target", {
+      topics: ["typescript", "programming"], status: "published", priority: 5,
+    });
+    await insertDoc("notes", "wrong-topic.md", "# W\n\nfilter target", {
+      topics: ["cooking"], status: "published", priority: 5,
+    });
+    await insertDoc("notes", "low-priority.md", "# L\n\nfilter target", {
+      topics: ["typescript", "programming"], status: "draft", priority: 1,
+    });
+
+    const filter: MetadataFilter = {
+      operator: "and",
+      operands: [
+        { key: "topics", operator: "all", value: ["typescript", "programming"] },
+        {
+          operator: "or",
+          operands: [
+            { key: "status", operator: "eq", value: "published" },
+            { key: "priority", operator: "gte", value: 3 },
+          ],
+        },
+      ],
+    };
+    const filtered = searchFTS(store.db, "filter target", 10, undefined, filter);
+    expect(filtered.map(r => r.displayPath)).toEqual(["notes/match.md"]);
+  });
+
+  test("selective filters may under-fill but never return an ineligible row", async () => {
+    for (let i = 0; i < 20; i++) {
+      await insertDoc("notes", `doc-${i}.md`, `# Doc ${i}\n\nrepeated keyword body ${i}`, {
+        status: i === 0 ? "published" : "draft",
+      });
+    }
+
+    const filtered = searchFTS(store.db, "repeated keyword", 5, undefined, {
+      key: "status", operator: "eq", value: "published",
+    });
+    expect(filtered.map(r => r.displayPath)).toEqual(["notes/doc-0.md"]);
+  });
+});
+
+describe("searchVec with metadata filter", () => {
+  const model = DEFAULT_EMBED_MODEL;
+  const queryEmbedding = [1, 0, 0];
+
+  async function insertEmbeddedDoc(
+    collection: string,
+    path: string,
+    body: string,
+    embedding: number[],
+    metadata?: DocumentMetadata,
+  ): Promise<void> {
+    const { hash } = await insertDoc(collection, path, body, metadata);
+    insertEmbedding(store.db, hash, 0, 0, new Float32Array(embedding), model, new Date().toISOString(), 1);
+  }
+
+  test("exact scan over the eligible set returns only matching documents", async () => {
+    store.ensureVecTable(3);
+    await insertEmbeddedDoc("notes", "close-draft.md", "# Close draft", [1, 0, 0], { status: "draft" });
+    await insertEmbeddedDoc("notes", "far-published.md", "# Far published", [0, 1, 0], { status: "published" });
+
+    const unfiltered = await searchVec(store.db, "q", model, 10, undefined, undefined, queryEmbedding);
+    expect(unfiltered.map(r => r.displayPath)).toEqual(["notes/close-draft.md", "notes/far-published.md"]);
+
+    const filtered = await searchVec(
+      store.db, "q", model, 10, undefined, undefined, queryEmbedding, undefined,
+      { key: "status", operator: "eq", value: "published" },
+    );
+    expect(filtered.map(r => r.displayPath)).toEqual(["notes/far-published.md"]);
+    expect(filtered[0]!.metadata).toEqual({ status: "published" });
+  });
+
+  test("returns empty when no documents are eligible", async () => {
+    store.ensureVecTable(3);
+    await insertEmbeddedDoc("notes", "doc.md", "# Doc", [1, 0, 0], { status: "draft" });
+
+    const filtered = await searchVec(
+      store.db, "q", model, 10, undefined, undefined, queryEmbedding, undefined,
+      { key: "status", operator: "eq", value: "published" },
+    );
+    expect(filtered).toEqual([]);
+  });
+
+  test("shared content hash returns only the matching document path", async () => {
+    store.ensureVecTable(3);
+    const now = new Date().toISOString();
+    const body = "# Shared body";
+    const hash = await hashContent(body);
+    insertContent(store.db, hash, body, now);
+
+    const publishedId = insertDocument(store.db, "notes", "published-copy.md", "t", hash, now, now);
+    const draftId = insertDocument(store.db, "docs", "draft-copy.md", "t", hash, now, now);
+    replaceDocumentMetadata(store.db, publishedId, {
+      metadata: { status: "published" }, extractionVersion: METADATA_EXTRACTION_VERSION,
+    });
+    replaceDocumentMetadata(store.db, draftId, {
+      metadata: { status: "draft" }, extractionVersion: METADATA_EXTRACTION_VERSION,
+    });
+    insertEmbedding(store.db, hash, 0, 0, new Float32Array([1, 0, 0]), model, now, 1);
+
+    const filtered = await searchVec(
+      store.db, "q", model, 10, undefined, undefined, queryEmbedding, undefined,
+      { key: "status", operator: "eq", value: "published" },
+    );
+    expect(filtered.map(r => r.displayPath)).toEqual(["notes/published-copy.md"]);
+  });
+
+  test("composes collection scope with the metadata filter", async () => {
+    store.ensureVecTable(3);
+    await insertEmbeddedDoc("notes", "a.md", "# A", [1, 0, 0], { status: "published" });
+    await insertEmbeddedDoc("docs", "b.md", "# B", [0.9, 0.1, 0], { status: "published" });
+
+    const filtered = await searchVec(
+      store.db, "q", model, 10, "docs", undefined, queryEmbedding, undefined,
+      { key: "status", operator: "eq", value: "published" },
+    );
+    expect(filtered.map(r => r.displayPath)).toEqual(["docs/b.md"]);
+  });
+});
+
+describe("structuredSearch with metadata filter", () => {
+  test("lex-only structured search filters and attaches metadata", async () => {
+    // Ensure metadata comes from real frontmatter extraction end to end.
+    const publishedBody = "---\nqmd:\n  metadata:\n    status: published\n---\n\n# Pub\n\nstructured keyword";
+    const { documentId: publishedId } = await insertDoc("notes", "published.md", publishedBody);
+    syncDocumentMetadata(store.db, publishedId, publishedBody, "published.md");
+
+    const draftBody = "---\nqmd:\n  metadata:\n    status: draft\n---\n\n# Draft\n\nstructured keyword";
+    const { documentId: draftId } = await insertDoc("notes", "draft.md", draftBody);
+    syncDocumentMetadata(store.db, draftId, draftBody, "draft.md");
+
+    const results = await structuredSearch(store, [{ type: "lex", query: "structured keyword" }], {
+      filter: { key: "status", operator: "eq", value: "published" },
+      skipRerank: true,
+    });
+
+    expect(results.map(r => r.displayPath)).toEqual(["notes/published.md"]);
+    expect(results[0]!.metadata).toEqual({ status: "published" });
+  });
+
+  test("unfiltered structured search attaches metadata to every result", async () => {
+    await insertDoc("notes", "a.md", "# A\n\nmeta keyword", { topics: ["x"] });
+    await insertDoc("notes", "b.md", "# B\n\nmeta keyword");
+
+    const results = await structuredSearch(store, [{ type: "lex", query: "meta keyword" }], {
+      skipRerank: true,
+    });
+
+    expect(results.length).toBe(2);
+    const byPath = new Map(results.map(r => [r.displayPath, r.metadata]));
+    expect(byPath.get("notes/a.md")).toEqual({ topics: ["x"] });
+    expect(byPath.get("notes/b.md")).toEqual({});
+  });
+});

--- a/test/metadata-store.test.ts
+++ b/test/metadata-store.test.ts
@@ -1,0 +1,277 @@
+/**
+ * metadata-store.test.ts - Metadata persistence lifecycle: schema wiring,
+ * replacement semantics, reindex synchronization, and cleanup cascades.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createStore,
+  reindexCollection,
+  insertContent,
+  insertDocument,
+  hashContent,
+  removeCollection,
+  deleteInactiveDocuments,
+  getStatus,
+  type Store,
+} from "../src/store.js";
+import {
+  syncDocumentMetadata,
+  replaceDocumentMetadata,
+  countDocumentsPendingMetadata,
+  getMetadataByFilepath,
+} from "../src/metadata-store.js";
+import { METADATA_EXTRACTION_VERSION, type DocumentMetadata } from "../src/metadata.js";
+
+let testDir: string;
+let store: Store;
+
+beforeAll(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "qmd-metadata-store-"));
+});
+
+afterAll(async () => {
+  await rm(testDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  const dbPath = join(testDir, `test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+  store = createStore(dbPath);
+});
+
+afterEach(() => {
+  store.close();
+});
+
+function buildDoc(frontmatterYaml: string | null, body: string): string {
+  if (frontmatterYaml === null) return body;
+  return `---\n${frontmatterYaml}---\n\n${body}`;
+}
+
+async function insertDoc(collection: string, path: string, content: string): Promise<number> {
+  const now = new Date().toISOString();
+  const hash = await hashContent(content);
+  insertContent(store.db, hash, content, now);
+  return insertDocument(store.db, collection, path, path, hash, now, now);
+}
+
+function getMetadataRow(documentId: number): { metadata_json: string; extraction_version: number; extraction_error: string | null } | undefined {
+  return store.db.prepare(`
+    SELECT metadata_json, extraction_version, extraction_error
+    FROM document_metadata WHERE document_id = ?
+  `).get(documentId) as { metadata_json: string; extraction_version: number; extraction_error: string | null } | undefined;
+}
+
+function countValueRows(documentId: number): number {
+  const row = store.db.prepare(`SELECT COUNT(*) as c FROM document_metadata_values WHERE document_id = ?`)
+    .get(documentId) as { c: number };
+  return row.c;
+}
+
+describe("syncDocumentMetadata", () => {
+  test("persists metadata and value rows for a new document", async () => {
+    const content = buildDoc("qmd:\n  metadata:\n    topics: [a, b]\n    priority: 3\n", "# Doc\n");
+    const documentId = await insertDoc("notes", "doc.md", content);
+
+    const extraction = syncDocumentMetadata(store.db, documentId, content, "doc.md");
+    expect(extraction?.error).toBeUndefined();
+
+    const row = getMetadataRow(documentId);
+    expect(JSON.parse(row!.metadata_json)).toEqual({ topics: ["a", "b"], priority: 3 });
+    expect(row!.extraction_version).toBe(METADATA_EXTRACTION_VERSION);
+    expect(row!.extraction_error).toBeNull();
+    expect(countValueRows(documentId)).toBe(3);
+  });
+
+  test("records extraction state for documents without metadata", async () => {
+    const content = "# Plain doc\n";
+    const documentId = await insertDoc("notes", "plain.md", content);
+
+    syncDocumentMetadata(store.db, documentId, content, "plain.md");
+
+    const row = getMetadataRow(documentId);
+    expect(JSON.parse(row!.metadata_json)).toEqual({});
+    expect(row!.extraction_error).toBeNull();
+    expect(countValueRows(documentId)).toBe(0);
+  });
+
+  test("onlyIfStale skips documents with a current extraction row", async () => {
+    const content = buildDoc("qmd:\n  metadata:\n    status: ok\n", "# Doc\n");
+    const documentId = await insertDoc("notes", "doc.md", content);
+
+    expect(syncDocumentMetadata(store.db, documentId, content, "doc.md")).not.toBeNull();
+    expect(syncDocumentMetadata(store.db, documentId, content, "doc.md", { onlyIfStale: true })).toBeNull();
+    expect(syncDocumentMetadata(store.db, documentId, content, "doc.md")).not.toBeNull();
+  });
+
+  test("invalid metadata replaces prior rows with empty metadata and an error", async () => {
+    const documentId = await insertDoc("notes", "doc.md", "# Doc\n");
+
+    const validContent = buildDoc("qmd:\n  metadata:\n    status: ok\n", "# Doc\n");
+    syncDocumentMetadata(store.db, documentId, validContent, "doc.md");
+    expect(countValueRows(documentId)).toBe(1);
+
+    const invalidContent = buildDoc("qmd:\n  metadata:\n    status: null\n", "# Doc\n");
+    const extraction = syncDocumentMetadata(store.db, documentId, invalidContent, "doc.md");
+    expect(extraction?.error).toMatch(/null is not supported/);
+
+    const row = getMetadataRow(documentId);
+    expect(JSON.parse(row!.metadata_json)).toEqual({});
+    expect(row!.extraction_error).toMatch(/null is not supported/);
+    expect(countValueRows(documentId)).toBe(0);
+  });
+
+  test("metadata removal clears value rows", async () => {
+    const documentId = await insertDoc("notes", "doc.md", "# Doc\n");
+
+    syncDocumentMetadata(store.db, documentId, buildDoc("qmd:\n  metadata:\n    status: ok\n", "# Doc\n"), "doc.md");
+    expect(countValueRows(documentId)).toBe(1);
+
+    syncDocumentMetadata(store.db, documentId, "# Doc\n", "doc.md");
+    expect(countValueRows(documentId)).toBe(0);
+    expect(getMetadataRow(documentId)!.extraction_error).toBeNull();
+  });
+
+  test("two paths sharing one content hash keep separate metadata rows", async () => {
+    const content = buildDoc("qmd:\n  metadata:\n    status: shared\n", "# Same content\n");
+    const firstId = await insertDoc("notes", "first.md", content);
+    const secondId = await insertDoc("docs", "second.md", content);
+
+    syncDocumentMetadata(store.db, firstId, content, "first.md");
+    replaceDocumentMetadata(store.db, secondId, {
+      metadata: { status: "overridden" },
+      extractionVersion: METADATA_EXTRACTION_VERSION,
+    });
+
+    expect(JSON.parse(getMetadataRow(firstId)!.metadata_json)).toEqual({ status: "shared" });
+    expect(JSON.parse(getMetadataRow(secondId)!.metadata_json)).toEqual({ status: "overridden" });
+  });
+});
+
+describe("countDocumentsPendingMetadata", () => {
+  test("counts unextracted, stale, and errored documents", async () => {
+    const extractedId = await insertDoc("notes", "extracted.md", "# A\n");
+    const pendingId = await insertDoc("notes", "pending.md", "# B\n");
+    const erroredId = await insertDoc("notes", "errored.md", "# C\n");
+    const staleId = await insertDoc("notes", "stale.md", "# D\n");
+
+    syncDocumentMetadata(store.db, extractedId, "# A\n", "extracted.md");
+    replaceDocumentMetadata(store.db, erroredId, {
+      metadata: {},
+      error: "boom",
+      extractionVersion: METADATA_EXTRACTION_VERSION,
+    });
+    replaceDocumentMetadata(store.db, staleId, {
+      metadata: {},
+      extractionVersion: METADATA_EXTRACTION_VERSION - 1,
+    });
+
+    expect(countDocumentsPendingMetadata(store.db)).toBe(3);
+    expect(getStatus(store.db).pendingMetadata).toBe(3);
+
+    // Deactivated documents leave the pending count.
+    store.db.prepare(`UPDATE documents SET active = 0 WHERE id = ?`).run(pendingId);
+    expect(countDocumentsPendingMetadata(store.db)).toBe(2);
+  });
+});
+
+describe("reindexCollection metadata synchronization", () => {
+  let collectionDir: string;
+
+  beforeEach(async () => {
+    collectionDir = join(testDir, `coll-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(collectionDir, { recursive: true });
+  });
+
+  async function reindex() {
+    return reindexCollection(store, collectionDir, "**/*.md", "notes");
+  }
+
+  function getMetadataForPath(path: string): DocumentMetadata | undefined {
+    return getMetadataByFilepath(store.db, [`qmd://notes/${path}`]).get(`qmd://notes/${path}`);
+  }
+
+  test("extracts metadata for new, changed, and unchanged documents", async () => {
+    await writeFile(join(collectionDir, "doc.md"), buildDoc("qmd:\n  metadata:\n    status: draft\n", "# Doc\n"));
+
+    const firstResult = await reindex();
+    expect(firstResult.indexed).toBe(1);
+    expect(firstResult.metadataErrors).toBe(0);
+    expect(getMetadataForPath("doc.md")).toEqual({ status: "draft" });
+    expect(countDocumentsPendingMetadata(store.db)).toBe(0);
+
+    // Unchanged content on a later pass keeps extraction current.
+    const secondResult = await reindex();
+    expect(secondResult.unchanged).toBe(1);
+    expect(countDocumentsPendingMetadata(store.db)).toBe(0);
+
+    // Edited metadata replaces the previous rows.
+    await writeFile(join(collectionDir, "doc.md"), buildDoc("qmd:\n  metadata:\n    status: published\n", "# Doc\n"));
+    await reindex();
+    expect(getMetadataForPath("doc.md")).toEqual({ status: "published" });
+  });
+
+  test("backfills documents indexed before the metadata schema existed", async () => {
+    await writeFile(join(collectionDir, "doc.md"), buildDoc("qmd:\n  metadata:\n    status: ok\n", "# Doc\n"));
+    await reindex();
+
+    // Simulate a pre-metadata index: drop the extraction rows.
+    store.db.prepare(`DELETE FROM document_metadata`).run();
+    expect(countDocumentsPendingMetadata(store.db)).toBe(1);
+
+    const result = await reindex();
+    expect(result.unchanged).toBe(1);
+    expect(countDocumentsPendingMetadata(store.db)).toBe(0);
+    expect(getMetadataForPath("doc.md")).toEqual({ status: "ok" });
+  });
+
+  test("counts extraction errors without aborting the collection", async () => {
+    await writeFile(join(collectionDir, "bad.md"), buildDoc("qmd:\n  metadata:\n    mixed: [1, two]\n", "# Bad\n"));
+    await writeFile(join(collectionDir, "good.md"), buildDoc("qmd:\n  metadata:\n    status: ok\n", "# Good\n"));
+
+    const result = await reindex();
+    expect(result.indexed).toBe(2);
+    expect(result.metadataErrors).toBe(1);
+    expect(getMetadataForPath("good.md")).toEqual({ status: "ok" });
+    expect(getMetadataForPath("bad.md")).toEqual({});
+    expect(countDocumentsPendingMetadata(store.db)).toBe(1);
+  });
+
+  test("deactivation excludes metadata from batch loads; reactivation restores it", async () => {
+    await writeFile(join(collectionDir, "doc.md"), buildDoc("qmd:\n  metadata:\n    status: ok\n", "# Doc\n"));
+    await reindex();
+
+    await rm(join(collectionDir, "doc.md"));
+    const removedResult = await reindex();
+    expect(removedResult.removed).toBe(1);
+    expect(getMetadataForPath("doc.md")).toBeUndefined();
+
+    await writeFile(join(collectionDir, "doc.md"), buildDoc("qmd:\n  metadata:\n    status: ok\n", "# Doc\n"));
+    await reindex();
+    expect(getMetadataForPath("doc.md")).toEqual({ status: "ok" });
+  });
+
+  test("hard deletion cascades metadata rows", async () => {
+    await writeFile(join(collectionDir, "doc.md"), buildDoc("qmd:\n  metadata:\n    status: ok\n", "# Doc\n"));
+    await reindex();
+
+    await rm(join(collectionDir, "doc.md"));
+    await reindex();
+
+    deleteInactiveDocuments(store.db);
+    expect((store.db.prepare(`SELECT COUNT(*) as c FROM document_metadata`).get() as { c: number }).c).toBe(0);
+    expect((store.db.prepare(`SELECT COUNT(*) as c FROM document_metadata_values`).get() as { c: number }).c).toBe(0);
+  });
+
+  test("collection removal cascades metadata rows", async () => {
+    await writeFile(join(collectionDir, "doc.md"), buildDoc("qmd:\n  metadata:\n    status: ok\n", "# Doc\n"));
+    await reindex();
+
+    removeCollection(store.db, "notes");
+    expect((store.db.prepare(`SELECT COUNT(*) as c FROM document_metadata`).get() as { c: number }).c).toBe(0);
+    expect((store.db.prepare(`SELECT COUNT(*) as c FROM document_metadata_values`).get() as { c: number }).c).toBe(0);
+  });
+});

--- a/test/metadata-surfaces.test.ts
+++ b/test/metadata-surfaces.test.ts
@@ -1,0 +1,251 @@
+/**
+ * metadata-surfaces.test.ts - Metadata filter support across the public
+ * surfaces: SDK, MCP tool, and HTTP REST endpoints. Uses lex-only searches
+ * with reranking disabled so no models are needed.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import YAML from "yaml";
+import { createStore, type QMDStore } from "../src/index.js";
+import {
+  createStore as createInternalStore,
+  insertContent,
+  insertDocument,
+  hashContent,
+  syncConfigToDb,
+  _resetProductionModeForTesting,
+} from "../src/store.js";
+import { replaceDocumentMetadata } from "../src/metadata-store.js";
+import { METADATA_EXTRACTION_VERSION, type DocumentMetadata } from "../src/metadata.js";
+import { startMcpHttpServer, type HttpServerHandle } from "../src/mcp/server.js";
+import type { CollectionConfig } from "../src/collections.js";
+
+let testDir: string;
+
+beforeAll(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "qmd-metadata-surfaces-"));
+});
+
+afterAll(async () => {
+  await rm(testDir, { recursive: true, force: true });
+});
+
+function buildDoc(status: string, body: string): string {
+  return `---\nqmd:\n  metadata:\n    status: ${status}\n    topics: [typescript]\n---\n\n${body}`;
+}
+
+// =============================================================================
+// SDK
+// =============================================================================
+
+describe("SDK metadata filter", () => {
+  let store: QMDStore;
+  let collectionDir: string;
+
+  beforeAll(async () => {
+    collectionDir = join(testDir, "sdk-collection");
+    await mkdir(collectionDir, { recursive: true });
+    await writeFile(join(collectionDir, "published.md"), buildDoc("published", "# Pub\n\nsdk keyword body"));
+    await writeFile(join(collectionDir, "draft.md"), buildDoc("draft", "# Draft\n\nsdk keyword body"));
+
+    store = await createStore({
+      dbPath: join(testDir, "sdk.sqlite"),
+      config: { collections: { docs: { path: collectionDir, pattern: "**/*.md" } } },
+    });
+    await store.update();
+  });
+
+  afterAll(async () => {
+    await store.close();
+  });
+
+  test("searchLex applies the filter and returns metadata", async () => {
+    const unfiltered = await store.searchLex("sdk keyword");
+    expect(unfiltered.length).toBe(2);
+
+    const filtered = await store.searchLex("sdk keyword", {
+      filter: { key: "status", operator: "eq", value: "published" },
+    });
+    expect(filtered.map(r => r.displayPath)).toEqual(["docs/published.md"]);
+    expect(filtered[0]!.metadata).toEqual({ status: "published", topics: ["typescript"] });
+  });
+
+  test("search with pre-expanded queries applies the filter", async () => {
+    const results = await store.search({
+      queries: [{ type: "lex", query: "sdk keyword" }],
+      filter: { key: "status", operator: "ne", value: "draft" },
+      rerank: false,
+    });
+    expect(results.map(r => r.displayPath)).toEqual(["docs/published.md"]);
+    expect(results[0]!.metadata).toEqual({ status: "published", topics: ["typescript"] });
+  });
+
+  test("getStatus exposes the pending metadata count", async () => {
+    const status = await store.getStatus();
+    expect(status.pendingMetadata).toBe(0);
+  });
+});
+
+// =============================================================================
+// MCP tool + HTTP REST
+// =============================================================================
+
+describe("MCP and HTTP metadata filter", () => {
+  let handle: HttpServerHandle;
+  let baseUrl: string;
+  let dbPath: string;
+  let configDir: string;
+  const origIndexPath = process.env.INDEX_PATH;
+  const origConfigDir = process.env.QMD_CONFIG_DIR;
+
+  async function seedDoc(db: import("../src/db.js").Database, path: string, body: string, metadata: DocumentMetadata): Promise<void> {
+    const now = new Date().toISOString();
+    const hash = await hashContent(body);
+    insertContent(db, hash, body, now);
+    const documentId = insertDocument(db, "docs", path, path, hash, now, now);
+    replaceDocumentMetadata(db, documentId, { metadata, extractionVersion: METADATA_EXTRACTION_VERSION });
+  }
+
+  beforeAll(async () => {
+    dbPath = join(testDir, `mcp-${Date.now()}.sqlite`);
+    const internal = createInternalStore(dbPath);
+    await seedDoc(internal.db, "published.md", "# Pub\n\nhttp keyword body", { status: "published" });
+    await seedDoc(internal.db, "draft.md", "# Draft\n\nhttp keyword body", { status: "draft" });
+
+    const testConfig: CollectionConfig = {
+      collections: { docs: { path: "/test/docs", pattern: "**/*.md" } },
+    };
+    syncConfigToDb(internal.db, testConfig);
+    internal.close();
+
+    configDir = await mkdtemp(join(tmpdir(), "qmd-metadata-surfaces-config-"));
+    await writeFile(join(configDir, "index.yml"), YAML.stringify(testConfig));
+
+    process.env.INDEX_PATH = dbPath;
+    process.env.QMD_CONFIG_DIR = configDir;
+    handle = await startMcpHttpServer(0, { quiet: true, dbPath });
+    baseUrl = `http://localhost:${handle.port}`;
+  });
+
+  afterAll(async () => {
+    if (handle) await handle.stop();
+    _resetProductionModeForTesting();
+    if (origIndexPath !== undefined) process.env.INDEX_PATH = origIndexPath;
+    else delete process.env.INDEX_PATH;
+    if (origConfigDir !== undefined) process.env.QMD_CONFIG_DIR = origConfigDir;
+    else delete process.env.QMD_CONFIG_DIR;
+    try { unlinkSync(dbPath); } catch {}
+    await rm(configDir, { recursive: true, force: true });
+  });
+
+  async function postJson(path: string, body: object): Promise<{ status: number; json: any }> {
+    const res = await fetch(`${baseUrl}${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    return { status: res.status, json: await res.json() };
+  }
+
+  async function callQueryTool(args: Record<string, unknown>): Promise<{ status: number; json: any }> {
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "MCP-Protocol-Version": "2026-07-28",
+        "Mcp-Method": "tools/call",
+        "Mcp-Name": "query",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "query",
+          arguments: args,
+          _meta: {
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientInfo": { name: "metadata-test", version: "1.0.0" },
+            "io.modelcontextprotocol/clientCapabilities": {},
+          },
+        },
+      }),
+    });
+    return { status: res.status, json: await res.json() };
+  }
+
+  test("POST /query applies the filter and includes metadata", async () => {
+    const { status, json } = await postJson("/query", {
+      searches: [{ type: "lex", query: "http keyword" }],
+      filter: { key: "status", operator: "eq", value: "published" },
+      rerank: false,
+    });
+    expect(status).toBe(200);
+    expect(json.results.length).toBe(1);
+    expect(json.results[0].file).toBe("qmd://docs/published.md");
+    expect(json.results[0].metadata).toEqual({ status: "published" });
+  });
+
+  test("POST /search alias accepts the same filter", async () => {
+    const { status, json } = await postJson("/search", {
+      searches: [{ type: "lex", query: "http keyword" }],
+      filter: { key: "status", operator: "eq", value: "draft" },
+      rerank: false,
+    });
+    expect(status).toBe(200);
+    expect(json.results.length).toBe(1);
+    expect(json.results[0].file).toBe("qmd://docs/draft.md");
+  });
+
+  test("POST /query rejects non-object and invalid filters with 400", async () => {
+    const stringFilter = await postJson("/query", {
+      searches: [{ type: "lex", query: "http keyword" }],
+      filter: "status = published",
+    });
+    expect(stringFilter.status).toBe(400);
+    expect(stringFilter.json.error).toMatch(/must be an object/);
+
+    const invalidAst = await postJson("/query", {
+      searches: [{ type: "lex", query: "http keyword" }],
+      filter: { key: "status", operator: "equal", value: "published" },
+    });
+    expect(invalidAst.status).toBe(400);
+    expect(invalidAst.json.error).toMatch(/unknown operator 'equal'/);
+  });
+
+  test("MCP query tool applies a nested filter and includes metadata", async () => {
+    const { status, json } = await callQueryTool({
+      searches: [{ type: "lex", query: "http keyword" }],
+      filter: {
+        operator: "and",
+        operands: [
+          { key: "status", operator: "eq", value: "published" },
+          { operator: "not", operand: { key: "status", operator: "eq", value: "draft" } },
+        ],
+      },
+      rerank: false,
+    });
+    expect(status).toBe(200);
+    expect(json.result.isError).toBeFalsy();
+    const items = json.result.structuredContent.results;
+    expect(items.length).toBe(1);
+    expect(items[0].file).toBe("docs/published.md");
+    expect(items[0].metadata).toEqual({ status: "published" });
+  });
+
+  test("MCP query tool rejects invalid filters", async () => {
+    const { status, json } = await callQueryTool({
+      searches: [{ type: "lex", query: "http keyword" }],
+      filter: { operator: "and", operands: [] },
+      rerank: false,
+    });
+    expect(status).toBe(200);
+    expect(json.result.isError).toBe(true);
+    expect(json.result.content[0].text).toMatch(/non-empty 'operands'/);
+  });
+});

--- a/test/metadata-surfaces.test.ts
+++ b/test/metadata-surfaces.test.ts
@@ -88,6 +88,12 @@ describe("SDK metadata filter", () => {
     const status = await store.getStatus();
     expect(status.pendingMetadata).toBe(0);
   });
+
+  test("validates filters at the SDK runtime boundary", async () => {
+    await expect(store.searchLex("sdk keyword", {
+      filter: { operator: "and", operands: [] },
+    })).rejects.toThrow(/non-empty 'operands'/);
+  });
 });
 
 // =============================================================================
@@ -142,7 +148,9 @@ describe("MCP and HTTP metadata filter", () => {
     await rm(configDir, { recursive: true, force: true });
   });
 
-  async function postJson(path: string, body: object): Promise<{ status: number; json: any }> {
+  type HttpRequestBody = Record<string, unknown>;
+
+  async function postJson(path: string, body: HttpRequestBody): Promise<{ status: number; json: any }> {
     const res = await fetch(`${baseUrl}${path}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/test/metadata.test.ts
+++ b/test/metadata.test.ts
@@ -1,0 +1,193 @@
+/**
+ * metadata.test.ts - Frontmatter metadata extraction and normalization.
+ */
+
+import { describe, test, expect } from "vitest";
+import {
+  extractDocumentMetadata,
+  METADATA_EXTRACTION_VERSION,
+  METADATA_LIMITS,
+} from "../src/metadata.js";
+
+function buildDoc(frontmatterYaml: string, body: string = "# Title\n\nBody text.\n"): string {
+  return `---\n${frontmatterYaml}---\n\n${body}`;
+}
+
+describe("extractDocumentMetadata", () => {
+  test("document without frontmatter yields empty metadata", () => {
+    const extraction = extractDocumentMetadata("# Title\n\nBody.\n", "doc.md");
+    expect(extraction).toEqual({ metadata: {}, extractionVersion: METADATA_EXTRACTION_VERSION });
+  });
+
+  test("frontmatter without qmd namespace yields empty metadata", () => {
+    const extraction = extractDocumentMetadata(buildDoc("title: Hello\ntags: [a, b]\n"), "doc.md");
+    expect(extraction.metadata).toEqual({});
+    expect(extraction.error).toBeUndefined();
+  });
+
+  test("qmd namespace without metadata yields empty metadata", () => {
+    const extraction = extractDocumentMetadata(buildDoc("qmd:\n  other: true\n"), "doc.md");
+    expect(extraction.metadata).toEqual({});
+    expect(extraction.error).toBeUndefined();
+  });
+
+  test("empty qmd.metadata mapping yields empty metadata", () => {
+    const extraction = extractDocumentMetadata(buildDoc("qmd:\n  metadata: {}\n"), "doc.md");
+    expect(extraction.metadata).toEqual({});
+    expect(extraction.error).toBeUndefined();
+  });
+
+  test("extracts string, number, and boolean scalars", () => {
+    const extraction = extractDocumentMetadata(
+      buildDoc("qmd:\n  metadata:\n    status: published\n    priority: 3\n    reviewed: true\n"),
+      "doc.md",
+    );
+    expect(extraction.metadata).toEqual({ status: "published", priority: 3, reviewed: true });
+    expect(extraction.error).toBeUndefined();
+  });
+
+  test("extracts homogeneous arrays of every scalar type", () => {
+    const extraction = extractDocumentMetadata(
+      buildDoc([
+        "qmd:",
+        "  metadata:",
+        "    topics: [typescript, programming]",
+        "    scores: [1, 2.5, 3]",
+        "    flags: [true, false]",
+        "",
+      ].join("\n")),
+      "doc.md",
+    );
+    expect(extraction.metadata).toEqual({
+      topics: ["typescript", "programming"],
+      scores: [1, 2.5, 3],
+      flags: [true, false],
+    });
+  });
+
+  test("de-duplicates array values preserving first-seen order", () => {
+    const extraction = extractDocumentMetadata(
+      buildDoc("qmd:\n  metadata:\n    topics: [b, a, b, c, a]\n"),
+      "doc.md",
+    );
+    expect(extraction.metadata["topics"]).toEqual(["b", "a", "c"]);
+  });
+
+  test("tolerates BOM, CRLF, and '...' closing marker", () => {
+    const bomDoc = "\uFEFF---\nqmd:\n  metadata:\n    status: ok\n---\nBody\n";
+    expect(extractDocumentMetadata(bomDoc, "doc.md").metadata).toEqual({ status: "ok" });
+
+    const crlfDoc = "---\r\nqmd:\r\n  metadata:\r\n    status: ok\r\n---\r\nBody\r\n";
+    expect(extractDocumentMetadata(crlfDoc, "doc.md").metadata).toEqual({ status: "ok" });
+
+    const dotsDoc = "---\nqmd:\n  metadata:\n    status: ok\n...\nBody\n";
+    expect(extractDocumentMetadata(dotsDoc, "doc.md").metadata).toEqual({ status: "ok" });
+  });
+
+  test("missing closing delimiter is treated as no frontmatter", () => {
+    const extraction = extractDocumentMetadata("---\nqmd:\n  metadata:\n    status: ok\n", "doc.md");
+    expect(extraction).toEqual({ metadata: {}, extractionVersion: METADATA_EXTRACTION_VERSION });
+  });
+
+  test("non-markdown extensions are not parsed as frontmatter", () => {
+    const content = buildDoc("qmd:\n  metadata:\n    status: ok\n");
+    expect(extractDocumentMetadata(content, "script.ts").metadata).toEqual({});
+    expect(extractDocumentMetadata(content, "noext").metadata).toEqual({});
+    expect(extractDocumentMetadata(content, "doc.markdown").metadata).toEqual({ status: "ok" });
+    expect(extractDocumentMetadata(content, "doc.mdx").metadata).toEqual({ status: "ok" });
+  });
+
+  test("malformed YAML records an extraction error", () => {
+    const extraction = extractDocumentMetadata(buildDoc("qmd: [unclosed\n"), "doc.md");
+    expect(extraction.metadata).toEqual({});
+    expect(extraction.error).toMatch(/invalid frontmatter YAML/);
+  });
+
+  test("non-mapping qmd or qmd.metadata records an extraction error", () => {
+    const qmdScalar = extractDocumentMetadata(buildDoc("qmd: hello\n"), "doc.md");
+    expect(qmdScalar.error).toMatch(/'qmd' must be a mapping/);
+
+    const metadataScalar = extractDocumentMetadata(buildDoc("qmd:\n  metadata: hello\n"), "doc.md");
+    expect(metadataScalar.error).toMatch(/'qmd.metadata' must be a mapping/);
+  });
+
+  test("rejects nested objects, null, empty arrays, nested arrays, and mixed arrays", () => {
+    const cases: [string, RegExp][] = [
+      ["qmd:\n  metadata:\n    nested:\n      a: 1\n", /unsupported value type/],
+      ["qmd:\n  metadata:\n    empty: null\n", /null is not supported/],
+      ["qmd:\n  metadata:\n    empty: []\n", /empty arrays are not supported/],
+      ["qmd:\n  metadata:\n    nested: [[1, 2]]\n", /nested arrays are not supported/],
+      ["qmd:\n  metadata:\n    mixed: [1, two]\n", /mixed-type arrays are not supported/],
+    ];
+
+    for (const [frontmatterYaml, expected] of cases) {
+      const extraction = extractDocumentMetadata(buildDoc(frontmatterYaml), "doc.md");
+      expect(extraction.metadata).toEqual({});
+      expect(extraction.error).toMatch(expected);
+    }
+  });
+
+  test("rejects non-finite numbers", () => {
+    const extraction = extractDocumentMetadata(buildDoc("qmd:\n  metadata:\n    bad: .inf\n"), "doc.md");
+    expect(extraction.metadata).toEqual({});
+    expect(extraction.error).toMatch(/finite/);
+  });
+
+  test("rejects oversized keys, strings, arrays, and key counts", () => {
+    const longKey = "k".repeat(METADATA_LIMITS.maxKeyBytes + 1);
+    expect(extractDocumentMetadata(buildDoc(`qmd:\n  metadata:\n    ${longKey}: 1\n`), "doc.md").error)
+      .toMatch(/key exceeds/);
+
+    const longString = "v".repeat(METADATA_LIMITS.maxStringLength + 1);
+    expect(extractDocumentMetadata(buildDoc(`qmd:\n  metadata:\n    long: "${longString}"\n`), "doc.md").error)
+      .toMatch(/string exceeds/);
+
+    const bigArray = `[${Array.from({ length: METADATA_LIMITS.maxArrayLength + 1 }, (_, i) => i).join(", ")}]`;
+    expect(extractDocumentMetadata(buildDoc(`qmd:\n  metadata:\n    big: ${bigArray}\n`), "doc.md").error)
+      .toMatch(/array exceeds/);
+
+    const manyKeys = Array.from({ length: METADATA_LIMITS.maxKeys + 1 }, (_, i) => `    key${i}: 1`).join("\n");
+    expect(extractDocumentMetadata(buildDoc(`qmd:\n  metadata:\n${manyKeys}\n`), "doc.md").error)
+      .toMatch(/keys \(max/);
+  });
+
+  test("rejects oversized frontmatter blocks", () => {
+    const filler = `filler: "${"x".repeat(METADATA_LIMITS.maxFrontmatterBytes)}"\n`;
+    const extraction = extractDocumentMetadata(buildDoc(`${filler}qmd:\n  metadata:\n    status: ok\n`), "doc.md");
+    expect(extraction.metadata).toEqual({});
+    expect(extraction.error).toMatch(/frontmatter exceeds/);
+  });
+
+  test("bounds YAML alias expansion", () => {
+    const aliasBomb = [
+      "a: &a [x, x, x, x, x, x, x, x, x, x]",
+      "b: &b [*a, *a, *a, *a, *a, *a, *a, *a, *a, *a]",
+      "c: &c [*b, *b, *b, *b, *b, *b, *b, *b, *b, *b]",
+      "qmd:",
+      "  metadata:",
+      "    status: ok",
+      "",
+    ].join("\n");
+    const extraction = extractDocumentMetadata(buildDoc(aliasBomb), "doc.md");
+    expect(extraction.metadata).toEqual({});
+    expect(extraction.error).toMatch(/invalid frontmatter YAML/);
+  });
+
+  test("bounds extraction error message length", () => {
+    const longKey = "k".repeat(600);
+    const extraction = extractDocumentMetadata(
+      buildDoc(`qmd:\n  metadata:\n    valid: 1\n    "${longKey}x": 1\n`),
+      "doc.md",
+    );
+    expect(extraction.error).toBeDefined();
+    expect(extraction.error!.length).toBeLessThanOrEqual(METADATA_LIMITS.maxErrorLength);
+  });
+
+  test("unquoted dates stay strings", () => {
+    const extraction = extractDocumentMetadata(
+      buildDoc("qmd:\n  metadata:\n    published: 2024-01-15\n"),
+      "doc.md",
+    );
+    expect(extraction.metadata).toEqual({ published: "2024-01-15" });
+  });
+});

--- a/test/metadata.test.ts
+++ b/test/metadata.test.ts
@@ -73,6 +73,19 @@ describe("extractDocumentMetadata", () => {
     expect(extraction.metadata["topics"]).toEqual(["b", "a", "c"]);
   });
 
+  test("treats prototype-shaped metadata keys as ordinary data", () => {
+    const extraction = extractDocumentMetadata(
+      buildDoc("qmd:\n  metadata:\n    __proto__: inherited\n    constructor: built\n"),
+      "doc.md",
+    );
+    expect(Object.keys(extraction.metadata)).toEqual(["__proto__", "constructor"]);
+    expect(extraction.metadata["__proto__"]).toBe("inherited");
+    expect(extraction.metadata["constructor"]).toBe("built");
+    expect(JSON.stringify(extraction.metadata)).toBe(
+      '{"__proto__":"inherited","constructor":"built"}',
+    );
+  });
+
   test("tolerates BOM, CRLF, and '...' closing marker", () => {
     const bomDoc = "\uFEFF---\nqmd:\n  metadata:\n    status: ok\n---\nBody\n";
     expect(extractDocumentMetadata(bomDoc, "doc.md").metadata).toEqual({ status: "ok" });


### PR DESCRIPTION
Documents can opt into typed metadata through frontmatter, and every search surface can filter on it.

```markdown
---
qmd:
  metadata:
    topics: [typescript, programming]
    status: published
    priority: 3
---

# Document body starts here
```

```sh
qmd query "dependency injection" --filter '{"key":"status","operator":"eq","value":"published"}'
```

The same filter works on `search`, `vsearch`, and `query`, on the SDK's `search()`/`searchLex()`/`searchVector()`, on the MCP `query` tool, and on HTTP `POST /query`. Results carry the document's metadata in JSON, SDK, MCP, and HTTP output. Documents without `qmd.metadata` behave exactly as before, and unfiltered search benchmarks unchanged.

The motivating use case is agentic retrieval. Relevance search answers "what is about X", but agents also need structured slicing: only published docs, only a given audience, only priority above a threshold. Today that means over-fetching and post-filtering client-side, with no way to express "and don't show me drafts" at all.

Collections already scope retrieval, and this composes with them rather than replacing them. A collection is one coarse dimension, where a document lives, chosen at indexing time. Metadata lets each document declare its own dimensions (status, audience, priority) and lets every query combine them, so `-c notes --filter ...` narrows by place and by properties at once.

### What this adds

- An opt-in, namespaced `qmd.metadata` frontmatter block (`.md`, `.markdown`, `.mdx`) extracted at index time. Values are strings, numbers, booleans, or flat homogeneous arrays of one of those.
- One recursive filter language, shared verbatim by CLI, SDK, MCP, and HTTP.
- Two derived SQLite tables holding canonical metadata JSON plus typed, indexed rows for filtering.
- `qmd status` reports documents pending extraction, and a plain `qmd update` backfills existing indexes (no schema version bump, no forced re-embedding).

### What this deliberately does not change

- Raw content is untouched. Frontmatter stays ordinary searchable text: same content hash, same FTS body, same chunking and embeddings, same snippets and line numbers. #770's evaluation showed no retrieval win from stripping frontmatter, so this PR does not touch that path.
- No tagging subsystem. `tags` is an ordinary user-defined key with no special behavior. Multi-valued classification is array-valued metadata.
- No index-only mutation API. The SQLite tables are a derived index, and the document remains the authority, so metadata survives rebuilds, syncs across machines, and reviews in version control.
- No new dependencies. Extraction reuses the existing `yaml` package.
- Nothing changes for anyone who never writes `qmd.metadata`.

### The filter language

A filter is a JSON AST discriminated by `operator`:

| Node | Shape |
|------|-------|
| Logical group | `{ "operator": "and" \| "or", "operands": [...] }` |
| Negation | `{ "operator": "not", "operand": {...} }` |
| Comparison | `{ "key", "operator": "eq" \| "ne" \| "gt" \| "gte" \| "lt" \| "lte", "value" }` |
| Membership | `{ "key", "operator": "in" \| "nin" \| "all", "value": [...] }` |
| Presence | `{ "key", "operator": "exists", "value": true \| false }` |

```sh
qmd query "dependency injection" --filter '{
  "operator": "and",
  "operands": [
    { "key": "topics", "operator": "all", "value": ["typescript", "programming"] },
    { "key": "status", "operator": "nin", "value": ["draft", "archived"] },
    { "operator": "or", "operands": [
      { "key": "priority", "operator": "gte", "value": 3 },
      { "key": "reviewed", "operator": "eq", "value": true }
    ] }
  ]
}'
```

Semantics are strict and typed: no coercion, type mismatches never match (including `ne` and `nin`), arrays match when any element satisfies a condition (`all` requires every filter value), and missing keys only match through `exists: false`. Composition is always explicit: no implicit AND, no `$`-prefixed shorthand, no reserved metadata keys. Validation errors point at the failing node by JSON path.

Two guarantees:

- Soundness is absolute. Every returned result satisfies the filter, applied before RRF fusion and reranking on every path.
- Completeness is best-effort for top-K under highly selective filters, matching the existing collection-filter contract exactly (candidate over-fetch, then relational filtering).

### Design notes

The shape of the filter language came out of a survey of metadata filtering in Pinecone, Chroma, MongoDB, Weaviate, Qdrant, and Elasticsearch, and the storage and retrieval design generalizes machinery already in QMD rather than adding parallel systems. Details collapsed below.

<details>
<summary>Why an explicit operator-discriminated AST (and not a $-prefixed DSL)</summary>

The operator vocabulary is the established one: `and`/`or`/`not` (logical), `eq`/`ne`/`gt`/`gte`/`lt`/`lte` (comparison), `in`/`nin`/`all` (membership), and `exists` (presence) all carry their MongoDB/Pinecone/Chroma meanings. `key` for the metadata key follows Qdrant. The node shape (one `operator` property discriminating groups with `operands` from leaf conditions) follows Weaviate's public GraphQL filter API.

The deliberate departure is rejecting the compact Mongo-style form (`{ status: "published", $or: [...] }`). That shape cannot be expressed precisely in TypeScript: an index signature cannot say "every string except the reserved `$` keys", so arbitrary keys broaden into a union of logical and field shapes, excess-property checking degrades, and the SDK type stops matching the runtime grammar. With one finite `operator` discriminator:

- The SDK exports a discriminated union that narrows per operator, so operator-specific `value` types are compile-time checked.
- The runtime validator mirrors the same union and rejects unknown properties, with errors that name the failing JSON path.
- Metadata keys stay pure data and can never collide with grammar keys.

`operands`/`operand` (over `filters`/`filter` or `rules`) is the standard term for the recursive expressions a logical operator consumes, and the singular form encodes `not`'s unary arity in the type system. Leaf conditions keep explicit `key` and `value` roles instead of a positional array.

Validation enforces bounded depth, operand counts, key lengths, and value sizes (shared limits across all four surfaces).

</details>

<details>
<summary>Storage: two derived tables, extraction state, typed rows</summary>

```sql
document_metadata          -- one row per document
  document_id PRIMARY KEY REFERENCES documents(id) ON DELETE CASCADE
  metadata_json            -- canonical JSON, returned with results
  extraction_version       -- current extractor version (backfill trigger)
  extraction_error         -- bounded message when frontmatter is invalid

document_metadata_values   -- one row per (key, element), typed
  (document_id, key, ordinal) PRIMARY KEY
  value_type + text_value / number_value / boolean_value
  CHECK: exactly one value column populated, matching value_type
```

Three covering partial indexes (`(key, text_value, document_id)` and the number/boolean equivalents) serve the filter compiler. Metadata attaches to documents rather than content hashes because two documents can share a hash while carrying different metadata, and filters conceptually select documents.

Metadata is data, not schema, so there is no `user_version` bump: the tables are `CREATE TABLE IF NOT EXISTS` on open, existing indexes keep working, and `qmd update` backfills extraction for unchanged documents (tracked by `extraction_version`). Invalid metadata records a bounded per-document error, the document still indexes and searches normally, and `qmd update` surfaces a warning. `qmd status` shows the pending count.

Extraction is defensive: BOM/CRLF tolerated, a missing closing delimiter means "no frontmatter" rather than an error, YAML alias expansion is bounded, nested objects/nulls/mixed arrays are rejected with precise messages, and arrays are deduplicated preserving order.

</details>

<details>
<summary>Retrieval integration and the completeness contract</summary>

The compiler turns a filter into parameterized correlated `EXISTS`/`NOT EXISTS` subqueries over `document_metadata_values` (all user data bound, never interpolated). One compiler serves both retrieval backends, so FTS and vector search cannot drift semantically.

FTS keeps the existing CTE that forces FTS5 to run first (the comment in `searchFTS` documents the full-scan regression this prevents), then applies the compiled predicate alongside the collection filter with the same `limit * 10` candidate over-fetch. Filtered search additionally requires current, error-free extraction, so a document that has not been processed cannot accidentally satisfy `exists: false`.

Vector search generalizes the collection exact-scan path from #791/#803: a filter resolves an eligible document set, eligible sets up to 20,000 vectors get an exact cosine scan (no post-filter starvation of small sets), larger sets fall back to global ANN with the capped over-fetch. The filter is re-applied on the document join because vectors are content-scoped while metadata is document-scoped, which also handles shared-hash documents correctly.

Hybrid `query` passes the filter to both backends before RRF and reranking. Results attach metadata via one batch lookup (LEFT JOIN in the backends, one query in hybrid paths), no per-row N+1.

sqlite-vec 0.1.9's native vec0 metadata columns were evaluated and don't fit the general case (16 fixed columns, no multi-valued arrays, dynamic user-defined keys), though a native pre-filter through one internal id column is a plausible follow-up optimization. Pinned docs: [vec0](https://github.com/asg017/sqlite-vec/blob/v0.1.9/site/features/vec0.md), [knn](https://github.com/asg017/sqlite-vec/blob/v0.1.9/site/features/knn.md).

</details>

### Performance

Benchmarked at 10,000 documents (Apple M3 Pro, fresh database per scenario, p50 of 300 timed iterations after warmup), baseline v2.8.3 vs this branch:

| Scenario | Baseline | This branch |
|---|---|---|
| Unfiltered FTS (query matching all 10k docs) | 8.07ms | 8.08ms (no metadata) / 8.15ms (metadata on all docs) |
| Unfiltered vector KNN | 14.7ms | 14.7ms / 13.7ms |
| Filtered FTS, any selectivity from 90% to 0% | n/a | 7.9-8.6ms |
| Filtered vector, 90% eligible (exact scan) | 306ms (collection scope, same path) | 323ms |

Unfiltered search is unchanged within noise. Filtered FTS costs at most ~0.5ms over unfiltered, even for nested filters. Filtered vector search inherits the existing collection exact-scan cost profile (~5% over collection scoping at equal eligible-set size, for the EXISTS predicates), and the collection path itself does not regress.

Scripts and full results are reproducible from [`benchmarks/` on a companion branch](https://github.com/aaronccasanova/qmd/tree/bench/metadata-filtering/benchmarks) of my fork, kept off this branch to keep the diff reviewable.

<details>
<summary>Query plans</summary>

Unfiltered `searchFTS` keeps the FTS-first CTE shape. The new `LEFT JOIN document_metadata` (which returns result metadata without an N+1) is a rowid primary-key lookup on only the emitted rows, which is why the unfiltered delta doesn't show up in measurement:

```text
CO-ROUTINE fts_matches
SCAN documents_fts VIRTUAL TABLE INDEX 0:M3
USE TEMP B-TREE FOR ORDER BY
SCAN fm
SEARCH d USING INTEGER PRIMARY KEY (rowid=?)
SEARCH content USING INDEX sqlite_autoindex_content_1 (hash=?)
SEARCH dm USING INTEGER PRIMARY KEY (rowid=?) LEFT-JOIN
```

Filtered `searchFTS` (`and(status eq, priority gte)`) keeps the same shape and resolves every EXISTS through the covering partial indexes:

```text
CO-ROUTINE fts_matches
SCAN documents_fts VIRTUAL TABLE INDEX 0:M3
USE TEMP B-TREE FOR ORDER BY
SCAN fm
SEARCH dm USING INTEGER PRIMARY KEY (rowid=?)
SEARCH d USING INTEGER PRIMARY KEY (rowid=?)
SEARCH content USING INDEX sqlite_autoindex_content_1 (hash=?)
SEARCH mv EXISTS USING COVERING INDEX idx_metadata_text_lookup (key=? AND text_value=? AND document_id=?)
SEARCH mv EXISTS USING COVERING INDEX idx_metadata_number_lookup (key=? AND number_value>?)
```

</details>

### Testing

72 new tests across six suites, green under both Node (vitest) and Bun:

- Extraction: frontmatter edge cases (BOM, CRLF, missing delimiters, alias bombs, every rejection path)
- Filter language: validation with JSON-path errors, SQL semantics against a real SQLite database, and SQL-injection payloads staying inert data
- Persistence: replacement, shared content hashes, cascade deletes, and `qmd update` backfill
- Search integration: FTS/vector/structured with precomputed embeddings (no model downloads in CI)
- Surfaces: SDK, MCP tool, HTTP endpoints, and spawned-CLI runs including exit codes and error messages

Full suite: typecheck, 1215 Node tests, 1215 Bun tests, and the package smoke all pass. Also verified end to end with real models (embedding, expansion, reranking) against a live index.

### Review guide

The five commits build the feature in dependency order, each independently green:

1. `feat(metadata): add metadata domain modules` (extraction, filter AST + validation + SQL compiler, storage, pure and heavily tested)
2. `feat(metadata): persist document metadata during indexing`
3. `feat(metadata): filter FTS, vector, hybrid, and structured search`
4. `feat(metadata): expose --filter and filter options on every search surface`
5. `docs(metadata): document metadata and metadata filtering`

### Limitations and future work

- Filtered vector search over large eligible sets pays the exact-scan cost (same as collection scoping today). A native sqlite-vec pre-filter through an internal id metadata column is a candidate follow-up.
- Conditions match array elements independently. There is no `elemMatch`-style "same element satisfies all" operator yet.
- Strings compare exactly and case-sensitively, dates stay strings, and dots in keys carry no path semantics. Each is a deliberate first-version restriction that can be relaxed compatibly.
- Frontmatter is the only metadata source. The extraction layer produces a canonical object, so external sources (config files, sidecars) can be added without touching the filter or storage layers.

### Related work

- #551 and #770: prior frontmatter work. This PR follows #770's evidence and leaves content processing alone.
- #703 and #441: earlier filtering attempts across surfaces, useful context for why one shared AST beats per-surface flags.
- #791 and #803: the collection-starvation fixes whose exact-scan machinery the filtered vector path generalizes.

