### PR TITLE
fix(store): split a query term on every separator the tokenizer splits on

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -880,18 +880,15 @@ function containsCjk(text: string): boolean {
 }
 
 function sanitizeFTS5Phrase(phrase: string): string {
-  // Dotted tokens (1.0.21, 2026.4.10) are indexed as adjacent parts by the
-  // porter unicode61 tokenizer. Stripping the dots would produce "1021",
-  // which never matches — split them into phrase terms instead (#757).
+  // A quoted phrase is matched against tokens the porter unicode61 tokenizer
+  // produced, and that tokenizer splits document text on every separator.
+  // Deleting the separators here instead would collapse "1.0.21" to "1021" and
+  // "PIO-1384" to "pio1384", tokens no document holds, so the query returns
+  // nothing with no error (#757 for dots, #916 for the rest). Split on the same
+  // separators the tokenizer does and emit the parts as adjacent phrase terms.
   return normalizeCjkForFTS(phrase)
     .split(/\s+/)
-    .flatMap(t => {
-      if (isDottedToken(t)) {
-        return t.split('.').map(p => sanitizeFTS5Term(p)).filter(p => p);
-      }
-      const sanitized = sanitizeFTS5Term(t);
-      return sanitized ? [sanitized] : [];
-    })
+    .flatMap(t => splitFTS5CompoundTerm(t))
     .join(' ');
 }
 
@@ -3831,41 +3828,30 @@ export function sanitizeFTS5Term(term: string): string {
 }
 
 /**
- * Check if a token is a hyphenated compound word (e.g., multi-agent, DEC-0054, gpt-4).
- * Returns true if the token contains internal hyphens between word/digit characters.
+ * A run of characters the FTS tokenizer treats as a separator.
+ *
+ * `documents_fts` is tokenized with `porter unicode61`, which starts a new
+ * token at every character that is not a letter or a digit. Underscore is one
+ * of those, but it is deliberately kept here rather than split on: FTS5 applies
+ * the same tokenizer to a quoted phrase, so leaving `apply_secrets` intact lets
+ * it split symmetrically into `apply secrets` on both sides, and that is the
+ * behaviour #305 shipped. The apostrophe is kept for the same reason.
  */
