### PR TITLE
fix(store): scope keyword retrieval at the index, not after it

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -4062,55 +4062,83 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
   const ftsQuery = buildFTS5Query(query);
   if (!ftsQuery) return [];
 
-  // Use a CTE to keep FTS5 driving the query. Without it, SQLite's planner
-  // combines the FTS5 MATCH and the collection filter into a single WHERE
-  // clause, which can make it abandon the FTS5 index and fall back to a full
-  // scan, turning an 8ms query into a 17-second query on large collections.
+  // Two SQL shapes, chosen by whether a collection scope is present, because
+  // the correct-and-fast plan differs:
+  //
+  //   Unscoped: the FTS5 MATCH is the whole answer, so bound the CTE with the
+  //   requested LIMIT and let FTS5 early-terminate once the top-N are settled.
+  //
+  //   Scoped: the collection filter must be applied to a COMPLETE match set,
+  //   never to a pre-truncated one. A LIMIT inside the CTE (the earlier
+  //   `limit * 10` over-fetch) is a correctness bug: a collection holding a
+  //   small share of the index loses every row whenever the global top-N holds
+  //   none of its documents, and the caller gets an empty result that reads as
+  //   "this collection has nothing on the subject". But the obvious correct
+  //   form, pushing the collection into the CTE as a
+  //   `rowid IN (SELECT id FROM documents WHERE collection = ?)` prefilter,
+  //   defeats FTS5 early termination: SQLite drives the query from the
+  //   collection's whole doclist and probes the FTS5 index once per candidate
+  //   rowid (EXPLAIN: `... VIRTUAL TABLE INDEX 0:=M3`), which measured about
+  //   55ms per in-scope document, 0.02s unscoped versus 21s scoped to a large
+  //   collection.
+  //
+  //   So the scoped shape keeps the MATCH global and unbounded, MATERIALIZEs
+  //   the complete match set once (corpus-bounded, at most one row per matching
+  //   document), and applies the collection filter, ORDER BY and LIMIT in the
+  //   outer query. MATERIALIZED is load-bearing: without it the planner may
+  //   flatten the CTE and fold the collection predicate back into the MATCH,
+  //   reintroducing exactly the per-rowid plan this avoids.
+
   const params: (string | number)[] = [ftsQuery];
 
-  // Scope the FTS lookup itself with a rowid prefilter instead of taking a
-  // global top-N and dropping the out-of-scope rows afterwards. The over-fetch
-  // this replaces (limit * 10 candidates when scoped) could not make a
-  // post-filter correct, it only moved the cutoff: a collection holding a
-  // small share of the index still lost every row whenever the global top-N
-  // happened to contain none of its documents, and the caller got an empty
-  // result that reads as "this collection has nothing on the subject".
-  //
-  // documents_fts.rowid is documents.id, so the subquery is a covering-index
-  // read on idx_documents_collection and the MATCH still runs against the FTS5
-  // index (EXPLAIN QUERY PLAN: SCAN documents_fts VIRTUAL TABLE INDEX 0:=M3),
-  // which is what the CTE above exists to protect.
-  let scopeFilter = "";
+  let sql: string;
   if (collectionFilter) {
-    scopeFilter = `\n        AND rowid IN (SELECT id FROM documents WHERE active = 1 AND collection = ?)`;
-    params.push(String(collectionFilter));
+    sql = `
+      WITH fts_matches AS MATERIALIZED (
+        SELECT rowid, bm25(documents_fts, 1.5, 4.0, 1.0) as bm25_score
+        FROM documents_fts
+        WHERE documents_fts MATCH ?
+      )
+      SELECT
+        'qmd://' || d.collection || '/' || d.path as filepath,
+        d.collection || '/' || d.path as display_path,
+        d.title,
+        content.doc as body,
+        d.hash,
+        fm.bm25_score
+      FROM fts_matches fm
+      JOIN documents d ON d.id = fm.rowid
+      JOIN content ON content.hash = d.hash
+      WHERE d.active = 1 AND d.collection = ?
+      ORDER BY fm.bm25_score ASC
+      LIMIT ?
+    `;
+    params.push(String(collectionFilter), limit);
+  } else {
+    sql = `
+      WITH fts_matches AS (
+        SELECT rowid, bm25(documents_fts, 1.5, 4.0, 1.0) as bm25_score
+        FROM documents_fts
+        WHERE documents_fts MATCH ?
+        ORDER BY bm25_score ASC
+        LIMIT ${limit}
+      )
+      SELECT
+        'qmd://' || d.collection || '/' || d.path as filepath,
+        d.collection || '/' || d.path as display_path,
+        d.title,
+        content.doc as body,
+        d.hash,
+        fm.bm25_score
+      FROM fts_matches fm
+      JOIN documents d ON d.id = fm.rowid
+      JOIN content ON content.hash = d.hash
+      WHERE d.active = 1
+      ORDER BY fm.bm25_score ASC
+      LIMIT ?
+    `;
+    params.push(limit);
   }
