### PR TITLE
fix: harden daemon and embed-lock process identity on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@
 
 - Added Oxlint lint fence.
 
+### Changed
+
+- MCP daemon and embed-lock files now use structured process identity. A
+  pre-upgrade numeric file is acted on only when the live process command line
+  verifies the expected QMD role; otherwise it is left untouched.
+
+### Fixed
+
+- MCP daemon state and embed locks now bind a PID to its process start time
+  and role, preventing recycled or unrelated PIDs from being treated as their
+  owner. This also restores daemon and embedding-lock lifecycle checks on
+  native Windows.
+- Embed locks are published exclusively from a flushed temporary file. Fresh
+  malformed locks fail closed; unchanged malformed locks are reclaimed after
+  a 30-second grace period with a path-specific recovery message.
+- Legacy numeric state is recognized only when the live process command line
+  matches the expected QMD role, preserving safe upgrades on POSIX systems.
+- Source-checkout MCP daemons now pass the TSX loader as a file URL, allowing
+  detached daemon launches from Windows drive-letter paths.
+- Bun source-checkout daemons now launch TypeScript directly instead of
+  receiving Node's TSX loader flags.
+- Windows start identity now uses the CIM process creation timestamp, including
+  for protected system processes where `Process.StartTime` is inaccessible.
+- If a process-start token cannot be obtained, daemon and embed state falls
+  back to a legacy PID record that remains fail-closed while the PID is live.
+
 ## [2.8.3] - 2026-08-16
 
 ### Security

