### PR TITLE
fix(config): sanitize Windows absolute paths in index/config names

### DIFF
--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -222,11 +222,16 @@ function mcpDaemonPaths(): { cacheDir: string; pidPath: string; logPath: string 
 
 function setIndexName(name: string | null): void {
   let normalizedName = name;
-  // Normalize relative paths to prevent malformed database paths
-  if (name && name.includes('/')) {
-    const absolutePath = pathResolve(process.cwd(), name);
-    // Replace path separators with underscores to create a valid filename
-    normalizedName = absolutePath.replace(/\//g, '_').replace(/^_/, '');
+  // Normalize relative paths to prevent malformed database paths. Windows
+  // absolute paths (C:\..., \\server\share) are already absolute -- skip
+  // pathResolve() for those and sanitize `:` and `\` alongside `/`.
+  if (name) {
+    const isWindowsAbsolute = /^[a-zA-Z]:[\\/]/.test(name) || /^\\/.test(name);
+    if (isWindowsAbsolute || /[\\/]/.test(name)) {
+      const absolutePath = isWindowsAbsolute ? name : pathResolve(process.cwd(), name);
+      // Replace path separators with underscores to create a valid filename
+      normalizedName = absolutePath.replace(/[:\\/]+/g, '_').replace(/^_+/, '');
+    }
   }
   currentIndexName = normalizedName || "index";
   storeDbPathOverride = normalizedName ? getDefaultDbPath(normalizedName) : undefined;

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -101,11 +101,16 @@ export function setConfigSource(source?: { configPath?: string; config?: Collect
  * Config file will be ~/.config/qmd/{indexName}.yml
  */
 export function setConfigIndexName(name: string): void {
-  // Resolve relative paths to absolute paths and sanitize for use as filename
-  if (name.includes('/')) {
-    const absolutePath = resolve(process.cwd(), name);
+  // Resolve relative paths to absolute paths and sanitize for use as filename.
+  // Windows absolute paths (C:\..., \\server\share) are already absolute --
+  // skip resolve() for those (POSIX path.resolve doesn't recognize a drive
+  // letter as absolute and would wrongly prefix it with cwd) and sanitize
+  // `:` and `\` alongside `/` so the derived filename is valid on Windows.
+  const isWindowsAbsolute = /^[a-zA-Z]:[\\/]/.test(name) || /^\\/.test(name);
+  if (isWindowsAbsolute || /[\\/]/.test(name)) {
+    const absolutePath = isWindowsAbsolute ? name : resolve(process.cwd(), name);
     // Replace path separators with underscores to create a valid filename
-    currentIndexName = absolutePath.replace(/\//g, '_').replace(/^_/, '');
+    currentIndexName = absolutePath.replace(/[:\\/]+/g, '_').replace(/^_+/, '');
   } else {
     currentIndexName = name;
   }

--- a/test/collections-config.test.ts
+++ b/test/collections-config.test.ts
@@ -85,6 +85,15 @@ describe("getConfigDir via getConfigPath", () => {
     expect(getConfigPath()).toBe(join("/xdg/config", "qmd", "myindex.yml"));
   });
 
+  test("sanitizes a Windows absolute index name into a safe filename", () => {
+    delete process.env.QMD_CONFIG_DIR;
+    process.env.XDG_CONFIG_HOME = "/xdg/config";
+    setConfigIndexName("C:\\Users\\axulo\\Documents\\ppttest");
+    expect(getConfigPath()).toBe(
+      join("/xdg/config", "qmd", "C_Users_axulo_Documents_ppttest.yml")
+    );
+  });
+
   test("loadConfig treats an empty YAML file as an empty config", async () => {
     const dir = await mkdtemp(join(tmpdir(), "qmd-empty-config-"));
     try {


### PR DESCRIPTION
## Impact

Windows users who point qmd at a collection or config using an absolute path (e.g. `D:\data\project`, or a UNC share) get a broken or invalid derived index/config filename -- the drive-letter colon and backslashes are written straight into the filename qmd computes for the on-disk config/DB, and Windows filenames cannot contain `:` or use `\` as anything but a path separator. This can produce a config file at an unintended nested path or fail outright depending on how the OS resolves the resulting string.

## Repro

At HEAD `dbfd0b4736aeaf761d1a16ca8e424f071df8feb9`, on Windows:

```
setConfigIndexName("D:\data\project")
```

`src/collections.ts:105` only special-cases names containing `/`; a Windows-style absolute path with no forward slash falls through to the `else` branch and is used verbatim as `currentIndexName`, so `getConfigFilePath()` (`src/collections.ts:127`) builds a path like `.../D:_data_project` is never sanitized -- it stays `D:\data\project.yml`, which contains a bare colon and backslashes. The same gap exists in `setIndexName()` in `src/cli/qmd.ts:220-228`, used when deriving the on-disk DB/index name from a CLI-supplied path.

## Fix

Detect a Windows-absolute path explicitly (`^[a-zA-Z]:[\/]` or a UNC `\server\share` prefix) in both `setConfigIndexName` (`src/collections.ts`) and `setIndexName` (`src/cli/qmd.ts`), and strip `:` and `\` alongside the existing `/` handling when deriving the sanitized filename. Added a regression test in `test/collections-config.test.ts` covering a Windows absolute path.

Found while maintaining a downstream fork.
