### PR TITLE
fix(store): hydrate document bodies after dedupe, not per chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@
 
 - Added Oxlint lint fence.
 
+### Fixed
+
+- `qmd vsearch` and `qmd query` no longer exhaust the V8 heap on collections
+  holding book-length documents. `searchVec` selected `content.doc` in the
+  query that joins one-row-per-document `content` to one-row-per-chunk
+  `content_vectors`, so every matching chunk carried a full copy of its
+  document's body, and all of them were materialised before dedupe and `limit`
+  were applied. A 300-chunk match on an 8 MB document built roughly 2.4 GB of
+  strings — more where the text is outside Latin-1 and V8 stores two bytes per
+  character, which is routine in scientific prose. `vsearch --all` (limit
+  100000) and `query` (several expanded queries, each over-fetching candidates)
+  therefore died with `Reached heap limit Allocation failed` on indexes as small
+  as a single file. Bodies are now fetched by hash in a second pass, after
+  results are deduped and truncated, so memory scales with `-n` instead of with
+  the number of matching chunks. The `content` join is kept, so which rows match
+  is unchanged, and search output is byte-identical.
+
 ## [2.8.3] - 2026-08-16
 
 ### Security

--- a/src/store.ts
+++ b/src/store.ts
@@ -4191,6 +4191,28 @@ function annVecScan(
   `).all(new Float32Array(embedding), vecK) as { hash_seq: string; distance: number }[];
 }
 
+/**
+ * Fetch document bodies for a set of content hashes, keyed by hash.
+ *
+ * Called *after* results are deduped and truncated to `limit`, so body text is
+ * materialised once per surviving document rather than once per matching
+ * chunk. Chunked with the same IN-list budget as `exactVecScanByHashSeq` to
+ * stay under SQLITE_MAX_VARIABLE_NUMBER.
+ */
+function fetchContentBodies(db: Database, hashes: string[]): Map<string, string> {
+  const bodies = new Map<string, string>();
+  const unique = [...new Set(hashes)];
+  for (let i = 0; i < unique.length; i += VEC_HASH_SEQ_IN_CHUNK) {
+    const chunk = unique.slice(i, i + VEC_HASH_SEQ_IN_CHUNK);
+    const placeholders = chunk.map(() => "?").join(",");
+    const rows = db.prepare(`
+      SELECT hash, doc FROM content WHERE hash IN (${placeholders})
+    `).all(...chunk) as { hash: string; doc: string }[];
+    for (const row of rows) bodies.set(row.hash, row.doc);
+  }
+  return bodies;
+}
+
 export async function searchVec(db: Database, query: string, model: string, limit: number = 20, collectionName?: string | readonly string[], session?: ILLMSession, precomputedEmbedding?: number[], llm?: LlamaCpp): Promise<SearchResult[]> {
   const tableExists = db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'`).get();
   if (!tableExists) return [];
