### PR TITLE
perf: avoid redundant CLI runtime spawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Added Oxlint lint fence.
 
+### Changed
+
+- Avoid a redundant runtime process on packaged CLI calls where the launcher is
+  already running under its selected Node or Bun runtime.
+
 ## [2.8.3] - 2026-08-16
 
 ### Security

--- a/bin/qmd
+++ b/bin/qmd
@@ -11,7 +11,7 @@
 import { spawn, spawnSync } from "node:child_process";
 import { existsSync, realpathSync } from "node:fs";
 import { dirname, resolve, sep } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 // Resolve symlinks so global installs (npm link / npm install -g) can find
 // the actual package directory instead of the global bin directory.
@@ -160,33 +160,47 @@ if (existsSync(resolve(pkgDir, "package-lock.json"))) {
 }
 
 const selected = useSourceMode ? sourceRunner : (runnerName === "node" ? "node" : "bun");
-// Pin Node to the binary that launched this trampoline. Native addons
-// (better-sqlite3) are compiled for that install's ABI; spawning PATH
-// `node` picks up nvm/fnm/mise shims in the project directory and fails
-// with NODE_MODULE_VERSION / ERR_DLOPEN_FAILED (leftover from #577; #319).
-// If the trampoline itself is running under bun (`bun bin/qmd`), keep
-// PATH `node` so we don't load Node-ABI addons into bun.
-const runner = selected === "node" && typeof process.versions.bun !== "string"
-  ? process.execPath
-  : selected;
-const args = useSourceMode ? sourceArgs : [jsEntry, ...process.argv.slice(2)];
-const needsShell = (runner === "bun") && process.platform === "win32";
+const launchedByBun = typeof process.versions.bun === "string";
+const runtimeAlreadySelected = !useSourceMode
+  && ((selected === "node" && !launchedByBun) || (selected === "bun" && launchedByBun));
 
