### PR TITLE
fix(llm): distinguish an unreadable model file from a confirmed-bad one

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -365,7 +365,13 @@ const GGUF_MAGIC = Buffer.from("GGUF");
 export type GgufFileInspection = {
   exists: boolean;
   valid: boolean;
-  kind: "missing" | "gguf" | "html" | "invalid";
+  /**
+   * "html" and "invalid" mean the header was read and is confirmed bad.
+   * "unreadable" means the read itself failed, so nothing is known about the
+   * content. The two stay distinct because only the first justifies deleting
+   * the file.
+   */
+  kind: "missing" | "gguf" | "html" | "invalid" | "unreadable";
   sizeBytes?: number;
   magic?: string;
   details: string;
@@ -435,10 +441,13 @@ export function inspectGgufFile(filePath: string): GgufFileInspection {
       details: `not valid GGUF (expected magic "GGUF", got "${magic}", ${formatModelFileSize(sizeBytes)})`,
     };
   } catch (error) {
+    // stat/open/read threw, so the header was never seen. Reporting this as
+    // "invalid" would claim a verdict no read supports, and `magic` stays
+    // undefined for the same reason.
     return {
       exists: true,
       valid: false,
-      kind: "invalid",
+      kind: "unreadable",
       sizeBytes,
       details: `cannot read model file: ${error instanceof Error ? error.message : String(error)}`,
     };
@@ -454,10 +463,27 @@ function validateGgufFile(filePath: string, modelUri: string): void {
   const inspection = inspectGgufFile(filePath);
   if (!inspection.exists || inspection.valid) return; // let downstream handle missing files
 
-  // Remove the bad file so the next attempt re-downloads
+  // A read that failed says nothing about the bytes on disk. Deleting here
+  // throws away a file that is usually fine (fd exhaustion, a concurrent
+  // loader, a volume that briefly went away) and re-downloading it can cost
+  // gigabytes, so surface the real error and leave the file alone.
+  if (inspection.kind === "unreadable") {
+    throw new Error(
+      `Model file could not be read, so it could not be validated (${inspection.details}).\n` +
+      `Model: ${modelUri}\n` +
+      `Path:  ${filePath}\n\n` +
+      `The file has been left in place. If this repeats, check open file limits, ` +
+      `permissions, and whether the volume holding the model cache is still mounted.`
+    );
+  }
+
+  // Confirmed bad content: remove it so the next attempt re-downloads.
+  let removed = true;
   try {
     unlinkSync(filePath);
-  } catch { /* best effort */ }
+  } catch {
+    removed = false;
+  }
 
   if (inspection.kind === "html") {
     throw new Error(
@@ -477,7 +503,9 @@ function validateGgufFile(filePath: string, modelUri: string): void {
     `Model file is not valid GGUF (expected magic "GGUF", got "${inspection.magic ?? "unknown"}", file is ${formatModelFileSize(inspection.sizeBytes ?? 0)}).\n` +
     `Model: ${modelUri}\n` +
     `Path:  ${filePath}\n\n` +
-    `The file has been removed. Run the command again to re-download.`
+    (removed
+      ? `The file has been removed. Run the command again to re-download.`
+      : `The file could NOT be removed. Delete it manually, then run the command again.`)
   );
 }
 

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll, vi } from "vitest";
-import { chmodSync, mkdirSync, mkdtempSync, rmSync } from "fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
@@ -34,9 +34,82 @@ import {
   withLLMSession,
   canUnloadLLM,
   SessionReleasedError,
+  inspectGgufFile,
   type RerankDocument,
   type ILLMSession,
 } from "../src/llm.js";
+
+describe("inspectGgufFile", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "qmd-gguf-inspect-"));
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("missing file", () => {
+    const result = inspectGgufFile(join(dir, "does-not-exist.gguf"));
+    expect(result.exists).toBe(false);
+    expect(result.valid).toBe(false);
+    expect(result.kind).toBe("missing");
+  });
+
+  test("valid GGUF header", () => {
+    const filePath = join(dir, "valid.gguf");
+    const header = Buffer.alloc(16);
+    header.write("GGUF", 0, "ascii");
+    writeFileSync(filePath, header);
+
+    const result = inspectGgufFile(filePath);
+    expect(result.exists).toBe(true);
+    expect(result.valid).toBe(true);
+    expect(result.kind).toBe("gguf");
+    expect(result.magic).toBe("GGUF");
+  });
+
+  test("HTML error page is reported as html, not invalid", () => {
+    const filePath = join(dir, "html.gguf");
+    writeFileSync(filePath, "<!DOCTYPE html><html><body>502 Bad Gateway</body></html>");
+
+    const result = inspectGgufFile(filePath);
+    expect(result.exists).toBe(true);
+    expect(result.valid).toBe(false);
+    expect(result.kind).toBe("html");
+  });
+
+  test("wrong magic bytes are reported as invalid (content was actually read)", () => {
+    const filePath = join(dir, "wrong-magic.gguf");
+    writeFileSync(filePath, Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]));
+
+    const result = inspectGgufFile(filePath);
+    expect(result.exists).toBe(true);
+    expect(result.valid).toBe(false);
+    expect(result.kind).toBe("invalid");
+    expect(result.magic).toBeDefined();
+  });
+
+  // A read/stat failure (fd exhaustion, a concurrent loader, a volume that
+  // briefly went away) must not be reported as "invalid": that kind means the
+  // content was read and confirmed bad, which is what drives validateGgufFile
+  // to delete the file. Opening a directory as if it were a file is a
+  // portable, privilege-free way to make open/read fail after stat has already
+  // succeeded, which is the shape of the real failure.
+  test("unreadable path (read fails after stat succeeds) is reported as unreadable, not invalid", () => {
+    const dirAsFile = join(dir, "actually-a-directory.gguf");
+    mkdirSync(dirAsFile);
+
+    const result = inspectGgufFile(dirAsFile);
+    expect(result.exists).toBe(true);
+    expect(result.valid).toBe(false);
+    expect(result.kind).toBe("unreadable");
+    // Nothing was read, so it must not claim to know the header.
+    expect(result.magic).toBeUndefined();
+    expect(result.details).toContain("cannot read model file");
+  });
+});
 
 describe("canWriteLlamaDir", () => {
   test("returns true when llama/ exists and is writable", () => {


### PR DESCRIPTION
## What

`inspectGgufFile()` gains an `"unreadable"` kind, and `validateGgufFile()` stops deleting model files on read errors it never diagnosed.

## Why

The catch branch in `inspectGgufFile()` returned the same `kind: "invalid"` as a confirmed bad-magic read. A `stat`/`open`/`read` failure therefore reached `validateGgufFile()` indistinguishable from a file whose header had actually been read and found wrong. Three consequences, all visible to the user:

1. The message says `Expected GGUF magic "GGUF", got "unknown"`, naming a cause that was never established. The real error (`EISDIR`, `EBUSY`, an I/O error, a truncated read) is discarded.
2. The file is unlinked. On a transient read failure that costs a full re-download of a multi-GB model.
3. The message claims `The file has been removed` unconditionally, including when the `unlinkSync` itself threw and the file is still on disk.

Observed on a 1.28 GB model whose magic, version, and tensor/kv counts were all valid and unchanged across the whole episode: the same file, same code, same process succeeded on most calls and failed transiently on others, and every failure reported the file as invalid GGUF.

## Details

- `GgufFileInspection.kind` becomes `"valid" | "html" | "invalid" | "unreadable"`. `"html"` and `"invalid"` keep their meaning exactly: the header was read and is confirmed bad. `"unreadable"` means the read failed and nothing is known about the content, so `magic` stays `undefined` rather than being reported as `"unknown"`.
- `validateGgufFile()` deletes only for a confirmed-bad read. For `"unreadable"` it surfaces the underlying error and says the file was left in place.
- The `file has been removed` claim is now conditioned on the unlink actually succeeding, with a distinct message when it did not.

`qmd doctor` is unaffected: it reads `valid` and `details`, never `kind`.

## Testing

`bun test test/llm.test.ts` on this branch: 5 passed, 0 failed for the new `inspectGgufFile` describe, and the file's existing tests are unchanged.

The five cases cover all four outcomes plus the regression:

| Case | Expected `kind` |
|---|---|
| file does not exist | `unreadable` |
| valid GGUF header | `valid` |
| HTML error page saved as a model | `html` |
| readable file, wrong magic | `invalid` |
| a directory opened as if it were a file | `unreadable` |

The last one is the regression case for the read-fails-after-stat-succeeds path. It is portable and needs no privileges: `open()` on a directory succeeds on the platforms in CI and the subsequent read throws `EISDIR`, which is the same shape as the transient failure observed in the field. On `main` that case returns `kind: "invalid"` with `magic: "unknown"` and the file would be unlinked.