-
-  const sql = `
-    WITH fts_matches AS (
-      SELECT rowid, bm25(documents_fts, 1.5, 4.0, 1.0) as bm25_score
-      FROM documents_fts
-      WHERE documents_fts MATCH ?${scopeFilter}
-      ORDER BY bm25_score ASC
-      LIMIT ${limit}
-    )
-    SELECT
-      'qmd://' || d.collection || '/' || d.path as filepath,
-      d.collection || '/' || d.path as display_path,
-      d.title,
-      content.doc as body,
-      d.hash,
-      fm.bm25_score
-    FROM fts_matches fm
-    JOIN documents d ON d.id = fm.rowid
-    JOIN content ON content.hash = d.hash
-    WHERE d.active = 1
-    ORDER BY fm.bm25_score ASC
-    LIMIT ?
-  `;
-
-  // bm25 lower is better; sort ascending.
-  params.push(limit);
 
   const rows = db.prepare(sql).all(...params) as { filepath: string; display_path: string; title: string; body: string; hash: string; bm25_score: number }[];
   return rows.map(row => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -4062,25 +4062,37 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
   const ftsQuery = buildFTS5Query(query);
   if (!ftsQuery) return [];
 
-  // Use a CTE to force FTS5 to run first, then filter by collection.
-  // Without the CTE, SQLite's query planner combines FTS5 MATCH with the
-  // collection filter in a single WHERE clause, which can cause it to
-  // abandon the FTS5 index and fall back to a full scan — turning an 8ms
-  // query into a 17-second query on large collections.
+  // Use a CTE to keep FTS5 driving the query. Without it, SQLite's planner
+  // combines the FTS5 MATCH and the collection filter into a single WHERE
+  // clause, which can make it abandon the FTS5 index and fall back to a full
+  // scan, turning an 8ms query into a 17-second query on large collections.
   const params: (string | number)[] = [ftsQuery];
 
-  // When filtering by collection, fetch extra candidates from the FTS index
-  // since some will be filtered out. Without a collection filter we can
-  // fetch exactly the requested limit.
-  const ftsLimit = collectionFilter ? limit * 10 : limit;
+  // Scope the FTS lookup itself with a rowid prefilter instead of taking a
+  // global top-N and dropping the out-of-scope rows afterwards. The over-fetch
+  // this replaces (limit * 10 candidates when scoped) could not make a
+  // post-filter correct, it only moved the cutoff: a collection holding a
+  // small share of the index still lost every row whenever the global top-N
+  // happened to contain none of its documents, and the caller got an empty
+  // result that reads as "this collection has nothing on the subject".
+  //
+  // documents_fts.rowid is documents.id, so the subquery is a covering-index
+  // read on idx_documents_collection and the MATCH still runs against the FTS5
+  // index (EXPLAIN QUERY PLAN: SCAN documents_fts VIRTUAL TABLE INDEX 0:=M3),
+  // which is what the CTE above exists to protect.
+  let scopeFilter = "";
+  if (collectionFilter) {
+    scopeFilter = `\n        AND rowid IN (SELECT id FROM documents WHERE active = 1 AND collection = ?)`;
+    params.push(String(collectionFilter));
+  }
 
-  let sql = `
+  const sql = `
     WITH fts_matches AS (
       SELECT rowid, bm25(documents_fts, 1.5, 4.0, 1.0) as bm25_score
       FROM documents_fts
-      WHERE documents_fts MATCH ?
+      WHERE documents_fts MATCH ?${scopeFilter}
       ORDER BY bm25_score ASC
-      LIMIT ${ftsLimit}
+      LIMIT ${limit}
     )
     SELECT
       'qmd://' || d.collection || '/' || d.path as filepath,
@@ -4093,15 +4105,11 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
     JOIN documents d ON d.id = fm.rowid
     JOIN content ON content.hash = d.hash
     WHERE d.active = 1
+    ORDER BY fm.bm25_score ASC
+    LIMIT ?
   `;
 
-  if (collectionFilter) {
-    sql += ` AND d.collection = ?`;
-    params.push(String(collectionFilter));
-  }
-
   // bm25 lower is better; sort ascending.
-  sql += ` ORDER BY fm.bm25_score ASC LIMIT ?`;
   params.push(limit);
 
   const rows = db.prepare(sql).all(...params) as { filepath: string; display_path: string; title: string; body: string; hash: string; bm25_score: number }[];

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -3744,6 +3744,44 @@ describe("Vector Search collection filter", () => {
 
     await cleanupTestDb(store);
   });
+
+  test("searchFTS finds a scoped doc the global candidate window does not contain", async () => {
+    const store = await createTestStore();
+    const large = await createTestCollection({ name: "large-fts", pwd: "/test/large-fts" });
+    const small = await createTestCollection({ name: "small-fts", pwd: "/test/small-fts" });
+
+    // 40 short noise docs carrying the term in the title (bm25 title weight
+    // 4.0), so every one of them outranks the target globally.
+    for (let i = 0; i < 40; i++) {
+      await insertTestDocument(store.db, large, {
+        name: `noise-${i}`,
+        title: `zebra zebra ${i}`,
+        body: `# Noise ${i}\n\nzebra zebra zebra, noise document ${i}.`,
+        displayPath: `noise-${i}.md`,
+      });
+    }
+
+    // One long target doc that mentions the term once, dead last globally.
+    await insertTestDocument(store.db, small, {
+      name: "target",
+      title: "Target",
+      body: `# Target\n\n${"filler prose without the search term. ".repeat(40)}zebra.`,
+      displayPath: "target.md",
+    });
+
+    // Unscoped, the target is nowhere near the top of the ranking.
+    const global = store.searchFTS("zebra", 2);
+    expect(global).toHaveLength(2);
+    expect(global.every(r => r.collectionName === large)).toBe(true);
+
+    // Scoped, it is the only answer. Taking a global top-(limit * 10) and
+    // filtering afterwards returned nothing here: all 20 candidates were
+    // large-fts documents.
+    const scoped = store.searchFTS("zebra", 2, small);
+    expect(scoped.map(r => r.displayPath)).toEqual([`${small}/target.md`]);
+
+    await cleanupTestDb(store);
+  });
 });
 
 // =============================================================================