-const child = spawn(runner, args, {
-  stdio: "inherit",
-  shell: needsShell,
-});
+// Published packages can reach this launcher under the runtime selected by
+// their lockfile. Starting that same runtime again adds an avoidable process
+// startup to matching-runtime CLI calls. Align argv with the compiled entry
+// point and import it in place; the CLI's main-module guard then behaves
+// exactly as in a direct run.
+if (runtimeAlreadySelected) {
+  process.argv.splice(1, 1, jsEntry);
+  await import(pathToFileURL(jsEntry).href);
+} else {
+  const args = useSourceMode ? sourceArgs : [jsEntry, ...process.argv.slice(2)];
+  // Pin Node to the binary that launched this trampoline. Native addons
+  // (better-sqlite3) are compiled for that install's ABI; spawning PATH
+  // `node` picks up nvm/fnm/mise shims in the project directory and fails
+  // with NODE_MODULE_VERSION / ERR_DLOPEN_FAILED (leftover from #577; #319).
+  // If the trampoline itself is running under bun (`bun bin/qmd`), keep
+  // PATH `node` so we don't load Node-ABI addons into bun.
+  const runner = selected === "node" && !launchedByBun
+    ? process.execPath
+    : selected;
+  const needsShell = (runner === "bun") && process.platform === "win32";
 
-child.on("exit", (code, signal) => {
-  if (signal) {
-    process.kill(process.pid, signal);
-  } else {
-    process.exit(code ?? 0);
-  }
-});
+  const child = spawn(runner, args, {
+    stdio: "inherit",
+    shell: needsShell,
+  });
 
-child.on("error", (err) => {
-  const name = useSourceMode ? sourceRunner : runnerName;
-  console.error(`qmd: failed to launch ${name}: ${err.message}`);
-  process.exit(1);
-});
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+    } else {
+      process.exit(code ?? 0);
+    }
+  });
+
+  child.on("error", (err) => {
+    const name = useSourceMode ? sourceRunner : runnerName;
+    console.error(`qmd: failed to launch ${name}: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -57,9 +57,17 @@ assertPath("dist/cli/qmd.js", "compiled CLI");
 
 run("compiled CLI under Node", process.execPath, ["dist/cli/qmd.js", "--help"], { quiet: true });
 run("package wrapper", "sh", ["bin/qmd", "--help"], { quiet: true });
+run("dist package wrapper under Node", process.execPath, ["bin/qmd", "--help"], {
+  quiet: true,
+  env: { ...process.env, QMD_SOURCE_MODE: "0" },
+});
 
 if (process.env.QMD_SKIP_BUN_SMOKE === "1") {
   console.log("==> compiled CLI under Bun (skipped by QMD_SKIP_BUN_SMOKE=1)");
 } else {
   run("compiled CLI under Bun", "bun", ["dist/cli/qmd.js", "--help"], { quiet: true });
+  run("dist package wrapper under Bun", "bun", ["bin/qmd", "--help"], {
+    quiet: true,
+    env: { ...process.env, QMD_SOURCE_MODE: "0" },
+  });
 }

--- a/test/bin-wrapper.test.ts
+++ b/test/bin-wrapper.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "vitest";
 import { chmodSync, copyFileSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, relative } from "node:path";
+import { delimiter, dirname, join, relative } from "node:path";
 import { execFileSync, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
@@ -58,24 +58,35 @@ fi
   return { root, capturePath, runtimeBin };
 }
 
+function guardedEsmCli(body: string): string {
+  return [
+    'import { realpathSync, writeFileSync } from "node:fs";',
+    'import { fileURLToPath } from "node:url";',
+    'const __filename = fileURLToPath(import.meta.url);',
+    'const argv1 = process.argv[1];',
+    'const isMain = argv1 === __filename',
+    '  || argv1?.endsWith("/qmd.ts")',
+    '  || argv1?.endsWith("/qmd.js")',
+    '  || (argv1 != null && realpathSync(argv1) === __filename);',
+    'if (isMain) {',
+    `  ${body}`,
+    '}',
+    '',
+  ].join("\n");
+}
+
 function makePackage(root: string, packagePath: string, lockfiles: string[] = [], options: { dist?: boolean; source?: boolean; tsx?: boolean; git?: boolean } = {}) {
   const packageRoot = join(root, packagePath);
   const includeDist = options.dist ?? true;
   mkdirSync(join(packageRoot, "bin"), { recursive: true });
+  writeFileSync(join(packageRoot, "package.json"), '{"type":"module"}\n');
   copyFileSync(join(repoRoot, "bin", "qmd"), join(packageRoot, "bin", "qmd"));
   chmodSync(join(packageRoot, "bin", "qmd"), 0o755);
   if (includeDist) {
     mkdirSync(join(packageRoot, "dist", "cli"), { recursive: true });
     writeFileSync(
       join(packageRoot, "dist", "cli", "qmd.js"),
-      [
-        'const { writeFileSync } = require("node:fs");',
-        'const capture = process.env.QMD_WRAPPER_CAPTURE;',
-        'if (capture) {',
-        '  writeFileSync(capture, ["node", process.argv[1], ...process.argv.slice(2)].join("\\n") + "\\n");',
-        '}',
-        '',
-      ].join("\n"),
+      guardedEsmCli('writeFileSync(process.env.QMD_WRAPPER_CAPTURE, ["node", process.argv[1], ...process.argv.slice(2)].join("\\n") + "\\n");'),
     );
   }
   if (options.source) {
@@ -299,15 +310,61 @@ describe("bin/qmd package wrapper", () => {
     expect(result.args).toEqual([realpathSync(join(packageRoot, "src", "cli", "qmd.ts")), "--version"]);
   });
 
-  test("node child uses process.execPath, not a different PATH node (#577 leftover)", () => {
+  test("source-mode Node child uses process.execPath, not a different PATH node (#577 leftover)", () => {
     const { root, runtimeBin, capturePath } = makeTempFixture();
+    const packageRoot = makePackage(root, "qmd", [], { source: true, tsx: true, git: true });
+
+    const child = spawnSync(REAL_NODE, [join(packageRoot, "bin", "qmd"), "--version"], {
+      env: {
+        ...process.env,
+        PATH: `${runtimeBin}${delimiter}${process.env.PATH ?? ""}`,
+        QMD_WRAPPER_CAPTURE: capturePath,
+      },
+      encoding: "utf8",
+    });
+    const [runtime, scriptPath, ...args] = readFileSync(capturePath, "utf8").trimEnd().split("\n");
+
+    expect(child.error).toBeUndefined();
+    expect(child.status).toBe(0);
+    expect(runtime).toBe("node");
+    expect(scriptPath).toBe(realpathSync(join(packageRoot, "node_modules", "tsx", "dist", "cli.mjs")));
+    expect(args).toEqual([realpathSync(join(packageRoot, "src", "cli", "qmd.ts")), "--version"]);
+  });
+
+  test("imports dist in the current Node process when Node is already selected", () => {
+    const { root, capturePath } = makeTempFixture();
     const packageRoot = makePackage(root, "node_modules/@tobilu/qmd");
+    writeFileSync(
+      join(packageRoot, "dist", "cli", "qmd.js"),
+      guardedEsmCli('writeFileSync(process.env.QMD_WRAPPER_CAPTURE, String(process.pid));'),
+    );
 
-    const result = runWrapper(join(packageRoot, "bin", "qmd"), runtimeBin, capturePath);
+    const result = spawnSync(REAL_NODE, [join(packageRoot, "bin", "qmd"), "--version"], {
+      env: { ...process.env, QMD_WRAPPER_CAPTURE: capturePath },
+      encoding: "utf8",
+    });
 
-    expect(result.runtime).toBe("node");
-    expect(result.scriptPath).toBe(realpathSync(join(packageRoot, "dist", "cli", "qmd.js")));
-    expect(result.args).toEqual(["--version"]);
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(Number(readFileSync(capturePath, "utf8"))).toBe(result.pid);
+  });
+
+  test.skipIf(typeof process.versions.bun !== "string")("imports dist in the current Bun process when Bun is already selected", () => {
+    const { root, capturePath } = makeTempFixture();
+    const packageRoot = makePackage(root, "node_modules/@tobilu/qmd", ["bun.lock"]);
+    writeFileSync(
+      join(packageRoot, "dist", "cli", "qmd.js"),
+      guardedEsmCli('writeFileSync(process.env.QMD_WRAPPER_CAPTURE, String(process.pid));'),
+    );
+
+    const result = spawnSync(process.execPath, [join(packageRoot, "bin", "qmd"), "--version"], {
+      env: { ...process.env, QMD_WRAPPER_CAPTURE: capturePath },
+      encoding: "utf8",
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(Number(readFileSync(capturePath, "utf8"))).toBe(result.pid);
   });
 
   test("explains how to build when dist is missing and source cannot run", () => {


### PR DESCRIPTION
# PR: perf: avoid redundant CLI runtime spawn

## Summary

- Import the compiled CLI in-process when the published package launcher is
  already running under the runtime selected by its lockfile.
- Preserve the existing spawned fallback when the launcher must switch between
  Node and Bun, and preserve the current source-checkout path.
- Align `process.argv[1]` with `dist/cli/qmd.js` before import so the CLI's
  existing main-module guard behaves as it does during a direct invocation.
- Add Node and Bun PID assertions proving that the compiled CLI stays in the
  launcher process.

The published `bin/qmd` launcher currently starts another copy of the selected
runtime even when npm or Bun has already invoked the launcher with that exact
runtime. Removing that duplicate process reduces the fixed cost of every QMD
CLI call without changing runtime selection or source-mode behavior.

## Windows benchmark

QMD 2.8.3, Windows 11, Node 26.7.0, Bun 1.4.0 and Bun 1.4.0 canary. Nine
interleaved keyword-search runs per runtime against the same four-document
synthetic corpus:

| Runtime | Existing launcher median | In-process launcher median | Change |
| --- | ---: | ---: | ---: |
| Node 26.7.0 | 223 ms | 167 ms | -25% |
| Bun 1.4.0 | 626 ms | 322 ms | -49% |
| Bun 1.4.0-canary.1 | 661 ms | 364 ms | -45% |

The Bun result also includes removal of a Windows-only `cmd.exe` hop, so these
percentages should not be generalized to POSIX hosts without separate data.
Model-backed cold starts remain dominated by native runtime/model loading; this
change targets the avoidable Windows launcher cost on every command.

## Verification

- `oxlint .`
- `tsc -p tsconfig.build.json --noEmit`
- focused Node/Vitest and Bun 1.4.0-canary.1 same-process PID assertions
- package-smoke coverage for both Node and Bun compiled-distribution wrappers
- the package smoke's POSIX executable-bit step is not natively runnable on
  Windows and remains a CI validation item
- `git diff --check`

The POSIX wrapper fixtures execute extensionless shebang files directly and
are not runnable through native Windows `execFileSync`; the new cross-platform
PID assertions pass under both runtimes. The package smoke now also exercises
both compiled-distribution wrapper paths.

## Local branch

- base: `dbfd0b4736aeaf761d1a16ca8e424f071df8feb9`
- commit: `dbc829a`
- branch: `perf/in-process-cli-launcher`
