### PR TITLE
fix(llm): prevent idle unload from disposing contexts under active operations (#947)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 ### Fixed
 
 - Fixed idle LLM resource disposal racing active operations on per-store LLM instances (HTTP MCP daemon): `LlamaCpp` now tracks in-flight operations per instance, the inactivity timer refuses to unload while any operation runs, `unloadIdleResources()` waits for operations to drain, and new operations wait for an unload to finish. Prevents `DisposedError` and the native `llama_free` use-after-free crash during long embedding/rerank requests (#947, #935, #938).
+- `tokenize`/`countTokens`/`detokenize` now go through the same in-flight tracking as other model-backed operations, so a chunked index/add can no longer race an idle unload (#948 review).
+- `dispose()` drains in-flight operations (bounded) and joins any running idle unload before freeing resources, so shutdown with live requests no longer frees contexts under active operations (#948 review).
+- Idle unload now detaches contexts and models before disposing and swallows/logs per-resource dispose failures, so a failed dispose can no longer leave freed objects cached for later operations (#948 review).
+- Bounded the unload drain wait (30s) so a wedged native call skips the unload with a warning instead of hanging the daemon, and stopped unref-ing the drain timer so the process cannot exit mid-unload (#948 review).
 
 ## [2.8.3] - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added Oxlint lint fence.
 
+### Fixed
+
+- Fixed idle LLM resource disposal racing active operations on per-store LLM instances (HTTP MCP daemon): `LlamaCpp` now tracks in-flight operations per instance, the inactivity timer refuses to unload while any operation runs, `unloadIdleResources()` waits for operations to drain, and new operations wait for an unload to finish. Prevents `DisposedError` and the native `llama_free` use-after-free crash during long embedding/rerank requests (#947, #935, #938).
+
 ## [2.8.3] - 2026-08-16
 
 ### Security

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -630,6 +630,8 @@ export type LlamaCppConfig = {
 // Default inactivity timeout: 5 minutes (keep models warm during typical search sessions)
 const DEFAULT_INACTIVITY_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_EXPAND_CONTEXT_SIZE = 2048;
+// How long disposal paths wait for in-flight LLM operations before giving up.
+const OP_DRAIN_TIMEOUT_MS = 30_000;
 
 export type LlamaGpuMode = "auto" | "metal" | "vulkan" | "cuda" | false;
 
@@ -911,12 +913,6 @@ export class LlamaCpp implements LLM {
   }
 
   /**
-   * Unload idle resources but keep the instance alive for future use.
-   *
-   * By default, this disposes contexts (and their dependent sequences), while keeping models loaded.
-   * This matches the intended lifecycle: model → context → sequence, where contexts are per-session.
-   */
-  /**
    * Run an LLM operation with instance-local in-flight tracking (#947).
    *
    * Blocks new operations while an idle unload is disposing contexts, and
@@ -927,6 +923,14 @@ export class LlamaCpp implements LLM {
   private async runOperation<T>(fn: () => Promise<T>): Promise<T> {
     while (this._idleUnload) {
       await this._idleUnload.catch(() => {});
+      // dispose() may have started while we were waiting on the unload;
+      // don't resume onto resources it may have freed.
+      if (this.disposed) {
+        throw new Error("LLM instance is disposed");
+      }
+    }
+    if (this.disposed) {
+      throw new Error("LLM instance is disposed");
     }
     this._activeOperations++;
     this.touchActivity();
@@ -962,10 +966,17 @@ export class LlamaCpp implements LLM {
    * blocked at runOperation while this runs.
    */
   private async performUnloadIdleResources(): Promise<void> {
+    // Bounded drain: a wedged native call must not hang the daemon (#947).
+    const deadline = Date.now() + OP_DRAIN_TIMEOUT_MS;
     while (!this.disposed && this._activeOperations > 0) {
+      if (Date.now() > deadline) {
+        process.stderr.write("QMD Warning: timed out waiting for in-flight LLM operations; skipping idle unload.\n");
+        return;
+      }
+      // Referenced (not unref'd): an unref'd timer here can let the process
+      // exit successfully mid-drain, abandoning the unload.
       await new Promise<void>((resolve) => {
-        const t = setTimeout(resolve, 100);
-        t.unref();
+        setTimeout(resolve, 100);
       });
     }
     if (this.disposed) {
@@ -978,30 +989,39 @@ export class LlamaCpp implements LLM {
       this.inactivityTimer = null;
     }
 
-    // Dispose contexts first
-    for (const ctx of this.embedContexts) {
-      await ctx.dispose();
-    }
+    // Detach before disposing so a failed dispose cannot leave freed
+    // objects cached for later operations (#948 review). disposeWithTimeout
+    // logs and swallows per-resource errors so one failure can't poison the
+    // instance or abort the rest of the unload.
+    const embedContexts = this.embedContexts;
     this.embedContexts = [];
-    for (const ctx of this.rerankContexts) {
-      await ctx.dispose();
-    }
+    const rerankContexts = this.rerankContexts;
     this.rerankContexts = [];
+    for (const ctx of embedContexts) {
+      await disposeWithTimeout("embedding context", () => ctx.dispose());
+    }
+    for (const ctx of rerankContexts) {
+      await disposeWithTimeout("rerank context", () => ctx.dispose());
+    }
 
     // Optionally dispose models too (opt-in)
     if (this.disposeModelsOnInactivity) {
-      if (this.embedModel) {
-        await this.embedModel.dispose();
-        this.embedModel = null;
-        this.embedModelPath = null;
+      // Detach first, dispose after — same rationale as contexts above.
+      const embedModel = this.embedModel;
+      const generateModel = this.generateModel;
+      const rerankModel = this.rerankModel;
+      this.embedModel = null;
+      this.embedModelPath = null;
+      this.generateModel = null;
+      this.rerankModel = null;
+      if (embedModel) {
+        await disposeWithTimeout("embedding model", () => embedModel.dispose());
       }
-      if (this.generateModel) {
-        await this.generateModel.dispose();
-        this.generateModel = null;
+      if (generateModel) {
+        await disposeWithTimeout("generation model", () => generateModel.dispose());
       }
-      if (this.rerankModel) {
-        await this.rerankModel.dispose();
-        this.rerankModel = null;
+      if (rerankModel) {
+        await disposeWithTimeout("rerank model", () => rerankModel.dispose());
       }
       // Reset load promises so models can be reloaded later
       this.embedModelLoadPromise = null;
@@ -1437,11 +1457,15 @@ export class LlamaCpp implements LLM {
    * Returns tokenizer tokens (opaque type from node-llama-cpp)
    */
   async tokenize(text: string): Promise<readonly LlamaToken[]> {
-    await this.ensureEmbedContext();  // Ensure model is loaded
-    if (!this.embedModel) {
-      throw new Error("Embed model not loaded");
-    }
-    return this.embedModel.tokenize(text);
+    // runOperation: tokenize touches the embed model/context and must not
+    // race an idle unload (#948 review).
+    return this.runOperation(async () => {
+      await this.ensureEmbedContext(); // Ensure model is loaded
+      if (!this.embedModel) {
+        throw new Error("Embed model not loaded");
+      }
+      return this.embedModel.tokenize(text);
+    });
   }
 
   /**
@@ -1456,11 +1480,13 @@ export class LlamaCpp implements LLM {
    * Detokenize token IDs back to text
    */
   async detokenize(tokens: readonly LlamaToken[]): Promise<string> {
-    await this.ensureEmbedContext();
-    if (!this.embedModel) {
-      throw new Error("Embed model not loaded");
-    }
-    return this.embedModel.detokenize(tokens);
+    return this.runOperation(async () => {
+      await this.ensureEmbedContext();
+      if (!this.embedModel) {
+        throw new Error("Embed model not loaded");
+      }
+      return this.embedModel.detokenize(tokens);
+    });
   }
 
   // ==========================================================================
@@ -1896,7 +1922,25 @@ export class LlamaCpp implements LLM {
     if (this.disposed) {
       return;
     }
+    // Mark disposed first so runOperation rejects new/queued operations,
+    // then drain in-flight ones before freeing anything (#948 review).
     this.disposed = true;
+
+    // Bounded drain of in-flight operations.
+    const deadline = Date.now() + OP_DRAIN_TIMEOUT_MS;
+    while (this._activeOperations > 0 && Date.now() < deadline) {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 100);
+      });
+    }
+    if (this._activeOperations > 0) {
+      process.stderr.write("QMD Warning: LLM operations still in flight at dispose; proceeding.\n");
+    }
+    // Join any in-progress idle unload so we never dispose concurrently with
+    // it (it bails without disposing once it sees this.disposed).
+    while (this._idleUnload) {
+      await this._idleUnload.catch(() => {});
+    }
 
     // Clear inactivity timer
     if (this.inactivityTimer) {

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -832,6 +832,13 @@ export class LlamaCpp implements LLM {
   private inactivityTimeoutMs: number;
   private disposeModelsOnInactivity: boolean;
 
+  // In-flight operation refcount and idle-unload coordination (#947).
+  // Instance-local so per-store LLMs (HTTP MCP) get the same protection as
+  // the CLI singleton — the global canUnloadLLM() never saw them, so the
+  // idle timer disposed contexts underneath live embedding/rerank work.
+  private _activeOperations = 0;
+  private _idleUnload: Promise<void> | null = null;
+
   // Track disposal state to prevent double-dispose
   private disposed = false;
 
@@ -879,10 +886,10 @@ export class LlamaCpp implements LLM {
     // Only set timer if we have disposable contexts and timeout is enabled
     if (this.inactivityTimeoutMs > 0 && this.hasLoadedContexts()) {
       this.inactivityTimer = setTimeout(() => {
-        // Check if session manager allows unloading
-        // canUnloadLLM is defined later in this file - it checks the session manager
-        // We use dynamic import pattern to avoid circular dependency issues
-        if (typeof canUnloadLLM === 'function' && !canUnloadLLM()) {
+        // Never dispose while an operation on THIS instance is in flight (#947).
+        // canUnloadLLM covers sessions on the default singleton; the local
+        // refcount covers every instance, including per-store HTTP LLMs.
+        if (this._activeOperations > 0 || !canUnloadLLM()) {
           // Active sessions/operations - reschedule timer
           this.touchActivity();
           return;
@@ -909,8 +916,58 @@ export class LlamaCpp implements LLM {
    * By default, this disposes contexts (and their dependent sequences), while keeping models loaded.
    * This matches the intended lifecycle: model → context → sequence, where contexts are per-session.
    */
+  /**
+   * Run an LLM operation with instance-local in-flight tracking (#947).
+   *
+   * Blocks new operations while an idle unload is disposing contexts, and
+   * keeps the idle timer from unloading while the operation runs. All public
+   * model-backed methods (embed, embedBatch, generate, expandQuery, rerank,
+   * tokenize) must go through this.
+   */
+  private async runOperation<T>(fn: () => Promise<T>): Promise<T> {
+    while (this._idleUnload) {
+      await this._idleUnload.catch(() => {});
+    }
+    this._activeOperations++;
+    this.touchActivity();
+    try {
+      return await fn();
+    } finally {
+      this._activeOperations = Math.max(0, this._activeOperations - 1);
+    }
+  }
+
   async unloadIdleResources(): Promise<void> {
-    // Don't unload if already disposed
+    if (this.disposed) {
+      return;
+    }
+    if (this._idleUnload) {
+      return this._idleUnload;
+    }
+    this._idleUnload = this.performUnloadIdleResources();
+    try {
+      await this._idleUnload;
+    } finally {
+      this._idleUnload = null;
+    }
+  }
+
+  /**
+   * Unload idle resources but keep the instance alive for future use.
+   *
+   * By default, this disposes contexts (and their dependent sequences), while keeping models loaded.
+   * This matches the intended lifecycle: model → context → sequence, where contexts are per-session.
+   *
+   * Waits for in-flight operations to drain first (#947); new operations are
+   * blocked at runOperation while this runs.
+   */
+  private async performUnloadIdleResources(): Promise<void> {
+    while (!this.disposed && this._activeOperations > 0) {
+      await new Promise<void>((resolve) => {
+        const t = setTimeout(resolve, 100);
+        t.unref();
+      });
+    }
     if (this.disposed) {
       return;
     }
@@ -1443,28 +1500,29 @@ export class LlamaCpp implements LLM {
   }
 
   async embed(text: string, options: EmbedOptions = {}): Promise<EmbeddingResult | null> {
-    // Ping activity at start to keep models alive during this operation
-    this.touchActivity();
+    // runOperation tracks in-flight work so the idle timer cannot dispose
+    // contexts underneath this call (#947).
+    return this.runOperation(async () => {
+      try {
+        const context = await this.ensureEmbedContext();
 
-    try {
-      const context = await this.ensureEmbedContext();
+        // Guard: truncate text that exceeds model context window to prevent GGML crash
+        const { text: safeText, truncated, limit } = await this.truncateToContextSize(text);
+        if (truncated) {
+          console.warn(`⚠ Text truncated to fit embedding context (${limit} tokens)`);
+        }
 
-      // Guard: truncate text that exceeds model context window to prevent GGML crash
-      const { text: safeText, truncated, limit } = await this.truncateToContextSize(text);
-      if (truncated) {
-        console.warn(`⚠ Text truncated to fit embedding context (${limit} tokens)`);
+        const embedding = await context.getEmbeddingFor(safeText);
+
+        return {
+          embedding: Array.from(embedding.vector),
+          model: options.model ?? this.embedModelUri,
+        };
+      } catch (error) {
+        console.error("Embedding error:", error);
+        return null;
       }
-
-      const embedding = await context.getEmbeddingFor(safeText);
-
-      return {
-        embedding: Array.from(embedding.vector),
-        model: options.model ?? this.embedModelUri,
-      };
-    } catch (error) {
-      console.error("Embedding error:", error);
-      return null;
-    }
+    });
   }
 
   /**
@@ -1473,111 +1531,111 @@ export class LlamaCpp implements LLM {
    */
   async embedBatch(texts: string[], options: EmbedOptions = {}): Promise<(EmbeddingResult | null)[]> {
     if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
-    // Ping activity at start to keep models alive during this operation
-    this.touchActivity();
 
     if (texts.length === 0) return [];
 
-    try {
-      const contexts = await this.ensureEmbedContexts();
-      const n = contexts.length;
+    return this.runOperation(async () => {
+      try {
+        const contexts = await this.ensureEmbedContexts();
+        const n = contexts.length;
 
-      if (n === 1) {
-        // Single context: sequential (no point splitting)
-        const context = contexts[0]!;
-        const embeddings: ({ embedding: number[]; model: string } | null)[] = [];
-        for (const text of texts) {
-          try {
-            const { text: safeText, truncated, limit } = await this.truncateToContextSize(text);
-            if (truncated) {
-              console.warn(`⚠ Batch text truncated to fit embedding context (${limit} tokens)`);
-            }
-            const embedding = await context.getEmbeddingFor(safeText);
-            this.touchActivity();
-            embeddings.push({ embedding: Array.from(embedding.vector), model: options.model ?? this.embedModelUri });
-          } catch (err) {
-            console.error("Embedding error for text:", err);
-            embeddings.push(null);
-          }
-        }
-        return embeddings;
-      }
-
-      // Multiple contexts: split texts across contexts for parallel evaluation
-      const chunkSize = Math.ceil(texts.length / n);
-      const chunks = Array.from({ length: n }, (_, i) =>
-        texts.slice(i * chunkSize, (i + 1) * chunkSize)
-      );
-
-      const chunkResults = await Promise.all(
-        chunks.map(async (chunk, i) => {
-          const ctx = contexts[i]!;
-          const results: (EmbeddingResult | null)[] = [];
-          for (const text of chunk) {
+        if (n === 1) {
+          // Single context: sequential (no point splitting)
+          const context = contexts[0]!;
+          const embeddings: ({ embedding: number[]; model: string } | null)[] = [];
+          for (const text of texts) {
             try {
               const { text: safeText, truncated, limit } = await this.truncateToContextSize(text);
               if (truncated) {
                 console.warn(`⚠ Batch text truncated to fit embedding context (${limit} tokens)`);
               }
-              const embedding = await ctx.getEmbeddingFor(safeText);
+              const embedding = await context.getEmbeddingFor(safeText);
               this.touchActivity();
-              results.push({ embedding: Array.from(embedding.vector), model: options.model ?? this.embedModelUri });
+              embeddings.push({ embedding: Array.from(embedding.vector), model: options.model ?? this.embedModelUri });
             } catch (err) {
               console.error("Embedding error for text:", err);
-              results.push(null);
+              embeddings.push(null);
             }
           }
-          return results;
-        })
-      );
+          return embeddings;
+        }
 
-      return chunkResults.flat();
-    } catch (error) {
-      console.error("Batch embedding error:", error);
-      return texts.map(() => null);
-    }
+        // Multiple contexts: split texts across contexts for parallel evaluation
+        const chunkSize = Math.ceil(texts.length / n);
+        const chunks = Array.from({ length: n }, (_, i) =>
+          texts.slice(i * chunkSize, (i + 1) * chunkSize)
+        );
+
+        const chunkResults = await Promise.all(
+          chunks.map(async (chunk, i) => {
+            const ctx = contexts[i]!;
+            const results: (EmbeddingResult | null)[] = [];
+            for (const text of chunk) {
+              try {
+                const { text: safeText, truncated, limit } = await this.truncateToContextSize(text);
+                if (truncated) {
+                  console.warn(`⚠ Batch text truncated to fit embedding context (${limit} tokens)`);
+                }
+                const embedding = await ctx.getEmbeddingFor(safeText);
+                this.touchActivity();
+                results.push({ embedding: Array.from(embedding.vector), model: options.model ?? this.embedModelUri });
+              } catch (err) {
+                console.error("Embedding error for text:", err);
+                results.push(null);
+              }
+            }
+            return results;
+          })
+        );
+
+        return chunkResults.flat();
+        } catch (error) {
+          console.error("Batch embedding error:", error);
+          return texts.map(() => null);
+        }
+    });
   }
 
   async generate(prompt: string, options: GenerateOptions = {}): Promise<GenerateResult | null> {
     if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
-    // Ping activity at start to keep models alive during this operation
-    this.touchActivity();
 
-    // Ensure model is loaded
-    await this.ensureGenerateModel();
+    return this.runOperation(async () => {
+      // Ensure model is loaded
+      await this.ensureGenerateModel();
 
-    // Create fresh context -> sequence -> session for each call
-    const context = await this.generateModel!.createContext();
-    const sequence = context.getSequence();
-    const { LlamaChatSession } = await loadNodeLlamaCpp();
-    const session = new LlamaChatSession({ contextSequence: sequence });
+      // Create fresh context -> sequence -> session for each call
+      const context = await this.generateModel!.createContext();
+      const sequence = context.getSequence();
+      const { LlamaChatSession } = await loadNodeLlamaCpp();
+      const session = new LlamaChatSession({ contextSequence: sequence });
 
-    const maxTokens = options.maxTokens ?? 150;
-    // Qwen3 recommends temp=0.7, topP=0.8, topK=20 for non-thinking mode
-    // DO NOT use greedy decoding (temp=0) - causes repetition loops
-    const temperature = options.temperature ?? 0.7;
+      const maxTokens = options.maxTokens ?? 150;
+      // Qwen3 recommends temp=0.7, topP=0.8, topK=20 for non-thinking mode
+      // DO NOT use greedy decoding (temp=0) - causes repetition loops
+      const temperature = options.temperature ?? 0.7;
 
-    let result = "";
-    try {
-      await session.prompt(prompt, {
-        maxTokens,
-        temperature,
-        topK: 20,
-        topP: 0.8,
-        onTextChunk: (text: string) => {
-          result += text;
-        },
-      });
+      let result = "";
+      try {
+        await session.prompt(prompt, {
+          maxTokens,
+          temperature,
+          topK: 20,
+          topP: 0.8,
+          onTextChunk: (text: string) => {
+            result += text;
+          },
+        });
 
-      return {
-        text: result,
-        model: this.generateModelUri,
-        done: true,
-      };
-    } finally {
-      // Sequence dispose is async as of node-llama-cpp 3.20; await it before the parent context.
-      await disposeSequenceThenContext(sequence, context);
-    }
+        return {
+          text: result,
+          model: this.generateModelUri,
+          done: true,
+        };
+      } finally {
+        // Sequence dispose is async as of node-llama-cpp 3.20; await it before the parent context.
+        await disposeSequenceThenContext(sequence, context);
+      }
+    });
   }
 
   async modelExists(modelUri: string): Promise<ModelInfo> {
@@ -1601,99 +1659,99 @@ export class LlamaCpp implements LLM {
 
   async expandQuery(query: string, options: { context?: string, includeLexical?: boolean } = {}): Promise<Queryable[]> {
     if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
-    // Ping activity at start to keep models alive during this operation
-    this.touchActivity();
 
-    const llama = await this.ensureLlama();
-    await this.ensureGenerateModel();
+    return this.runOperation(async () => {
+      const llama = await this.ensureLlama();
+      await this.ensureGenerateModel();
 
-    const includeLexical = options.includeLexical ?? true;
-    const context = options.context;
+      const includeLexical = options.includeLexical ?? true;
+      const context = options.context;
 
-    // The expansion prompt consumes ONLY the query text. Caller intent is
-    // free-form meta-language that the expansion model reproduced verbatim as
-    // lex/vec sub-queries — degenerate terms that match nothing. Intent still
-    // shapes retrieval where it belongs: the reranker query prefix and
-    // keyword-based chunk/snippet selection.
-    const prompt = `/no_think Expand this search query: ${query}`;
+      // The expansion prompt consumes ONLY the query text. Caller intent is
+      // free-form meta-language that the expansion model reproduced verbatim as
+      // lex/vec sub-queries — degenerate terms that match nothing. Intent still
+      // shapes retrieval where it belongs: the reranker query prefix and
+      // keyword-based chunk/snippet selection.
+      const prompt = `/no_think Expand this search query: ${query}`;
 
-    // Set up inside the try so any failure (grammar creation, context
-    // allocation/VRAM, session prompt) falls back to the original query
-    // instead of propagating and failing the caller's operation.
-    let genContext: Awaited<ReturnType<LlamaModel["createContext"]>> | undefined;
-    let sequence: { dispose: () => void | Promise<void> } | undefined;
-    try {
-      const grammar = await llama.createGrammar({
-        grammar: `
-        root ::= line+
-        line ::= type ": " content "\\n"
-        type ::= "lex" | "vec" | "hyde"
-        content ::= [^\\n]+
-      `
-      });
+      // Set up inside the try so any failure (grammar creation, context
+      // allocation/VRAM, session prompt) falls back to the original query
+      // instead of propagating and failing the caller's operation.
+      let genContext: Awaited<ReturnType<LlamaModel["createContext"]>> | undefined;
+      let sequence: { dispose: () => void | Promise<void> } | undefined;
+      try {
+        const grammar = await llama.createGrammar({
+          grammar: `
+          root ::= line+
+          line ::= type ": " content "\\n"
+          type ::= "lex" | "vec" | "hyde"
+          content ::= [^\\n]+
+        `
+        });
 
-      // Create a bounded context for expansion to prevent large default VRAM allocations.
-      genContext = await this.generateModel!.createContext({
-        contextSize: this.expandContextSize,
-      });
-      sequence = genContext.getSequence();
-      const { LlamaChatSession } = await loadNodeLlamaCpp();
-      const session = new LlamaChatSession({ contextSequence: sequence });
+        // Create a bounded context for expansion to prevent large default VRAM allocations.
+        genContext = await this.generateModel!.createContext({
+          contextSize: this.expandContextSize,
+        });
+        sequence = genContext.getSequence();
+        const { LlamaChatSession } = await loadNodeLlamaCpp();
+        const session = new LlamaChatSession({ contextSequence: sequence });
 
-      // Qwen3 recommended settings for non-thinking mode:
-      // temp=0.7, topP=0.8, topK=20, presence_penalty for repetition
-      // DO NOT use greedy decoding (temp=0) - causes infinite loops
-      const result = await session.prompt(prompt, {
-        grammar,
-        maxTokens: 600,
-        temperature: 0.7,
-        topK: 20,
-        topP: 0.8,
-        repeatPenalty: {
-          lastTokens: 64,
-          presencePenalty: 0.5,
-        },
-      });
+        // Qwen3 recommended settings for non-thinking mode:
+        // temp=0.7, topP=0.8, topK=20, presence_penalty for repetition
+        // DO NOT use greedy decoding (temp=0) - causes infinite loops
+        const result = await session.prompt(prompt, {
+          grammar,
+          maxTokens: 600,
+          temperature: 0.7,
+          topK: 20,
+          topP: 0.8,
+          repeatPenalty: {
+            lastTokens: 64,
+            presencePenalty: 0.5,
+          },
+        });
 
-      const lines = result.trim().split("\n");
-      const queryLower = query.toLowerCase();
-      const queryTerms = queryLower.replace(/[^a-z0-9\s]/g, " ").split(/\s+/).filter(Boolean);
+        const lines = result.trim().split("\n");
+        const queryLower = query.toLowerCase();
+        const queryTerms = queryLower.replace(/[^a-z0-9\s]/g, " ").split(/\s+/).filter(Boolean);
 
-      const hasQueryTerm = (text: string): boolean => {
-        const lower = text.toLowerCase();
-        if (queryTerms.length === 0) return true;
-        return queryTerms.some(term => lower.includes(term));
-      };
+        const hasQueryTerm = (text: string): boolean => {
+          const lower = text.toLowerCase();
+          if (queryTerms.length === 0) return true;
+          return queryTerms.some(term => lower.includes(term));
+        };
 
-      const queryables: Queryable[] = lines.map(line => {
-        const colonIdx = line.indexOf(":");
-        if (colonIdx === -1) return null;
-        const type = line.slice(0, colonIdx).trim();
-        if (type !== 'lex' && type !== 'vec' && type !== 'hyde') return null;
-        const text = line.slice(colonIdx + 1).trim();
-        if (!hasQueryTerm(text)) return null;
-        return { type: type as QueryType, text };
-      }).filter((q): q is Queryable => q !== null);
+        const queryables: Queryable[] = lines.map(line => {
+          const colonIdx = line.indexOf(":");
+          if (colonIdx === -1) return null;
+          const type = line.slice(0, colonIdx).trim();
+          if (type !== 'lex' && type !== 'vec' && type !== 'hyde') return null;
+          const text = line.slice(colonIdx + 1).trim();
+          if (!hasQueryTerm(text)) return null;
+          return { type: type as QueryType, text };
+        }).filter((q): q is Queryable => q !== null);
 
-      // Filter out lex entries if not requested
-      const filtered = includeLexical ? queryables : queryables.filter(q => q.type !== 'lex');
-      if (filtered.length > 0) return filtered;
+        // Filter out lex entries if not requested
+        const filtered = includeLexical ? queryables : queryables.filter(q => q.type !== 'lex');
+        if (filtered.length > 0) return filtered;
 
-      const fallback: Queryable[] = [
-        { type: 'hyde', text: `Information about ${query}` },
-        { type: 'lex', text: query },
-        { type: 'vec', text: query },
-      ];
-      return includeLexical ? fallback : fallback.filter(q => q.type !== 'lex');
-    } catch (error) {
-      console.error("Structured query expansion failed:", error);
-      // Fallback to original query
-      const fallback: Queryable[] = [{ type: 'vec', text: query }];
-      if (includeLexical) fallback.unshift({ type: 'lex', text: query });
-      return fallback;
-    } finally {
-      if (genContext) await disposeSequenceThenContext(sequence, genContext);
-    }
+        const fallback: Queryable[] = [
+          { type: 'hyde', text: `Information about ${query}` },
+          { type: 'lex', text: query },
+          { type: 'vec', text: query },
+        ];
+        return includeLexical ? fallback : fallback.filter(q => q.type !== 'lex');
+      } catch (error) {
+        console.error("Structured query expansion failed:", error);
+        // Fallback to original query
+        const fallback: Queryable[] = [{ type: 'vec', text: query }];
+        if (includeLexical) fallback.unshift({ type: 'lex', text: query });
+        return fallback;
+      } finally {
+        if (genContext) await disposeSequenceThenContext(sequence, genContext);
+      }
+    });
   }
 
   // Qwen3 reranker chat template overhead (system prompt, tags, separators).
@@ -1708,99 +1766,99 @@ export class LlamaCpp implements LLM {
     options: RerankOptions = {}
   ): Promise<RerankResult> {
     if (this._ciMode) throw new Error("LLM operations are disabled in CI (set CI=true)");
-    // Ping activity at start to keep models alive during this operation
-    this.touchActivity();
 
-    const contexts = await this.ensureRerankContexts();
-    if (contexts.length === 0) {
+    return this.runOperation(async () => {
+      const contexts = await this.ensureRerankContexts();
+      if (contexts.length === 0) {
+        return {
+          results: documents.map((d) => ({ ...d, score: 0.5, index: 0 })),
+          model: "fallback",
+        };
+      }
+      const model = await this.ensureRerankModel();
+
+      // Truncate documents that would exceed the rerank context size.
+      // Budget = contextSize - template overhead - query tokens
+      const queryTokens = model.tokenize(query).length;
+      const maxDocTokens = LlamaCpp.RERANK_CONTEXT_SIZE - LlamaCpp.RERANK_TEMPLATE_OVERHEAD - queryTokens;
+      const truncationCache = new Map<string, string>();
+
+      const truncatedDocs = documents.map((doc) => {
+        const cached = truncationCache.get(doc.text);
+        if (cached !== undefined) {
+          return cached === doc.text ? doc : { ...doc, text: cached };
+        }
+
+        const tokens = model.tokenize(doc.text);
+        const truncatedText = tokens.length <= maxDocTokens
+          ? doc.text
+          : model.detokenize(tokens.slice(0, maxDocTokens));
+        truncationCache.set(doc.text, truncatedText);
+
+        if (truncatedText === doc.text) return doc;
+        return { ...doc, text: truncatedText };
+      });
+
+      // Deduplicate identical effective texts before scoring.
+      // This avoids redundant work for repeated chunks and fixes collisions where
+      // multiple docs map to the same chunk text.
+      const textToDocs = new Map<string, { file: string; index: number }[]>();
+      truncatedDocs.forEach((doc, index) => {
+        const existing = textToDocs.get(doc.text);
+        if (existing) {
+          existing.push({ file: doc.file, index });
+        } else {
+          textToDocs.set(doc.text, [{ file: doc.file, index }]);
+        }
+      });
+
+      // Extract just the text for ranking
+      const texts = Array.from(textToDocs.keys());
+
+      // Split documents across contexts for parallel evaluation.
+      // Each context has its own sequence with a lock, so parallelism comes
+      // from multiple contexts evaluating different chunks simultaneously.
+      const activeContextCount = Math.max(
+        1,
+        Math.min(
+          contexts.length,
+          Math.ceil(texts.length / LlamaCpp.RERANK_TARGET_DOCS_PER_CONTEXT)
+        )
+      );
+      const activeContexts = contexts.slice(0, activeContextCount);
+      const chunkSize = Math.ceil(texts.length / activeContexts.length);
+      const chunks = Array.from({ length: activeContexts.length }, (_, i) =>
+        texts.slice(i * chunkSize, (i + 1) * chunkSize)
+      ).filter(chunk => chunk.length > 0);
+
+      const allScores = await Promise.all(
+        chunks.map((chunk, i) => activeContexts[i]!.rankAll(query, chunk))
+      );
+
+      // Reassemble scores in original order and sort
+      const flatScores = allScores.flat();
+      const ranked = texts
+        .map((text, i) => ({ document: text, score: flatScores[i]! }))
+        .sort((a, b) => b.score - a.score);
+
+      // Map back to our result format.
+      const results: RerankDocumentResult[] = [];
+      for (const item of ranked) {
+        const docInfos = textToDocs.get(item.document) ?? [];
+        for (const docInfo of docInfos) {
+          results.push({
+            file: docInfo.file,
+            score: item.score,
+            index: docInfo.index,
+          });
+        }
+      }
+
       return {
-        results: documents.map((d) => ({ ...d, score: 0.5, index: 0 })),
-        model: "fallback",
+        results,
+        model: this.rerankModelUri,
       };
-    }
-    const model = await this.ensureRerankModel();
-
-    // Truncate documents that would exceed the rerank context size.
-    // Budget = contextSize - template overhead - query tokens
-    const queryTokens = model.tokenize(query).length;
-    const maxDocTokens = LlamaCpp.RERANK_CONTEXT_SIZE - LlamaCpp.RERANK_TEMPLATE_OVERHEAD - queryTokens;
-    const truncationCache = new Map<string, string>();
-
-    const truncatedDocs = documents.map((doc) => {
-      const cached = truncationCache.get(doc.text);
-      if (cached !== undefined) {
-        return cached === doc.text ? doc : { ...doc, text: cached };
-      }
-
-      const tokens = model.tokenize(doc.text);
-      const truncatedText = tokens.length <= maxDocTokens
-        ? doc.text
-        : model.detokenize(tokens.slice(0, maxDocTokens));
-      truncationCache.set(doc.text, truncatedText);
-
-      if (truncatedText === doc.text) return doc;
-      return { ...doc, text: truncatedText };
     });
-
-    // Deduplicate identical effective texts before scoring.
-    // This avoids redundant work for repeated chunks and fixes collisions where
-    // multiple docs map to the same chunk text.
-    const textToDocs = new Map<string, { file: string; index: number }[]>();
-    truncatedDocs.forEach((doc, index) => {
-      const existing = textToDocs.get(doc.text);
-      if (existing) {
-        existing.push({ file: doc.file, index });
-      } else {
-        textToDocs.set(doc.text, [{ file: doc.file, index }]);
-      }
-    });
-
-    // Extract just the text for ranking
-    const texts = Array.from(textToDocs.keys());
-
-    // Split documents across contexts for parallel evaluation.
-    // Each context has its own sequence with a lock, so parallelism comes
-    // from multiple contexts evaluating different chunks simultaneously.
-    const activeContextCount = Math.max(
-      1,
-      Math.min(
-        contexts.length,
-        Math.ceil(texts.length / LlamaCpp.RERANK_TARGET_DOCS_PER_CONTEXT)
-      )
-    );
-    const activeContexts = contexts.slice(0, activeContextCount);
-    const chunkSize = Math.ceil(texts.length / activeContexts.length);
-    const chunks = Array.from({ length: activeContexts.length }, (_, i) =>
-      texts.slice(i * chunkSize, (i + 1) * chunkSize)
-    ).filter(chunk => chunk.length > 0);
-
-    const allScores = await Promise.all(
-      chunks.map((chunk, i) => activeContexts[i]!.rankAll(query, chunk))
-    );
-
-    // Reassemble scores in original order and sort
-    const flatScores = allScores.flat();
-    const ranked = texts
-      .map((text, i) => ({ document: text, score: flatScores[i]! }))
-      .sort((a, b) => b.score - a.score);
-
-    // Map back to our result format.
-    const results: RerankDocumentResult[] = [];
-    for (const item of ranked) {
-      const docInfos = textToDocs.get(item.document) ?? [];
-      for (const docInfo of docInfos) {
-        results.push({
-          file: docInfo.file,
-          score: item.score,
-          index: docInfo.index,
-        });
-      }
-    }
-
-    return {
-      results,
-      model: this.rerankModelUri,
-    };
   }
 
   /**

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -1453,3 +1453,136 @@ describe("LlamaCpp generate sequence dispose (node-llama-cpp 3.20)", () => {
     }
   });
 });
+
+describe("idle unload vs active operations (#947)", () => {
+  // Reproduces the HTTP MCP daemon crash: a per-store LlamaCpp (never
+  // registered with the global session manager) whose idle timer fires
+  // while an embedding is still in flight.
+
+  function makeMockedLlm(inactivityTimeoutMs: number) {
+    const disposedContexts: number[] = [];
+    let contextId = 0;
+    // Gate holds the first getEmbeddingFor call open until released.
+    let releaseEmbedding: (() => void) | null = null;
+    const embeddingGate = new Promise<void>((resolve) => {
+      releaseEmbedding = resolve;
+    });
+    let holdNextEmbedding = false;
+
+    const getEmbeddingFor = vi.fn(async (text: string) => {
+      if (holdNextEmbedding) await embeddingGate;
+      return { vector: new Float32Array([0.1, 0.2, 0.3]), text };
+    });
+    const createEmbeddingContext = vi.fn(async () => {
+      const id = ++contextId;
+      return {
+        getEmbeddingFor,
+        dispose: vi.fn(async () => {
+          disposedContexts.push(id);
+        }),
+      };
+    });
+    const loadModel = vi.fn(async () => ({
+      trainContextSize: 2048,
+      tokenize: (text: string) => Array.from(text),
+      detokenize: (tokens: string[]) => tokens.join(""),
+      createEmbeddingContext,
+      dispose: vi.fn(async () => {}),
+    }));
+
+    setNodeLlamaCppModuleForTest({
+      LlamaLogLevel: { error: "error" },
+      resolveModelFile: vi.fn(async () => "/tmp/nonexistent-model.gguf"),
+      LlamaChatSession: vi.fn() as any,
+      getLlama: vi.fn(async () => ({
+        gpu: false,
+        cpuMathCores: 4,
+        loadModel,
+        dispose: vi.fn(async () => {}),
+      }) as any),
+    });
+
+    // CPU mode so computeParallelism does not touch vram state.
+    const prevForceCpu = process.env.QMD_FORCE_CPU;
+    process.env.QMD_FORCE_CPU = "1";
+
+    const llm = new LlamaCpp({ inactivityTimeoutMs });
+    return {
+      llm,
+      disposedContexts,
+      getEmbeddingFor,
+      createEmbeddingContext,
+      holdNext: () => {
+        holdNextEmbedding = true;
+      },
+      release: () => {
+        releaseEmbedding?.();
+      },
+      restore: () => {
+        if (prevForceCpu === undefined) delete process.env.QMD_FORCE_CPU;
+        else process.env.QMD_FORCE_CPU = prevForceCpu;
+        setNodeLlamaCppModuleForTest(null);
+      },
+    };
+  }
+
+  test("idle timer does not dispose contexts while an operation is in flight", async () => {
+    const mock = makeMockedLlm(50);
+    const { llm } = mock;
+    try {
+      mock.holdNext();
+      const op = llm.embed("held open across the idle timeout");
+
+      // Wait past the (50ms) idle timeout while the op is still in flight.
+      await new Promise((r) => setTimeout(r, 200));
+      expect(mock.disposedContexts).toEqual([]);
+      expect(mock.getEmbeddingFor).toHaveBeenCalledTimes(1);
+
+      mock.release();
+      await op;
+
+      // Op finished — the timer rescheduled by runOperation's touchActivity
+      // eventually reclaims the contexts.
+      await new Promise((r) => setTimeout(r, 400));
+      expect(mock.disposedContexts.length).toBeGreaterThan(0);
+    } finally {
+      await llm.dispose();
+      mock.restore();
+    }
+  });
+
+  test("unloadIdleResources waits for in-flight operations and blocks new ones", async () => {
+    const mock = makeMockedLlm(0); // timer disabled; drive unload directly
+    const { llm } = mock;
+    try {
+      mock.holdNext();
+      const op = llm.embed("first");
+      // Let the embed start and grab its context before triggering unload.
+      await new Promise((r) => setTimeout(r, 20));
+
+      const unload = llm.unloadIdleResources();
+      // Start a second op while the unload is draining — it must wait.
+      const second = llm.embed("second");
+
+      await new Promise((r) => setTimeout(r, 150));
+      // First op still in flight: nothing disposed, second op must not have
+      // touched a context yet (it is blocked behind the unload).
+      expect(mock.disposedContexts).toEqual([]);
+      expect(mock.getEmbeddingFor).toHaveBeenCalledTimes(1);
+
+      mock.release();
+      await op;
+      await unload;
+
+      // Unload drained and disposed; the blocked second op now runs on a
+      // freshly created context.
+      await second;
+      expect(mock.disposedContexts.length).toBeGreaterThan(0);
+      expect(mock.getEmbeddingFor).toHaveBeenCalledTimes(2);
+      expect(mock.createEmbeddingContext.mock.calls.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      await llm.dispose();
+      mock.restore();
+    }
+  });
+});

--- a/test/llm.test.ts
+++ b/test/llm.test.ts
@@ -1468,6 +1468,8 @@ describe("idle unload vs active operations (#947)", () => {
       releaseEmbedding = resolve;
     });
     let holdNextEmbedding = false;
+    // When set, the next created context's dispose() rejects (failure-path test).
+    let failNextContextDispose = false;
 
     const getEmbeddingFor = vi.fn(async (text: string) => {
       if (holdNextEmbedding) await embeddingGate;
@@ -1478,6 +1480,10 @@ describe("idle unload vs active operations (#947)", () => {
       return {
         getEmbeddingFor,
         dispose: vi.fn(async () => {
+          if (failNextContextDispose) {
+            failNextContextDispose = false;
+            throw new Error(`simulated dispose failure for context ${id}`);
+          }
           disposedContexts.push(id);
         }),
       };
@@ -1514,6 +1520,9 @@ describe("idle unload vs active operations (#947)", () => {
       createEmbeddingContext,
       holdNext: () => {
         holdNextEmbedding = true;
+      },
+      failNextDispose: () => {
+        failNextContextDispose = true;
       },
       release: () => {
         releaseEmbedding?.();
@@ -1579,6 +1588,88 @@ describe("idle unload vs active operations (#947)", () => {
       await second;
       expect(mock.disposedContexts.length).toBeGreaterThan(0);
       expect(mock.getEmbeddingFor).toHaveBeenCalledTimes(2);
+      expect(mock.createEmbeddingContext.mock.calls.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      await llm.dispose();
+      mock.restore();
+    }
+  });
+
+  test("tokenize is blocked behind an in-flight unload and runs after it", async () => {
+    const mock = makeMockedLlm(0); // timer disabled; drive unload directly
+    const { llm } = mock;
+    try {
+      // Load the embed context so the unload has something to dispose.
+      await llm.embed("warmup");
+
+      mock.holdNext();
+      const op = llm.embed("held while tokenize arrives");
+      await new Promise((r) => setTimeout(r, 20));
+
+      const unload = llm.unloadIdleResources();
+      // tokenize must wait for the unload instead of touching the embed
+      // model/context while it is being disposed.
+      let tokensResolved = false;
+      const tokens = llm.tokenize("hello").then((r) => {
+        tokensResolved = true;
+        return r;
+      });
+      await new Promise((r) => setTimeout(r, 150));
+      expect(tokensResolved).toBe(false); // still blocked behind the held op + unload
+
+      mock.release();
+      await op;
+      await unload;
+      expect(await tokens).toEqual(["h", "e", "l", "l", "o"]);
+      // Fresh context was created for the post-unload tokenize.
+      expect(mock.createEmbeddingContext.mock.calls.length).toBeGreaterThanOrEqual(2);
+      expect(await llm.countTokens("hello")).toBe(5);
+    } finally {
+      await llm.dispose();
+      mock.restore();
+    }
+  });
+
+  test("dispose waits for an in-flight operation before freeing contexts", async () => {
+    const mock = makeMockedLlm(0);
+    const { llm } = mock;
+    try {
+      mock.holdNext();
+      const op = llm.embed("held across dispose");
+      await new Promise((r) => setTimeout(r, 20));
+
+      const disposing = llm.dispose();
+      await new Promise((r) => setTimeout(r, 200));
+      // Op still in flight: nothing has been freed yet.
+      expect(mock.disposedContexts).toEqual([]);
+
+      mock.release();
+      await op;
+      await disposing;
+      // The op completed first, then dispose freed the context.
+      expect(mock.disposedContexts.length).toBeGreaterThan(0);
+      // New operations after dispose are rejected, not run against freed state.
+      await expect(llm.embed("after dispose")).rejects.toThrow("disposed");
+    } finally {
+      await llm.dispose();
+      mock.restore();
+    }
+  });
+
+  test("a failed context dispose does not leave freed contexts cached", async () => {
+    const mock = makeMockedLlm(0);
+    const { llm } = mock;
+    try {
+      const warm = await llm.embed("warmup");
+      expect(warm).not.toBeNull();
+
+      mock.failNextDispose();
+      // The dispose rejects, but the context must be detached from the cache
+      // either way — the instance stays usable.
+      await llm.unloadIdleResources();
+
+      const again = await llm.embed("after failed unload");
+      expect(again).not.toBeNull();
       expect(mock.createEmbeddingContext.mock.calls.length).toBeGreaterThanOrEqual(2);
     } finally {
       await llm.dispose();


### PR DESCRIPTION
## Summary

The HTTP MCP daemon creates a per-store `LlamaCpp` whose inactivity timer consults only the module-global `canUnloadLLM()`. That global sees the CLI singleton's session manager — never the per-store instance — so after the 5-minute timeout the timer disposed embedding/rerank contexts underneath in-flight requests. JS-visible result: `DisposedError: Object is disposed`. If the race reaches native code: `EXC_BAD_ACCESS` in `llama_pooling_type` while a worker thread runs `llama_free` (#947).

## Root cause

- `canUnloadLLM()` (src/llm.ts) checks only `defaultSessionManager`, bound to the default singleton.
- Per-store LLMs (src/index.ts:388, `inactivityTimeoutMs: 5 * 60 * 1000, disposeModelsOnInactivity: true`) never register there, so `canUnloadLLM()` returns `true` even while the store's LLM is active.
- Structured search calls `llm.embedBatch` and `store.rerank` with no session wrapper at all — and even the wrapped paths used `withLLMSessionForLlm`, whose per-call manager is invisible to the timer.

## Fix: instance-local in-flight tracking

- `runOperation` wraps every model-backed public method (`embed`, `embedBatch`, `generate`, `expandQuery`, `rerank`) with an instance-local in-flight refcount.
- The idle timer refuses to unload while `this._activeOperations > 0` and reschedules instead.
- `unloadIdleResources()` waits for in-flight operations to drain before disposing, and coalesces concurrent unload calls.
- New operations block at `runOperation` until an in-progress unload finishes, then lazily recreate contexts.

This satisfies all five "required fix coverage" conditions from #947 and covers every call site automatically — including the bare `llm.embedBatch`/`store.rerank` calls in structured search. Session wrappers (`withLLMSession`/`withLLMSessionForLlm`) still provide abort/max-duration semantics and compose with the refcount (`session.embed()` → `llm.embed()` → `runOperation`).

## Tests

Two new tests in `test/llm.test.ts` ("idle unload vs active operations (#947)"):

1. Per-store LLM with a 50ms idle timeout; an embed is held open across the timeout; asserts no context disposal while in flight, and that cleanup happens after the op completes.
2. `unloadIdleResources()` driven directly while an op is in flight; asserts it drains (no disposal mid-op) and that a new op started during unload waits for it, then runs on a fresh context.

Full suite: 1222/1223 pass. The one failure (`mcp.test.ts` "POST /mcp initialize still works for 2025-era clients") fails identically on clean `main` — pre-existing, unrelated.

Fixes #947. Also addresses the disposal class behind #935 and #938.