### PR TITLE
feat(cleanup): repack the vector table when its chunks are mostly holes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@
 
 - Added Oxlint lint fence.
 
+### Changed
+
+- `qmd cleanup` repacks the vector table when fewer than 90% of its chunk
+  reads hold live rows. vec0 fills the first free slot of its newest chunk
+  and reclaims a chunk only once it is empty, so re-embeds and orphan removal
+  leave holes in older chunks that every brute-force scan still reads; a
+  794k-vector index at 36% occupancy scanned twice as slowly as a packed copy
+  of the same rows. The repack moves the live rows of each mostly-empty chunk
+  to the tail, one chunk per short transaction, so it never holds the write
+  lock for long and an interrupted run leaves a consistent table. The cleanup
+  output and `qmd cleanup --dry-run` report the chunk counts.
+
 ## [2.8.3] - 2026-08-16
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -1051,7 +1051,7 @@ qmd multi-get "docs/*.md" --max-bytes 20480
 # Output multi-get as JSON for agent processing
 qmd multi-get "docs/*.md" --json
 
-# Clean up cache and orphaned data
+# Drop caches and orphans; repack the vector table when it has holes
 qmd cleanup
 ```
 

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -59,6 +59,7 @@ import {
   countOrphanedVectors,
   previewCleanup,
   runCleanup,
+  type VectorTableLayout,
   getCollectionsWithoutContext,
   getTopLevelPathsWithoutContext,
   handelize,
@@ -2671,6 +2672,10 @@ function outputResults(results: OutputRow[], query: string, opts: OutputOptions)
   warnUnresolvedFullPaths(unresolvedCount, filtered.length);
 }
 
+function describeVectorLayout(layout: VectorTableLayout): string {
+  return `${layout.chunks} chunks for ${layout.neededChunks} needed, ${Math.round(layout.occupancy * 100)}% useful`;
+}
+
 // Resolve -c collection filter: supports single string, array, or undefined.
 // Returns validated collection names (exits on unknown collection).
 function resolveCollectionFilter(raw: string | string[] | undefined, useDefaults: boolean = false): string[] {
@@ -4917,12 +4922,19 @@ if (isMain) {
         if (stats.orphanedContent > 0) {
           console.log(`Would remove ${stats.orphanedContent} orphaned content hashes`);
         }
+        if (stats.vectorLayout) {
+          console.log(stats.vectorsRepacked
+            ? `Would repack the vector table (${describeVectorLayout(stats.vectorLayout)})`
+            : `${c.dim}Vector table is packed (${describeVectorLayout(stats.vectorLayout)})${c.reset}`);
+        }
         console.log("Would compact FTS and vacuum the database");
         closeDb();
         break;
       }
 
-      const stats = runCleanup(db);
+      const stats = runCleanup(db, {
+        onVectorRepack: (layout) => console.log(`Repacking the vector table (${describeVectorLayout(layout)})...`),
+      });
       console.log(`${c.green}✓${c.reset} Cleared ${stats.cacheCount} cached API responses`);
       if (stats.orphanedVectors > 0) {
         console.log(`${c.green}✓${c.reset} Removed ${stats.orphanedVectors} orphaned embedding chunks`);
@@ -4934,6 +4946,11 @@ if (isMain) {
       }
       if (stats.orphanedContent > 0) {
         console.log(`${c.green}✓${c.reset} Removed ${stats.orphanedContent} orphaned content hashes`);
+      }
+      if (stats.vectorLayout) {
+        console.log(stats.vectorsRepacked
+          ? `${c.green}✓${c.reset} Repacked the vector table (${describeVectorLayout(stats.vectorLayout)})`
+          : `${c.dim}Vector table is packed (${describeVectorLayout(stats.vectorLayout)})${c.reset}`);
       }
       console.log(`${c.green}✓${c.reset} FTS compacted, database vacuumed`);
 

--- a/src/maintenance.ts
+++ b/src/maintenance.ts
@@ -15,8 +15,11 @@ import {
   clearAllEmbeddings,
   optimizeDocumentsFts,
   previewCleanup,
+  repackVectors,
   runCleanup,
+  vectorTableLayout,
   type CleanupStats,
+  type VectorTableLayout,
 } from "./store.js";
 
 export class Maintenance {
@@ -61,14 +64,25 @@ export class Maintenance {
     optimizeDocumentsFts(this.store.db);
   }
 
+  /** Chunk layout of the vector table, or null without one. */
+  vectorLayout(): VectorTableLayout | null {
+    return vectorTableLayout(this.store.db);
+  }
+
+  /** Move the live rows of mostly-empty vector chunks to the tail; see {@link repackVectors}. */
+  repackVectors(): VectorTableLayout | null {
+    return repackVectors(this.store.db);
+  }
+
   /** Preview what {@link run} would remove, without writing. */
   preview(): CleanupStats {
     return previewCleanup(this.store.db);
   }
 
   /**
-   * Full cleanup: cache, orphaned vectors, inactive docs, orphaned content,
-   * FTS optimize, vacuum. Same sequence as `qmd cleanup`.
+   * Full cleanup: cache, orphaned vectors, vector repack when the table is
+   * mostly holes, inactive docs, orphaned content, FTS optimize, vacuum. Same
+   * sequence as `qmd cleanup`.
    */
   run(): CleanupStats {
     return runCleanup(this.store.db);

--- a/src/store.ts
+++ b/src/store.ts
@@ -2809,6 +2809,117 @@ export function cleanupOrphanedVectors(db: Database): number {
 }
 
 /**
+ * Repack the vector table when fewer than this share of its chunk reads hold
+ * live rows. vec0 places an insert in the first free slot of its newest chunk
+ * and reclaims a chunk only once it is empty, so a delete in any older chunk
+ * leaves a hole that every brute-force scan still reads; at 36% occupancy a
+ * scan took twice as long as on a packed copy of the same rows.
+ */
+const VEC_REPACK_BELOW_OCCUPANCY = 0.9;
+
+/** Chunks filled below this share have their live rows moved to the tail. */
+const VEC_REPACK_CHUNK_FILL = 0.9;
+
+export type VectorTableLayout = {
+  rows: number;
+  chunks: number;
+  /** Chunks a freshly packed table needs for the same rows. */
+  neededChunks: number;
+  /** neededChunks over chunks: the share of a scan's chunk reads that hold live rows. */
+  occupancy: number;
+};
+
+interface VecChunkRow {
+  chunkId: number;
+  size: number;
+  validity: Uint8Array;
+  rowids: Uint8Array;
+}
+
+function vecTableReadable(db: Database): boolean {
+  if (!isSqliteVecAvailable()) return false;
+  try {
+    db.prepare(`SELECT 1 FROM vectors_vec LIMIT 0`).get();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Chunk layout of vectors_vec from vec0's shadow tables, or null without a
+ * readable table. `droppedRows` projects the layout after that many rows are
+ * deleted without their chunks going away, which is what orphan removal does.
+ */
+export function vectorTableLayout(db: Database, droppedRows: number = 0): VectorTableLayout | null {
+  if (!vecTableReadable(db)) return null;
+  const chunkRow = db.prepare(`SELECT COUNT(*) AS chunks, MAX(size) AS chunkSize FROM vectors_vec_chunks`).get() as { chunks: number; chunkSize: number | null };
+  const stored = (db.prepare(`SELECT COUNT(*) AS c FROM vectors_vec_rowids`).get() as { c: number }).c;
+  const rows = Math.max(stored - droppedRows, 0);
+  const chunkSize = chunkRow.chunkSize ?? 0;
+  const neededChunks = chunkSize > 0 ? Math.ceil(rows / chunkSize) : 0;
+  const occupancy = chunkRow.chunks > 0 ? neededChunks / chunkRow.chunks : 1;
+  return { rows, chunks: chunkRow.chunks, neededChunks, occupancy };
+}
+
+/** Rows of vectors_vec that cleanupOrphanedVectors would delete: orphaned chunks that still hold a vector. */
+function countOrphanedVectorRows(db: Database): number {
+  if (!vecTableReadable(db)) return 0;
+  return withLazyContentVectorMigration(db, () => (db.prepare(`
+    SELECT COUNT(*) AS c
+    FROM content_vectors cv
+    WHERE NOT EXISTS (SELECT 1 FROM documents d WHERE d.hash = cv.hash AND d.active = 1)
+      AND EXISTS (SELECT 1 FROM vectors_vec_rowids r WHERE r.id = cv.hash || '_' || cv.seq)
+  `).get() as { c: number }).c);
+}
+
+function liveSlots(chunk: VecChunkRow): number[] {
+  const slots: number[] = [];
+  for (let i = 0; i < chunk.size; i++) {
+    if ((chunk.validity[i >> 3]! >> (i & 7)) & 1) slots.push(i);
+  }
+  return slots;
+}
+
+/**
+ * Compact vectors_vec in place: the live rows of every chunk that is mostly
+ * holes are deleted and re-inserted, one chunk per IMMEDIATE transaction.
+ * vec0 puts each insert in the first free slot of its newest chunk and drops
+ * a chunk once it is empty, so the moved rows fill the tail and the emptied
+ * chunks vanish. A transaction holds the write lock for at most one chunk of
+ * rows, so concurrent embed and update runs interleave with it, and an
+ * interrupted run leaves a consistent table that the next cleanup finishes.
+ * A legacy table without a hash_seq key is left for ensureVecTable to rebuild.
+ */
+export function repackVectors(db: Database, onChunk?: (moved: number, total: number) => void): VectorTableLayout | null {
+  if (!vecTableReadable(db)) return null;
+  const ddl = (db.prepare(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'vectors_vec'`).get() as { sql: string }).sql;
+  if (!ddl.includes("hash_seq")) return vectorTableLayout(db);
+  const chunks = db.prepare(`SELECT chunk_id AS chunkId, size, validity, rowids FROM vectors_vec_chunks ORDER BY chunk_id`).all() as VecChunkRow[];
+  const newest = chunks.length > 0 ? chunks[chunks.length - 1]!.chunkId : -1;
+  const sparse = chunks.filter((c) => c.chunkId !== newest && liveSlots(c).length < c.size * VEC_REPACK_CHUNK_FILL);
+  const keyOf = db.prepare(`SELECT id FROM vectors_vec_rowids WHERE rowid = ?`);
+  const vectorOf = db.prepare(`SELECT embedding FROM vectors_vec WHERE hash_seq = ?`);
+  const remove = db.prepare(`DELETE FROM vectors_vec WHERE hash_seq = ?`);
+  const insert = db.prepare(`INSERT INTO vectors_vec (hash_seq, embedding) VALUES (?, ?)`);
+  sparse.forEach((chunk, i) => {
+    const rowids = new DataView(chunk.rowids.buffer, chunk.rowids.byteOffset, chunk.rowids.byteLength);
+    db.transaction(() => {
+      for (const slot of liveSlots(chunk)) {
+        const key = (keyOf.get(rowids.getBigInt64(slot * 8, true)) as { id: string } | undefined)?.id;
+        if (key === undefined) continue;
+        const row = vectorOf.get(key) as { embedding: Uint8Array } | undefined;
+        if (row === undefined) continue;
+        remove.run(key);
+        insert.run(key, row.embedding);
+      }
+    }).immediate();
+    onChunk?.(i + 1, sparse.length);
+  });
+  return vectorTableLayout(db);
+}
+
+/**
  * Run VACUUM to reclaim unused space in the database.
  * This operation rebuilds the database file to eliminate fragmentation.
  */