-function isHyphenatedToken(token: string): boolean {
-  return /^[\p{L}\p{N}][\p{L}\p{N}'-]*-[\p{L}\p{N}][\p{L}\p{N}'-]*$/u.test(token);
-}
+const FTS5_SEPARATOR_RUN = /[^\p{L}\p{N}'_]+/u;
 
 /**
- * Sanitize a hyphenated term into an FTS5 phrase by splitting on hyphens
- * and sanitizing each part. Returns the parts joined by spaces for use
- * inside FTS5 quotes: "multi agent" matches "multi-agent" in porter tokenizer.
+ * Split one query term the way the tokenizer split the document text, and
+ * sanitize each part.
+ *
+ * `PIO-1384` becomes ["pio", "1384"], `src/lib/i18n.ts` becomes
+ * ["src", "lib", "i18n", "ts"], and a term with no separator in it comes back
+ * as a single part. Callers join the parts into an FTS5 phrase, which is what
+ * makes the parts have to be adjacent in the document rather than merely all
+ * present. Parts that sanitize to nothing are dropped, so a term that is all
+ * punctuation yields an empty list and the caller skips it.
  */
-function sanitizeHyphenatedTerm(term: string): string {
-  return term.split('-').map(t => sanitizeFTS5Term(t)).filter(t => t).join(' ');
-}
-
-/**
- * Check if a token is a dotted version/version-like string (e.g., 2026.4.10, 3.14.0).
- * Returns true if splitting on dots yields at least 2 non-empty parts consisting of
- * word/digit characters only. This avoids incorrectly splitting tokens with leading/
- * trailing dots. Version strings like "2026.4.10" split into ["2026","4","10"] (3 parts).
- */
-function isDottedToken(token: string): boolean {
-  const parts = token.split('.');
-  return parts.length >= 2 && parts.every(p => p.length > 0 && /^[\p{L}\p{N}_]+$/u.test(p));
-}
-
-/**
- * Sanitize a dotted term into individual FTS5 tokens joined with AND.
- * e.g. "2026.4.10" → '"2026"* AND "4"* AND "10"*'
- * The AND ensures all parts must appear, matching how the porter tokenizer
- * indexes dotted strings.
- */
-function sanitizeDottedTerm(term: string): string {
-  return term.split('.').map(t => sanitizeFTS5Term(t)).filter(t => t).map(t => `"${t}"*`).join(' AND ');
+function splitFTS5CompoundTerm(term: string): string[] {
+  return term.split(FTS5_SEPARATOR_RUN).map(p => sanitizeFTS5Term(p)).filter(p => p);
 }
 
 /**
@@ -3874,7 +3860,8 @@ function sanitizeDottedTerm(term: string): string {
  * Supports:
  * - Quoted phrases: "exact phrase" → "exact phrase" (exact match)
  * - Negation: -term or -"phrase" → uses FTS5 NOT operator
- * - Hyphenated tokens: multi-agent, DEC-0054, gpt-4 → treated as phrases
+ * - Terms holding a separator: multi-agent, DEC-0054, gpt-4, 2026.4.10,
+ *   src/lib/i18n.ts, @tobilu/qmd → treated as phrases over their parts
  * - Plain terms: term → "term"* (prefix match)
  *
  * FTS5 NOT is a binary operator: `term1 NOT term2` means "match term1 but not term2".
@@ -3891,6 +3878,8 @@ function sanitizeDottedTerm(term: string): string {
  *   multi-agent memory      → "multi agent" AND "memory"*
  *   DEC-0054               → "dec 0054"
  *   -multi-agent            → NOT "multi agent"
+ *   "DEC-0054"              → "dec 0054"
+ *   src/lib/i18n.ts         → "src lib i18n ts"
  */
 function buildFTS5Query(query: string): string | null {
   const positive: string[] = [];
@@ -3932,37 +3921,7 @@ function buildFTS5Query(query: string): string | null {
       while (i < s.length && !/[\s"]/.test(s[i]!)) i++;
       const term = s.slice(start, i);
 
-      // Handle hyphenated tokens: multi-agent, DEC-0054, gpt-4
-      // These get split into phrase queries so FTS5 porter tokenizer matches them.
-      if (isHyphenatedToken(term)) {
-        const sanitized = sanitizeHyphenatedTerm(term);
-        if (sanitized) {
-          const ftsPhrase = `"${sanitized}"`;  // Phrase match (no prefix)
-          if (negated) {
-            negative.push(ftsPhrase);
-          } else {
-            positive.push(ftsPhrase);
-          }
-        }
-      } else if (isDottedToken(term)) {
-        // Handle dotted version strings: 2026.4.10, 3.14.0, v1.2.3
-        // The porter tokenizer splits on dots, so the index has individual tokens.
-        // We AND all parts together so the query matches documents containing all parts.
-        const sanitized = sanitizeDottedTerm(term);
-        if (sanitized) {
-          // sanitizeDottedTerm already wraps each part in quotes with prefix match
-          if (negated) {
-            // Wrap multi-token AND expression in parens for NOT negation
-            negative.push(`(${sanitized})`);
-          } else {
-            // Flatten individual AND'd terms into the positive list so they combine
-            // correctly with other terms (avoids double-wrapping in outer AND).
-            for (const part of sanitized.split(' AND ')) {
-              positive.push(part.trim());
-            }
-          }
-        }
-      } else if (containsCjk(term)) {
+      if (containsCjk(term)) {
         const sanitized = sanitizeFTS5Phrase(term);
         if (sanitized) {
           const ftsPhrase = `"${sanitized}"`;  // CJK phrase over character tokens
@@ -3973,9 +3932,16 @@ function buildFTS5Query(query: string): string | null {
           }
         }
       } else {
-        const sanitized = sanitizeFTS5Term(term);
-        if (sanitized) {
-          const ftsTerm = `"${sanitized}"*`;  // Prefix match
+        // Any separator inside the term (multi-agent, DEC-0054, 2026.4.10,
+        // src/lib/i18n.ts, @tobilu/qmd) split it at index time too, so the term
+        // has to be matched as the phrase those parts form. A term with no
+        // separator is one part and keeps its prefix match, which is what makes
+        // a plain word still match longer words that start with it.
+        const parts = splitFTS5CompoundTerm(term);
+        if (parts.length > 0) {
+          const ftsTerm = parts.length > 1
+            ? `"${parts.join(' ')}"`   // Phrase match (no prefix)
+            : `"${parts[0]}"*`;        // Prefix match
           if (negated) {
             negative.push(ftsTerm);
           } else {

--- a/test/store-fts-separator-queries.test.ts
+++ b/test/store-fts-separator-queries.test.ts
@@ -1,0 +1,235 @@
+/**
+ * store-fts-separator-queries.test.ts - lex queries whose terms contain a
+ * separator, bare and quoted.
+ *
+ * The FTS index uses `tokenize='porter unicode61'`, which splits on every
+ * non-alphanumeric character, so a document containing `PIO-1384` is stored as
+ * the adjacent tokens `pio` and `1384`. A query has to produce that same token
+ * sequence to match.
+ *
+ * Two query paths reach the index and they were fixed separately:
+ *
+ *   - The bare-term path in buildFTS5Query grew isHyphenatedToken /
+ *     sanitizeHyphenatedTerm (upstream #463) and isDottedToken /
+ *     sanitizeDottedTerm (upstream #696), so `PIO-1384` and `2026.4.10` split
+ *     into phrase terms.
+ *   - The quoted-phrase path, sanitizeFTS5Phrase, was introduced later for CJK
+ *     and inherited only sanitizeFTS5Term, which DELETES every separator.
+ *     `"PIO-1384"` therefore became the single token `pio1384`, which no
+ *     document holds, and the query returned zero rows with no error. Upstream
+ *     #757 added dotted-token splitting to this path and nothing else, so dots
+ *     worked and every other separator did not.
+ *
+ * These tests pin both paths to the same rule: a query term is split on any run
+ * of characters the tokenizer treats as a separator, and the parts are matched
+ * as an adjacent phrase. Underscore and case are covered because they bound the
+ * diagnosis: `_` already worked (sanitizeFTS5Term preserves it and FTS5
+ * re-tokenizes the phrase symmetrically) and must not regress, and matching is
+ * case-insensitive on both paths.
+ *
+ * PIO-3237, upstream https://github.com/tobi/qmd/issues/916.
+ *
+ * Run with: bun test test/store-fts-separator-queries.test.ts
+ *        or: pnpm test:node test/store-fts-separator-queries.test.ts
+ */
+
+import { describe, test, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import YAML from "yaml";
+import {
+  createStore,
+  hashContent,
+  insertContent,
+  insertDocument,
+  syncConfigToDb,
+  validateSemanticQuery,
+  type Store,
+} from "../src/store.js";
+import type { CollectionConfig } from "../src/collections.js";
+
+// =============================================================================
+// Fixtures / helpers
+// =============================================================================
+
+/**
+ * The PIO-3237 probe corpus. The title is the real title of
+ * twin-github/pionizer/gateway/pr-1.md, the document the four probes in that
+ * issue were measured against, so the separators under test are the ones the
+ * corpus actually contains rather than invented ones.
+ */
+const PROBE_TITLE =
+  "gateway #1: feat: flash-and-forget gateway scaffold, compose stack + cloud-init provisioning (PIO-1384)";
+
+const PROBE_BODY = [
+  "The flash-and-forget gateway scaffold lands the compose stack and the",
+  "cloud-init provisioning path together, under PIO-1384 and DEC-0066.",
+  "It touches src/lib/provision.ts and docs/SYNTAX.md, pins version 2026.4.10,",
+  "calls apply_secrets and __init__, and reaches qmd://Vault/wiki over zero-SSH.",
+  "Package @tobilu/qmd is a dependency.",
+].join("\n");
+
+let testDir: string;
+let testConfigDir: string;
+let currentStore: Store | null = null;
+
+async function createProbeStore(): Promise<{ store: Store; collection: string }> {
+  testConfigDir = await mkdtemp(join(testDir, "config-"));
+  process.env.QMD_CONFIG_DIR = testConfigDir;
+
+  const collection = "probes";
+  const config: CollectionConfig = {
+    collections: { [collection]: { path: "/test/probes", pattern: "**/*.md" } },
+  };
+  await writeFile(join(testConfigDir, "index.yml"), YAML.stringify(config));
+
+  const store = createStore(
+    join(testDir, `probe-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`),
+  );
+  currentStore = store;
+  syncConfigToDb(store.db, config);
+
+  const now = new Date().toISOString();
+  const hash = await hashContent(PROBE_BODY);
+  insertContent(store.db, hash, PROBE_BODY, now);
+  insertDocument(store.db, collection, "gateway/pr-1.md", PROBE_TITLE, hash, now, now);
+
+  return { store, collection };
+}
+
+beforeAll(async () => {
+  testDir = await mkdtemp(join(tmpdir(), "qmd-fts-separators-"));
+});
+
+afterEach(async () => {
+  currentStore?.close();
+  currentStore = null;
+  delete process.env.QMD_CONFIG_DIR;
+});
+
+afterAll(async () => {
+  await rm(testDir, { recursive: true, force: true });
+});
+
+// =============================================================================
+// The four PIO-3237 probes
+// =============================================================================
+
+describe("PIO-3237 probes: quoted and hyphenated is the combination that failed", () => {
+  /**
+   * The table as measured on 2026-09-03 against the live twin-github index.
+   * Rows 2, 3 and 4 already passed and are kept as the positive controls that
+   * make row 1's zero a defect rather than an absent document: the same store,
+   * the same document, one variable changed per row.
+   */
+  const probes: ReadonlyArray<{ probe: number; query: string; why: string }> = [
+    { probe: 1, query: '"flash-and-forget"', why: "quoted and hyphenated, returned 0" },
+    { probe: 2, query: "flash-and-forget", why: "hyphenated, unquoted, already worked" },
+    {
+      probe: 3,
+      query: '"flash and forget gateway scaffold"',
+      why: "quoted, no hyphen, already worked",
+    },
+    { probe: 4, query: '"gateway scaffold"', why: "quoted, no hyphen, already worked" },
+  ];
+
+  for (const { probe, query, why} of probes) {
+    test(`probe ${probe}: lex ${query} finds the document (${why})`, async () => {
+      const { store } = await createProbeStore();
+      expect(store.searchFTS(query, 10)).toHaveLength(1);
+    });
+  }
+});
+
+// =============================================================================
+// The separator class, not one separator
+// =============================================================================
+
+describe("a quoted term splits on every separator the tokenizer splits on", () => {
+  const quoted: ReadonlyArray<{ query: string; separator: string }> = [
+    { query: '"PIO-1384"', separator: "hyphen, identifier" },
+    { query: '"DEC-0066"', separator: "hyphen, identifier" },
+    { query: '"cloud-init"', separator: "hyphen, compound" },
+    { query: '"zero-SSH"', separator: "hyphen, mixed case" },
+    { query: '"2026.4.10"', separator: "dot, already fixed upstream (#757)" },
+    { query: '"src/lib/provision.ts"', separator: "slash, upstream #916" },
+    { query: '"docs/SYNTAX.md"', separator: "slash, upstream #916" },
+    { query: '"qmd://Vault/wiki"', separator: "scheme punctuation, upstream #916" },
+    { query: '"@tobilu/qmd"', separator: "at sign, upstream #916" },
+  ];
+
+  for (const { query, separator } of quoted) {
+    test(`lex ${query} finds the document (${separator})`, async () => {
+      const { store } = await createProbeStore();
+      expect(store.searchFTS(query, 10)).toHaveLength(1);
+    });
+  }
+
+  test("a bare term with the same separators still matches", async () => {
+    const { store } = await createProbeStore();
+    for (const query of ["PIO-1384", "cloud-init", "2026.4.10", "src/lib/provision.ts"]) {
+      expect(store.searchFTS(query, 10), `bare ${query}`).toHaveLength(1);
+    }
+  });
+
+  test("a quoted phrase spanning several separated terms matches in order", async () => {
+    const { store } = await createProbeStore();
+    expect(store.searchFTS('"flash-and-forget gateway scaffold"', 10)).toHaveLength(1);
+  });
+
+  test("a quoted phrase whose words are not adjacent does not match", async () => {
+    const { store } = await createProbeStore();
+    // Both tokens are in the document, in the other order and far apart, so a
+    // phrase query must still reject it. Without this the tests above would
+    // pass on a sanitizer that dropped separated terms entirely.
+    expect(store.searchFTS('"scaffold flash-and-forget"', 10)).toHaveLength(0);
+  });
+
+  test("a quoted term absent from the document does not match", async () => {
+    const { store } = await createProbeStore();
+    expect(store.searchFTS('"PIO-9999"', 10)).toHaveLength(0);
+    expect(store.searchFTS('"never-indexed-term"', 10)).toHaveLength(0);
+  });
+});
+
+// =============================================================================
+// Underscores and case, which bound the diagnosis
+// =============================================================================
+
+describe("underscores and case behave the same on both paths", () => {
+  test("underscored identifiers match bare and quoted", async () => {
+    const { store } = await createProbeStore();
+    for (const query of ["apply_secrets", '"apply_secrets"', "__init__", '"__init__"']) {
+      expect(store.searchFTS(query, 10), query).toHaveLength(1);
+    }
+  });
+
+  test("matching is case insensitive on both paths", async () => {
+    const { store } = await createProbeStore();
+    for (const query of ["pio-1384", "PIO-1384", '"pio-1384"', '"PIO-1384"', '"ZERO-ssh"']) {
+      expect(store.searchFTS(query, 10), query).toHaveLength(1);
+    }
+  });
+});
+
+// =============================================================================
+// Negation still parses, and vec/hyde still accept hyphens
+// =============================================================================
+
+describe("negation and semantic-query validation are unaffected", () => {
+  test("a leading hyphen still negates, inside quotes and out", async () => {
+    const { store } = await createProbeStore();
+    expect(store.searchFTS("gateway -scaffold", 10)).toHaveLength(0);
+    expect(store.searchFTS('gateway -"cloud-init"', 10)).toHaveLength(0);
+    expect(store.searchFTS("gateway -kubernetes", 10)).toHaveLength(1);
+  });
+
+  test("vec and hyde accept mid-term separators and still reject negation", () => {
+    expect(validateSemanticQuery("flash-and-forget gateway scaffold")).toBeNull();
+    expect(validateSemanticQuery("src/lib/provision.ts and @tobilu/qmd")).toBeNull();
+    expect(validateSemanticQuery('"cloud-init" provisioning')).toBeNull();
+    expect(validateSemanticQuery("gateway -scaffold")).toContain("Negation");
+    expect(validateSemanticQuery('gateway -"cloud-init"')).toContain("Negation");
+  });
+});


### PR DESCRIPTION
Closes #916.

## The problem

`documents_fts` is tokenized `porter unicode61`, which starts a new token at
every character that is not a letter or a digit. A document holding `PIO-1384`
is stored as the adjacent tokens `pio` and `1384`. A query has to produce that
same sequence, and two code paths have to do it independently:

- `buildFTS5Query`'s bare-term branch, which grew `isHyphenatedToken` in #463
  and `isDottedToken` in #696, one separator at a time.
- `sanitizeFTS5Phrase`, the quoted path, which was added later for CJK and
  inherited only `sanitizeFTS5Term`. That function's character class
  `/[^\p{L}\p{N}'_]/gu` **deletes** every separator rather than splitting on it,
  so `"PIO-1384"` becomes the single token `pio1384`, which no document holds.
  #859 added dotted tokens to this path and nothing else, so `"1.0.21"` works
  and every other separator does not.

Both paths therefore return zero rows, with no error, for a term the corpus
plainly contains. That reads as "not indexed" rather than "query was mangled",
which is the part that costs time.

Three symptoms, all the same cause:

| query | before | after |
| --- | --- | --- |
| `"PIO-1384"`, `"cloud-init"` | 0 | matches |
| `src/lib/i18n.ts`, `@tobilu/qmd`, `qmd://Vault/wiki`, bare or quoted | 0 | matches |
| `note -"cloud-init"` | returns the document it excludes | excludes it |

The third one is a negation that silently does nothing, because the NOT clause
holds a token that matches nothing. I did not find it filed separately.

## The change

One helper, `splitFTS5CompoundTerm`, splits a term on any run of characters the
tokenizer treats as a separator and sanitizes the parts. Both paths use it.

- A term with no separator is one part and keeps its prefix match, so a plain
  word still matches longer words starting with it.
- A term with more than one part becomes a phrase over its parts, so the parts
  must be adjacent rather than merely all present.

`isHyphenatedToken`, `sanitizeHyphenatedTerm`, `isDottedToken` and
`sanitizeDottedTerm` are subsumed and removed, so this is a net deletion in
`src/store.ts` rather than a fifth special case. The next separator someone
reports needs no code.

**Two deliberate decisions worth reviewing rather than skimming.**

**Dotted bare terms get stricter.** `sanitizeDottedTerm` produced
`"2026"* AND "4"* AND "10"*`, which matches a document containing those tokens
anywhere. They are now an adjacent phrase, which is what #463 already ships for
hyphens. I believe this is correct, since a version string is adjacent in any
document that genuinely contains it, and it makes the two paths agree. It is
still a behaviour change and easy to revert to AND if you would rather.

**Underscore and apostrophe stay inside a token.** `unicode61` does treat `_` as
a separator, but `sanitizeFTS5Term` keeps it and FTS5 applies the same tokenizer
to a quoted phrase, so `apply_secrets` already splits symmetrically on both
sides. That is the #305 behaviour; splitting on `_` here would change nothing at
best. The test pins it so a later refactor cannot quietly drop it.

## Testing

`test/store-fts-separator-queries.test.ts`, 21 cases, run against the unfixed
code first: **13 fail, 8 pass**. The 8 that pass are the ones this change is not
about, which is what makes the other 13 meaningful rather than decorative.

It covers, against one document:

- the separator class rather than one separator: `-`, `.`, `/`, `:`, `@`
- both query paths for each, bare and quoted
- underscores and case, which bound the diagnosis
- negation, quoted and bare
- two negative cases, so the tests can fail in both directions: a quoted phrase
  whose words are present but **not adjacent** must not match, and a term absent
  from the document must not match

Full suite on this branch, which is `main` plus this one commit:

- `CI=true vitest run test/`: 44 files, 1164 passed, 78 skipped, 0 failed
- `CI=true bun test --preload ./src/test-preload.ts test/`: 44 files, 1164 pass,
  87 skip, 0 fail
- `npm run test:types`: clean

That includes `store.test.ts`'s #563 and #757 dotted-token cases and
`store-cjk-fts.test.ts`, which are the two behaviours this unification could
have regressed.

Also carried as a local patch and running against an 11k-document corpus since
2026-09-03, where the four original probes behave correctly and a
deliberately-absent identifier still returns nothing.
