### PR TITLE
fix(store): pre-filtered KNN for collection-scoped vector search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@
 
 - Added Oxlint lint fence.
 
+### Fixed
+
+- Collection-scoped vector search runs one sqlite-vec KNN statement with the
+  requested collections as an IN pre-filter on the vector key, replacing a
+  chunked exact scan that walked the whole `vectors_vec` table once per 400
+  keys, once more per collection in the scope. On a 793k-vector index,
+  `vsearch -c <collection>` drops from 33s to 7s and a default-scope search
+  over 13 collections from 152s to 7.5s. Single-collection results are
+  unchanged; a multi-collection scope ranks from one pool that holds each
+  collection's three-per-result chunk budget, so its tail can include
+  higher-scoring files that a per-collection merge left out. A scope above
+  20k vectors is no longer served by a capped global top-k with a
+  post-filter, so it is no longer starved by nearer vectors outside the
+  scope; a scope that holds most of the index is answered from the global
+  scan with a verified over-fetch and falls back to the pre-filter when that
+  scan does not yield enough in-scope rows (#775, #791, #803).
+
 ## [2.8.3] - 2026-08-16
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -899,9 +899,11 @@ With no `-c` flag, all default-included collections are searched. Collections
 marked excluded (`qmd collection exclude <name>`) are skipped unless named
 explicitly with `-c`.
 
-> **Note:** With multiple `-c` flags, results come from a global top-K pool and are
-> then filtered. If one collection dominates the rankings, matches from smaller
-> collections may not appear at the default limit — raise `-n` or use `--all`.
+> **Note:** With multiple `-c` flags, vector search runs one nearest-neighbour
+> query over the union of the named collections, keeping three candidate
+> chunks per requested result for each named collection before collapsing to
+> one row per file. When a few long documents own the nearest chunks, fewer
+> files than `-n` can come back; raise `-n` or use `--all`.
 
 ### Output Format
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -12,7 +12,7 @@
  */
 
 import { openDatabase, loadSqliteVec } from "./db.js";
-import type { Database } from "./db.js";
+import type { Database, SQLiteValue } from "./db.js";
 import picomatch from "picomatch";
 import { createHash } from "crypto";
 import { readFileSync, realpathSync, statSync, mkdirSync } from "node:fs";
@@ -4137,58 +4137,122 @@ export function searchFTS(db: Database, query: string, limit: number = 20, colle
 const SQLITE_VEC_MAX_K = 4096;
 
 /**
- * Max collection-scoped vectors for an exact cosine scan. Above this we fall
- * back to global ANN with a capped over-fetch. Exact scan avoids the
- * post-filter starvation of small collections (#791, #803); ANN remains for
- * very large collections where a full scan would be expensive.
+ * A scope holding at least this share of the active documents is answered
+ * from the global KNN. vec0 resolves every key of an IN pre-filter one by one,
+ * so for a scope of hundreds of thousands of keys the pre-filter costs more
+ * than the scan itself, while the global top rows post-filtered to such a
+ * scope are its exact nearest chunks whenever enough of them come back.
  */
-const COLLECTION_VEC_EXACT_SCAN_MAX = 20_000;
-
-const VEC_HASH_SEQ_IN_CHUNK = 400;
+const GLOBAL_SCAN_MIN_SHARE = 0.5;
 
 /**
- * Exact cosine-distance scan over a known set of hash_seq keys.
- * Uses vec_distance_cosine with chunked IN lists (no JOIN with vectors_vec).
+ * Floor for the global over-fetch of a majority scope. A query whose nearest
+ * chunks sit in the out-of-scope minority would otherwise come back short and
+ * pay the pre-filtered scan on top of the global one; a hundred-odd rows cost
+ * the scan little and make that rare.
  */
-function exactVecScanByHashSeq(
-  db: Database,
-  embedding: number[],
-  hashSeqs: string[],
-  limit: number,
-): { hash_seq: string; distance: number }[] {
-  if (hashSeqs.length === 0 || limit <= 0) return [];
+const GLOBAL_SCAN_MIN_OVERFETCH = 128;
 
-  const queryVec = new Float32Array(embedding);
-  // Over-fetch a bit so multi-chunk docs can still yield `limit` unique files.
-  const fetchLimit = Math.max(limit * 3, limit);
-  const scored: { hash_seq: string; distance: number }[] = [];
-
-  for (let i = 0; i < hashSeqs.length; i += VEC_HASH_SEQ_IN_CHUNK) {
-    const chunk = hashSeqs.slice(i, i + VEC_HASH_SEQ_IN_CHUNK);
-    const placeholders = chunk.map(() => "?").join(",");
-    const rows = db.prepare(`
-      SELECT hash_seq, vec_distance_cosine(embedding, ?) AS distance
-      FROM vectors_vec
-      WHERE hash_seq IN (${placeholders})
-    `).all(queryVec, ...chunk) as { hash_seq: string; distance: number }[];
-    scored.push(...rows);
-  }
-
-  scored.sort((a, b) => a.distance - b.distance);
-  return scored.slice(0, fetchLimit);
+interface VecMatch {
+  hash_seq: string;
+  distance: number;
 }
 
-function annVecScan(
+interface HashSeqRow {
+  hash_seq: string;
+}
+
+interface DocumentShareRow {
+  scoped: number;
+  total: number;
+}
+
+/**
+ * Exact top-k cosine scan over vectors_vec; vec0 brute-forces its candidate
+ * set. With collection names the candidates are pre-filtered through an IN
+ * list on hash_seq, so k is selected within the scope and a small collection
+ * is never crowded out by a larger one (#775, #791, #803). vec0 returns no
+ * rows for a KNN whose IN list names a key it does not hold (sqlite-vec
+ * 0.1.9, pinned), so the list is drawn from the `vectors_vec_rowids` shadow
+ * table where vec0 keeps its keys: a content_vectors row without a vector
+ * narrows the scope instead of emptying it. The subselect never touches the
+ * vectors_vec virtual table itself, since a JOIN with it hangs
+ * (https://github.com/tobi/qmd/pull/23), and vec0 accepts one IN on its key.
+ */
+function knnVecScan(
   db: Database,
   embedding: number[],
   k: number,
-): { hash_seq: string; distance: number }[] {
+  collectionNames?: readonly string[],
+): VecMatch[] {
   const vecK = Math.max(1, Math.min(SQLITE_VEC_MAX_K, k));
-  return db.prepare(`
+  const params: SQLiteValue[] = [new Float32Array(embedding), vecK];
+  let sql = `
     SELECT hash_seq, distance
     FROM vectors_vec
     WHERE embedding MATCH ? AND k = ?
-  `).all(new Float32Array(embedding), vecK) as { hash_seq: string; distance: number }[];
+  `;
+  if (collectionNames) {
+    const placeholders = collectionNames.map(() => "?").join(",");
+    sql += `
+      AND hash_seq IN (
+        SELECT r.id
+        FROM content_vectors cv
+        JOIN documents d ON d.hash = cv.hash AND d.active = 1
+        JOIN vectors_vec_rowids r ON r.id = cv.hash || '_' || cv.seq
+        WHERE d.collection IN (${placeholders})
+      )
+    `;
+    params.push(...collectionNames);
+  }
+  return withLazyContentVectorMigration(db, () => db.prepare(sql).all(...params) as VecMatch[]);
+}
+
+function activeDocumentShare(db: Database, collectionNames: readonly string[]): number {
+  const placeholders = collectionNames.map(() => "?").join(",");
+  const row = db.prepare(`
+    SELECT
+      (SELECT COUNT(*) FROM documents WHERE active = 1 AND collection IN (${placeholders})) AS scoped,
+      (SELECT COUNT(*) FROM documents WHERE active = 1) AS total
+  `).get(...collectionNames) as DocumentShareRow;
+  return row.total === 0 ? 0 : row.scoped / row.total;
+}
+
+/** The matches whose chunk belongs to an active document in the scope, in the given order. */
+function keepInScope(db: Database, matches: VecMatch[], collectionNames: readonly string[]): VecMatch[] {
+  if (matches.length === 0) return matches;
+  const hashes = Array.from(new Set(matches.map((m) => m.hash_seq.slice(0, m.hash_seq.lastIndexOf("_")))));
+  const rows = withLazyContentVectorMigration(db, () => db.prepare(`
+    SELECT cv.hash || '_' || cv.seq AS hash_seq
+    FROM content_vectors cv
+    JOIN documents d ON d.hash = cv.hash AND d.active = 1
+    WHERE cv.hash IN (${hashes.map(() => "?").join(",")})
+      AND d.collection IN (${collectionNames.map(() => "?").join(",")})
+  `).all(...hashes, ...collectionNames) as HashSeqRow[]);
+  const inScope = new Set(rows.map((r) => r.hash_seq));
+  return matches.filter((m) => inScope.has(m.hash_seq));
+}
+
+/**
+ * Top-k chunks of a collection scope. A scope that holds most of the index is
+ * read from the global KNN with an over-fetch and post-filtered: the in-scope
+ * rows of a global top-k' are the exact in-scope top-m, so when m reaches k
+ * they equal the pre-filtered answer at the cost of one plain scan; a global
+ * pass that returned fewer rows than requested has exhausted the index, so
+ * its in-scope rows are complete as well. A smaller scope, a k whose
+ * over-fetch would not fit under the vec0 cap, or a global pass that filled
+ * its over-fetch without yielding k in-scope rows, runs the pre-filtered KNN.
+ */
+function scopedVecMatches(db: Database, embedding: number[], k: number, collectionNames: readonly string[]): VecMatch[] {
+  const share = activeDocumentShare(db, collectionNames);
+  const scaledK = share > 0 ? Math.ceil(k / share) * 4 : Infinity;
+  if (share >= GLOBAL_SCAN_MIN_SHARE && scaledK <= SQLITE_VEC_MAX_K) {
+    const overFetch = Math.min(SQLITE_VEC_MAX_K, Math.max(GLOBAL_SCAN_MIN_OVERFETCH, scaledK));
+    const global = knnVecScan(db, embedding, overFetch);
+    const inScope = keepInScope(db, global, collectionNames);
+    if (inScope.length >= k || global.length < overFetch) return inScope.slice(0, k);
+  }
+  return knnVecScan(db, embedding, k, collectionNames);
 }
 
 export async function searchVec(db: Database, query: string, model: string, limit: number = 20, collectionName?: string | readonly string[], session?: ILLMSession, precomputedEmbedding?: number[], llm?: LlamaCpp): Promise<SearchResult[]> {
@@ -4199,13 +4263,6 @@ export async function searchVec(db: Database, query: string, model: string, limi
   if (!embedding) return [];
 
   const names = scopedCollectionNames(collectionName);
-  if (names && names.length > 1) {
-    const lists = await Promise.all(
-      names.map(name => searchVec(db, query, model, limit, name, session, embedding, llm)),
-    );
-    return mergeSearchResultsByScore(lists, limit);
-  }
-  const collectionFilter = names?.[0];
 
   // IMPORTANT: We use a two-step query approach here because sqlite-vec virtual tables
   // hang indefinitely when combined with JOINs in the same query. Do NOT try to
@@ -4214,36 +4271,14 @@ export async function searchVec(db: Database, query: string, model: string, limi
 
   // Step 1: Get vector matches from sqlite-vec (no JOINs allowed).
   //
-  // Collection filter cannot be pushed into MATCH (sqlite-vec has no join-safe
-  // predicate here). Global ANN + post-filter starves small collections: they
-  // never enter the top-k (#791, #803). Multiplier over-fetch alone is not
-  // enough either — sqlite-vec caps k at 4096. For a collection filter we
-  // therefore exact-scan that collection's vectors when the set is small
-  // enough, and only then fall back to capped ANN + post-filter.
-  let vecResults: { hash_seq: string; distance: number }[];
-
-  if (collectionFilter) {
-    const collectionHashSeqs = withLazyContentVectorMigration(db, () =>
-      db.prepare(`
-        SELECT cv.hash || '_' || cv.seq AS hash_seq
-        FROM content_vectors cv
-        JOIN documents d ON d.hash = cv.hash AND d.active = 1
-        WHERE d.collection = ?
-      `).all(collectionFilter) as { hash_seq: string }[],
-    ).map((r) => r.hash_seq);
-
-    if (collectionHashSeqs.length === 0) return [];
-
-    if (collectionHashSeqs.length <= COLLECTION_VEC_EXACT_SCAN_MAX) {
-      vecResults = exactVecScanByHashSeq(db, embedding, collectionHashSeqs, limit);
-    } else {
-      // Large collection: ANN with over-fetch, hard-capped at sqlite-vec's max k.
-      vecResults = annVecScan(db, embedding, Math.max(limit * 30, limit * 3));
-    }
-  } else {
-    vecResults = annVecScan(db, embedding, limit * 3);
-  }
-
+  // A collection scope is an IN pre-filter inside the KNN statement, or the
+  // global KNN post-filtered when the scope holds most of the index (see
+  // scopedVecMatches); sqlite-vec caps k at 4096, so a wide over-fetch alone
+  // could not stand in for the pre-filter. Each collection in scope keeps the
+  // three-per-result chunk budget of a single scope, pooled into one k, so a
+  // long document in one collection cannot own the union's pool.
+  const k = limit * 3 * (names?.length ?? 1);
+  const vecResults = names ? scopedVecMatches(db, embedding, k, names) : knnVecScan(db, embedding, k);
   if (vecResults.length === 0) return [];
 
   // Step 2: Get chunk info and document data
@@ -4268,9 +4303,9 @@ export async function searchVec(db: Database, query: string, model: string, limi
   `;
   const params: string[] = [...hashSeqs];
 
-  if (collectionFilter) {
-    docSql += ` AND d.collection = ?`;
-    params.push(collectionFilter);
+  if (names) {
+    docSql += ` AND d.collection IN (${names.map(() => '?').join(',')})`;
+    params.push(...names);
   }
 
   const docRows = withLazyContentVectorMigration(db, () => db.prepare(docSql).all(...params) as {

--- a/test/multi-collection-filter.test.ts
+++ b/test/multi-collection-filter.test.ts
@@ -1,9 +1,10 @@
 /**
  * Unit tests for multi-collection CLI filter input (#191, #775).
  *
- * Collection scoping is applied in searchFTS/searchVec (search each collection,
- * then merge). These tests cover CLI parseArgs / input normalization only.
- * Starvation regressions live in store.test.ts.
+ * Collection scoping is applied in searchFTS (search each collection, then
+ * merge) and searchVec (one KNN pre-filtered to the requested set). These
+ * tests cover CLI parseArgs / input normalization only. Starvation
+ * regressions live in store.test.ts.
  */
 
 import { describe, test, expect } from "vitest";

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -3608,11 +3608,9 @@ describe("Vector Search collection filter", () => {
     const queryEmbedding = Array(dims).fill(0);
     queryEmbedding[0] = 1;
 
-    // 250 nearer neighbours in the large collection. With limit=3:
-    //   - old global k=limit*3=9 never sees `small`
-    //   - a plain multiplier (limit*30=90) still misses it
-    //   - sqlite-vec also caps k at 4096, so multipliers cannot fix tiny
-    //     collections in huge indexes. Collection-scoped exact scan does.
+    // 250 nearer neighbours in the large collection. With limit=3 the
+    // unscoped top-k (k=9) never reaches `small`; the scoped KNN pre-filters
+    // on the collection before selecting k, so `small` is found regardless.
     for (let i = 0; i < 250; i++) {
       const hash = `largehash${String(i).padStart(3, "0")}`;
       await insertTestDocument(store.db, large, {
@@ -3634,7 +3632,7 @@ describe("Vector Search collection filter", () => {
       body: "Target document in the small collection",
       displayPath: "target.md",
     });
-    // Farther than the noise vectors — only found via collection-scoped scan.
+    // Farther than the noise vectors; only a scoped KNN reaches it.
     const targetEmbedding = new Float32Array(dims);
     targetEmbedding[0] = 0.6;
     targetEmbedding[1] = 0.8;
@@ -3741,6 +3739,343 @@ describe("Vector Search collection filter", () => {
     );
     expect(union.map(r => r.collectionName).sort()).toEqual([knowledge, notes].sort());
     expect(union.every((r) => r.collectionName !== large)).toBe(true);
+
+    await cleanupTestDb(store);
+  });
+
+  const DIMS = 8;
+  const query: number[] = Array(DIMS).fill(0);
+  query[0] = 1;
+
+  function vector(x: number, y: number): Float32Array {
+    const embedding = new Float32Array(DIMS);
+    embedding[0] = x;
+    embedding[1] = y;
+    return embedding;
+  }
+
+  /** Chunk `seq` of `hash` sits at pos seq * 100. */
+  function insertChunkVectors(store: Store, hash: string, chunks: readonly Float32Array[]): void {
+    const now = new Date().toISOString();
+    const insertChunk = store.db.prepare(`INSERT INTO content_vectors (hash, seq, pos, model, embedded_at) VALUES (?, ?, ?, 'test', ?)`);
+    const insertVec = store.db.prepare(`INSERT INTO vectors_vec (hash_seq, embedding) VALUES (?, ?)`);
+    store.db.transaction(() => {
+      chunks.forEach((embedding, seq) => {
+        insertChunk.run(hash, seq, seq * 100, now);
+        insertVec.run(`${hash}_${seq}`, embedding);
+      });
+    })();
+  }
+
+  async function insertVecDoc(store: Store, collection: string, hash: string, chunks: readonly Float32Array[]): Promise<void> {
+    await insertTestDocument(store.db, collection, { name: hash, hash, body: `Document ${hash}`, displayPath: `${hash}.md` });
+    insertChunkVectors(store, hash, chunks);
+  }
+
+  /** Documents orthogonal to the query; they keep a scoped collection below the global-scan share so the pre-filter runs. */
+  async function insertFillerDocs(store: Store, collection: string, prefix: string, count: number): Promise<void> {
+    for (let i = 0; i < count; i++) {
+      await insertVecDoc(store, collection, `${prefix}${String(i).padStart(2, "0")}`, [vector(0, 1)]);
+    }
+  }
+
+  test("searchVec scoped to two of three collections returns exactly those two", async () => {
+    const store = await createTestStore();
+    const first = await createTestCollection({ name: "first", pwd: "/test/first" });
+    const second = await createTestCollection({ name: "second", pwd: "/test/second" });
+    const third = await createTestCollection({ name: "third", pwd: "/test/third" });
+    store.ensureVecTable(DIMS);
+    await insertVecDoc(store, first, "firsthash", [vector(1, 0)]);
+    await insertVecDoc(store, second, "secondhash", [vector(0.9, 0.44)]);
+    await insertVecDoc(store, third, "thirdhash", [vector(0.8, 0.6)]);
+    await insertFillerDocs(store, second, "secondfill", 4);
+
+    const results = await store.searchVec("ignored", "test-model", 3, [first, third], undefined, query);
+    expect(results.map((r) => r.collectionName).sort()).toEqual([first, third].sort());
+
+    await cleanupTestDb(store);
+  });
+
+  test("searchVec returns a hash shared with an out-of-scope collection once, named for the scoped collection", async () => {
+    const store = await createTestStore();
+    const included = await createTestCollection({ name: "included", pwd: "/test/included" });
+    const excluded = await createTestCollection({ name: "excluded", pwd: "/test/excluded" });
+    store.ensureVecTable(DIMS);
+    await insertVecDoc(store, excluded, "sharedhash", [vector(1, 0)]);
+    await insertFillerDocs(store, excluded, "excludedfill", 3);
+    await insertTestDocument(store.db, included, { name: "copy", hash: "sharedhash", body: "Document sharedhash", displayPath: "copy.md" });
+
+    const results = await store.searchVec("ignored", "test-model", 5, included, undefined, query);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.collectionName).toBe(included);
+    expect(results[0]!.displayPath).toBe(`${included}/copy.md`);
+
+    await cleanupTestDb(store);
+  });
+
+  test("searchVec ignores a hash whose only in-scope row is inactive", async () => {
+    const store = await createTestStore();
+    const included = await createTestCollection({ name: "included", pwd: "/test/included" });
+    const excluded = await createTestCollection({ name: "excluded", pwd: "/test/excluded" });
+    store.ensureVecTable(DIMS);
+    await insertVecDoc(store, excluded, "sharedhash", [vector(1, 0)]);
+    await insertTestDocument(store.db, included, { name: "stale", hash: "sharedhash", body: "Document sharedhash", displayPath: "stale.md", active: 0 });
+
+    const results = await store.searchVec("ignored", "test-model", 5, included, undefined, query);
+    expect(results).toEqual([]);
+
+    await cleanupTestDb(store);
+  });
+
+  test("searchVec returns a document once when its hash has an active and an inactive row in scope", async () => {
+    const store = await createTestStore();
+    const included = await createTestCollection({ name: "included", pwd: "/test/included" });
+    const outside = await createTestCollection({ name: "outside", pwd: "/test/outside" });
+    store.ensureVecTable(DIMS);
+    await insertVecDoc(store, included, "duphash", [vector(1, 0)]);
+    await insertFillerDocs(store, outside, "outsidefill", 3);
+    await insertTestDocument(store.db, included, { name: "stale", hash: "duphash", body: "Document duphash", displayPath: "stale.md", active: 0 });
+
+    const results = await store.searchVec("ignored", "test-model", 5, included, undefined, query);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.displayPath).toBe(`${included}/duphash.md`);
+
+    await cleanupTestDb(store);
+  });
+
+  test("searchVec returns empty for a scoped collection that has documents but no vectors", async () => {
+    const store = await createTestStore();
+    const embedded = await createTestCollection({ name: "embedded", pwd: "/test/embedded" });
+    const bare = await createTestCollection({ name: "bare", pwd: "/test/bare" });
+    store.ensureVecTable(DIMS);
+    await insertVecDoc(store, embedded, "embeddedhash", [vector(1, 0)]);
+    await insertFillerDocs(store, embedded, "embeddedfill", 2);
+    await insertTestDocument(store.db, bare, { name: "plain", body: "Not embedded", displayPath: "plain.md" });
+
+    const results = await store.searchVec("ignored", "test-model", 3, bare, undefined, query);
+    expect(results).toEqual([]);
+
+    await cleanupTestDb(store);
+  });
+
+  test("searchVec returns empty for a collection name that no document carries", async () => {
+    const store = await createTestStore();
+    const embedded = await createTestCollection({ name: "embedded", pwd: "/test/embedded" });
+    store.ensureVecTable(DIMS);
+    await insertVecDoc(store, embedded, "embeddedhash", [vector(1, 0)]);
+
+    const results = await store.searchVec("ignored", "test-model", 3, "never-indexed", undefined, query);
+    expect(results).toEqual([]);
+
+    await cleanupTestDb(store);
+  });
+
+  test("searchVec accepts a scoped limit above sqlite-vec's k cap", async () => {
+    const store = await createTestStore();
+    const embedded = await createTestCollection({ name: "embedded", pwd: "/test/embedded" });
+    const outside = await createTestCollection({ name: "outside", pwd: "/test/outside" });
+    store.ensureVecTable(DIMS);
+    await insertVecDoc(store, embedded, "nearhash", [vector(1, 0)]);
+    await insertVecDoc(store, embedded, "farhash", [vector(0.6, 0.8)]);
+    await insertFillerDocs(store, outside, "outsidefill", 4);
+
+    const results = await store.searchVec("ignored", "test-model", 2000, embedded, undefined, query);
+    expect(results.map((r) => r.hash)).toEqual(["nearhash", "farhash"]);
+
+    await cleanupTestDb(store);
+  });
+
+  test("searchVec treats an empty collection list like no scope", async () => {
+    const store = await createTestStore();
+    const first = await createTestCollection({ name: "first", pwd: "/test/first" });
+    const second = await createTestCollection({ name: "second", pwd: "/test/second" });
+    store.ensureVecTable(DIMS);
+    await insertVecDoc(store, first, "firsthash", [vector(1, 0)]);
+    await insertVecDoc(store, second, "secondhash", [vector(0.6, 0.8)]);
+
+    const unscoped = await store.searchVec("ignored", "test-model", 3, undefined, undefined, query);
+    const emptyScope = await store.searchVec("ignored", "test-model", 3, [], undefined, query);
+    expect(unscoped.map((r) => r.hash)).toEqual(["firsthash", "secondhash"]);
+    expect(emptyScope).toEqual(unscoped);
+
+    await cleanupTestDb(store);
+  });
+
+  test("searchVec collapses a scoped over-fetch to one row per file at its best chunk", async () => {
+    const store = await createTestStore();
+    const alpha = await createTestCollection({ name: "alpha", pwd: "/test/alpha" });
+    const beta = await createTestCollection({ name: "beta", pwd: "/test/beta" });
+    const outside = await createTestCollection({ name: "outside", pwd: "/test/outside" });
+    store.ensureVecTable(DIMS);
+    await insertFillerDocs(store, outside, "outsidefill", 30);
+    const near = vector(1, 0);
+    const far = vector(0.6, 0.8);
+    for (let i = 0; i < 3; i++) {
+      await insertVecDoc(store, alpha, `long${i}`, Array.from({ length: 10 }, () => near));
+    }
+    for (let i = 0; i < 20; i++) {
+      await insertVecDoc(store, i % 2 === 0 ? alpha : beta, `short${String(i).padStart(2, "0")}`, [far]);
+    }
+
+    const results = await store.searchVec("ignored", "test-model", 10, [alpha, beta], undefined, query);
+    expect(results).toHaveLength(10);
+    expect(results.slice(0, 3).map((r) => r.hash).sort()).toEqual(["long0", "long1", "long2"]);
+    expect(new Set(results.map((r) => r.filepath)).size).toBe(results.length);
+
+    await cleanupTestDb(store);
+  });
+
+  test("searchVec rows carry the vec source, a cosine score, and the best chunk position", async () => {
+    const store = await createTestStore();
+    const embedded = await createTestCollection({ name: "embedded", pwd: "/test/embedded" });
+    const outside = await createTestCollection({ name: "outside", pwd: "/test/outside" });
+    store.ensureVecTable(DIMS);
+    await insertVecDoc(store, embedded, "twochunks", [vector(0, 1), vector(0.6, 0.8)]);
+    await insertFillerDocs(store, outside, "outsidefill", 3);
+
+    const results = await store.searchVec("ignored", "test-model", 3, embedded, undefined, query);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.source).toBe("vec");
+    expect(results[0]!.chunkPos).toBe(100);
+    expect(results[0]!.score).toBeCloseTo(0.6, 5);
+
+    await cleanupTestDb(store);
+  });
+
+  test("searchVec keeps a scope of 20k+ chunks reachable behind nearer out-of-scope vectors", async () => {
+    const store = await createTestStore();
+    const big = await createTestCollection({ name: "big", pwd: "/test/big" });
+    const other = await createTestCollection({ name: "other", pwd: "/test/other" });
+    store.ensureVecTable(DIMS);
+    const far = vector(0.6, 0.8);
+    await insertVecDoc(store, big, "bighash", Array.from({ length: 20_001 }, () => far));
+    for (let i = 0; i < 100; i++) {
+      await insertVecDoc(store, other, `otherhash${String(i).padStart(3, "0")}`, [vector(1, 0)]);
+    }
+
+    const results = await store.searchVec("ignored", "test-model", 3, big, undefined, query);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.collectionName).toBe(big);
+
+    await cleanupTestDb(store);
+  });
+
+  test("searchVec union keeps a sibling collection reachable behind a long in-scope document", async () => {
+    const store = await createTestStore();
+    const small = await createTestCollection({ name: "small", pwd: "/test/small" });
+    const large = await createTestCollection({ name: "large", pwd: "/test/large" });
+    store.ensureVecTable(DIMS);
+    await insertVecDoc(store, large, "longhash", Array.from({ length: 12 }, () => vector(1, 0)));
+    await insertVecDoc(store, small, "smallhash", [vector(0.6, 0.8)]);
+    const outside = await createTestCollection({ name: "outside", pwd: "/test/outside" });
+    await insertFillerDocs(store, outside, "outsidefill", 4);
+
+    const results = await store.searchVec("ignored", "test-model", 3, [small, large], undefined, query);
+    expect(results.map((r) => r.collectionName).sort()).toEqual([large, small].sort());
+    expect(results.some((r) => r.hash === "smallhash")).toBe(true);
+
+    await cleanupTestDb(store);
+  });
+
+  test("searchVec scoped to a collection still answers when one chunk row has no vector", async () => {
+    const store = await createTestStore();
+    const partial = await createTestCollection({ name: "partial", pwd: "/test/partial" });
+    store.ensureVecTable(DIMS);
+    await insertVecDoc(store, partial, "wholehash0", [vector(1, 0)]);
+    await insertVecDoc(store, partial, "wholehash1", [vector(0.9, 0.44)]);
+    await insertVecDoc(store, partial, "ghosthash", [vector(0.8, 0.6)]);
+    const other = await createTestCollection({ name: "other", pwd: "/test/other" });
+    await insertFillerDocs(store, other, "otherfill", 4);
+    store.db.prepare(`DELETE FROM vectors_vec WHERE hash_seq = ?`).run("ghosthash_0");
+
+    const scoped = await store.searchVec("ignored", "test-model", 5, partial, undefined, query);
+    const unscoped = await store.searchVec("ignored", "test-model", 5, undefined, undefined, query);
+    expect(scoped.map((r) => r.hash)).toEqual(["wholehash0", "wholehash1"]);
+    expect(unscoped.filter((r) => r.collectionName === partial).map((r) => r.hash)).toEqual(["wholehash0", "wholehash1"]);
+
+    await cleanupTestDb(store);
+  });
+
+  test("searchVec scoped to a collection that holds most of the index returns its nearest documents", async () => {
+    const store = await createTestStore();
+    const big = await createTestCollection({ name: "big", pwd: "/test/big" });
+    const other = await createTestCollection({ name: "other", pwd: "/test/other" });
+    store.ensureVecTable(DIMS);
+    for (let i = 0; i < 30; i++) {
+      await insertVecDoc(store, big, `bighash${String(i).padStart(2, "0")}`, [vector(1, 0.02 + i * 0.01)]);
+    }
+    for (let i = 0; i < 12; i++) {
+      await insertVecDoc(store, other, `otherhash${String(i).padStart(2, "0")}`, [vector(1, 0)]);
+    }
+
+    const results = await store.searchVec("ignored", "test-model", 3, big, undefined, query);
+    expect(results.map((r) => r.hash)).toEqual(["bighash00", "bighash01", "bighash02"]);
+
+    await cleanupTestDb(store);
+  });
+
+  test("searchVec scoped to a majority collection is not starved by nearer vectors outside it", async () => {
+    const store = await createTestStore();
+    const big = await createTestCollection({ name: "big", pwd: "/test/big" });
+    const other = await createTestCollection({ name: "other", pwd: "/test/other" });
+    store.ensureVecTable(DIMS);
+    for (let i = 0; i < 100; i++) {
+      await insertVecDoc(store, big, `bighash${String(i).padStart(3, "0")}`, [vector(0.6, 0.8)]);
+    }
+    for (let i = 0; i < 80; i++) {
+      await insertVecDoc(store, other, `otherhash${String(i).padStart(3, "0")}`, [vector(1, 0)]);
+    }
+
+    const results = await store.searchVec("ignored", "test-model", 3, big, undefined, query);
+    expect(results).toHaveLength(3);
+    expect(results.every((r) => r.collectionName === big)).toBe(true);
+
+    await cleanupTestDb(store);
+  });
+
+  test("searchVec scoped to a majority collection larger than the over-fetch returns its nearest documents", async () => {
+    const store = await createTestStore();
+    const big = await createTestCollection({ name: "big", pwd: "/test/big" });
+    const other = await createTestCollection({ name: "other", pwd: "/test/other" });
+    store.ensureVecTable(DIMS);
+    for (let i = 0; i < 300; i++) {
+      await insertVecDoc(store, big, `bighash${String(i).padStart(3, "0")}`, [vector(1, 0.02 + i * 0.001)]);
+    }
+    for (let i = 0; i < 20; i++) {
+      await insertVecDoc(store, other, `otherhash${String(i).padStart(2, "0")}`, [vector(1, 0)]);
+    }
+
+    const results = await store.searchVec("ignored", "test-model", 3, big, undefined, query);
+    expect(results.map((r) => r.hash)).toEqual(["bighash000", "bighash001", "bighash002"]);
+
+    await cleanupTestDb(store);
+  });
+
+  test("searchVec reads a majority scope from the global scan and a minority scope through the pre-filter", async () => {
+    const store = await createTestStore();
+    const major = await createTestCollection({ name: "major", pwd: "/test/major" });
+    const minor = await createTestCollection({ name: "minor", pwd: "/test/minor" });
+    store.ensureVecTable(DIMS);
+    for (let i = 0; i < 6; i++) {
+      await insertVecDoc(store, major, `majorhash${i}`, [vector(1, 0.01 * i)]);
+    }
+    for (let i = 0; i < 3; i++) {
+      await insertVecDoc(store, minor, `minorhash${i}`, [vector(0.6, 0.8)]);
+    }
+    const prepare = vi.spyOn(store.db, "prepare");
+    const knnStatements = () => prepare.mock.calls.map((call) => String(call[0])).filter((sql) => sql.includes("MATCH"));
+    try {
+      await store.searchVec("ignored", "test-model", 3, major, undefined, query);
+      expect(knnStatements()).toHaveLength(1);
+      expect(knnStatements()[0]).not.toContain("vectors_vec_rowids");
+
+      prepare.mockClear();
+      await store.searchVec("ignored", "test-model", 3, minor, undefined, query);
+      expect(knnStatements()).toHaveLength(1);
+      expect(knnStatements()[0]).toContain("vectors_vec_rowids");
+    } finally {
+      prepare.mockRestore();
+    }
 
     await cleanupTestDb(store);
   });


### PR DESCRIPTION
# Collection-scoped vector search as a pre-filtered KNN statement

## Problem

`searchVec` with a collection filter collects the scope's `hash_seq` keys and evaluates `hash_seq IN (400 keys)` against `vectors_vec` in chunks (#847). vec0 uses its key index only for equality, so every chunk is a full pass over the table. On a 793k-vector index (12.6 GB) a 3.8k-key collection pays ten passes of about 0.7s per vector query: `qmd vsearch -c solutions` spends 30s of a 33s run there, and a default scope of 13 collections recurses once per collection and takes 152s. BM25 stays under a second for the same scopes.

Scopes above 20k keys take the other branch, a capped global top-k with a post-filter, which is the starvation the exact scan was added to avoid. On this index `vault` holds 20,844 active chunks, so a default-scope search returned one `vault` document while `stars` (761k keys) filled the top-k.

## Fix

One KNN statement per vector query, whatever the scope:

```sql
SELECT hash_seq, distance
FROM vectors_vec
WHERE embedding MATCH ? AND k = ?
  AND hash_seq IN (
    SELECT r.id
    FROM content_vectors cv
    JOIN documents d ON d.hash = cv.hash AND d.active = 1
    JOIN vectors_vec_rowids r ON r.id = cv.hash || '_' || cv.seq
    WHERE d.collection IN (?, ...)
  )
```

vec0 applies the IN list on its primary key before selecting k, so the result is an exact top-k over the scope and a small collection is never crowded out by a larger one, in or out of scope. The subselect reads `content_vectors`, `documents`, and vec0's own key table `vectors_vec_rowids`; it never touches the `vectors_vec` virtual table, so the two-statement rule from #23 still holds. The join on `vectors_vec_rowids` is load-bearing: vec0 0.1.9 answers a KNN whose IN list names a key it does not hold with no rows at all, and a `content_vectors` row whose vector is missing (the embed path writes the two tables in separate statements) would otherwise blank every scoped search that includes that document. Drawing the list from the shadow table narrows the scope instead.

A scope that holds at least half of the active documents skips the pre-filter: the global KNN runs with an over-fetch of four times k over the scope's share, its rows are post-filtered to the scope, and the result is kept when at least k in-scope rows came back (or the table ran out). The in-scope rows of a global top-k' are the exact in-scope top-m, so that answer is identical to the pre-filtered one; when the scan comes back short the pre-filtered statement runs. This matters because vec0 resolves every key of an IN list one by one, which for a 761k-key scope costs more than the brute-force pass itself. A 19ms document count picks the route, and the global attempt is skipped when its over-fetch would not fit under the 4096 cap, so a large `-n` or `--all` never pays both scans.

Without a scope the statement is the unchanged global KNN. Step 2 binds the same names as an IN list. k is three chunks per requested result for each collection in scope, pooled into the one statement and capped at 4096, so a long document in one collection cannot own a union's whole pool; a single scope keeps the previous k of three times the limit. Result assembly is unchanged: one row per file at its best chunk distance, score is one minus distance.

`exactVecScanByHashSeq`, its two constants, and the per-collection recursion in `searchVec` are gone. `searchFTS` and `structuredSearch` keep their per-collection loops, so RRF weighting does not change.

## Measured on a live index

12.6 GB index, 793k vectors; `stars` holds 761k keys, the 13 default collections 36k, `solutions` 3.8k. Best of the runs taken outside the index's five-minute update and embed windows. Both columns use the same warm model process for embedding and query expansion, so the difference is the vector stage.

| Command | Before | After |
| --- | --- | --- |
| `qmd vsearch "slow query" -c solutions -n 3` | 33.3s | 6.8s |
| `qmd query "slow query" -c solutions -n 3` | 32.0s | 6.9s |
| `qmd vsearch "slow query" -n 3` (13 collections) | 152.0s | 7.4s |
| `qmd vsearch "slow query" -c stars -n 3` (761k keys) | 18.2s | 14.1s |

`searchVec` alone, one precomputed query embedding, read-only connection:

| Scope | Before | After |
| --- | --- | --- |
| `solutions`, limit 20 | 5.6s | 1.6s |
| 13 default collections, limit 20 | 29.4s | 2.0s |
| `stars`, limit 3 | 3.8s | 3.4s |

The `stars` scope goes through the global-scan route; a pre-filtered statement over its 761k keys measures 5.2s per vector query because vec0 resolves each key in its shadow table one by one, and the old code paid 3.8s collecting the same keys in JavaScript before its global scan.

## Results before and after

Ordered result keys from `searchVec` with the same embedding are identical for `solutions` at limits 3 and 20, for the default scope at limit 3, and for `stars` at limit 3. The default scope at limit 20 shares its first eight rows; the old tail held rows scoring 0.541 to 0.547, the new tail holds eight `vault` files scoring 0.553 to 0.561 that the old code never fetched because vault's 20,844 chunks put it on the global top-k branch.

## Tests

`test/store.test.ts`, "Vector Search collection filter": the #791/#803 and #775 tests pass with their assertions unchanged. Added: two of three collections in scope; a hash shared with an out-of-scope collection returned once under the scoped name; a hash whose only in-scope row is inactive; an active plus an inactive row for one hash; a scoped collection with no vectors; an unknown name; a limit above the k cap; an empty list equals unscoped; chunk collapse across a union; result row fields; a 20,001-chunk scope behind 100 nearer out-of-scope vectors, which returns nothing on `main` and passes here; a scoped collection that still answers when one chunk row has no vector; a union that keeps a sibling collection reachable behind a long in-scope document; a majority collection served from the global scan, both below and above the over-fetch, plus the same scope not starved when the nearest vectors sit outside it; and a routing test that pins the global scan to a majority scope and the `vectors_vec_rowids` pre-filter to a minority scope through the prepared statements.

`CI=true` vitest and bun suites green under Node 26 and Bun 1.4; `tsc --noEmit` and `oxlint` clean.

## Known limits

- A document that owns every one of a union's pooled candidate chunks still collapses the result to fewer files than `-n`; the README note names `-n` and `--all` as the lever.
- A limit above 1365 loses part of its three-per-result over-fetch because sqlite-vec caps k at 4096.
- Every route still pays the brute-force pass over all stored chunks (about 1.8s on this index). Going below that floor needs a schema change, out of scope here: a vec0 partition key on collection so a scoped scan reads only its own chunks, an integer rowid key so the pre-filter binds rowids instead of text keys, or int8 vectors to shrink the pass.

## Related issues

#775, #791, #803 were closed by #847's exact scan, which this replaces. #918 is the keyword-side counterpart for `searchFTS`.
