### PR TITLE
fix(search): one search per leg, not one per leg per collection

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -5902,26 +5902,26 @@ export async function structuredSearch(
     `SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_vec'`
   ).get();
 
-  // Helper to run search across collections (or all if undefined)
-  const collectionList = collections ?? [undefined]; // undefined = all collections
+  // One query for the whole scope. searchFTS/searchVec already take a list, so
+  // looping the collections here only split one result set into N ranked lists,
+  // and RRF then treated each collection's best-of-a-bad-lot as a rank 1.
+  const collScope = collections && collections.length > 0 ? collections : undefined;
 
   // Step 1: Run FTS for all lex searches (sync, instant)
   for (const search of searches) {
     if (search.type === 'lex') {
-      for (const coll of collectionList) {
-        const ftsResults = store.searchFTS(search.query, 20, coll);
-        if (ftsResults.length > 0) {
-          for (const r of ftsResults) docidMap.set(r.filepath, r.docid);
-          rankedLists.push(ftsResults.map(r => ({
-            file: r.filepath, displayPath: r.displayPath,
-            title: r.title, body: r.body || "", score: r.score,
-          })));
-          rankedListMeta.push({
-            source: "fts",
-            queryType: "lex",
-            query: search.query,
-          });
-        }
+      const ftsResults = store.searchFTS(search.query, 20, collScope);
+      if (ftsResults.length > 0) {
+        for (const r of ftsResults) docidMap.set(r.filepath, r.docid);
+        rankedLists.push(ftsResults.map(r => ({
+          file: r.filepath, displayPath: r.displayPath,
+          title: r.title, body: r.body || "", score: r.score,
+        })));
+        rankedListMeta.push({
+          source: "fts",
+          queryType: "lex",
+          query: search.query,
+        });
       }
     }
   }
@@ -5945,23 +5945,21 @@ export async function structuredSearch(
         const embedding = embeddings[i]?.embedding;
         if (!embedding) continue;
 
-        for (const coll of collectionList) {
-          const vecResults = await store.searchVec(
-            vecSearches[i]!.query, embedModel, 20, coll,
-            undefined, embedding
-          );
-          if (vecResults.length > 0) {
-            for (const r of vecResults) docidMap.set(r.filepath, r.docid);
-            rankedLists.push(vecResults.map(r => ({
-              file: r.filepath, displayPath: r.displayPath,
-              title: r.title, body: r.body || "", score: r.score,
-            })));
-            rankedListMeta.push({
-              source: "vec",
-              queryType: vecSearches[i]!.type,
-              query: vecSearches[i]!.query,
-            });
-          }
+        const vecResults = await store.searchVec(
+          vecSearches[i]!.query, embedModel, 20, collScope,
+          undefined, embedding
+        );
+        if (vecResults.length > 0) {
+          for (const r of vecResults) docidMap.set(r.filepath, r.docid);
+          rankedLists.push(vecResults.map(r => ({
+            file: r.filepath, displayPath: r.displayPath,
+            title: r.title, body: r.body || "", score: r.score,
+          })));
+          rankedListMeta.push({
+            source: "vec",
+            queryType: vecSearches[i]!.type,
+            query: vecSearches[i]!.query,
+          });
         }
       }
     }


### PR DESCRIPTION
## The bug

`structuredSearch` loops the collection list and pushes each collection's results as its own RRF ranked list, so a scope of N collections builds N ranked lists per search leg. RRF ranks with no relevance floor, so every collection's best-of-a-bad-lot enters fusion as a rank 1 next to the real answer.

The 2x weight on `rankedLists[0]` compounds it. That weight is documented as "assume caller ordered by importance" — meant for the caller's `searches` array — but the per-collection fan-out makes list 0 whichever *collection* happened to sort first, which the caller never chose deliberately.

The symptom is that ranking depends on argument order. Over a 21-collection scope and a 14-question gold set, **reversing the collections array moved rank 1 for 13 of 14 queries**. Rank 1 clustered in whichever collections sat at the front of the array.

## The change

`searchFTS` and `searchVec` already take `string | readonly string[]`, so this passes the scope straight through instead of looping it. One FTS query and one vector query per leg, one ranked list per leg — which is what the 2x weight assumes.

Measured on the same set:

| unnarrowed scope, n=14 | before | after |
|---|---|---|
| P@1 | 0.000 | 0.500 |
| recall@5 | 0.643 | 0.786 |
| recall@10 | 0.714 | 0.786 |
| MRR | 0.279 | 0.607 |
| rank 1 moves when array reversed | 13/14 | 0/14 |
| median query | 0.499s | 0.060s |

Lexical-only ranking after the change matches `qmd search` over the same scope exactly (P@1 0.429, recall@10 0.714), which is the result you'd expect if the fan-out were the only difference between those two paths — it was.

The latency drop is arithmetic: 1 query instead of 21. `searchVec` was the worst of it, since it pulls the same global top-k from the vector index on every call and only filters by collection afterwards, so 20 of the 21 calls were redundant.

## Compatibility

Single-collection scopes are byte-identical — the loop ran exactly once there already. The public signatures don't change.

`vitest run` on main before and after: same 5 failing files, same failing test set, no new failures. (The failures are pre-existing on this machine and look model/environment dependent.)

## Note on the 2x weight

I left `weights = rankedLists.map((_, i) => i === 0 ? 2.0 : 1.0)` alone. With one list per leg it now does what its comment says. It seemed better to keep this change to the fan-out rather than also revisit the weighting in the same PR — happy to follow up if you'd rather it were derived from `rankedListMeta` explicitly.