### PR TITLE
nix: set meta.mainProgram on the flake package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -148,6 +148,7 @@
             homepage = "https://github.com/tobi/qmd";
             license = licenses.mit;
             platforms = platforms.unix;
+            mainProgram = "qmd";
           };
         };
       in


### PR DESCRIPTION
## Summary

- Remove evaluation warning for users of this flake. 
- Adds `meta.mainProgram = "qmd";` to the flake's package derivation.

## Why

Consumers that call `lib.getExe`/`lib.getExe'` on `qmd.packages.<system>.default` (e.g. wrapper tooling like [jail.nix](https://alexdav.id/projects/jail-nix/)) hit nixpkgs' `getExe` deprecation warning, since the derivation never declared its main program even though the build always installs a single `bin/qmd`:

```
evaluation warning: getExe: Package "qmd-2.8.3" does not have the meta.mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away. ...
```

Setting `meta.mainProgram` explicitly silences the warning and removes the reliance on the "assume it matches the package name" fallback.

## Test plan

- [x] `nix eval .#packages.x86_64-linux.default.meta.mainProgram` returns `"qmd"`
- [x] Verified against a downstream flake (NixOS config with `--override-input qmd <this branch>`): the `getExe` deprecation warning disappears from `nix build .#nixosConfigurations.<host>.config.system.build.toplevel`