### PR TITLE
fix(embed-lock): evict a live holder that has outlived its session cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@
 
 - Added Oxlint lint fence.
 
+### Fixed
+
+- `qmd embed` no longer skips itself forever behind a wedged predecessor. The
+  embed lock now records when it was taken and the session cap its holder
+  promised (`--timeout`, default 30 min); a holder still alive past twice that
+  cap (24 h if it declared no cap) is evicted with a warning naming its PID.
+  Previously a process stuck inside a native node-llama-cpp call kept its PID,
+  so the PID-liveness check kept the lock alive indefinitely and every later
+  run printed "Another embed process is already running" — the session cap is
+  a JS timer and cannot fire while the event loop is blocked (#735). Bare-PID
+  lockfiles from earlier versions are still understood, aged by mtime.
+
 ## [2.8.3] - 2026-08-16
 
 ### Security

--- a/src/cli/embed-lock.ts
+++ b/src/cli/embed-lock.ts
@@ -5,28 +5,121 @@
  * (UNIQUE constraint on hash_seq). This lockfile keeps a second process from
  * starting while another embed holds the lock. Stale files left by crashed
  * processes are recovered via PID identity checks (same spirit as mcp-pid.ts).
+ *
+ * A live PID is not proof of a live embed. The embed session cap
+ * (`--timeout`, default 30 minutes) is a JavaScript timer: it cannot fire
+ * while the event loop is blocked inside a native node-llama-cpp call, so a
+ * process wedged in Metal/CUDA keeps its PID, keeps the lock, and every later
+ * `qmd embed` skips itself with "Another embed process is already running"
+ * for as long as the zombie lives (observed: 39 hours, #735). The lock
+ * therefore also records when it was taken and the cap the holder promised
+ * to honour; a holder that has outlived twice its cap is treated as stale
+ * even though its PID still answers.
  */
 
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { isQmdMcpPid } from "./mcp-pid.js";
 
 export type EmbedLockHandle = {
   lockPath: string;
   release: () => void;
+  /** Set when a live-but-overdue holder was evicted to take this lock. */
+  reclaimedFrom?: EmbedLockRecord;
 };
+
+/** What the lockfile records about its holder. */
+export type EmbedLockRecord = {
+  pid: number;
+  /** Epoch milliseconds when the holder took the lock. */
+  startedAt: number;
+  /** The holder's embed session cap in ms; 0 = the holder declared no cap. */
+  maxDurationMs: number;
+  /** True when the file was written by an older qmd that only stored the PID. */
+  legacy: boolean;
+};
+
+export type EmbedLockOptions = {
+  /**
+   * This caller's embed session cap in ms (0 = no cap). Recorded in the lock
+   * so later callers can judge staleness by the promise the holder made.
+   * Defaults to {@link DEFAULT_EMBED_LOCK_MAX_DURATION_MS}.
+   */
+  maxDurationMs?: number;
+  /** Clock override for tests. */
+  now?: () => number;
+};
+
+/**
+ * Mirrors DEFAULT_EMBED_MAX_DURATION_MS in store.ts. Kept local so the lock
+ * module stays free of the store's SQLite/model dependencies.
+ */
+export const DEFAULT_EMBED_LOCK_MAX_DURATION_MS = 30 * 60 * 1000;
+
+/** A holder that declared no session cap is still evicted after this long. */
+export const EMBED_LOCK_UNCAPPED_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 /** Lockfile path sibling to the index database. */
 export function embedLockPathForDb(dbPath: string): string {
   return join(dirname(dbPath), ".qmd-embed.lock");
 }
 
-function readLockPid(lockPath: string): number | null {
+/**
+ * How long a holder may keep the lock before it counts as stale: twice the
+ * cap it promised to honour, or {@link EMBED_LOCK_UNCAPPED_MAX_AGE_MS} when it
+ * promised none. Twice, so a holder that is merely slow to notice its own
+ * abort is not evicted while it is still winding down.
+ */
+export function embedLockMaxAgeMs(maxDurationMs: number): number {
+  if (!Number.isFinite(maxDurationMs) || maxDurationMs <= 0) {
+    return EMBED_LOCK_UNCAPPED_MAX_AGE_MS;
+  }
+  return 2 * maxDurationMs;
+}
+
+function parseRecord(raw: string, fileMtimeMs: number, fallbackMaxDurationMs: number): EmbedLockRecord | null {
+  const text = raw.trim();
+  if (text === "") return null;
+
+  if (text.startsWith("{")) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      return null;
+    }
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const pid = (parsed as { pid?: unknown }).pid;
+    const startedAt = (parsed as { startedAt?: unknown }).startedAt;
+    const maxDurationMs = (parsed as { maxDurationMs?: unknown }).maxDurationMs;
+    if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return null;
+    return {
+      pid,
+      startedAt: typeof startedAt === "number" && Number.isFinite(startedAt) ? startedAt : fileMtimeMs,
+      maxDurationMs:
+        typeof maxDurationMs === "number" && Number.isFinite(maxDurationMs) && maxDurationMs >= 0
+          ? maxDurationMs
+          : fallbackMaxDurationMs,
+      legacy: false,
+    };
+  }
+
+  // Pre-2.9 format: the bare PID. Age comes from the file's mtime and the cap
+  // from this caller, since the holder recorded neither.
+  const pid = parseInt(text, 10);
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  return { pid, startedAt: fileMtimeMs, maxDurationMs: fallbackMaxDurationMs, legacy: true };
+}
+
+/** Read and parse the lockfile; null if missing, unreadable, or malformed. */
+export function readEmbedLockRecord(
+  lockPath: string,
+  fallbackMaxDurationMs: number = DEFAULT_EMBED_LOCK_MAX_DURATION_MS,
+): EmbedLockRecord | null {
   try {
-    const raw = readFileSync(lockPath, "utf-8").trim();
-    const pid = parseInt(raw, 10);
-    if (!Number.isInteger(pid) || pid <= 0) return null;
-    return pid;
+    const raw = readFileSync(lockPath, "utf-8");
+    const mtimeMs = statSync(lockPath).mtimeMs;
+    return parseRecord(raw, mtimeMs, fallbackMaxDurationMs);
   } catch {
     return null;
   }
@@ -40,16 +133,23 @@ export function isLiveEmbedLockHolder(pid: number): boolean {
   return isQmdMcpPid(pid);
 }
 
-function createOwnedLock(lockPath: string): EmbedLockHandle {
-  writeFileSync(lockPath, `${process.pid}\n`, { flag: "wx" });
+/** True when the holder has held the lock longer than its cap allows. */
+export function isOverdueEmbedLockHolder(record: EmbedLockRecord, nowMs: number): boolean {
+  const ageMs = nowMs - record.startedAt;
+  return ageMs > embedLockMaxAgeMs(record.maxDurationMs);
+}
+
+function createOwnedLock(lockPath: string, maxDurationMs: number, nowMs: number): EmbedLockHandle {
+  const record = { pid: process.pid, startedAt: nowMs, maxDurationMs };
+  writeFileSync(lockPath, `${JSON.stringify(record)}\n`, { flag: "wx" });
   let released = false;
   const release = () => {
     if (released) return;
     released = true;
     try {
       if (!existsSync(lockPath)) return;
-      const written = readLockPid(lockPath);
-      if (written === process.pid) unlinkSync(lockPath);
+      const written = readEmbedLockRecord(lockPath, maxDurationMs);
+      if (written?.pid === process.pid) unlinkSync(lockPath);
     } catch {
       // best-effort cleanup
     }
@@ -60,12 +160,20 @@ function createOwnedLock(lockPath: string): EmbedLockHandle {
 /**
  * Try to acquire an exclusive embed lock at `lockPath`.
  * Returns a handle with `release()` on success, or `null` if another live
- * qmd process already holds the lock.
+ * qmd process already holds the lock and is within its time budget. A live
+ * holder that has outlived twice its declared cap is evicted; the returned
+ * handle then carries `reclaimedFrom` so the caller can warn about it.
  */
-export function tryAcquireEmbedLock(lockPath: string): EmbedLockHandle | null {
+export function tryAcquireEmbedLock(lockPath: string, options: EmbedLockOptions = {}): EmbedLockHandle | null {
+  const maxDurationMs = options.maxDurationMs ?? DEFAULT_EMBED_LOCK_MAX_DURATION_MS;
+  const now = options.now ?? Date.now;
+  let reclaimedFrom: EmbedLockRecord | undefined;
+
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
-      return createOwnedLock(lockPath);
+      const handle = createOwnedLock(lockPath, maxDurationMs, now());
+      if (reclaimedFrom) handle.reclaimedFrom = reclaimedFrom;
+      return handle;
     } catch (err: unknown) {
       const code =
         typeof err === "object" && err !== null && "code" in err
@@ -73,12 +181,15 @@ export function tryAcquireEmbedLock(lockPath: string): EmbedLockHandle | null {
           : undefined;
       if (code !== "EEXIST") throw err;
 
-      const holderPid = readLockPid(lockPath);
-      if (holderPid !== null && isLiveEmbedLockHolder(holderPid)) {
-        return null;
+      const holder = readEmbedLockRecord(lockPath, maxDurationMs);
+      if (holder !== null && isLiveEmbedLockHolder(holder.pid)) {
+        if (!isOverdueEmbedLockHolder(holder, now())) {
+          return null;
+        }
+        reclaimedFrom = holder;
       }
 
-      // Stale / unreadable / recycled PID — remove and retry once.
+      // Stale / unreadable / recycled PID / overdue holder — remove and retry once.
       try {
         unlinkSync(lockPath);
       } catch {
@@ -88,13 +199,19 @@ export function tryAcquireEmbedLock(lockPath: string): EmbedLockHandle | null {
   }
 
   // Final attempt lost the race to a live holder (or repeated EEXIST).
-  const holderPid = readLockPid(lockPath);
-  if (holderPid !== null && isLiveEmbedLockHolder(holderPid)) {
-    return null;
-  }
   return null;
 }
 
 /** User-facing message when a second embed is skipped. */
 export const EMBED_LOCK_BUSY_MESSAGE =
   "Another embed process is already running. Skipping.";
+
+/** User-facing warning when an overdue holder was evicted. */
+export function embedLockReclaimedMessage(record: EmbedLockRecord, nowMs: number = Date.now()): string {
+  const ageMinutes = Math.round((nowMs - record.startedAt) / 60_000);
+  const capMinutes = Math.round(embedLockMaxAgeMs(record.maxDurationMs) / 60_000);
+  return (
+    `Reclaimed the embed lock from process ${record.pid}: it has held it for ${ageMinutes} min, ` +
+    `past its ${capMinutes} min limit. If that process is still running it is stuck in a native call; kill it.`
+  );
+}

--- a/src/cli/qmd.ts
+++ b/src/cli/qmd.ts
@@ -3,7 +3,7 @@ import type { Database, SQLiteValue } from "../db.js";
 import fastGlob from "fast-glob";
 import { spawn as nodeSpawn } from "child_process";
 import { isQmdMcpPid, mcpDaemonStateFiles } from "./mcp-pid.js";
-import { embedLockPathForDb, tryAcquireEmbedLock, EMBED_LOCK_BUSY_MESSAGE } from "./embed-lock.js";
+import { embedLockPathForDb, tryAcquireEmbedLock, embedLockReclaimedMessage, EMBED_LOCK_BUSY_MESSAGE } from "./embed-lock.js";
 import { fileURLToPath } from "url";
 import { basename, dirname, join as pathJoin, relative as relativePath, resolve as pathResolve } from "path";
 import { parseArgs } from "util";
@@ -72,6 +72,7 @@ import {
   DEFAULT_EMBED_MODEL,
   DEFAULT_EMBED_MAX_BATCH_BYTES,
   DEFAULT_EMBED_MAX_DOCS_PER_BATCH,
+  DEFAULT_EMBED_MAX_DURATION_MS,
   DEFAULT_RERANK_MODEL,
   DEFAULT_QUERY_MODEL,
   DEFAULT_GLOB,
@@ -2165,12 +2166,19 @@ async function vectorIndex(
   const storeInstance = getStore();
   const db = storeInstance.db;
 
-  // Exclusive process lock — concurrent embeds race on vectors_vec (#825)
-  const embedLock = tryAcquireEmbedLock(embedLockPathForDb(getDbPath()));
+  // Exclusive process lock — concurrent embeds race on vectors_vec (#825).
+  // The lock records this run's session cap so a later run can evict us if we
+  // wedge in a native call and outlive it (#735).
+  const embedLock = tryAcquireEmbedLock(embedLockPathForDb(getDbPath()), {
+    maxDurationMs: batchOptions?.maxDurationMs ?? DEFAULT_EMBED_MAX_DURATION_MS,
+  });
   if (!embedLock) {
     console.log(EMBED_LOCK_BUSY_MESSAGE);
     closeDb();
     return;
+  }
+  if (embedLock.reclaimedFrom) {
+    console.error(`${c.yellow}${embedLockReclaimedMessage(embedLock.reclaimedFrom)}${c.reset}`);
   }
 
   try {

--- a/test/embed-lock.test.ts
+++ b/test/embed-lock.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, test, expect } from "vitest";
 import { mkdtemp, rm, readFile } from "node:fs/promises";
-import { existsSync, writeFileSync, unlinkSync } from "node:fs";
+import { existsSync, writeFileSync, unlinkSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -12,7 +12,13 @@ import {
   embedLockPathForDb,
   tryAcquireEmbedLock,
   isLiveEmbedLockHolder,
+  isOverdueEmbedLockHolder,
+  readEmbedLockRecord,
+  embedLockMaxAgeMs,
+  embedLockReclaimedMessage,
   EMBED_LOCK_BUSY_MESSAGE,
+  DEFAULT_EMBED_LOCK_MAX_DURATION_MS,
+  EMBED_LOCK_UNCAPPED_MAX_AGE_MS,
 } from "../src/cli/embed-lock.ts";
 
 const thisDir = dirname(fileURLToPath(import.meta.url));
@@ -47,7 +53,10 @@ describe("tryAcquireEmbedLock", () => {
       const first = tryAcquireEmbedLock(lockPath);
       expect(first).not.toBeNull();
       expect(existsSync(lockPath)).toBe(true);
-      expect((await readFile(lockPath, "utf-8")).trim()).toBe(String(process.pid));
+      const record = JSON.parse(await readFile(lockPath, "utf-8"));
+      expect(record.pid).toBe(process.pid);
+      expect(record.maxDurationMs).toBe(DEFAULT_EMBED_LOCK_MAX_DURATION_MS);
+      expect(typeof record.startedAt).toBe("number");
 
       // Same process still holds the lock — second caller must skip.
       expect(tryAcquireEmbedLock(lockPath)).toBeNull();
@@ -119,7 +128,8 @@ describe("tryAcquireEmbedLock", () => {
       writeFileSync(lockPath, "999999999\n");
       const handle = tryAcquireEmbedLock(lockPath);
       expect(handle).not.toBeNull();
-      expect((await readFile(lockPath, "utf-8")).trim()).toBe(String(process.pid));
+      expect(handle!.reclaimedFrom).toBeUndefined();
+      expect(readEmbedLockRecord(lockPath)?.pid).toBe(process.pid);
       handle!.release();
       expect(existsSync(lockPath)).toBe(false);
     } finally {
@@ -143,6 +153,120 @@ describe("tryAcquireEmbedLock", () => {
       again!.release();
       expect(existsSync(lockPath)).toBe(true);
       unlinkSync(lockPath);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("overdue holders (#735)", () => {
+  const MIN = 60_000;
+  const HOUR = 60 * MIN;
+
+  test("embedLockMaxAgeMs is twice the cap, or the uncapped ceiling", () => {
+    expect(embedLockMaxAgeMs(30 * MIN)).toBe(60 * MIN);
+    expect(embedLockMaxAgeMs(0)).toBe(EMBED_LOCK_UNCAPPED_MAX_AGE_MS);
+    expect(embedLockMaxAgeMs(Number.NaN)).toBe(EMBED_LOCK_UNCAPPED_MAX_AGE_MS);
+  });
+
+  test("isOverdueEmbedLockHolder compares age against the holder's own cap", () => {
+    const record = { pid: 1, startedAt: 0, maxDurationMs: 30 * MIN, legacy: false };
+    expect(isOverdueEmbedLockHolder(record, 59 * MIN)).toBe(false);
+    expect(isOverdueEmbedLockHolder(record, 61 * MIN)).toBe(true);
+    const uncapped = { ...record, maxDurationMs: 0 };
+    expect(isOverdueEmbedLockHolder(uncapped, 23 * HOUR)).toBe(false);
+    expect(isOverdueEmbedLockHolder(uncapped, 25 * HOUR)).toBe(true);
+  });
+
+  test("a live holder within its budget still blocks", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "qmd-embed-lock-fresh-"));
+    const lockPath = join(dir, ".qmd-embed.lock");
+    try {
+      const t0 = 1_000_000_000_000;
+      // process.pid is the one PID guaranteed to be "live" without spawning.
+      writeFileSync(lockPath, `${JSON.stringify({ pid: process.pid, startedAt: t0, maxDurationMs: 30 * MIN })}\n`);
+      expect(tryAcquireEmbedLock(lockPath, { now: () => t0 + 59 * MIN })).toBeNull();
+      expect(readEmbedLockRecord(lockPath)?.startedAt).toBe(t0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a live holder past twice its cap is evicted and reported", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "qmd-embed-lock-zombie-"));
+    const lockPath = join(dir, ".qmd-embed.lock");
+    try {
+      const t0 = 1_000_000_000_000;
+      writeFileSync(lockPath, `${JSON.stringify({ pid: process.pid, startedAt: t0, maxDurationMs: 30 * MIN })}\n`);
+      const now = t0 + 39 * HOUR;
+      const handle = tryAcquireEmbedLock(lockPath, { now: () => now, maxDurationMs: 30 * MIN });
+      expect(handle).not.toBeNull();
+      expect(handle!.reclaimedFrom?.pid).toBe(process.pid);
+      expect(handle!.reclaimedFrom?.startedAt).toBe(t0);
+      const rewritten = readEmbedLockRecord(lockPath);
+      expect(rewritten?.startedAt).toBe(now);
+      const message = embedLockReclaimedMessage(handle!.reclaimedFrom!, now);
+      expect(message).toContain(`process ${process.pid}`);
+      expect(message).toContain("2340 min");
+      expect(message).toContain("60 min limit");
+      handle!.release();
+      expect(existsSync(lockPath)).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a holder that declared no cap is evicted only after the uncapped ceiling", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "qmd-embed-lock-uncapped-"));
+    const lockPath = join(dir, ".qmd-embed.lock");
+    try {
+      const t0 = 1_000_000_000_000;
+      writeFileSync(lockPath, `${JSON.stringify({ pid: process.pid, startedAt: t0, maxDurationMs: 0 })}\n`);
+      expect(tryAcquireEmbedLock(lockPath, { now: () => t0 + 23 * HOUR })).toBeNull();
+      const handle = tryAcquireEmbedLock(lockPath, { now: () => t0 + 25 * HOUR });
+      expect(handle?.reclaimedFrom?.maxDurationMs).toBe(0);
+      handle!.release();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("legacy bare-PID lock: age comes from mtime, cap from the caller", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "qmd-embed-lock-legacy-"));
+    const lockPath = join(dir, ".qmd-embed.lock");
+    try {
+      writeFileSync(lockPath, `${process.pid}\n`);
+      const record = readEmbedLockRecord(lockPath, 30 * MIN);
+      expect(record?.legacy).toBe(true);
+      expect(record?.pid).toBe(process.pid);
+      expect(record?.maxDurationMs).toBe(30 * MIN);
+
+      // Fresh file: still blocks.
+      expect(tryAcquireEmbedLock(lockPath, { maxDurationMs: 30 * MIN })).toBeNull();
+
+      // Backdate the file two hours: evicted.
+      const twoHoursAgo = new Date(Date.now() - 2 * HOUR);
+      utimesSync(lockPath, twoHoursAgo, twoHoursAgo);
+      const handle = tryAcquireEmbedLock(lockPath, { maxDurationMs: 30 * MIN });
+      expect(handle).not.toBeNull();
+      expect(handle!.reclaimedFrom?.legacy).toBe(true);
+      handle!.release();
+      expect(existsSync(lockPath)).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("malformed lock content is treated as stale", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "qmd-embed-lock-garbage-"));
+    const lockPath = join(dir, ".qmd-embed.lock");
+    try {
+      writeFileSync(lockPath, "{not json\n");
+      expect(readEmbedLockRecord(lockPath)).toBeNull();
+      const handle = tryAcquireEmbedLock(lockPath);
+      expect(handle).not.toBeNull();
+      expect(handle!.reclaimedFrom).toBeUndefined();
+      handle!.release();
     } finally {
       await rm(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Problem

A PID that still answers is not proof of a live embed.

The embed session cap (`--timeout`, default 30 min, `DEFAULT_EMBED_MAX_DURATION_MS`) is a `setTimeout` that aborts an `AbortController` (`LLMSession` in `src/llm.ts`). It cannot fire while the event loop is blocked inside a synchronous native node-llama-cpp call. So a process wedged in Metal/CUDA keeps its PID, keeps `.qmd-embed.lock`, and every later `qmd embed` prints `Another embed process is already running. Skipping.` for as long as the zombie lives.

Observed on an Apple M5 Pro (macOS 26.5.2, qmd 2.8.3, node-llama-cpp 3.20.0, Bun 1.3.11): a nightly `qmd embed` faulted inside `AddonContext::GetEmbedding`, the runtime turned the fault into a signal-handler spin, and the process sat at 100% CPU for 39 hours. The two following nightly embeds skipped themselves. `qmd status` gave no hint that the lock was the reason. Same hardware class and error signature as #735.

## Fix

The lockfile now records `{"pid", "startedAt", "maxDurationMs"}` instead of a bare PID.

On `EEXIST`, a live holder is still respected, unless it has held the lock longer than **twice the cap it declared** (24 h if it declared `--timeout 0`). Then it is evicted, the new handle carries `reclaimedFrom`, and the CLI prints:

```
Reclaimed the embed lock from process 11128: it has held it for 2340 min, past its 60 min limit. If that process is still running it is stuck in a native call; kill it.
```

Twice the cap, so a holder that is merely slow to notice its own abort is not evicted while winding down.

Bare-PID lockfiles written by earlier versions still parse: age comes from the file's mtime, cap from the caller's own `--timeout`. Malformed content is treated as stale, as before.

## Changes

- `src/cli/embed-lock.ts`: JSON lock record, `readEmbedLockRecord`, `isOverdueEmbedLockHolder`, `embedLockMaxAgeMs`, `embedLockReclaimedMessage`; `tryAcquireEmbedLock(lockPath, { maxDurationMs, now })`. `release()` still only unlinks its own lock.
- `src/cli/qmd.ts`: passes the run's cap into the lock; warns on eviction.
- `test/embed-lock.test.ts`: 7 new cases (fresh live holder still blocks; overdue live holder evicted and reported; uncapped ceiling; legacy bare-PID lock aged by mtime; malformed content). Existing cases adapted to the JSON record. The cross-process holder test is unchanged and still passes.
- `CHANGELOG.md`: entry under `[Unreleased]`.

Verified: `tsc --noEmit` clean, `oxlint` clean, `vitest run test/` 1150 passed, `bun test test/` 1237 passed (Bun 1.4.2, macOS 26.5.2).

## Notes

- Complementary to #924, which hardens *who* holds the lock (start-time token) but not *for how long*. If #924 lands first I will rebase onto its record format; the age check is orthogonal.
- Refs #735. Does not address the root cause there (the Metal 4 tensor probe on M5, fixed upstream in ggml-org/llama.cpp#27461, in llama.cpp ≥ b10699; node-llama-cpp 3.20.0 still pins b10361). This PR only stops one wedged run from blocking every later one.
- Not in scope, possibly a follow-up: running the embed loop in a worker or child process so the deadline is enforceable by a hard kill rather than a cooperative abort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbPmKhuD7KxgFBH93Us8xN