--- a/src/cli/embed-lock.ts
+++ b/src/cli/embed-lock.ts
@@ -7,9 +7,17 @@
  * processes are recovered via PID identity checks (same spirit as mcp-pid.ts).
  */
 
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { existsSync, linkSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { isQmdMcpPid } from "./mcp-pid.js";
+import {
+  createProcessRecord,
+  processRecordStatus,
+  readProcessRecord,
+  sameProcessRecord,
+  serializeProcessRecord,
+  type QmdProcessRecord,
+} from "./mcp-pid.js";
 
 export type EmbedLockHandle = {
   lockPath: string;
@@ -21,35 +29,42 @@ export function embedLockPathForDb(dbPath: string): string {
   return join(dirname(dbPath), ".qmd-embed.lock");
 }
 
-function readLockPid(lockPath: string): number | null {
-  try {
-    const raw = readFileSync(lockPath, "utf-8").trim();
-    const pid = parseInt(raw, 10);
-    if (!Number.isInteger(pid) || pid <= 0) return null;
-    return pid;
-  } catch {
-    return null;
-  }
-}
-
-/** True if `pid` still owns a live embed/qmd process (or is this process). */
-export function isLiveEmbedLockHolder(pid: number): boolean {
-  if (!Number.isInteger(pid) || pid <= 0) return false;
-  // Same-process re-check: we obviously still hold our own lock.
-  if (pid === process.pid) return true;
-  return isQmdMcpPid(pid);
+/** True only when this exact process incarnation still owns an embed lock. */
+export function isLiveEmbedLockHolder(record: QmdProcessRecord): boolean {
+  // Live legacy PIDs and malformed/in-flight records fail closed. A numeric
+  // legacy lock becomes reclaimable only after its process is dead.
+  return processRecordStatus(record, "embed") !== "dead";
 }
 
 function createOwnedLock(lockPath: string): EmbedLockHandle {
-  writeFileSync(lockPath, `${process.pid}\n`, { flag: "wx" });
+  const record = createProcessRecord("embed");
+  const serialized = serializeProcessRecord(record);
+  const temporaryPath = `${lockPath}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    writeFileSync(temporaryPath, serialized, { flag: "wx", flush: true });
+    try {
+      linkSync(temporaryPath, lockPath);
+    } catch (error: unknown) {
+      const code = typeof error === "object" && error !== null && "code" in error
+        ? (error as NodeJS.ErrnoException).code
+        : undefined;
+      if (code === "EEXIST") throw error;
+      writeFileSync(lockPath, serialized, { flag: "wx", flush: true });
+    }
+  } finally {
+    try {
+      unlinkSync(temporaryPath);
+    } catch {
+      // Best-effort cleanup after an interrupted or contended publish.
+    }
+  }
   let released = false;
   const release = () => {
     if (released) return;
     released = true;
     try {
       if (!existsSync(lockPath)) return;
-      const written = readLockPid(lockPath);
-      if (written === process.pid) unlinkSync(lockPath);
+      if (sameProcessRecord(record, readProcessRecord(lockPath))) unlinkSync(lockPath);
     } catch {
       // best-effort cleanup
     }
@@ -73,14 +88,33 @@ export function tryAcquireEmbedLock(lockPath: string): EmbedLockHandle | null {
           : undefined;
       if (code !== "EEXIST") throw err;
 
-      const holderPid = readLockPid(lockPath);
-      if (holderPid !== null && isLiveEmbedLockHolder(holderPid)) {
+      const holder = readProcessRecord(lockPath);
+      if (holder.kind === "invalid") {
+        try {
+          const before = statSync(lockPath);
+          const recheck = readProcessRecord(lockPath);
+          const after = statSync(lockPath);
+          if (
+            Date.now() - before.mtimeMs >= 30_000
+            && recheck.kind === "invalid"
+            && before.mtimeMs === after.mtimeMs
+            && before.size === after.size
+          ) {
+            unlinkSync(lockPath);
+            continue;
+          }
+        } catch {
+          // Another process changed the lock; retry the exclusive publish.
+          continue;
+        }
+      }
+      if (isLiveEmbedLockHolder(holder)) {
         return null;
       }
 
-      // Stale / unreadable / recycled PID — remove and retry once.
+      // Dead or recycled PID — remove and retry once.
       try {
-        unlinkSync(lockPath);
+        if (sameProcessRecord(holder, readProcessRecord(lockPath))) unlinkSync(lockPath);
       } catch {
         // Another process may have claimed it; loop and try wx again.
       }
@@ -88,8 +122,8 @@ export function tryAcquireEmbedLock(lockPath: string): EmbedLockHandle | null {
   }
 
   // Final attempt lost the race to a live holder (or repeated EEXIST).
-  const holderPid = readLockPid(lockPath);
-  if (holderPid !== null && isLiveEmbedLockHolder(holderPid)) {
+  const holder = readProcessRecord(lockPath);
+  if (isLiveEmbedLockHolder(holder)) {
     return null;
   }
   return null;
@@ -98,3 +132,7 @@ export function tryAcquireEmbedLock(lockPath: string): EmbedLockHandle | null {
 /** User-facing message when a second embed is skipped. */
 export const EMBED_LOCK_BUSY_MESSAGE =
   "Another embed process is already running. Skipping.";
+
+export function embedLockBusyMessage(lockPath: string): string {
+  return `${EMBED_LOCK_BUSY_MESSAGE}\nLock: ${lockPath}\nIf no embed is active and this file is corrupt, wait 30 seconds and retry; QMD will reclaim it.`;
+}

--- a/src/cli/mcp-pid.ts
+++ b/src/cli/mcp-pid.ts
@@ -9,6 +9,291 @@
 import { existsSync, readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 
+export type QmdProcessRole = "mcp-http" | "embed";
+
+export type QmdProcessIdentity = {
+  format: "qmd-process/v1";
+  pid: number;
+  role: QmdProcessRole;
+  startToken: string;
+  port?: number;
+};
+
+export type ProcessIdentityProbe = {
+  isAlive: (pid: number) => boolean;
+  startToken: (pid: number) => string | null;
+  cmdline?: (pid: number) => string | null;
+};
+
+export type ProcessIdentityStatus = "live" | "dead" | "unknown";
+
+export type QmdProcessRecord =
+  | { kind: "identity"; identity: QmdProcessIdentity }
+  | { kind: "legacy"; pid: number }
+  | { kind: "invalid" };
+
+/** Parse a structured QMD process identity file. Legacy numeric pidfiles are intentionally untrusted. */
+export function parseProcessIdentity(raw: string): QmdProcessIdentity | null {
+  try {
+    const value = JSON.parse(raw) as Partial<QmdProcessIdentity>;
+    if (value.format !== "qmd-process/v1") return null;
+    if (!Number.isInteger(value.pid) || (value.pid ?? 0) <= 0) return null;
+    if (value.role !== "mcp-http" && value.role !== "embed") return null;
+    if (typeof value.startToken !== "string" || value.startToken.length === 0) return null;
+    if (value.port !== undefined && (!Number.isInteger(value.port) || value.port <= 0 || value.port > 65535)) return null;
+    return value as QmdProcessIdentity;
+  } catch {
+    return null;
+  }
+}
+
+export function readProcessIdentity(path: string): QmdProcessIdentity | null {
+  try {
+    return parseProcessIdentity(readFileSync(path, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+/** Parse either the current JSON format or the numeric format written by QMD <= 2.8.3. */
+export function parseProcessRecord(raw: string): QmdProcessRecord {
+  const identity = parseProcessIdentity(raw);
+  if (identity) return { kind: "identity", identity };
+  const trimmed = raw.trim();
+  if (/^\d+$/.test(trimmed)) {
+    const pid = Number(trimmed);
+    if (Number.isSafeInteger(pid) && pid > 0) return { kind: "legacy", pid };
+  }
+  return { kind: "invalid" };
+}
+
+export function readProcessRecord(path: string): QmdProcessRecord {
+  try {
+    return parseProcessRecord(readFileSync(path, "utf-8"));
+  } catch {
+    return { kind: "invalid" };
+  }
+}
+
+export function processRecordPid(record: QmdProcessRecord): number | null {
+  if (record.kind === "identity") return record.identity.pid;
+  if (record.kind === "legacy") return record.pid;
+  return null;
+}
+
+export function serializeProcessIdentity(identity: QmdProcessIdentity): string {
+  return `${JSON.stringify(identity)}\n`;
+}
+
+export function sameProcessIdentity(
+  left: QmdProcessIdentity | null,
+  right: QmdProcessIdentity | null,
+): boolean {
+  return left !== null && right !== null
+    && left.pid === right.pid
+    && left.role === right.role
+    && left.startToken === right.startToken;
+}
+
+export function sameProcessRecord(left: QmdProcessRecord, right: QmdProcessRecord): boolean {
+  if (left.kind === "identity" && right.kind === "identity") {
+    return sameProcessIdentity(left.identity, right.identity);
+  }
+  if (left.kind === "legacy" && right.kind === "legacy") return left.pid === right.pid;
+  // Invalid records are never authoritative enough to delete.
+  return false;
+}
+
+let cachedCurrentProcessStartToken: string | undefined;
+
+function cacheCurrentProcessStartToken(pid: number, token: string | null): string | null {
+  if (pid === process.pid && token) cachedCurrentProcessStartToken = token;
+  return token;
+}
+
+/**
+ * Return an OS-issued process-start token. Combining this with PID prevents a
+ * recycled PID from inheriting authority to a daemon state file or embed lock.
+ */
+export function readProcessStartToken(pid: number): string | null {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  if (pid === process.pid && cachedCurrentProcessStartToken) return cachedCurrentProcessStartToken;
+
+  if (process.platform === "linux") {
+    try {
+      const stat = readFileSync(`/proc/${pid}/stat`, "utf-8");
+      const afterName = stat.slice(stat.lastIndexOf(")") + 2).trim().split(/\s+/);
+      const startTime = afterName[19]; // proc(5) field 22; array starts at field 3.
+      return cacheCurrentProcessStartToken(pid, startTime ? `linux:${startTime}` : null);
+    } catch {
+      return null;
+    }
+  }
+
+  if (process.platform === "win32") {
+    try {
+      const script = [
+        "$ErrorActionPreference='Stop'",
+        `$process = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"`,
+        "if ($null -eq $process) { exit 3 }",
+        "$process.CreationDate.ToUniversalTime().Ticks",
+      ].join("\n");
+      const output = execFileSync("powershell.exe", ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script], {
+        encoding: "utf-8",
+        // PowerShell 5.1 cold starts can be slow under Windows Defender. This
+        // probe is a safety boundary, so tolerate startup contention instead
+        // of turning a transient two-second delay into an unverifiable daemon.
+        timeout: 10_000,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      }).trim();
+      return cacheCurrentProcessStartToken(pid, /^\d+$/.test(output) ? `win32:${output}` : null);
+    } catch {
+      return null;
+    }
+  }
+
+  try {
+    const output = execFileSync("ps", ["-p", String(pid), "-o", "lstart="], {
+      encoding: "utf-8",
+      env: { ...process.env, LC_ALL: "C", TZ: "UTC" },
+      timeout: 2000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return cacheCurrentProcessStartToken(pid, output ? `${process.platform}:${output}` : null);
+  } catch {
+    return null;
+  }
+}
+
+export function createProcessIdentity(
+  role: QmdProcessRole,
+  options: { pid?: number; port?: number } = {},
+): QmdProcessIdentity {
+  const pid = options.pid ?? process.pid;
+  const startToken = readProcessStartToken(pid);
+  if (!startToken) {
+    throw new Error(`Cannot read process start identity for PID ${pid}`);
+  }
+  return {
+    format: "qmd-process/v1",
+    pid,
+    role,
+    startToken,
+    ...(options.port === undefined ? {} : { port: options.port }),
+  };
+}
+
+export function createProcessRecord(
+  role: QmdProcessRole,
+  options: { pid?: number; port?: number } = {},
+  identityFactory: typeof createProcessIdentity = createProcessIdentity,
+): QmdProcessRecord {
+  const pid = options.pid ?? process.pid;
+  try {
+    return { kind: "identity", identity: identityFactory(role, options) };
+  } catch {
+    return { kind: "legacy", pid };
+  }
+}
+
+export function serializeProcessRecord(record: QmdProcessRecord): string {
+  return record.kind === "identity"
+    ? serializeProcessIdentity(record.identity)
+    : record.kind === "legacy"
+      ? `${record.pid}\n`
+      : "";
+}
+
+const defaultIdentityProbe: ProcessIdentityProbe = {
+  isAlive(pid) {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (error: unknown) {
+      // EPERM means the process exists but cannot be signalled from this token.
+      return typeof error === "object" && error !== null && "code" in error
+        && (error as NodeJS.ErrnoException).code === "EPERM";
+    }
+  },
+  startToken: readProcessStartToken,
+  cmdline: readProcessCmdline,
+};
+
+/** True if a command line belongs to the expected QMD process role. */
+export function looksLikeQmdRoleCommand(cmdline: string, role: QmdProcessRole): boolean {
+  const normalized = cmdline.trim();
+  if (!/(?:^|[\s/\\])qmd(?:\.(?:ts|js))?(?:[\s]|$)/i.test(normalized)) return false;
+  return role === "embed"
+    ? /(?:^|\s)embed(?:\s|$)/i.test(normalized)
+    : /(?:^|\s)mcp(?:\s|$)/i.test(normalized) && /(?:^|\s)--http(?:\s|$)/i.test(normalized);
+}
+
+/** Read a process command line from procfs or the POSIX `ps` interface. */
+export function readProcessCmdline(pid: number): string | null {
+  if (!Number.isInteger(pid) || pid <= 0 || process.platform === "win32") return null;
+  const procPath = `/proc/${pid}/cmdline`;
+  if (existsSync(procPath)) {
+    try {
+      const value = readFileSync(procPath, "utf-8").replace(/\0/g, " ").trim();
+      if (value) return value;
+    } catch {
+      // Fall through to ps.
+    }
+  }
+  try {
+    const value = execFileSync("ps", ["-p", String(pid), "-o", "args="], {
+      encoding: "utf-8",
+      env: { ...process.env, LC_ALL: "C", TZ: "UTC" },
+      timeout: 2000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return value || null;
+  } catch {
+    return null;
+  }
+}
+
+export function isProcessAlive(pid: number, probe: ProcessIdentityProbe = defaultIdentityProbe): boolean {
+  return Number.isInteger(pid) && pid > 0 && probe.isAlive(pid);
+}
+
+export function processIdentityStatus(
+  identity: QmdProcessIdentity | null,
+  expectedRole: QmdProcessRole,
+  probe: ProcessIdentityProbe = defaultIdentityProbe,
+): ProcessIdentityStatus {
+  if (!identity || identity.role !== expectedRole) return "dead";
+  if (!probe.isAlive(identity.pid)) return "dead";
+  const startToken = probe.startToken(identity.pid);
+  if (!startToken) return "unknown";
+  return startToken === identity.startToken ? "live" : "dead";
+}
+
+export function isProcessIdentityLive(
+  identity: QmdProcessIdentity | null,
+  expectedRole: QmdProcessRole,
+  probe: ProcessIdentityProbe = defaultIdentityProbe,
+): boolean {
+  return processIdentityStatus(identity, expectedRole, probe) === "live";
+}
+
+/** Legacy live PIDs and malformed/in-flight records are deliberately unverifiable. */
+export function processRecordStatus(
+  record: QmdProcessRecord,
+  expectedRole: QmdProcessRole,
+  probe: ProcessIdentityProbe = defaultIdentityProbe,
+): ProcessIdentityStatus {
+  if (record.kind === "identity") return processIdentityStatus(record.identity, expectedRole, probe);
+  if (record.kind === "legacy") {
+    if (!isProcessAlive(record.pid, probe)) return "dead";
+    const cmdline = probe.cmdline?.(record.pid);
+    if (cmdline === undefined || cmdline === null) return "unknown";
+    return looksLikeQmdRoleCommand(cmdline, expectedRole) ? "live" : "unknown";
+  }
+  return "unknown";
+}
+
 /**
  * Pid/log filenames for the MCP HTTP daemon.
  * The default index keeps `mcp.pid` / `mcp.log` for compatibility; named
@@ -20,67 +305,4 @@ export function mcpDaemonStateFiles(indexName: string = "index"): { pidFile: str
     pidFile: `mcp${suffix}.pid`,
     logFile: `mcp${suffix}.log`,
   };
-}
-
-/** True if a process command line looks like a qmd CLI invocation. */
-export function looksLikeQmdMcpCommand(cmdline: string): boolean {
-  const s = cmdline.trim();
-  if (!s) return false;
-  // Match bare `qmd`, `qmd.ts`/`qmd.js`, or a path ending in /qmd(.ts|.js)
-  return /(?:^|[\s/\\])qmd(?:\.(?:ts|js))?(?:[\s]|$)/i.test(s);
-}
-
-/** Read process cmdline (Linux /proc preferred; ps fallback for macOS). */
-export function readProcessCmdline(pid: number): string | null {
-  if (!Number.isInteger(pid) || pid <= 0) return null;
-
-  const procPath = `/proc/${pid}/cmdline`;
-  if (existsSync(procPath)) {
-    try {
-      const raw = readFileSync(procPath, "utf-8");
-      const cmdline = raw.replace(/\0/g, " ").trim();
-      if (cmdline) return cmdline;
-    } catch {
-      // fall through to ps
-    }
-  }
-
-  try {
-    let cmdline = "";
-    try {
-      cmdline = execFileSync("ps", ["-p", String(pid), "-o", "args="], {
-        encoding: "utf-8",
-        timeout: 2000,
-        stdio: ["ignore", "pipe", "ignore"],
-      });
-    } catch {
-      cmdline = execFileSync("ps", ["-p", String(pid), "-o", "command="], {
-        encoding: "utf-8",
-        timeout: 2000,
-        stdio: ["ignore", "pipe", "ignore"],
-      });
-    }
-    const trimmed = cmdline.trim();
-    return trimmed || null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Returns true only if `pid` is alive AND its command line looks like qmd.
- * If cmdline cannot be read or does not match, returns false (treat as stale).
- */
-export function isQmdMcpPid(pid: number): boolean {
-  if (!Number.isInteger(pid) || pid <= 0) return false;
-
-  try {
-    process.kill(pid, 0);
-  } catch {
-    return false;
-  }
-
-  const cmdline = readProcessCmdline(pid);
-  if (!cmdline) return false;
-  return looksLikeQmdMcpCommand(cmdline);
 }

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -2,9 +2,17 @@ import { isBun, openDatabase } from "../db.js";
 import type { Database, SQLiteValue } from "../db.js";
 import fastGlob from "fast-glob";
 import { spawn as nodeSpawn } from "child_process";
-import { isQmdMcpPid, mcpDaemonStateFiles } from "./mcp-pid.js";
-import { embedLockPathForDb, tryAcquireEmbedLock, EMBED_LOCK_BUSY_MESSAGE } from "./embed-lock.js";
-import { fileURLToPath } from "url";
+import {
+  createProcessRecord,
+  mcpDaemonStateFiles,
+  processRecordPid,
+  processRecordStatus,
+  readProcessRecord,
+  sameProcessRecord,
+  serializeProcessRecord,
+} from "./mcp-pid.js";
+import { embedLockBusyMessage, embedLockPathForDb, tryAcquireEmbedLock } from "./embed-lock.js";
+import { fileURLToPath, pathToFileURL } from "url";
 import { basename, dirname, join as pathJoin, relative as relativePath, resolve as pathResolve } from "path";
 import { parseArgs } from "util";
 import { readFileSync, readdirSync, realpathSync, statSync, existsSync, unlinkSync, writeFileSync, openSync, closeSync, mkdirSync, lstatSync, rmSync, symlinkSync, readlinkSync, copyFileSync } from "fs";
@@ -199,6 +207,22 @@ function closeDb(): void {
 
 function getDbPath(): string {
   return store?.dbPath ?? storeDbPathOverride ?? getDefaultDbPath();
+}
+
+function reclaimStableInvalidProcessState(path: string, graceMs = 30_000): boolean {
+  try {
+    const before = statSync(path);
+    if (Date.now() - before.mtimeMs < graceMs) return false;
+    const record = readProcessRecord(path);
+    const after = statSync(path);
+    if (record.kind !== "invalid" || before.mtimeMs !== after.mtimeMs || before.size !== after.size) {
+      return false;
+    }
+    unlinkSync(path);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function getActiveIndexName(): string {
@@ -544,11 +568,18 @@ async function showStatus(): Promise<void> {
   // MCP daemon status (check PID file liveness; scoped per --index)
   const { pidPath: mcpPidPath } = mcpDaemonPaths();
   if (existsSync(mcpPidPath)) {
-    const mcpPid = parseInt(readFileSync(mcpPidPath, "utf-8").trim());
-    if (isQmdMcpPid(mcpPid)) {
-      console.log(`MCP:   ${c.green}running${c.reset} (PID ${mcpPid})`);
+    const record = readProcessRecord(mcpPidPath);
+    const status = processRecordStatus(record, "mcp-http");
+    const recordedPid = processRecordPid(record);
+    if (status === "live") {
+      console.log(`MCP:   ${c.green}running${c.reset} (PID ${recordedPid})`);
+    } else if (status === "unknown") {
+      const pidDetail = recordedPid === null ? "" : ` (PID ${recordedPid})`;
+      console.log(`MCP:   ${c.yellow}identity unavailable${c.reset}${pidDetail}; state: ${mcpPidPath}`);
     } else {
-      try { unlinkSync(mcpPidPath); } catch { /* ignore */ }
+      try {
+        if (sameProcessRecord(record, readProcessRecord(mcpPidPath))) unlinkSync(mcpPidPath);
+      } catch { /* ignore */ }
       // Stale / recycled PID file cleaned up silently
     }
   }
@@ -2168,7 +2199,7 @@ async function vectorIndex(
   // Exclusive process lock — concurrent embeds race on vectors_vec (#825)
   const embedLock = tryAcquireEmbedLock(embedLockPathForDb(getDbPath()));
   if (!embedLock) {
-    console.log(EMBED_LOCK_BUSY_MESSAGE);
+    console.log(embedLockBusyMessage(embedLockPathForDb(getDbPath())));
     closeDb();
     return;
   }
@@ -4744,19 +4775,68 @@ if (isMain) {
           console.log("Not running (no PID file).");
           process.exit(0);
         }
-        const pid = parseInt(readFileSync(pidPath, "utf-8").trim());
-        if (!isQmdMcpPid(pid)) {
-          try { unlinkSync(pidPath); } catch { /* ignore */ }
+        const record = readProcessRecord(pidPath);
+        if (record.kind === "invalid" && reclaimStableInvalidProcessState(pidPath)) {
+          console.log("Cleaned up stale invalid PID file (server was not running).");
+          process.exit(0);
+        }
+        const recordStatus = processRecordStatus(record, "mcp-http");
+        const recordedPid = processRecordPid(record);
+        if (recordStatus === "dead") {
+          try {
+            if (sameProcessRecord(record, readProcessRecord(pidPath))) unlinkSync(pidPath);
+          } catch { /* ignore */ }
           console.log("Cleaned up stale PID file (server was not running).");
           process.exit(0);
         }
-        try {
-          process.kill(pid, "SIGTERM");
-          unlinkSync(pidPath);
-          console.log(`Stopped QMD MCP server (PID ${pid}).`);
-        } catch {
-          try { unlinkSync(pidPath); } catch { /* ignore */ }
+        if (recordStatus === "unknown") {
+          const pidDetail = recordedPid === null ? "" : ` for PID ${recordedPid}`;
+          console.error(`Cannot verify QMD MCP process identity${pidDetail} from ${pidPath}; leaving it untouched.`);
+          console.error("After independently confirming that process is not QMD, remove the state file manually.");
+          process.exit(1);
+        }
+        // Recheck immediately before signalling to narrow the PID-reuse window.
+        const recheckRecord = readProcessRecord(pidPath);
+        if (!sameProcessRecord(record, recheckRecord)) {
+          console.error(`QMD MCP state changed while stopping PID ${recordedPid}; leaving it untouched.`);
+          process.exit(1);
+        }
+        const recheckStatus = processRecordStatus(recheckRecord, "mcp-http");
+        if (recheckStatus === "unknown") {
+          console.error(`QMD MCP process identity for PID ${recordedPid} became unavailable; leaving ${pidPath} untouched.`);
+          process.exit(1);
+        }
+        if (recheckStatus === "dead") {
+          try {
+            if (sameProcessRecord(recheckRecord, readProcessRecord(pidPath))) unlinkSync(pidPath);
+          } catch { /* ignore */ }
           console.log("Cleaned up stale PID file (server was not running).");
+          process.exit(0);
+        }
+        const targetPid = processRecordPid(recheckRecord);
+        if (targetPid === null) {
+          console.error(`QMD MCP state in ${pidPath} has no valid PID; leaving it untouched.`);
+          process.exit(1);
+        }
+        try {
+          process.kill(targetPid, "SIGTERM");
+          const finalRecord = readProcessRecord(pidPath);
+          if (sameProcessRecord(recheckRecord, finalRecord)) unlinkSync(pidPath);
+          console.log(`Stopped QMD MCP server (PID ${targetPid}).`);
+        } catch (error: unknown) {
+          const code = typeof error === "object" && error !== null && "code" in error
+            ? (error as NodeJS.ErrnoException).code
+            : undefined;
+          if (code === "ESRCH") {
+            const finalRecord = readProcessRecord(pidPath);
+            if (sameProcessRecord(recheckRecord, finalRecord)) {
+              try { unlinkSync(pidPath); } catch { /* ignore */ }
+            }
+            console.log("Cleaned up stale PID file (server was not running).");
+            process.exit(0);
+          }
+          console.error(`Failed to stop QMD MCP server (PID ${targetPid}); leaving ${pidPath} intact.`);
+          process.exit(1);
         }
         process.exit(0);
       }
@@ -4771,13 +4851,31 @@ if (isMain) {
         if (cli.values.daemon) {
           // Guard: check if already running (identity-checked — recycled PIDs are stale)
           if (existsSync(pidPath)) {
-            const existingPid = parseInt(readFileSync(pidPath, "utf-8").trim());
-            if (isQmdMcpPid(existingPid)) {
-              console.error(`Already running (PID ${existingPid}). Run 'qmd mcp stop' first.`);
-              process.exit(1);
+            const existing = readProcessRecord(pidPath);
+            if (existing.kind === "invalid" && reclaimStableInvalidProcessState(pidPath)) {
+              // Continue with a clean state file after a stable crash remnant.
+            } else {
+              const existingStatus = processRecordStatus(existing, "mcp-http");
+              const existingPid = processRecordPid(existing);
+              if (existingStatus === "live") {
+                console.error(`Already running (PID ${existingPid}). Run 'qmd mcp stop' first.`);
+                process.exit(1);
+              }
+              if (existingStatus === "unknown") {
+                const pidDetail = existingPid === null ? "" : ` for PID ${existingPid}`;
+                console.error(`Cannot verify existing QMD MCP process identity${pidDetail} from ${pidPath}; refusing to replace it.`);
+                console.error("After independently confirming that process is not QMD, remove the state file manually.");
+                process.exit(1);
+              }
+              // Stale or recycled PID file — remove and continue
+              try {
+                if (sameProcessRecord(existing, readProcessRecord(pidPath))) unlinkSync(pidPath);
+              } catch { /* ignore */ }
+              if (existsSync(pidPath)) {
+                console.error(`QMD MCP state changed while starting; refusing to replace ${pidPath}.`);
+                process.exit(1);
+              }
             }
-            // Stale or recycled PID file — remove and continue
-            try { unlinkSync(pidPath); } catch { /* ignore */ }
           }
 
           mkdirSync(cacheDir, { recursive: true });
@@ -4786,23 +4884,59 @@ if (isMain) {
           const indexArgs = cli.values.index ? ["--index", String(cli.values.index)] : [];
           const hostArgs = host ? ["--host", host] : [];
           const spawnArgs = selfPath.endsWith(".ts")
-            ? ["--import", pathJoin(dirname(selfPath), "..", "..", "node_modules", "tsx", "dist", "esm", "index.mjs"), selfPath, ...indexArgs, "mcp", "--http", "--port", String(port), ...hostArgs]
+            ? isBun
+              ? [selfPath, ...indexArgs, "mcp", "--http", "--port", String(port), ...hostArgs]
+              : ["--import", pathToFileURL(pathJoin(dirname(selfPath), "..", "..", "node_modules", "tsx", "dist", "esm", "index.mjs")).href, selfPath, ...indexArgs, "mcp", "--http", "--port", String(port), ...hostArgs]
             : [selfPath, ...indexArgs, "mcp", "--http", "--port", String(port), ...hostArgs];
           const child = nodeSpawn(process.execPath, spawnArgs, {
             stdio: ["ignore", logFd, logFd],
             detached: true,
+            windowsHide: true,
             env: {
               ...process.env,
               // Explicit resolved DB path so the child does not depend on
               // re-parsing --index (and cannot inherit a stale INDEX_PATH).
               INDEX_PATH: getDbPath(),
+              QMD_MCP_DAEMON_STATE_PATH: pidPath,
             },
           });
+          if (!child.pid) {
+            closeSync(logFd);
+            console.error("QMD MCP daemon did not report a process ID.");
+            process.exit(1);
+          }
           child.unref();
           closeSync(logFd); // parent's copy; child inherited the fd
 
-          writeFileSync(pidPath, String(child.pid));
+          // The child writes its own start token. Wait for that handshake so
+          // the parent never publishes a PID it could not identify exactly.
+          const startupDeadline = Date.now() + 30_000;
+          let startedRecord = readProcessRecord(pidPath);
+          while (processRecordPid(startedRecord) !== child.pid
+            && child.exitCode === null
+            && child.signalCode === null
+            && Date.now() < startupDeadline) {
+            await new Promise(resolve => setTimeout(resolve, 50));
+            startedRecord = readProcessRecord(pidPath);
+          }
+          if (processRecordPid(startedRecord) !== child.pid
+            || (startedRecord.kind === "identity" && startedRecord.identity.role !== "mcp-http")) {
+            if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
+            let detail = "";
+            try { detail = `: ${readFileSync(logPath, "utf-8").trim().slice(-1000)}`; } catch { /* ignore */ }
+            const reason = child.exitCode !== null
+              ? `exited before publishing process identity (code ${child.exitCode})`
+              : child.signalCode !== null
+                ? `exited before publishing process identity (signal ${child.signalCode})`
+                : "did not publish process identity within 30 seconds";
+            console.error(`QMD MCP daemon ${reason}${detail}`);
+            process.exit(1);
+          }
+
           console.log(`Started on http://${host ?? "localhost"}:${port}/mcp (PID ${child.pid})`);
+          if (startedRecord.kind === "legacy") {
+            console.log("Warning: process start identity was unavailable; lifecycle state is fail-closed.");
+          }
           console.log(`Logs: ${logPath}`);
           process.exit(0);
         }
@@ -4811,25 +4945,38 @@ if (isMain) {
         // async cleanup handlers in startMcpHttpServer actually run.
         process.removeAllListeners("SIGTERM");
         process.removeAllListeners("SIGINT");
-        // Best-effort: if this process owns the daemon pidfile, unlink on exit
+        const daemonStatePath = process.env.QMD_MCP_DAEMON_STATE_PATH;
+        let publishedRecord: ReturnType<typeof createProcessRecord> | null = null;
+        // Best-effort: if this process owns the daemon state file, unlink on exit
         // (covers SIGTERM/SIGINT via startMcpHttpServer's process.exit).
         const unlinkOwnPidfile = () => {
           try {
-            if (!existsSync(pidPath)) return;
-            const written = parseInt(readFileSync(pidPath, "utf-8").trim());
-            if (written === process.pid) unlinkSync(pidPath);
+            if (!daemonStatePath || !publishedRecord || !existsSync(daemonStatePath)) return;
+            if (sameProcessRecord(publishedRecord, readProcessRecord(daemonStatePath))) unlinkSync(daemonStatePath);
           } catch { /* ignore */ }
         };
         process.on("exit", unlinkOwnPidfile);
         const { startMcpHttpServer } = await import("../mcp/server.js");
         try {
-          await startMcpHttpServer(port, { dbPath: getDbPath(), host });
+          const handle = await startMcpHttpServer(port, { dbPath: getDbPath(), host });
+          if (daemonStatePath) {
+            try {
+              const record = createProcessRecord("mcp-http", { port: handle.port });
+              writeFileSync(daemonStatePath, serializeProcessRecord(record), { flag: "wx", flush: true });
+              publishedRecord = record;
+            } catch (error) {
+              await handle.stop();
+              throw error;
+            }
+          }
         } catch (e: unknown) {
           if (typeof e === "object" && e !== null && "code" in e && e.code === "EADDRINUSE") {
             console.error(`Port ${port} already in use. Try a different port with --port.`);
             process.exit(1);
           }
-          throw e;
+          const message = e instanceof Error ? e.message : String(e);
+          console.error(`Failed to start QMD MCP server: ${message}`);
+          process.exit(1);
         }
       } else {
         // Default: stdio transport

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import { chmod, copyFile, mkdtemp, rm, writeFile, mkdir } from "fs/promises";
-import { existsSync, lstatSync, readFileSync, symlinkSync, writeFileSync, unlinkSync } from "fs";
+import { existsSync, lstatSync, readFileSync, symlinkSync, writeFileSync, unlinkSync, utimesSync } from "fs";
 import { tmpdir } from "os";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
@@ -17,6 +17,7 @@ import { buildEditorUri, termLink, resolveEmbedModelForCli } from "../src/cli/qm
 import { openDatabase } from "../src/db.ts";
 import { DEFAULT_EMBED_MODEL_URI, DEFAULT_GENERATE_MODEL_URI, DEFAULT_RERANK_MODEL_URI } from "../src/llm.ts";
 import { setConfigSource } from "../src/collections.ts";
+import { readProcessIdentity } from "../src/cli/mcp-pid.ts";
 
 // Test fixtures directory and database path
 let testDir: string;
@@ -59,6 +60,7 @@ async function runQmd(
       ...options.env,
     },
     stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
   });
 
   const stdoutPromise = new Promise<string>((resolve, reject) => {
@@ -2525,6 +2527,12 @@ describe("mcp http daemon", () => {
     return join(daemonCacheDir, "qmd", "mcp.pid");
   }
 
+  function readDaemonPid(path = pidPath()): number {
+    const identity = readProcessIdentity(path);
+    if (!identity) throw new Error(`Invalid daemon identity file: ${path}`);
+    return identity.pid;
+  }
+
   /** Run qmd with test-isolated env (cache, db, config) */
   async function runDaemonQmd(
     args: string[],
@@ -2552,6 +2560,7 @@ describe("mcp http daemon", () => {
         ...options.env,
       },
       stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
     });
     if (proc.pid) spawnedPids.push(proc.pid);
     return proc;
@@ -2595,7 +2604,7 @@ describe("mcp http daemon", () => {
     try {
       const pf = pidPath();
       if (existsSync(pf)) {
-        const pid = parseInt(readFileSync(pf, "utf-8").trim());
+        const pid = readDaemonPid(pf);
         try { process.kill(pid, "SIGTERM"); } catch {}
         unlinkSync(pf);
       }
@@ -2744,7 +2753,7 @@ describe("mcp http daemon", () => {
     expect(existsSync(namedPidPath)).toBe(true);
     expect(existsSync(defaultPidPath)).toBe(false);
 
-    const pid = parseInt(readFileSync(namedPidPath, "utf-8").trim());
+    const pid = readDaemonPid(namedPidPath);
     spawnedPids.push(pid);
 
     try {
@@ -2792,7 +2801,7 @@ describe("mcp http daemon", () => {
     ]);
     expect(defaultCode).toBe(0);
     expect(existsSync(pidPath())).toBe(true);
-    const defaultPid = parseInt(readFileSync(pidPath(), "utf-8").trim());
+    const defaultPid = readDaemonPid();
     spawnedPids.push(defaultPid);
 
     const { stdout, stderr, exitCode: namedCode } = await runDaemonQmd([
@@ -2805,7 +2814,7 @@ describe("mcp http daemon", () => {
       expect(stdout).toContain(`http://localhost:${portNamed}/mcp`);
       expect(existsSync(namedPidPath)).toBe(true);
 
-      const namedPid = parseInt(readFileSync(namedPidPath, "utf-8").trim());
+      const namedPid = readDaemonPid(namedPidPath);
       spawnedPids.push(namedPid);
       expect(namedPid).not.toBe(defaultPid);
 
@@ -2815,7 +2824,7 @@ describe("mcp http daemon", () => {
       try { process.kill(defaultPid, "SIGTERM"); } catch {}
       try {
         if (existsSync(namedPidPath)) {
-          const namedPid = parseInt(readFileSync(namedPidPath, "utf-8").trim());
+          const namedPid = readDaemonPid(namedPidPath);
           try { process.kill(namedPid, "SIGTERM"); } catch {}
         }
       } catch {}
@@ -2831,16 +2840,16 @@ describe("mcp http daemon", () => {
 
   test("--daemon writes PID file and starts server", async () => {
     const port = randomPort();
-    const { stdout, exitCode } = await runDaemonQmd([
+    const { stdout, stderr, exitCode } = await runDaemonQmd([
       "mcp", "--http", "--daemon", "--port", String(port),
     ]);
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
     expect(stdout).toContain(`http://localhost:${port}/mcp`);
 
     // PID file should exist
     expect(existsSync(pidPath())).toBe(true);
 
-    const pid = parseInt(readFileSync(pidPath(), "utf-8").trim());
+    const pid = readDaemonPid();
     spawnedPids.push(pid);
 
     // Server should be reachable
@@ -2856,12 +2865,12 @@ describe("mcp http daemon", () => {
   test("stop kills daemon and removes PID file", async () => {
     const port = randomPort();
     // Start daemon
-    const { exitCode: startCode } = await runDaemonQmd([
+    const { stderr: startErr, exitCode: startCode } = await runDaemonQmd([
       "mcp", "--http", "--daemon", "--port", String(port),
     ]);
-    expect(startCode).toBe(0);
+    expect(startCode, startErr).toBe(0);
 
-    const pid = parseInt(readFileSync(pidPath(), "utf-8").trim());
+    const pid = readDaemonPid();
     spawnedPids.push(pid);
 
     await waitForServer(port);
@@ -2894,12 +2903,12 @@ describe("mcp http daemon", () => {
   test("--daemon rejects if already running", async () => {
     const port = randomPort();
     // Start first daemon
-    const { exitCode: firstCode } = await runDaemonQmd([
+    const { stderr: firstErr, exitCode: firstCode } = await runDaemonQmd([
       "mcp", "--http", "--daemon", "--port", String(port),
     ]);
-    expect(firstCode).toBe(0);
+    expect(firstCode, firstErr).toBe(0);
 
-    const pid = parseInt(readFileSync(pidPath(), "utf-8").trim());
+    const pid = readDaemonPid();
     spawnedPids.push(pid);
 
     await waitForServer(port);
@@ -2917,6 +2926,29 @@ describe("mcp http daemon", () => {
     try { unlinkSync(pidPath()); } catch {}
   });
 
+  test("--daemon does not publish state when the HTTP port cannot bind", async () => {
+    const port = randomPort();
+    // Keep both processes on the same address family. Bun and Node can resolve
+    // `localhost` differently across POSIX hosts, which otherwise permits one
+    // listener on ::1 and the other on 127.0.0.1 at the same numeric port.
+    const bindHost = "127.0.0.1";
+    const blocker = spawnHttpServer(port, { args: ["--host", bindHost] });
+    try {
+      expect(await waitForServer(port)).toBe(true);
+
+      const { stderr, exitCode } = await runDaemonQmd([
+        "mcp", "--http", "--daemon", "--port", String(port), "--host", bindHost,
+      ]);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain(`Port ${port} already in use`);
+      expect(existsSync(pidPath())).toBe(false);
+    } finally {
+      const closed = new Promise(resolve => blocker.once("close", resolve));
+      blocker.kill("SIGTERM");
+      await closed;
+    }
+  });
+
   test("--daemon cleans stale PID file and starts fresh", async () => {
     // Write a stale PID file
     writeFileSync(pidPath(), "999999999");
@@ -2928,7 +2960,7 @@ describe("mcp http daemon", () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain(`http://localhost:${port}/mcp`);
 
-    const pid = parseInt(readFileSync(pidPath(), "utf-8").trim());
+    const pid = readDaemonPid();
     spawnedPids.push(pid);
     expect(pid).not.toBe(999999999);
 
@@ -2940,18 +2972,34 @@ describe("mcp http daemon", () => {
     try { unlinkSync(pidPath()); } catch {}
   });
 
-  test("stop does not SIGTERM a live non-qmd PID from a recycled pidfile (#806)", async () => {
-    // Stand-in for a recycled PID owner (must not be killed)
-    const decoy = spawn("sleep", ["1000000"], { stdio: "ignore" });
+  test("stop reclaims an unchanged old invalid PID file", async () => {
+    writeFileSync(pidPath(), "");
+    const old = new Date(Date.now() - 31_000);
+    utimesSync(pidPath(), old, old);
+
+    const { stdout, exitCode } = await runDaemonQmd(["mcp", "stop"]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Cleaned up stale invalid PID file");
+    expect(existsSync(pidPath())).toBe(false);
+  });
+
+  test("stop leaves a live legacy pidfile untouched (#806)", async () => {
+    // A pre-upgrade numeric pidfile cannot safely identify the process owner.
+    const decoy = spawn(process.execPath, ["-e", "setTimeout(() => {}, 1_000_000)"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
     expect(decoy.pid).toBeTruthy();
     spawnedPids.push(decoy.pid!);
     writeFileSync(pidPath(), String(decoy.pid));
 
     try {
-      const { stdout, exitCode } = await runDaemonQmd(["mcp", "stop"]);
-      expect(exitCode).toBe(0);
-      expect(stdout).toContain("stale");
-      expect(existsSync(pidPath())).toBe(false);
+      const { stderr, exitCode } = await runDaemonQmd(["mcp", "stop"]);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("Cannot verify");
+      expect(stderr).toContain(pidPath().replace(/\\/g, "/"));
+      expect(existsSync(pidPath())).toBe(true);
 
       // Decoy must still be alive
       expect(() => process.kill(decoy.pid!, 0)).not.toThrow();
@@ -2961,33 +3009,27 @@ describe("mcp http daemon", () => {
     }
   });
 
-  test("--daemon treats live non-qmd pidfile PID as stale and starts (#806)", async () => {
-    const decoy = spawn("sleep", ["1000000"], { stdio: "ignore" });
+  test("--daemon refuses to replace a live legacy pidfile (#806)", async () => {
+    const decoy = spawn(process.execPath, ["-e", "setTimeout(() => {}, 1_000_000)"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
     expect(decoy.pid).toBeTruthy();
     spawnedPids.push(decoy.pid!);
     writeFileSync(pidPath(), String(decoy.pid));
 
     const port = randomPort();
     try {
-      const { stdout, stderr, exitCode } = await runDaemonQmd([
+      const { stderr, exitCode } = await runDaemonQmd([
         "mcp", "--http", "--daemon", "--port", String(port),
       ]);
-      expect(exitCode).toBe(0);
-      expect(stderr).not.toContain("Already running");
-      expect(stdout).toContain(`http://localhost:${port}/mcp`);
-
-      const pid = parseInt(readFileSync(pidPath(), "utf-8").trim());
-      spawnedPids.push(pid);
-      expect(pid).not.toBe(decoy.pid);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("Cannot verify");
+      expect(stderr).toContain(pidPath().replace(/\\/g, "/"));
+      expect(readFileSync(pidPath(), "utf-8").trim()).toBe(String(decoy.pid));
 
       // Decoy must still be alive
       expect(() => process.kill(decoy.pid!, 0)).not.toThrow();
-
-      const ready = await waitForServer(port);
-      expect(ready).toBe(true);
-      process.kill(pid, "SIGTERM");
-      await sleep(500);
-      try { unlinkSync(pidPath()); } catch {}
     } finally {
       decoy.kill("SIGTERM");
       await new Promise<void>((resolve) => decoy.once("close", () => resolve()));

--- a/test/embed-lock.test.ts
+++ b/test/embed-lock.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, test, expect } from "vitest";
 import { mkdtemp, rm, readFile } from "node:fs/promises";
-import { existsSync, writeFileSync, unlinkSync } from "node:fs";
+import { existsSync, writeFileSync, unlinkSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -13,7 +13,9 @@ import {
   tryAcquireEmbedLock,
   isLiveEmbedLockHolder,
   EMBED_LOCK_BUSY_MESSAGE,
+  embedLockBusyMessage,
 } from "../src/cli/embed-lock.ts";
+import { createProcessIdentity, parseProcessIdentity, parseProcessRecord } from "../src/cli/mcp-pid.ts";
 
 const thisDir = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(thisDir, "..");
@@ -22,20 +24,28 @@ const isBunRuntime = typeof (globalThis as { Bun?: unknown }).Bun !== "undefined
 
 describe("embedLockPathForDb", () => {
   test("places .qmd-embed.lock next to the index database", () => {
-    expect(embedLockPathForDb("/tmp/qmd-cache/index.sqlite")).toBe("/tmp/qmd-cache/.qmd-embed.lock");
-    expect(embedLockPathForDb("/var/lib/qmd/custom.sqlite")).toBe("/var/lib/qmd/.qmd-embed.lock");
+    const firstDb = join(tmpdir(), "qmd-cache", "index.sqlite");
+    const secondDb = join(tmpdir(), "qmd-other", "custom.sqlite");
+    expect(embedLockPathForDb(firstDb)).toBe(join(tmpdir(), "qmd-cache", ".qmd-embed.lock"));
+    expect(embedLockPathForDb(secondDb)).toBe(join(tmpdir(), "qmd-other", ".qmd-embed.lock"));
   });
 });
 
 describe("isLiveEmbedLockHolder", () => {
   test("treats the current process as a live holder", () => {
-    expect(isLiveEmbedLockHolder(process.pid)).toBe(true);
+    expect(isLiveEmbedLockHolder({ kind: "identity", identity: createProcessIdentity("embed") })).toBe(true);
+    expect(isLiveEmbedLockHolder(parseProcessRecord(String(process.pid)))).toBe(true);
   });
 
-  test("rejects invalid and dead PIDs", () => {
-    expect(isLiveEmbedLockHolder(0)).toBe(false);
-    expect(isLiveEmbedLockHolder(-1)).toBe(false);
-    expect(isLiveEmbedLockHolder(999999999)).toBe(false);
+  test("fails closed for malformed state and rejects recycled process identity", () => {
+    expect(isLiveEmbedLockHolder({ kind: "invalid" })).toBe(true);
+    expect(isLiveEmbedLockHolder({
+      kind: "identity",
+      identity: {
+        ...createProcessIdentity("embed"),
+        startToken: "recycled-process-token",
+      },
+    })).toBe(false);
   });
 });
 
@@ -47,7 +57,7 @@ describe("tryAcquireEmbedLock", () => {
       const first = tryAcquireEmbedLock(lockPath);
       expect(first).not.toBeNull();
       expect(existsSync(lockPath)).toBe(true);
-      expect((await readFile(lockPath, "utf-8")).trim()).toBe(String(process.pid));
+      expect(parseProcessIdentity(await readFile(lockPath, "utf-8"))?.pid).toBe(process.pid);
 
       // Same process still holds the lock — second caller must skip.
       expect(tryAcquireEmbedLock(lockPath)).toBeNull();
@@ -70,13 +80,15 @@ describe("tryAcquireEmbedLock", () => {
     const holderTs = join(thisDir, "_helpers", "embed-lock-holder.ts");
     const holdMs = 1000;
 
-    // Include a bare `qmd` argv token so isQmdMcpPid(child) is true.
     const args = isBunRuntime
       ? [holderTs, lockPath, String(holdMs), "qmd", "embed"]
       : [tsxCli, holderTs, lockPath, String(holdMs), "qmd", "embed"];
 
     try {
-      const child = spawn(process.execPath, args, { stdio: ["ignore", "pipe", "pipe"] });
+      const child = spawn(process.execPath, args, {
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      });
       let stdout = "";
       let stderr = "";
       child.stdout.on("data", (d: Buffer) => { stdout += d.toString(); });
@@ -119,9 +131,25 @@ describe("tryAcquireEmbedLock", () => {
       writeFileSync(lockPath, "999999999\n");
       const handle = tryAcquireEmbedLock(lockPath);
       expect(handle).not.toBeNull();
-      expect((await readFile(lockPath, "utf-8")).trim()).toBe(String(process.pid));
+      expect(parseProcessIdentity(await readFile(lockPath, "utf-8"))?.pid).toBe(process.pid);
       handle!.release();
       expect(existsSync(lockPath)).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("fails closed for a fresh corrupt lock, then reclaims it after the grace period", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "qmd-embed-lock-invalid-"));
+    const lockPath = join(dir, ".qmd-embed.lock");
+    try {
+      writeFileSync(lockPath, "");
+      expect(tryAcquireEmbedLock(lockPath)).toBeNull();
+      const old = new Date(Date.now() - 31_000);
+      utimesSync(lockPath, old, old);
+      const handle = tryAcquireEmbedLock(lockPath);
+      expect(handle).not.toBeNull();
+      handle!.release();
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -152,5 +180,12 @@ describe("tryAcquireEmbedLock", () => {
 describe("EMBED_LOCK_BUSY_MESSAGE", () => {
   test("matches the issue-requested skip message", () => {
     expect(EMBED_LOCK_BUSY_MESSAGE).toBe("Another embed process is already running. Skipping.");
+  });
+
+  test("includes the lock path and corrupt-state recovery guidance", () => {
+    const path = join(tmpdir(), ".qmd-embed.lock");
+    const message = embedLockBusyMessage(path);
+    expect(message).toContain(path);
+    expect(message).toContain("wait 30 seconds and retry");
   });
 });

--- a/test/mcp-pid.test.ts
+++ b/test/mcp-pid.test.ts
@@ -3,32 +3,22 @@
  */
 
 import { describe, test, expect } from "vitest";
-import { looksLikeQmdMcpCommand, isQmdMcpPid, mcpDaemonStateFiles } from "../src/cli/mcp-pid.ts";
-
-describe("looksLikeQmdMcpCommand", () => {
-  test("matches bare qmd and common CLI script paths", () => {
-    expect(looksLikeQmdMcpCommand("qmd mcp --http --port 8181")).toBe(true);
-    expect(looksLikeQmdMcpCommand("/usr/local/bin/qmd mcp --http")).toBe(true);
-    expect(looksLikeQmdMcpCommand("node /home/me/qmd/src/cli/qmd.ts mcp --http")).toBe(true);
-    expect(looksLikeQmdMcpCommand("node /home/me/qmd/dist/cli/qmd.js mcp --http")).toBe(true);
-    expect(looksLikeQmdMcpCommand("tsx src/cli/qmd.ts mcp --http --daemon")).toBe(true);
-  });
-
-  test("rejects empty / whitespace and unrelated processes", () => {
-    expect(looksLikeQmdMcpCommand("")).toBe(false);
-    expect(looksLikeQmdMcpCommand("   ")).toBe(false);
-    expect(looksLikeQmdMcpCommand(
-      "/System/Library/PrivateFrameworks/GenerativeExperiencesRuntime.framework/Versions/A/generativeexperiencesd",
-    )).toBe(false);
-    expect(looksLikeQmdMcpCommand("sleep 1000000")).toBe(false);
-    expect(looksLikeQmdMcpCommand("node server.js")).toBe(false);
-  });
-
-  test("does not match qmd as a substring of another token", () => {
-    expect(looksLikeQmdMcpCommand("myqmdtool serve")).toBe(false);
-    expect(looksLikeQmdMcpCommand("qmdfoo")).toBe(false);
-  });
-});
+import {
+  createProcessIdentity,
+  createProcessRecord,
+  isProcessIdentityLive,
+  mcpDaemonStateFiles,
+  looksLikeQmdRoleCommand,
+  parseProcessIdentity,
+  parseProcessRecord,
+  processIdentityStatus,
+  processRecordStatus,
+  sameProcessIdentity,
+  sameProcessRecord,
+  serializeProcessIdentity,
+  type ProcessIdentityProbe,
+  type QmdProcessIdentity,
+} from "../src/cli/mcp-pid.ts";
 
 describe("mcpDaemonStateFiles", () => {
   test("default index keeps mcp.pid / mcp.log", () => {
@@ -45,25 +35,77 @@ describe("mcpDaemonStateFiles", () => {
   });
 });
 
-describe("isQmdMcpPid", () => {
-  test("returns false for invalid / dead PIDs", () => {
-    expect(isQmdMcpPid(0)).toBe(false);
-    expect(isQmdMcpPid(-1)).toBe(false);
-    expect(isQmdMcpPid(1.5)).toBe(false);
-    expect(isQmdMcpPid(999999999)).toBe(false);
+describe("structured process identity", () => {
+  const identity: QmdProcessIdentity = {
+    format: "qmd-process/v1",
+    pid: 4242,
+    role: "mcp-http",
+    startToken: "win32:123456789",
+    port: 8181,
+  };
+
+  test("round-trips valid identity and rejects legacy or malformed state", () => {
+    expect(parseProcessIdentity(serializeProcessIdentity(identity))).toEqual(identity);
+    expect(parseProcessIdentity("4242\n")).toBeNull();
+    expect(parseProcessIdentity('{"format":"qmd-process/v1","pid":4242,"role":"embed","startToken":""}')).toBeNull();
+    expect(parseProcessRecord("4242\n")).toEqual({ kind: "legacy", pid: 4242 });
+    expect(parseProcessRecord("not-a-pid")).toEqual({ kind: "invalid" });
   });
 
-  test("returns true for the current process when it looks like qmd", () => {
-    // Vitest/tsx argv typically includes the test file, not qmd — so this
-    // process itself usually fails the cmdline check. Assert the live+match
-    // path using our own PID only when argv happens to include qmd; otherwise
-    // just confirm a clearly-alive non-qmd PID (self) returns false.
-    const self = process.pid;
-    const argvJoined = process.argv.join(" ");
-    if (looksLikeQmdMcpCommand(argvJoined)) {
-      expect(isQmdMcpPid(self)).toBe(true);
-    } else {
-      expect(isQmdMcpPid(self)).toBe(false);
-    }
+  test("requires liveness, exact start token, and expected role", () => {
+    const liveProbe: ProcessIdentityProbe = {
+      isAlive: pid => pid === identity.pid,
+      startToken: pid => pid === identity.pid ? identity.startToken : null,
+    };
+    expect(isProcessIdentityLive(identity, "mcp-http", liveProbe)).toBe(true);
+    expect(isProcessIdentityLive(identity, "embed", liveProbe)).toBe(false);
+    expect(isProcessIdentityLive({ ...identity, startToken: "win32:recycled" }, "mcp-http", liveProbe)).toBe(false);
+    expect(isProcessIdentityLive(identity, "mcp-http", { ...liveProbe, isAlive: () => false })).toBe(false);
+    expect(processIdentityStatus(identity, "mcp-http", { ...liveProbe, startToken: () => null })).toBe("unknown");
+    expect(processRecordStatus({ kind: "legacy", pid: identity.pid }, "mcp-http", liveProbe)).toBe("unknown");
+    expect(processRecordStatus({ kind: "legacy", pid: identity.pid }, "mcp-http", {
+      ...liveProbe,
+      cmdline: () => "node /opt/qmd/dist/cli/qmd.js mcp --http --daemon",
+    })).toBe("live");
+    expect(processRecordStatus({ kind: "legacy", pid: identity.pid }, "mcp-http", {
+      ...liveProbe,
+      cmdline: () => "node unrelated.js",
+    })).toBe("unknown");
+    expect(processRecordStatus({ kind: "legacy", pid: identity.pid }, "mcp-http", {
+      ...liveProbe,
+      isAlive: () => false,
+    })).toBe("dead");
+    expect(processRecordStatus({ kind: "invalid" }, "mcp-http", liveProbe)).toBe("unknown");
+    expect(sameProcessIdentity(identity, { ...identity })).toBe(true);
+    expect(sameProcessIdentity(identity, { ...identity, pid: identity.pid + 1 })).toBe(false);
+    expect(sameProcessIdentity(identity, { ...identity, startToken: "win32:replacement" })).toBe(false);
+    expect(sameProcessRecord({ kind: "legacy", pid: 42 }, { kind: "legacy", pid: 42 })).toBe(true);
+    expect(sameProcessRecord({ kind: "invalid" }, { kind: "invalid" })).toBe(false);
+  });
+
+  test("recognizes role-specific legacy qmd commands", () => {
+    expect(looksLikeQmdRoleCommand("node /opt/qmd/qmd.js embed", "embed")).toBe(true);
+    expect(looksLikeQmdRoleCommand("node /opt/qmd/qmd.js mcp --http --daemon", "mcp-http")).toBe(true);
+    expect(looksLikeQmdRoleCommand("node /opt/qmd/qmd.js search query", "mcp-http")).toBe(false);
+  });
+
+  test("creates a verifiable identity for the current process on this platform", () => {
+    const current = createProcessIdentity("embed");
+    expect(current.pid).toBe(process.pid);
+    expect(current.role).toBe("embed");
+    expect(current.startToken.length).toBeGreaterThan(0);
+    expect(isProcessIdentityLive(current, "embed")).toBe(true);
+  });
+
+  test("falls back to fail-closed legacy state when start identity is unavailable", () => {
+    const record = createProcessRecord("embed", { pid: 1234 }, () => {
+      throw new Error("identity unavailable");
+    });
+
+    expect(record).toEqual({ kind: "legacy", pid: 1234 });
+    expect(processRecordStatus(record, "embed", {
+      isAlive: () => true,
+      startToken: () => null,
+    })).toBe("unknown");
   });
 });


### PR DESCRIPTION
# PR: fix: harden daemon and embed-lock process identity on Windows

## Summary

- Replace bare daemon/embed PIDs with `qmd-process/v1` records containing the
  PID, role, and an OS-issued process-start token.
- Use Windows CIM process creation timestamps with hidden PowerShell execution,
  Linux `/proc/<pid>/stat` field 22, and `ps lstart` on other POSIX systems.
- Publish daemon identity only after the HTTP listener binds, observe early
  child exit, and verify the exact same identity immediately before signalling.
- Treat live pre-upgrade numeric state as unverifiable and fail closed instead
  of orphaning a daemon or stealing an active embed lock; role-specific POSIX
  command-line checks retain safe recognition where the owner can be proven.
- Pass the TSX loader as a file URL and hide spawned Windows process windows.
- Publish embed locks atomically, fail closed on fresh malformed state, and
  reclaim only an unchanged malformed lock after a 30-second grace period.

If the Windows CIM probe cannot obtain a process-start token, QMD writes a
legacy PID record and deliberately leaves it untouched while that PID remains
live. This degraded mode favors avoiding signals or lock theft against an
unrelated process; normal lifecycle management resumes after the process exits
or its ownership is independently reconciled.

## Why

The previous command-line inspection could not identify native Windows QMD
processes reliably. Bare PIDs are also unsafe after PID reuse and allowed
status/start/stop and embed-lock recovery to act on unrelated processes.

## Review-driven hardening

Two earlier adversarial Opus passes challenged upgrade compatibility, PID
reuse, protected-process probes, lock publication/recovery, runtime-specific
daemon launching, and Windows test coverage. A final Claude ultrareview then
found and verified two POSIX/signal-exit defects; both were corrected, and a
second ultrareview of the amended candidate completed with no findings. The
revision uses role-aware legacy checks, CIM creation timestamps, atomic lock
publication with a non-hardlink fallback, guarded malformed-state recovery,
and a Bun-native TypeScript child path.

## Verification

- `bun run lint`
- `bun run test:types`
- Node/Vitest and Bun 1.4.0-canary.1 process-identity and embed-lock tests:
  17 passed under each runtime
- native Windows `mcp http daemon` group: 13 passed under Node and 13 under
  Bun 1.4.0-canary.1
- `git diff --check`

## Local branch

- base: `dbfd0b4736aeaf761d1a16ca8e424f071df8feb9`
- commit: `355f4c8`
- branch: `fix/windows-process-identity`