### PR DESCRIPTION
## What

`searchFTS()` scopes a collection filter by materializing the complete FTS5 match set once and filtering it in the outer query, instead of a global top-N post-filter (the original bug) or a `rowid IN (...)` prefilter (correct but slow). This is the keyword-side twin of #847, with the cost characteristic the vector side already has.

## Why

Two ways to get collection scoping wrong, and this PR avoids both:

1. **Global top-N, then post-filter** (the code before this PR). `searchFTS()` took a global top-`limit * 10` from the FTS5 index and dropped the out-of-scope rows afterwards. The over-fetch cannot make a post-filter correct; it only moves the cutoff. A collection holding a small share of the index loses every row whenever the global window contains none of its documents, and the caller cannot tell that apart from the collection genuinely having nothing on the subject: both return `[]`.

2. **`rowid IN (subquery)` prefilter inside the MATCH** (the obvious correctness fix). It is correct, but it defeats FTS5 early termination: with an extra rowid constraint SQLite drives the query from the collection's whole doclist and probes the FTS5 index once per candidate rowid. `EXPLAIN QUERY PLAN` shows `SCAN documents_fts VIRTUAL TABLE INDEX 0:=M3` (rowid-equality-constrained), which measured about 55ms per in-scope document: 0.02s unscoped versus 21s scoped to a large collection, and 507s for a single pass over 19 collections on the live index (roughly 8,900 documents). On a single-threaded MCP server that turns one scoped auto-expand recall into a multi-minute outage for every client.

## How

Keep the FTS5 MATCH global and unbounded, `MATERIALIZE` the complete match set once, and apply the collection filter, `ORDER BY` and `LIMIT` in the outer query:

```sql
WITH fts_matches AS MATERIALIZED (
  SELECT rowid, bm25(documents_fts, 1.5, 4.0, 1.0) AS bm25_score
  FROM documents_fts WHERE documents_fts MATCH ?
)
SELECT ...
FROM fts_matches fm
JOIN documents d ON d.id = fm.rowid
JOIN content ON content.hash = d.hash
WHERE d.active = 1 AND d.collection = ?
ORDER BY fm.bm25_score ASC
LIMIT ?
```

Correct, because the materialized set is complete, so the outer filter cannot truncate it. Fast, because the MATCH is the natural FTS5 operation rather than a per-rowid probe: `EXPLAIN QUERY PLAN` becomes `MATERIALIZE fts_matches` / `SCAN documents_fts VIRTUAL TABLE INDEX 0:M3`, the same MATCH plan the unscoped path uses. The match set is corpus-bounded (at most one row per matching document). `MATERIALIZED` is load-bearing: without it the planner may flatten the CTE and fold the collection predicate back into the MATCH, reintroducing the per-rowid plan.

The unscoped path is unchanged: there the MATCH is the whole answer, so it keeps the inner `LIMIT` and FTS5 early-terminates at the requested count. Multi-collection scopes still fan out per collection and merge by score (#871); each leg is now materialize-and-filter.

## Measured

Same match string (`the* AND process* AND of*`), live index, read-only, result rows identical in every comparison:

| scope | prefilter (`0:=M3`) | materialize (`0:M3`) |
| --- | --- | --- |
| collection-1 | 23.6s | 0.021s |
| collection-2 | 18.7s | 0.018s |
| collection-3 | 8.0s | 0.017s |

The actual outage recall (a longer auto-expand query) over all 19 collections: 507.7s per fan-out pass before, 2.0s after.

## Testing

The scoped `searchFTS` body here is identical to a version validated locally against `bun test test/store.test.ts` (green). The regression test in this PR (a scoped collection's only match ranks below the global top-N) fails on the pre-PR post-filter and passes here; it also passes under the prefilter, so it guards correctness but not the cost. A plan-guard (assert the scoped plan is `MATERIALIZE` / `0:M3` and not `0:=M3`) is the right cost guard, but a plan-string assertion is SQLite-version-sensitive, so it is called out here rather than baked in.