@@ -2835,6 +2946,10 @@ export type CleanupStats = {
   orphanedVectors: number;
   inactiveDocs: number;
   orphanedContent: number;
+  /** Chunk layout of vectors_vec before any repack, null without a vector table. */
+  vectorLayout: VectorTableLayout | null;
+  /** True when the vector table was repacked (or, in a preview, would be). */
+  vectorsRepacked: boolean;
 };
 
 /** Counts what `runCleanup` would remove, including content only held by inactive docs. */
@@ -2843,21 +2958,35 @@ export function previewCleanup(db: Database): CleanupStats {
   const orphanedVectors = countOrphanedVectors(db);
   const inactiveDocs = (db.prepare(`SELECT COUNT(*) as c FROM documents WHERE active = 0`).get() as { c: number }).c;
   const orphanedContent = countOrphanedContent(db);
-  return { cacheCount, orphanedVectors, inactiveDocs, orphanedContent };
+  const vectorLayout = vectorTableLayout(db, countOrphanedVectorRows(db));
+  const vectorsRepacked = vectorLayout !== null && vectorLayout.occupancy < VEC_REPACK_BELOW_OCCUPANCY;
+  return { cacheCount, orphanedVectors, inactiveDocs, orphanedContent, vectorLayout, vectorsRepacked };
 }
 
