### PR TITLE
fix(mcp): guard REST /query,/search JSON.parse against malformed bodies

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1018,7 +1018,14 @@ export async function startMcpHttpServer(
       // REST endpoint: POST /query (alias: /search) — structured search without MCP protocol
       if ((pathname === "/query" || pathname === "/search") && nodeReq.method === "POST") {
         const rawBody = await collectBody(nodeReq);
-        const params = JSON.parse(rawBody) as Record<string, unknown>;
+        let params: Record<string, unknown>;
+        try {
+          params = JSON.parse(rawBody) as Record<string, unknown>;
+        } catch {
+          nodeRes.writeHead(400, { "Content-Type": "application/json" });
+          nodeRes.end(JSON.stringify({ error: "Invalid JSON body" }));
+          return;
+        }
 
         // Validate required fields
         if (!params.searches || !Array.isArray(params.searches)) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1018,14 +1018,20 @@ export async function startMcpHttpServer(
       // REST endpoint: POST /query (alias: /search) — structured search without MCP protocol
       if ((pathname === "/query" || pathname === "/search") && nodeReq.method === "POST") {
         const rawBody = await collectBody(nodeReq);
-        let params: Record<string, unknown>;
+        let parsedParams: unknown;
         try {
-          params = JSON.parse(rawBody) as Record<string, unknown>;
+          parsedParams = JSON.parse(rawBody);
         } catch {
           nodeRes.writeHead(400, { "Content-Type": "application/json" });
           nodeRes.end(JSON.stringify({ error: "Invalid JSON body" }));
           return;
         }
+        if (typeof parsedParams !== "object" || parsedParams === null || Array.isArray(parsedParams)) {
+          nodeRes.writeHead(400, { "Content-Type": "application/json" });
+          nodeRes.end(JSON.stringify({ error: "JSON body must be an object" }));
+          return;
+        }
+        const params = parsedParams as Record<string, unknown>;
 
         // Validate required fields
         if (!params.searches || !Array.isArray(params.searches)) {

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1031,15 +1031,22 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
     expect(res.status).toBe(404);
   });
 
-  test("POST /query with malformed JSON body returns 400, not a 500", async () => {
-    const res = await fetch(`${baseUrl}/query`, {
+  test("POST /query rejects malformed and non-object JSON with 400", async () => {
+    const malformed = await fetch(`${baseUrl}/query`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: "{not valid json",
     });
-    expect(res.status).toBe(400);
-    const body = await res.json();
-    expect(body.error).toBe("Invalid JSON body");
+    expect(malformed.status).toBe(400);
+    expect((await malformed.json()).error).toBe("Invalid JSON body");
+
+    const nonObject = await fetch(`${baseUrl}/query`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "null",
+    });
+    expect(nonObject.status).toBe(400);
+    expect((await nonObject.json()).error).toBe("JSON body must be an object");
   });
 
   // ---------------------------------------------------------------------------

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1031,6 +1031,17 @@ describe.skipIf(!!process.env.CI)("MCP HTTP Transport", () => {
     expect(res.status).toBe(404);
   });
 
+  test("POST /query with malformed JSON body returns 400, not a 500", async () => {
+    const res = await fetch(`${baseUrl}/query`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{not valid json",
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON body");
+  });
+
   // ---------------------------------------------------------------------------
   // MCP protocol over HTTP (2026-07-28, sessionless)
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Impact

A malformed request body posted to the REST `/query` or `/search` endpoints returns an opaque `500 Internal Server Error` and dumps a stack trace into the daemon log, instead of a clean, actionable `400`. Anyone building a REST integration against these endpoints (rather than the JSON-RPC `/mcp` endpoint) gets no useful signal about what was wrong with their request.

## Repro

At HEAD `dbfd0b4736aeaf761d1a16ca8e424f071df8feb9`:

```
curl -X POST http://localhost:PORT/query -d '{not valid json' -H 'Content-Type: application/json'
```

`src/mcp/server.ts:985` calls `JSON.parse(rawBody)` directly with no try/catch. The thrown `SyntaxError` propagates up to the outer handler's catch block (`src/mcp/server.ts:1073-1076`), which logs the error (`console.error("HTTP handler error:", err)`, stack trace included) and always responds `500`.

The `/mcp` endpoint (added later) already guards its own `JSON.parse(rawBody)` (`src/mcp/server.ts:1043-1049`) with a try/catch that falls back to `parsedBody = undefined` instead of throwing.

## Fix

Wrap the REST `/query`/`/search` `JSON.parse` call in the same kind of try/catch and return a `400` with `{ "error": "Invalid JSON body" }` on failure, mirroring the `/mcp` guard. Added a regression test in `test/mcp.test.ts` asserting the `400` status and message for a malformed `/query` body.

Found while maintaining a downstream fork.