@@ -4259,8 +4281,7 @@ export async function searchVec(db: Database, query: string, model: string, limi
       cv.pos,
       'qmd://' || d.collection || '/' || d.path as filepath,
       d.collection || '/' || d.path as display_path,
-      d.title,
-      content.doc as body
+      d.title
     FROM content_vectors cv
     JOIN documents d ON d.hash = cv.hash AND d.active = 1
     JOIN content ON content.hash = d.hash
@@ -4275,7 +4296,7 @@ export async function searchVec(db: Database, query: string, model: string, limi
 
   const docRows = withLazyContentVectorMigration(db, () => db.prepare(docSql).all(...params) as {
     hash_seq: string; hash: string; pos: number; filepath: string;
-    display_path: string; title: string; body: string;
+    display_path: string; title: string;
   }[]);
 
   // Combine with distances and dedupe by filepath
@@ -4288,11 +4309,23 @@ export async function searchVec(db: Database, query: string, model: string, limi
     }
   }
 
-  return Array.from(seen.values())
+  const winners = Array.from(seen.values())
     .sort((a, b) => a.bestDist - b.bestDist)
-    .slice(0, limit)
+    .slice(0, limit);
+
+  // Hydrate bodies only for the rows we are about to return. Selecting
+  // content.doc in the query above joins one-row-per-document content to
+  // one-row-per-chunk content_vectors, so every matching chunk carries a full
+  // copy of its document body — for book-sized documents that is hundreds of
+  // multi-megabyte strings materialised before `limit` is ever applied, which
+  // exhausts the V8 heap. The `JOIN content` is deliberately kept above so row
+  // filtering is unchanged; only the string materialisation moves here.
+  const bodyMap = fetchContentBodies(db, winners.map(({ row }) => row.hash));
+
+  return winners
     .map(({ row, bestDist }) => {
       const collectionName = row.filepath.split('//')[1]?.split('/')[0] || "";
+      const body = bodyMap.get(row.hash) ?? "";
       return {
         filepath: row.filepath,
         displayPath: row.display_path,
@@ -4301,8 +4334,9 @@ export async function searchVec(db: Database, query: string, model: string, limi
         docid: getDocid(row.hash),
         collectionName,
         modifiedAt: "",  // Not available in vec query
-        bodyLength: row.body.length,
-        body: row.body,
+        // `JOIN content` above guarantees a row exists; "" is defensive only.
+        bodyLength: body.length,
+        body,
         context: getContextForFile(db, row.filepath),
         score: 1 - bestDist,  // Cosine similarity = 1 - cosine distance
         source: "vec" as const,

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
 import { openDatabase, loadSqliteVec } from "../src/db.js";
-import type { Database } from "../src/db.js";
+import type { Database, SQLiteValue } from "../src/db.js";
 import { unlink, mkdtemp, rmdir, writeFile, rm, mkdir, rename, chmod, readFile, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -3745,6 +3745,167 @@ describe("Vector Search collection filter", () => {
     await cleanupTestDb(store);
   });
 });
+
+// =============================================================================
+// Vector Search body hydration (no LLM — uses precomputed embeddings)
+// =============================================================================
+
+/**
+ * Count how many times one of `bodies` crosses the SQLite -> JS boundary while
+ * `fn` runs.
+ *
+ * This is the quantity that exhausted the heap: the fan-out bug selected
+ * `content.doc` in a query joining one-row-per-document `content` to
+ * one-row-per-chunk `content_vectors`, so the number of full body copies scaled
+ * with chunks-per-document instead of with `limit`. Counting the copies
+ * directly — rather than asserting on SQL text — keeps the test meaningful if
+ * the query is later rewritten.
+ */
+async function countBodyReads<T>(
+  db: Database,
+  bodies: readonly string[],
+  fn: () => Promise<T>,
+): Promise<{ reads: number; result: T }> {
+  const known = new Set(bodies);
+  const originalPrepare = db.prepare.bind(db);
+  let reads = 0;
+
+  db.prepare = (sql: string) => {
+    const stmt = originalPrepare(sql);
+    const originalAll = stmt.all.bind(stmt);
+    stmt.all = ((...params: SQLiteValue[]) => {
+      const rows = originalAll(...params) as unknown[];
+      for (const row of rows) {
+        if (!row || typeof row !== "object") continue;
+        for (const value of Object.values(row)) {
+          if (typeof value === "string" && known.has(value)) reads++;
+        }
+      }
+      return rows;
+    }) as typeof stmt.all;
+    return stmt;
+  };
+
+  try {
+    const result = await fn();
+    return { reads, result };
+  } finally {
+    db.prepare = originalPrepare;
+  }
+}
+
+/** Insert one document whose body is covered by `chunks` embedded chunks. */
+async function seedChunkedDoc(
+  store: Store,
+  collection: string,
+  opts: { hash: string; name: string; body: string; chunks: number; dims: number },
+): Promise<void> {
+  const now = new Date().toISOString();
+  await insertTestDocument(store.db, collection, {
+    name: opts.name,
+    hash: opts.hash,
+    body: opts.body,
+    displayPath: `${opts.name}.md`,
+  });
+
+  const insertChunk = store.db.prepare(
+    `INSERT INTO content_vectors (hash, seq, pos, model, embedded_at) VALUES (?, ?, ?, 'test', ?)`,
+  );
+  const insertVector = store.db.prepare(
+    `INSERT INTO vectors_vec (hash_seq, embedding) VALUES (?, ?)`,
+  );
+  for (let seq = 0; seq < opts.chunks; seq++) {
+    const embedding = new Float32Array(opts.dims);
+    embedding[0] = 1;
+    // Spread chunks slightly so they are distinct, near-but-not-equal vectors.
+    embedding[1] = seq / opts.chunks;
+    insertChunk.run(opts.hash, seq, seq * 100, now);
+    insertVector.run(`${opts.hash}_${seq}`, embedding);
+  }
+}
+
+describe("Vector Search body hydration", () => {
+  const dims = 8;
+  const queryEmbedding = Array(dims).fill(0).map((_, i) => (i === 0 ? 1 : 0));
+
+  test("hydrates a body once per document, not once per matching chunk", async () => {
+    const store = await createTestStore();
+    const collection = await createTestCollection({ name: "books", pwd: "/test/books" });
+    store.ensureVecTable(dims);
+
+    const body = "Chunked book body. ".repeat(200);
+    await seedChunkedDoc(store, collection, {
+      hash: "bookhash1", name: "book", body, chunks: 300, dims,
+    });
+
+    const { reads, result } = await countBodyReads(store.db, [body], () =>
+      store.searchVec("ignored — embedding precomputed", "test-model", 5, collection, undefined, queryEmbedding),
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.body).toBe(body);
+    expect(result[0]!.bodyLength).toBe(body.length);
+    // Exactly one: more is the fan-out regression (the over-fetch made this 15),
+    // zero would mean the body never loaded at all.
+    expect(reads).toBe(1);
+
+    await cleanupTestDb(store);
+  });
+
+  test("a high limit (--all) does not fan body text out across chunks", async () => {
+    const store = await createTestStore();
+    const collection = await createTestCollection({ name: "books", pwd: "/test/books" });
+    store.ensureVecTable(dims);
+
+    const body = "Chunked book body. ".repeat(200);
+    await seedChunkedDoc(store, collection, {
+      hash: "bookhash1", name: "book", body, chunks: 300, dims,
+    });
+
+    // `qmd vsearch --all` maps to limit 100000, which previously pulled a full
+    // body copy for every one of the document's chunks before dedupe ran.
+    const { reads, result } = await countBodyReads(store.db, [body], () =>
+      store.searchVec("ignored — embedding precomputed", "test-model", 100_000, collection, undefined, queryEmbedding),
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.body).toBe(body);
+    // Must not scale with the document's chunk count (was 300).
+    expect(reads).toBe(1);
+
+    await cleanupTestDb(store);
+  });
+
+  test("hydrates the matching body for each returned document", async () => {
+    const store = await createTestStore();
+    const collection = await createTestCollection({ name: "books", pwd: "/test/books" });
+    store.ensureVecTable(dims);
+
+    const bodyA = "Body of the first book. ".repeat(50);
+    const bodyB = "Body of the second book. ".repeat(50);
+    await seedChunkedDoc(store, collection, {
+      hash: "bookhasha", name: "book-a", body: bodyA, chunks: 4, dims,
+    });
+    await seedChunkedDoc(store, collection, {
+      hash: "bookhashb", name: "book-b", body: bodyB, chunks: 4, dims,
+    });
+
+    const { reads, result } = await countBodyReads(store.db, [bodyA, bodyB], () =>
+      store.searchVec("ignored — embedding precomputed", "test-model", 10, collection, undefined, queryEmbedding),
+    );
+
+    // Bodies are now fetched by hash in a second pass — guard against a result
+    // being paired with another document's body.
+    expect(result).toHaveLength(2);
+    const bodyByPath = new Map(result.map((r) => [r.displayPath, r.body]));
+    expect(bodyByPath.get(`${collection}/book-a.md`)).toBe(bodyA);
+    expect(bodyByPath.get(`${collection}/book-b.md`)).toBe(bodyB);
+    expect(reads).toBe(2);  // one per surviving document, not per chunk
+
+    await cleanupTestDb(store);
+  });
+});
+
 
 // =============================================================================
 // LlamaCpp Integration Tests (using real local models)


### PR DESCRIPTION
## Problem

`searchVec`'s step-2 document lookup selects `content.doc as body` while joining
`content_vectors` (one row **per chunk**) to `content` (one row **per document**).
Every matching chunk therefore carries a full copy of its document's body, and all of
them are materialised into JS before dedupe or `limit` are applied.

For notes and source files this is invisible. For book-length documents it is fatal:
a 300-chunk match on an 8 MB document builds ~2.4 GB of strings, and V8 stores strings
two bytes per character once the text leaves Latin-1 (Greek letters, `µ`, typographic
dashes — routine in scientific prose), so the real cost is roughly double again.

## Reproduction

```
qmd vsearch "<any query>" --all
# FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

```
 6: v8::internal::FactoryBase<v8::internal::Factory>::NewRawTwoByteString
 7: v8::internal::Factory::NewStringFromUtf8
 8: v8::String::NewFromUtf8
 9: napi_create_string_utf8
10: Data::GetValueJS            (better-sqlite3)
11: RowBuilder::GetRowJS        (better-sqlite3)
12: Statement::JS_all           (better-sqlite3)
```

`qmd search` and `qmd vsearch -n 5` survive, because `documents_fts` is per-document
and the outer `LIMIT` caps returned rows — but even `vsearch -n 5` hydrates 15 full
document copies to return 1.

### Previously reported

This is the crash in #430 ("qmd query crashes with out-of-memory on large libraries"),
which reported the same `Statement::JS_all` heap-limit trace on a 32 GB machine and was
closed `NOT_PLANNED` in the post-v2.5.1 backlog sweep, with a note to reopen if it still
reproduced. It still reproduces on 2.8.3 — repro steps and measurements below.

That issue proposed pagination as the fix. Paging the fan-out would cap the rows in
flight, but the cost per row is a whole document body; removing the body from the
per-chunk query addresses the cause rather than the batch size.

## Measured on a real index

A 440 MB index over 19 book-length `.txt` files (52,922 vectors), on a 16 GB machine.
Same queries, same models, `main` vs this branch. "Peak" is `/usr/bin/time -l`'s peak
memory footprint; both sides load the same three models, so the delta is attributable to
this change.

| command | `main` | this branch |
|---|---|---|
| `vsearch "sensory receptors" --all -c neuro` | **dies after 97 s**, 46.4 GB peak, 0 results | **4.5 s**, 1.6 GB peak, 19 results |
| `vsearch "…sensory neurons in the fingertips" --all` | **dies after 132 s**, 46.4 GB peak | 15.5 s, 1.6 GB peak |
| `query "choroid plexus" -c neuro` | completes, 17.2 GB peak | completes, 3.4 GB peak |
| `query "where the fluid in the ventricles is made" -c neuro` | 24.9 s, 15.2 GB peak (11.1 GB RSS) | 18.0 s, 3.4 GB peak (5.5 GB RSS) |

### Why some queries are far worse than others

sqlite-vec caps `k` at 4096, so the fan-out tops out at 4096 chunks — but the cost is set
by *which documents those chunks belong to*, since each chunk carries its own full copy.

Replicating step 1 for a range of queries and totalling the body bytes the current code
would materialise:

| query | body text materialised |
|---|---|
| `sensory receptors` | 64.5 GB |
| `sensory transduction` | 63.8 GB |
| `types of sensory neurons in the fingertips` | 61.7 GB |
| `psychophysics of sensory perception` | 51.0 GB |
| `where the fluid in the ventricles is made` | 44.2 GB |

`sensory receptors` puts 2,694 of its 4,096 chunks (66%) inside a single 18.9 MB
reference work, so that one file is copied 2,694 times. The ceiling on this corpus is
`4096 x 18.9 MB` = 77 GB.

Note the shape of this: the *vaguer* the query, the worse it is. Broad queries match
across a large reference work and concentrate the fan-out in the biggest file; more
specific queries spread across smaller books and cost less. Cheap-looking queries are the
dangerous ones.

The `query` runs do not crash, but on a 16 GB machine they peak at 15-17 GB — above
physical RAM, with system time rising to 8.0 s as the allocator thrashes. Same fan-out,
spread across several expanded queries instead of concentrated in one.

Output is unchanged: every command that completes on both sides produces
**byte-identical stdout**.

## Fix

Drop `body` from the per-chunk SELECT and hydrate it from `content` once results are
deduped and truncated to `limit`.

- The `JOIN content` is **retained**, so row filtering semantics are unchanged — only
  the string materialisation moves.
- Body lookups are chunked at `VEC_HASH_SEQ_IN_CHUNK`, matching the existing convention
  in `exactVecScanByHashSeq`.

Memory now scales with `limit` rather than with the number of matching chunks.

## Tests

`test/store.test.ts` gains a `Vector Search body hydration` block. Rather than asserting
on SQL text — which silently stops matching if the query is rewritten — the tests count
how many times a known document body crosses the SQLite → JS boundary during a search.

| case | before | after |
|---|---|---|
| `limit 5`, one 300-chunk document | 15 copies | 1 |
| `limit 100000` (`--all`), same document | 300 copies | 1 |
| two 4-chunk documents, `limit 10` | 8 copies | 2 |

The third case also asserts each result carries *its own* document's body, guarding the
new hash→body map against mispairing. All three fail on `main` and pass with this change.

Counts are asserted with exact equality, so a regression to fan-out (>N) and a broken
test harness (0) both fail.

Full suite: 1146 passed / 0 failed under both `bun test` and `vitest`. Typecheck and
oxlint clean.

## Not addressed here

`searchVec` dedupes by `filepath`, so each document yields at most one result regardless
of `-n`. That is right for notes and surprising for books, where the best five passages
may all live in one file. It is a behaviour change rather than a memory fix, so it is
left for a separate PR — and it is considerably easier to implement once bodies are no
longer attached to every chunk.