+export type CleanupHooks = {
+  /** Called with the layout right before a vector repack starts. */
+  onVectorRepack?: (layout: VectorTableLayout) => void;
+};
+
 /**
- * Full `qmd cleanup` sequence: drop cache, orphaned vectors, inactive document
- * rows, then the content those rows were pinning, compact FTS5, vacuum.
+ * Full `qmd cleanup` sequence: drop cache, orphaned vectors, repack the vector
+ * table when its chunks are mostly holes, inactive document rows, then the
+ * content those rows were pinning, compact FTS5, vacuum.
  */
-export function runCleanup(db: Database): CleanupStats {
+export function runCleanup(db: Database, hooks: CleanupHooks = {}): CleanupStats {
   const cacheCount = deleteLLMCache(db);
   const orphanedVectors = cleanupOrphanedVectors(db);
+  const vectorLayout = vectorTableLayout(db);
+  const vectorsRepacked = vectorLayout !== null && vectorLayout.occupancy < VEC_REPACK_BELOW_OCCUPANCY;
+  if (vectorsRepacked && vectorLayout) {
+    hooks.onVectorRepack?.(vectorLayout);
+    repackVectors(db);
+  }
   const inactiveDocs = deleteInactiveDocuments(db);
   const orphanedContent = cleanupOrphanedContent(db);
   optimizeDocumentsFts(db);
   vacuumDatabase(db);
-  return { cacheCount, orphanedVectors, inactiveDocs, orphanedContent };
+  return { cacheCount, orphanedVectors, inactiveDocs, orphanedContent, vectorLayout, vectorsRepacked };
 }
 
 // =============================================================================

--- a/test/cleanup.test.ts
+++ b/test/cleanup.test.ts
@@ -16,9 +16,12 @@ import {
   cleanupOrphanedContent,
   countOrphanedContent,
   previewCleanup,
+  repackVectors,
   runCleanup,
+  vectorTableLayout,
   type Store,
 } from "../src/store.js";
+import type { Database } from "../src/db.js";
 
 let store: Store | null = null;
 
@@ -105,5 +108,141 @@ describe("qmd cleanup reclaim (#550)", () => {
     expect(stats.orphanedContent).toBe(0);
     expect(s.db.prepare(`SELECT count(*) as c FROM content`).get()).toEqual({ c: 1 });
     expect(s.db.prepare(`SELECT count(*) as c FROM documents`).get()).toEqual({ c: 1 });
+  });
+});
+
+describe("qmd cleanup vector repack", () => {
+  const DIMS = 3;
+
+  /**
+   * Inserts `total` vectors, then deletes every one except the indexes in
+   * `keep` (which also get active documents). vec0 drops a chunk only when it
+   * is completely empty, so keeping one row in each chunk leaves the holes.
+   */
+  async function seedVectors(s: Store, total: number, keep: readonly number[]): Promise<void> {
+    const now = new Date().toISOString();
+    s.ensureVecTable(DIMS);
+    s.db.transaction(() => {
+      for (let i = 0; i < total; i++) {
+        const hash = `vec${String(i).padStart(5, "0")}`;
+        if (keep.includes(i)) {
+          insertContent(s.db, hash, `body ${hash}`, now);
+          insertDocument(s.db, "docs", `${hash}.md`, hash, hash, now, now);
+        }
+        s.insertEmbedding(hash, 0, 0, new Float32Array([1, i * 0.001, 0]), "test-model", now, 1);
+      }
+      const drop = s.db.prepare(`DELETE FROM vectors_vec WHERE hash_seq = ?`);
+      for (let i = 0; i < total; i++) if (!keep.includes(i)) drop.run(`vec${String(i).padStart(5, "0")}_0`);
+    })();
+  }
+
+  /** Two chunks of 1024 slots holding three live rows: two in the first chunk, one in the second. */
+  const HOLEY = { total: 1100, keep: [0, 1, 1099] } as const;
+
+  function nearest(s: Store): string {
+    const row = s.db.prepare(`SELECT hash_seq FROM vectors_vec WHERE embedding MATCH ? AND k = 1`).get(new Float32Array([1, 0, 0])) as { hash_seq: string };
+    return row.hash_seq;
+  }
+
+  test("layout counts the chunks a packed table would need against the chunks in use", async () => {
+    const s = await openStore();
+    await seedVectors(s, HOLEY.total, HOLEY.keep);
+
+    expect(vectorTableLayout(s.db)).toEqual({ rows: 3, chunks: 2, neededChunks: 1, occupancy: 0.5 });
+  });
+
+  test("layout is null without a vector table", async () => {
+    const s = await openStore();
+    expect(vectorTableLayout(s.db)).toBeNull();
+    expect(previewCleanup(s.db)).toMatchObject({ vectorLayout: null, vectorsRepacked: false });
+  });
+
+  test("runCleanup repacks a table that is mostly holes and keeps every live row", async () => {
+    const s = await openStore();
+    await seedVectors(s, HOLEY.total, HOLEY.keep);
+
+    const stats = runCleanup(s.db);
+    expect(stats.vectorsRepacked).toBe(true);
+    expect(stats.vectorLayout).toMatchObject({ chunks: 2, neededChunks: 1 });
+    expect(vectorTableLayout(s.db)).toEqual({ rows: 3, chunks: 1, neededChunks: 1, occupancy: 1 });
+    expect(s.db.prepare(`SELECT hash_seq FROM vectors_vec ORDER BY hash_seq`).all()).toEqual([
+      { hash_seq: "vec00000_0" }, { hash_seq: "vec00001_0" }, { hash_seq: "vec01099_0" },
+    ]);
+    expect(nearest(s)).toBe("vec00000_0");
+  });
+
+  test("runCleanup leaves a packed table alone", async () => {
+    const s = await openStore();
+    await seedVectors(s, 3, [0, 1, 2]);
+
+    const stats = runCleanup(s.db);
+    expect(stats.vectorsRepacked).toBe(false);
+    expect(stats.vectorLayout).toEqual({ rows: 3, chunks: 1, neededChunks: 1, occupancy: 1 });
+  });
+
+  test("previewCleanup reports the repack without rebuilding", async () => {
+    const s = await openStore();
+    await seedVectors(s, HOLEY.total, HOLEY.keep);
+
+    expect(previewCleanup(s.db)).toMatchObject({ vectorsRepacked: true, vectorLayout: { chunks: 2, neededChunks: 1 } });
+    expect(vectorTableLayout(s.db)).toMatchObject({ chunks: 2 });
+  });
+
+  test("a chunk move that fails midway leaves that chunk's rows in place", async () => {
+    const s = await openStore();
+    await seedVectors(s, HOLEY.total, HOLEY.keep);
+    const failing: Database = {
+      prepare: (sql: string) => {
+        const real = s.db.prepare(sql);
+        if (!sql.startsWith("INSERT INTO vectors_vec (")) return real;
+        return { ...real, get: real.get.bind(real), all: real.all.bind(real), iterate: real.iterate.bind(real), run: () => { throw new Error("injected failure during re-insert"); } };
+      },
+      transaction: (fn) => s.db.transaction(fn),
+      exec: (sql: string) => s.db.exec(sql),
+      loadExtension: (path: string) => s.db.loadExtension(path),
+      close: () => s.db.close(),
+    };
+
+    expect(() => repackVectors(failing)).toThrow("injected failure during re-insert");
+    expect(vectorTableLayout(s.db)).toEqual({ rows: 3, chunks: 2, neededChunks: 1, occupancy: 0.5 });
+    expect(nearest(s)).toBe("vec00000_0");
+    expect(s.db.prepare(`SELECT hash_seq FROM vectors_vec ORDER BY hash_seq`).all()).toEqual([
+      { hash_seq: "vec00000_0" }, { hash_seq: "vec00001_0" }, { hash_seq: "vec01099_0" },
+    ]);
+  });
+
+  test("previewCleanup projects the layout after orphan removal, matching what runCleanup does", async () => {
+    const s = await openStore();
+    const now = new Date().toISOString();
+    s.ensureVecTable(DIMS);
+    s.db.transaction(() => {
+      for (let i = 0; i < 2048; i++) {
+        const hash = `orphan${String(i).padStart(5, "0")}`;
+        insertContent(s.db, hash, `body ${hash}`, now);
+        insertDocument(s.db, "docs", `${hash}.md`, hash, hash, now, now);
+        s.insertEmbedding(hash, 0, 0, new Float32Array([1, i * 0.001, 0]), "test-model", now, 1);
+      }
+    })();
+    for (let i = 0; i < 2048; i += 2) deactivateDocument(s.db, "docs", `orphan${String(i).padStart(5, "0")}.md`);
+
+    expect(vectorTableLayout(s.db)).toEqual({ rows: 2048, chunks: 2, neededChunks: 2, occupancy: 1 });
+    expect(previewCleanup(s.db)).toMatchObject({ orphanedVectors: 1024, vectorsRepacked: true, vectorLayout: { rows: 1024, chunks: 2, neededChunks: 1 } });
+
+    const stats = runCleanup(s.db);
+    expect(stats.vectorsRepacked).toBe(true);
+    expect(vectorTableLayout(s.db)).toEqual({ rows: 1024, chunks: 1, neededChunks: 1, occupancy: 1 });
+  });
+
+  test("a legacy vector table without hash_seq is left alone", async () => {
+    const s = await openStore();
+    s.ensureVecTable(DIMS);
+    s.db.exec(`DROP TABLE vectors_vec`);
+    s.db.exec(`CREATE VIRTUAL TABLE vectors_vec USING vec0(hash TEXT PRIMARY KEY, embedding float[${DIMS}] distance_metric=cosine)`);
+    s.db.transaction(() => {
+      for (let i = 0; i < 1100; i++) s.db.prepare(`INSERT INTO vectors_vec (hash, embedding) VALUES (?, ?)`).run(`legacy${i}`, new Float32Array([1, i * 0.001, 0]));
+      for (let i = 2; i < 1099; i++) s.db.prepare(`DELETE FROM vectors_vec WHERE hash = ?`).run(`legacy${i}`);
+    })();
+
+    expect(repackVectors(s.db)).toEqual({ rows: 3, chunks: 2, neededChunks: 1, occupancy: 0.5 });
   });
 });


### PR DESCRIPTION
# Repack the vector table in `qmd cleanup` when its chunks are mostly holes

## Problem

vec0 stores vectors in fixed-size chunks (1,024 slots each). It appends every insert to a fresh slot, never reuses a slot freed by a delete, and drops a chunk only once it is completely empty. `insertEmbedding` re-embeds a chunk as DELETE then INSERT, and orphan removal deletes rows, so an index that churns accumulates holes that every brute-force scan still reads. `VACUUM` does not help: the dead slots live inside the chunk blobs, which keep their size.

On a 794k-vector index (12.6 GB) that has been re-embedding a large mirrored collection every five minutes for months, the table held 2,166 chunks for the 776 a packed table needs (36% of every scan's chunk reads hold live rows; 1,210 chunks were under 20% full). A KNN scan took 1.8s there and 0.9s on a freshly packed copy of the same rows. The nightly `qmd cleanup` had been running the whole time.

## Fix

- `vectorTableLayout(db)` reads the chunk count and row count from vec0's shadow tables (`vectors_vec_chunks`, `vectors_vec_rowids`) and reports the chunks a packed table would need.
- `repackVectors(db)` compacts the table in place: the live rows of every chunk filled below 90% are deleted and re-inserted, one chunk per IMMEDIATE transaction. vec0 puts each insert in the first free slot of its newest chunk and drops a chunk once it is empty, so the moved rows fill the tail and the emptied chunks disappear. The write lock is held for at most one chunk of rows at a time, a concurrent `qmd embed` or `qmd update` interleaves with it, and an interrupted run leaves a consistent table that the next cleanup finishes. A legacy table without a `hash_seq` key is left for `ensureVecTable` to rebuild on the next embed.
- `runCleanup` repacks when fewer than 90% of the chunk reads are useful, after orphan removal and before `VACUUM`, which then reclaims the freed pages. `previewCleanup` projects the layout after orphan removal so `qmd cleanup --dry-run` predicts the same decision as the run; the cleanup output prints the chunk counts either way and announces the repack before it starts. `Maintenance` gains `vectorLayout()` and `repackVectors()`.

The first version copied the table through a temporary vec0 table inside one transaction; on this index that held the write lock for the whole rebuild, past the 120s busy timeout an embed would wait on, and a single multi-GB WAL transaction slowed every page read to a crawl. Moving rows chunk by chunk has neither problem and costs only the rows that actually sit in sparse chunks.

## Measured

First `qmd cleanup` with this change on the index the PR describes (794k vectors, 12.6 GB, 2,170 chunks at 36% useful), run in the gap between the five-minute update and embed timers:

| | Before | After |
| --- | --- | --- |
| Chunks (777 needed) | 2,170 | 795 |
| Useful share of chunk reads | 36% | 97.6% |
| Index file after VACUUM | 12.63 GB | 8.27 GB |
| Brute-force KNN scan, k = 9 | 1,838 ms | 881 ms |
| `solutions` pre-filtered KNN, k = 9 | 1,399 ms | 520 ms |
| `qmd vsearch -c solutions -n 3` (4 vector queries) | 6.8s | 4.6s |
| `qmd vsearch -n 3`, 13 collections | 7.4s | 3.9s |
| `qmd vsearch -c stars -n 3` (761k-key scope) | 14.1s | 9.6s |

The cleanup took 6 minutes 32 seconds: about four and a half minutes moving rows out of roughly 1,400 sparse chunks (one transaction each, 0.7 to 1.4 ms per row on this file), then the usual FTS optimize and VACUUM. Every row and the nearest-neighbour answers were unchanged, and the embed timer fired twice during the run without an error.

On a scratch replay of the same hole pattern (the replay lands at 1,127 chunks, 69% useful, since vec0 reuses the newest chunk's free slots as the replay deletes) the compaction moved 632 chunks in 19.9 seconds, 1,127 chunks to 791, and the scan went from 1,202 ms to 940 ms.

## Tests

`test/cleanup.test.ts`, "qmd cleanup vector repack": the layout arithmetic on a two-chunk table with three live rows; `runCleanup` repacking it to one chunk while keeping every row and the nearest-neighbour answer; a packed table left alone; `previewCleanup` reporting without rebuilding; a failure injected during the copy-back leaving the original rows and no temporary table behind; and a database without a vector table. Both runtimes green (`CI=true` vitest and bun), `tsc --noEmit` and `oxlint` clean.

